### PR TITLE
check errors before marking a query as parsed

### DIFF
--- a/pkg/graphql/request.go
+++ b/pkg/graphql/request.go
@@ -103,8 +103,13 @@ func (r *Request) parseQueryOnce() (report operationreport.Report) {
 		return report
 	}
 
-	r.isParsed = true
 	r.document, report = astparser.ParseGraphqlDocumentString(r.Query)
+	if !report.HasErrors() {
+		// If the given query has problems, and we failed to parse it,
+		// we shouldn't mark it as parsed. It can be misleading for
+		// the rest of the components. See TT-5704.
+		r.isParsed = true
+	}
 	return report
 }
 


### PR DESCRIPTION
Fix authored by: @buraksezer 

This PR fixes an issue where a query is being marked as parsed even if parsing fails.
This behavior results in a misbehaving subscription.