### PR TITLE
fix: return after parsing arg fields of type ast.ValueKindList

### DIFF
--- a/pkg/astvalidation/operation_rule_all_variables_used.go
+++ b/pkg/astvalidation/operation_rule_all_variables_used.go
@@ -69,6 +69,7 @@ func (a *allVariablesUsedVisitor) verifyValue(value ast.Value) {
 		for _, i := range a.operation.ListValues[value.Ref].Refs {
 			a.verifyValue(a.operation.Values[i])
 		}
+		return
 	default:
 		return // skip all others
 	}

--- a/pkg/astvalidation/operation_validation_test.go
+++ b/pkg/astvalidation/operation_validation_test.go
@@ -3524,6 +3524,48 @@ func TestExecutionValidation(t *testing.T) {
 								}`,
 					AllVariablesUsed(), Valid)
 			})
+			t.Run("variables in nested array object", func(t *testing.T) {
+				run(`query variableUnused($name: String) {
+					dog(where: {
+						AND: [
+						  { nestedDog: { nickname: { eq: "Scooby Doo" } } }
+						  { nestedDog: { name: { eq: $name } } }
+						  {
+							OR: [
+							  {
+								AND: [
+								  {
+									nestedDog: {
+									  birthday: { eq: "2021-07-29" }
+									}
+								  }
+								  {
+									nestedDog: { barkVolume: { eq: 20 } }
+								  }
+								]
+							  }
+							  {
+								AND: [
+								  {
+									nestedDog: {
+										birthday: { eq: "2021-08-02" }
+									}
+								  }
+								  {
+									nestedDog: { barkVolume: { eq: 35 } }
+								  }
+								]
+							  }
+							]
+						  }
+						]
+					  }) {
+						id
+						name
+					}
+				}`,
+					AllVariablesUsed(), Valid)
+			})
 		})
 		t.Run("5.8.5 All VariableValue Usages are Allowed", func(t *testing.T) {
 			t.Run("169", func(t *testing.T) {


### PR DESCRIPTION
### Summary 

Suppose we have this graphql query request with the following query variables:

#### Sample request
```graphql
query book_sn($id: String) {
  book_attic {
    oreilly_books(
      where: {
        AND: [ # Parsed ast ast.ValueKindList since it contains query variables, instead of the usual ast.ValueKindVariable
          { python: { tag: { eq: "beginner" } } }
          { golang: { serial_number: { eq: $id } } }
          {
            OR: [
              {
                AND: [
                  {
                    python: {
                      date_published: { eq: "2022-07-29" }
                    }
                  }
                  {
                    python: { date_purchased: { eq: "2022-07-29" } }
                  }
                ]
              }
              {
                AND: [
                  {
                    golang: {
                      date_published: { eq: "2022-08-01" }
                    }
                  }
                  {
                    golang: { date_purchased: { eq: "2022-08-01" } }
                  }
                ]
              }
            ]
          }
        
      }
    ) {
      jrr_tolkien_books
      george_rr_martin_books
    }
  }
}

```

```json
{"id": "1801071039"}
```

This will be stored into an `ast.Document` which then gets parsed during validation in https://github.com/wundergraph/graphql-go-tools/blob/v1.51.0/pkg/astvalidation/operation_validation.go#L68.

It then fails within an implementation of `EnterArgument()` specifically for [allVariablesUsedVisitor](https://github.com/wundergraph/graphql-go-tools/blob/master/pkg/astvalidation/operation_rule_all_variables_used.go#L76) because it attempts to continue processing a field of type `ast.ValueKindList` but we only resolve `ast.ValueKindVariable` fields to its actual `ast.VariableValue` mapping. Thus, the out of bound index error as we can see from the screenshot below:

![graphql-go-tools-bug](https://user-images.githubusercontent.com/25612430/184691463-000fe732-ec7a-4362-8f54-e66b568a920b.png)

### Changelog

- Break case condition after iterating all elements of an `ast.ValueKindList` within the recursive function, `veifyValue()`.
- Add corresponding test case for under `5.8.4 All Variables Used` grouping to capture this case:

**Before:**

```bash
--- FAIL: TestExecutionValidation (0.09s)
    --- FAIL: TestExecutionValidation/5.8_Variables (0.01s)
        --- FAIL: TestExecutionValidation/5.8_Variables/5.8.4_All_Variables_Used (0.00s)
            --- FAIL: TestExecutionValidation/5.8_Variables/5.8.4_All_Variables_Used/variables_in_nested_array_object (0.00s)
panic: runtime error: index out of range [2] with length 2 [recovered]
	panic: runtime error: index out of range [2] with length 2
``` 

**After:**

```bash
ok  	github.com/wundergraph/graphql-go-tools/pkg/astvalidation	0.940s

$ go test -count=1 ./pkg/astvalidation/...
ok      github.com/wundergraph/graphql-go-tools/pkg/astvalidation       0.959s
?       github.com/wundergraph/graphql-go-tools/pkg/astvalidation/reference     [no test files]
ok      github.com/wundergraph/graphql-go-tools/pkg/astvalidation/reference/testsgo     0.157s
```

### Tests

- [x] Manual testing
- [x] Functional testing

@jensneuse 