### PR TITLE
Calculate the hash during schema creation and make Hash() only return…

### DIFF
--- a/pkg/graphql/validation.go
+++ b/pkg/graphql/validation.go
@@ -15,10 +15,7 @@ func (r *Request) ValidateForSchema(schema *Schema) (result ValidationResult, er
 		return ValidationResult{Valid: false, Errors: nil}, ErrNilSchema
 	}
 
-	schemaHash, err := schema.Hash()
-	if err != nil {
-		return ValidationResult{Valid: false}, err
-	}
+	schemaHash := schema.Hash()
 
 	if r.validForSchema == nil {
 		r.validForSchema = map[uint64]ValidationResult{}


### PR DESCRIPTION
… the calculated hash.

This is a proposal for how to fix #386 