### PR TITLE
subscription: add support for ka while waiting for ack (#277)

### DIFF
--- a/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
@@ -3,6 +3,7 @@ package graphql_datasource
 import (
 	"context"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -26,6 +27,82 @@ func logger() ll.Logger {
 	}
 
 	return ll.NewZapLogger(logger, ll.DebugLevel)
+}
+
+func TestWebSocketSubscriptionClientInitIncludeKA(t *testing.T) {
+	serverDone := make(chan struct{})
+	assertion := require.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		assertion.NoError(err)
+
+		// write "ka" every second
+		go func() {
+			for {
+				err := conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"ka"}`))
+				if err != nil {
+					break
+				}
+				time.Sleep(time.Second)
+			}
+		}()
+		ctx := context.Background()
+		msgType, data, err := conn.Read(ctx)
+		assertion.NoError(err)
+		assertion.Equal(websocket.MessageText, msgType)
+		assertion.Equal(`{"type":"connection_init"}`, string(data))
+
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"connection_ack"}`))
+		assertion.NoError(err)
+
+		msgType, data, err = conn.Read(ctx)
+		assertion.NoError(err)
+		assertion.Equal(websocket.MessageText, msgType)
+		assertion.Equal(`{"type":"start","id":"1","payload":{"query":"subscription {messageAdded(roomName: \"room\"){text}}"}}`, string(data))
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"data","id":"1","payload":{"data":{"messageAdded":{"text":"first"}}}}`))
+		assertion.NoError(err)
+		err = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"data","id":"1","payload":{"data":{"messageAdded":{"text":"second"}}}}`))
+		assertion.NoError(err)
+		assertion.NoError(err)
+
+		msgType, data, err = conn.Read(ctx)
+		assertion.NoError(err)
+		assertion.Equal(websocket.MessageText, msgType)
+		assertion.Equal(`{"type":"stop","id":"1"}`, string(data))
+		close(serverDone)
+	}))
+
+	defer server.Close()
+	ctx, clientCancel := context.WithCancel(context.Background())
+	defer clientCancel()
+	serverCtx, serverCancel := context.WithCancel(context.Background())
+	defer serverCancel()
+
+	client := NewWebSocketGraphQLSubscriptionClient(http.DefaultClient, serverCtx,
+		WithReadTimeout(time.Millisecond),
+		WithLogger(logger()),
+	)
+	next := make(chan []byte)
+	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+		URL: strings.Replace(server.URL, "http", "ws", -1),
+		Body: GraphQLBody{
+			Query: `subscription {messageAdded(roomName: "room"){text}}`,
+		},
+	}, next)
+	assertion.NoError(err)
+	first := <-next
+	second := <-next
+	assertion.Equal(`{"data":{"messageAdded":{"text":"first"}}}`, string(first))
+	assertion.Equal(`{"data":{"messageAdded":{"text":"second"}}}`, string(second))
+	clientCancel()
+	assertion.Eventuallyf(func() bool {
+		<-serverDone
+		return true
+	}, time.Second, time.Millisecond*10, "server did not close")
+	serverCancel()
+	assertion.Eventuallyf(func() bool {
+		return len(client.handlers) == 0
+	}, time.Second, time.Millisecond, "client handlers not 0")
 }
 
 func TestWebsocketSubscriptionClient(t *testing.T) {


### PR DESCRIPTION
## Issue
When running a GQL subscription (and thus using a WSS connection) and upstream does not return connection_ack as its first response, the subscription fails and "message": "expected connection_ack, got: ka” is shown. Also, logs are spammed with messages

## Solution
While waiting for a connection_ack message also listen and accept ka messages

[Spec here](https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md)