### PR TITLE
export SubscriptionClient and ws protocol variables

### DIFF
--- a/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
@@ -1170,22 +1170,24 @@ type Factory struct {
 	HTTPClient                 *http.Client
 	StreamingClient            *http.Client
 	OnWsConnectionInitCallback *OnWsConnectionInitCallback
-	subscriptionClient         *SubscriptionClient
+	SubscriptionClient         *SubscriptionClient
 }
 
 func (f *Factory) Planner(ctx context.Context) plan.DataSourcePlanner {
-	if f.subscriptionClient == nil {
+	if f.SubscriptionClient == nil {
 		opts := make([]Options, 0)
 		if f.OnWsConnectionInitCallback != nil {
 			opts = append(opts, WithOnWsConnectionInitCallback(f.OnWsConnectionInitCallback))
 		}
 
-		f.subscriptionClient = NewGraphQLSubscriptionClient(f.HTTPClient, f.StreamingClient, ctx, opts...)
+		f.SubscriptionClient = NewGraphQLSubscriptionClient(f.HTTPClient, f.StreamingClient, ctx, opts...)
+	} else if f.SubscriptionClient.engineCtx == nil {
+		f.SubscriptionClient.engineCtx = ctx
 	}
 	return &Planner{
 		batchFactory:       f.BatchFactory,
 		fetchClient:        f.HTTPClient,
-		subscriptionClient: f.subscriptionClient,
+		subscriptionClient: f.SubscriptionClient,
 	}
 }
 

--- a/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
@@ -5600,7 +5600,7 @@ func TestSubscription_GTWS_SubProtocol(t *testing.T) {
 	newSubscriptionSource := func(ctx context.Context) SubscriptionSource {
 		httpClient := http.Client{}
 		subscriptionSource := SubscriptionSource{
-			client: NewGraphQLSubscriptionClient(&httpClient, http.DefaultClient, ctx, WithWSSubProtocol(protocolGraphQLTWS)),
+			client: NewGraphQLSubscriptionClient(&httpClient, http.DefaultClient, ctx, WithWSSubProtocol(ProtocolGraphQLTWS)),
 		}
 		return subscriptionSource
 	}

--- a/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
@@ -189,7 +189,7 @@ func (c *SubscriptionClient) generateHandlerIDHash(options GraphQLSubscriptionOp
 }
 
 func (c *SubscriptionClient) newWSConnectionHandler(reqCtx context.Context, options GraphQLSubscriptionOptions) (ConnectionHandler, error) {
-	subProtocols := []string{protocolGraphQLWS, protocolGraphQLTWS}
+	subProtocols := []string{ProtocolGraphQLWS, ProtocolGraphQLTWS}
 	if c.wsSubProtocol != "" {
 		subProtocols = []string{c.wsSubProtocol}
 	}
@@ -227,9 +227,9 @@ func (c *SubscriptionClient) newWSConnectionHandler(reqCtx context.Context, opti
 	}
 
 	switch c.wsSubProtocol {
-	case protocolGraphQLWS:
+	case ProtocolGraphQLWS:
 		return newGQLWSConnectionHandler(c.engineCtx, conn, c.readTimeout, c.log), nil
-	case protocolGraphQLTWS:
+	case ProtocolGraphQLTWS:
 		return newGQLTWSConnectionHandler(c.engineCtx, conn, c.readTimeout, c.log), nil
 	default:
 		return nil, fmt.Errorf("unknown protocol %s", conn.Subprotocol())

--- a/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
@@ -154,7 +154,7 @@ func TestWebsocketSubscriptionClientDeDuplication(t *testing.T) {
 	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
 		WithReadTimeout(time.Millisecond),
 		WithLogger(logger()),
-		WithWSSubProtocol(protocolGraphQLWS),
+		WithWSSubProtocol(ProtocolGraphQLWS),
 	)
 	clientsDone := &sync.WaitGroup{}
 
@@ -211,7 +211,7 @@ func TestWebsocketSubscriptionClientImmediateClientCancel(t *testing.T) {
 	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
 		WithReadTimeout(time.Millisecond),
 		WithLogger(logger()),
-		WithWSSubProtocol(protocolGraphQLWS),
+		WithWSSubProtocol(ProtocolGraphQLWS),
 	)
 	next := make(chan []byte)
 	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
@@ -266,7 +266,7 @@ func TestWebsocketSubscriptionClientWithServerDisconnect(t *testing.T) {
 	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
 		WithReadTimeout(time.Millisecond),
 		WithLogger(logger()),
-		WithWSSubProtocol(protocolGraphQLWS),
+		WithWSSubProtocol(ProtocolGraphQLWS),
 	)
 	next := make(chan []byte)
 	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{

--- a/pkg/engine/datasource/graphql_datasource/graphql_tws_handler_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_tws_handler_test.go
@@ -54,7 +54,7 @@ func TestWebsocketSubscriptionClient_GQLTWS(t *testing.T) {
 	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
 		WithReadTimeout(time.Millisecond),
 		WithLogger(logger()),
-		WithWSSubProtocol(protocolGraphQLTWS),
+		WithWSSubProtocol(ProtocolGraphQLTWS),
 	)
 
 	next := make(chan []byte)
@@ -129,7 +129,7 @@ func TestWebsocketSubscriptionClientPing_GQLTWS(t *testing.T) {
 	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
 		WithReadTimeout(time.Millisecond),
 		WithLogger(logger()),
-		WithWSSubProtocol(protocolGraphQLTWS),
+		WithWSSubProtocol(ProtocolGraphQLTWS),
 	)
 
 	next := make(chan []byte)
@@ -190,7 +190,7 @@ func TestWebsocketSubscriptionClientError_GQLTWS(t *testing.T) {
 	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
 		WithReadTimeout(time.Millisecond),
 		WithLogger(logger()),
-		WithWSSubProtocol(protocolGraphQLTWS),
+		WithWSSubProtocol(ProtocolGraphQLTWS),
 	)
 
 	next := make(chan []byte)
@@ -274,7 +274,7 @@ func TestWebSocketSubscriptionClientInitIncludePing_GQLTWS(t *testing.T) {
 	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
 		WithReadTimeout(time.Millisecond),
 		WithLogger(logger()),
-		WithWSSubProtocol(protocolGraphQLTWS),
+		WithWSSubProtocol(ProtocolGraphQLTWS),
 	)
 	next := make(chan []byte)
 	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{

--- a/pkg/engine/datasource/graphql_datasource/graphql_ws_handler_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_ws_handler_test.go
@@ -65,7 +65,7 @@ func TestWebSocketSubscriptionClientInitIncludeKA_GQLWS(t *testing.T) {
 	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
 		WithReadTimeout(time.Millisecond),
 		WithLogger(logger()),
-		WithWSSubProtocol(protocolGraphQLWS),
+		WithWSSubProtocol(ProtocolGraphQLWS),
 	)
 	next := make(chan []byte)
 	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
@@ -128,7 +128,7 @@ func TestWebsocketSubscriptionClient_GQLWS(t *testing.T) {
 	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
 		WithReadTimeout(time.Millisecond),
 		WithLogger(logger()),
-		WithWSSubProtocol(protocolGraphQLWS),
+		WithWSSubProtocol(ProtocolGraphQLWS),
 	)
 	next := make(chan []byte)
 	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
@@ -187,7 +187,7 @@ func TestWebsocketSubscriptionClientErrorArray(t *testing.T) {
 	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
 		WithReadTimeout(time.Millisecond),
 		WithLogger(logger()),
-		WithWSSubProtocol(protocolGraphQLWS),
+		WithWSSubProtocol(ProtocolGraphQLWS),
 	)
 	next := make(chan []byte)
 	err := client.Subscribe(clientCtx, GraphQLSubscriptionOptions{
@@ -240,7 +240,7 @@ func TestWebsocketSubscriptionClientErrorObject(t *testing.T) {
 	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
 		WithReadTimeout(time.Millisecond),
 		WithLogger(logger()),
-		WithWSSubProtocol(protocolGraphQLWS),
+		WithWSSubProtocol(ProtocolGraphQLWS),
 	)
 	next := make(chan []byte)
 	err := client.Subscribe(clientCtx, GraphQLSubscriptionOptions{

--- a/pkg/engine/datasource/graphql_datasource/graphql_ws_proto_types.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_ws_proto_types.go
@@ -14,7 +14,7 @@ const (
 // websocket sub-protocol:
 // https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md
 const (
-	protocolGraphQLWS = "graphql-ws"
+	ProtocolGraphQLWS = "graphql-ws"
 
 	startMessage = `{"type":"start","id":"%s","payload":%s}`
 	stopMessage  = `{"type":"stop","id":"%s"}`
@@ -27,7 +27,7 @@ const (
 // websocket sub-protocol:
 // https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md
 const (
-	protocolGraphQLTWS = "graphql-transport-ws"
+	ProtocolGraphQLTWS = "graphql-transport-ws"
 
 	subscribeMessage = `{"id":"%s","type":"subscribe","payload":%s}`
 	pongMessage      = `{"type":"pong"}`


### PR DESCRIPTION
This PR exports the `SubscriptionClient`and also exports the protocol variables.

**Motivation**
In our case, we are creating the SubscriptionClient outside of the engine; without exporting the SubscriptionClient it is impossible to achieve it.
It also means that we added an extra check for the case, that a SubscriptionClient exists but does not have a context - because it was created outside of the engine context.