### PR TITLE
add new subscription types to graphql package

### DIFF
--- a/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
@@ -65,6 +65,18 @@ type opts struct {
 	onWsConnectionInitCallback *OnWsConnectionInitCallback
 }
 
+// GraphQLSubscriptionClientFactory abstracts the way of creating a new GraphQLSubscriptionClient.
+// This can be very handy for testing purposes.
+type GraphQLSubscriptionClientFactory interface {
+	NewSubscriptionClient(httpClient, streamingClient *http.Client, engineCtx context.Context, options ...Options) GraphQLSubscriptionClient
+}
+
+type DefaultSubscriptionClientFactory struct{}
+
+func (d *DefaultSubscriptionClientFactory) NewSubscriptionClient(httpClient, streamingClient *http.Client, engineCtx context.Context, options ...Options) GraphQLSubscriptionClient {
+	return NewGraphQLSubscriptionClient(httpClient, streamingClient, engineCtx, options...)
+}
+
 func NewGraphQLSubscriptionClient(httpClient, streamingClient *http.Client, engineCtx context.Context, options ...Options) *SubscriptionClient {
 	op := &opts{
 		readTimeout: time.Second,

--- a/pkg/graphql/subscription.go
+++ b/pkg/graphql/subscription.go
@@ -1,0 +1,16 @@
+package graphql
+
+type SubscriptionType int
+
+const (
+	// SubscriptionTypeUnknown is for unknown or undefined subscriptions.
+	SubscriptionTypeUnknown = iota
+	// SubscriptionTypeSSE is for Server-Sent Events (SSE) subscriptions.
+	SubscriptionTypeSSE
+	// SubscriptionTypeGraphQLWS is for subscriptions using a WebSocket connection with
+	// 'graphql-ws' as protocol.
+	SubscriptionTypeGraphQLWS
+	// SubscriptionTypeGraphQLTransportWS is for subscriptions using a WebSocket connection with
+	// 'graphql-transport-ws' as protocol.
+	SubscriptionTypeGraphQLTransportWS
+)


### PR DESCRIPTION
This PR adds new subscription types to:
 - config generator for proxy-only
 - config generator for federation

Also fixes https://github.com/wundergraph/graphql-go-tools/issues/428.