### PR TITLE
fix validation errors on accessing nested fields of inputs / arguments

### DIFF
--- a/pkg/engine/resolve/inputtemplate.go
+++ b/pkg/engine/resolve/inputtemplate.go
@@ -62,7 +62,7 @@ func (i *InputTemplate) renderObjectVariable(ctx context.Context, variables []by
 	if valueType == jsonparser.String {
 		value = variables[offset-len(value)-2 : offset]
 		switch segment.Renderer.GetKind() {
-		case VariableRendererKindPlain:
+		case VariableRendererKindPlain, VariableRendererKindPlanWithValidation:
 			if plainRenderer, ok := (segment.Renderer).(*PlainVariableRenderer); ok {
 				plainRenderer.rootValueType.Value = valueType
 			}
@@ -79,6 +79,12 @@ func (i *InputTemplate) renderContextVariable(ctx *Context, segment TemplateSegm
 	}
 	if valueType == jsonparser.String {
 		value = ctx.Variables[offset-len(value)-2 : offset]
+		switch segment.Renderer.GetKind() {
+		case VariableRendererKindPlain, VariableRendererKindPlanWithValidation:
+			if plainRenderer, ok := (segment.Renderer).(*PlainVariableRenderer); ok {
+				plainRenderer.rootValueType.Value = valueType
+			}
+		}
 	}
 	return segment.Renderer.RenderVariable(ctx, value, preparedInput)
 }

--- a/pkg/engine/resolve/variable.go
+++ b/pkg/engine/resolve/variable.go
@@ -117,8 +117,14 @@ func NewPlainVariableRendererWithValidation(jsonSchema string) *PlainVariableRen
 
 // NewPlainVariableRendererWithValidationFromTypeRef creates a new PlainVariableRenderer
 // The argument typeRef must exist on the operation ast.Document, otherwise it will panic!
-func NewPlainVariableRendererWithValidationFromTypeRef(operation, definition *ast.Document, variableTypeRef int) (*PlainVariableRenderer, error) {
-	jsonSchema := graphqljsonschema.FromTypeRef(operation, definition, variableTypeRef)
+func NewPlainVariableRendererWithValidationFromTypeRef(operation, definition *ast.Document, variableTypeRef int, variablePath ...string) (*PlainVariableRenderer, error) {
+	var jsonSchema graphqljsonschema.JsonSchema
+	if len(variablePath) > 1 {
+		jsonSchema = graphqljsonschema.FromTypeRef(operation, definition, variableTypeRef, graphqljsonschema.WithPath(variablePath[1:]))
+	} else {
+		jsonSchema = graphqljsonschema.FromTypeRef(operation, definition, variableTypeRef)
+	}
+
 	validator, err := graphqljsonschema.NewValidatorFromSchema(jsonSchema)
 	if err != nil {
 		return nil, err
@@ -187,7 +193,7 @@ func NewGraphQLVariableRendererFromTypeRef(operation, definition *ast.Document, 
 }
 
 func NewGraphQLVariableRendererFromTypeRefWithOverrides(operation, definition *ast.Document, variableTypeRef int, overrides map[string]graphqljsonschema.JsonSchema) (*GraphQLVariableRenderer, error) {
-	jsonSchema := graphqljsonschema.FromTypeRefWithOverrides(operation, definition, variableTypeRef, overrides)
+	jsonSchema := graphqljsonschema.FromTypeRef(operation, definition, variableTypeRef, graphqljsonschema.WithOverrides(overrides))
 	validator, err := graphqljsonschema.NewValidatorFromSchema(jsonSchema)
 	if err != nil {
 		return nil, err

--- a/pkg/graphql/execution_engine_v2_test.go
+++ b/pkg/graphql/execution_engine_v2_test.go
@@ -418,14 +418,18 @@ func TestExecutionEngineV2_Execute(t *testing.T) {
 		},
 	))
 
-	t.Run("execute with .object placeholder", runWithoutError(
+	t.Run("execute with .object and .arguments placeholder", runWithoutError(
 		ExecutionEngineV2TestCase{
 			schema: func(t *testing.T) *Schema {
 				t.Helper()
 				schema := `
 					type Query {
-					  getPet(id: ID): Pet
+					  getPet(id: ID, metadata: APIMetadata): Pet
 					  countries: [Country]
+					}
+
+					input APIMetadata {
+						version: String!
 					}
 					
 					type Country {
@@ -451,8 +455,8 @@ func TestExecutionEngineV2_Execute(t *testing.T) {
 				return Request{
 					OperationName: "MyQuery",
 					Query: `
-						query MyQuery {
-						  getPet(id: 1) {
+						query MyQuery($metadata: APIMetadata) {
+						  getPet(id: 1, metadata: $metadata) {
 							id
 							name
 							country {
@@ -461,6 +465,7 @@ func TestExecutionEngineV2_Execute(t *testing.T) {
 						  }
 						}
 					`,
+					Variables: []byte(`{"metadata":{"version":"v2"}}`),
 				}
 			},
 			dataSources: []plan.DataSourceConfiguration{
@@ -482,7 +487,7 @@ func TestExecutionEngineV2_Execute(t *testing.T) {
 					},
 					Custom: rest_datasource.ConfigJSON(rest_datasource.Configuration{
 						Fetch: rest_datasource.FetchConfiguration{
-							URL:    "https://petstore.swagger.io/v2/pet/{{.arguments.id}}",
+							URL:    "https://petstore.swagger.io/{{.arguments.metadata.version}}/pet/{{.arguments.id}}",
 							Method: "GET",
 						},
 					}),
@@ -497,7 +502,7 @@ func TestExecutionEngineV2_Execute(t *testing.T) {
 					Factory: &rest_datasource.Factory{
 						Client: testNetHttpClient(t, roundTripperTestCase{
 							expectedHost:     "rest-countries.example.com",
-							expectedPath:     "/type/dog/name/doggie",
+							expectedPath:     "/type/1-dog/name/doggie",
 							expectedBody:     "",
 							sendResponseBody: `{"name":"Germany"}`,
 							sendStatusCode:   200,
@@ -505,7 +510,7 @@ func TestExecutionEngineV2_Execute(t *testing.T) {
 					},
 					Custom: rest_datasource.ConfigJSON(rest_datasource.Configuration{
 						Fetch: rest_datasource.FetchConfiguration{
-							URL:    "https://rest-countries.example.com/type/{{.object.category.name}}/name/{{.object.name}}",
+							URL:    "https://rest-countries.example.com/type/{{.object.category.id}}-{{.object.category.name}}/name/{{.object.name}}",
 							Method: "POST",
 						},
 					}),
@@ -520,6 +525,10 @@ func TestExecutionEngineV2_Execute(t *testing.T) {
 					Arguments: []plan.ArgumentConfiguration{
 						{
 							Name:       "id",
+							SourceType: plan.FieldArgumentSource,
+						},
+						{
+							Name:       "metadata",
 							SourceType: plan.FieldArgumentSource,
 						},
 					},

--- a/pkg/graphql/execution_engine_v2_test.go
+++ b/pkg/graphql/execution_engine_v2_test.go
@@ -476,7 +476,7 @@ func TestExecutionEngineV2_Execute(t *testing.T) {
 							expectedHost:     "petstore.swagger.io",
 							expectedPath:     "/v2/pet/1",
 							expectedBody:     "",
-							sendResponseBody: `{"id":1,"category":{"id":1,"name":"string"},"name":"doggie"}`,
+							sendResponseBody: `{"id":1,"category":{"id":1,"name":"dog"},"name":"doggie"}`,
 							sendStatusCode:   200,
 						}),
 					},
@@ -497,7 +497,7 @@ func TestExecutionEngineV2_Execute(t *testing.T) {
 					Factory: &rest_datasource.Factory{
 						Client: testNetHttpClient(t, roundTripperTestCase{
 							expectedHost:     "rest-countries.example.com",
-							expectedPath:     "/name/doggie",
+							expectedPath:     "/type/dog/name/doggie",
 							expectedBody:     "",
 							sendResponseBody: `{"name":"Germany"}`,
 							sendStatusCode:   200,
@@ -505,7 +505,7 @@ func TestExecutionEngineV2_Execute(t *testing.T) {
 					},
 					Custom: rest_datasource.ConfigJSON(rest_datasource.Configuration{
 						Fetch: rest_datasource.FetchConfiguration{
-							URL:    "https://rest-countries.example.com/name/{{.object.name}}",
+							URL:    "https://rest-countries.example.com/type/{{.object.category.name}}/name/{{.object.name}}",
 							Method: "POST",
 						},
 					}),


### PR DESCRIPTION
This PR solves an issue where nested fields of inputs were not accessible anymore because it failed JSON schema validation. It also solves an issue similar to #369 for arguments, where quotes are not removed for the PlainRenderer.

*Before / did not work*:
- `{{ .arguments.parent.nested }}` => validation error
- when `nested` is a string: `{{ .arguments.parent.nested }}` => `"nested string value"`

*After change*:
- `{{ .arguments.parent.nested}}` => `nested string value`