### PR TITLE
Feature/improve values validation to reflect reference implementation

### DIFF
--- a/internal/pkg/unsafebytes/unsafebytes.go
+++ b/internal/pkg/unsafebytes/unsafebytes.go
@@ -51,6 +51,11 @@ func BytesIsValidInt64(byteSlice []byte) bool {
 	return err == nil
 }
 
+func BytesIsValidInt32(byteSlice []byte) bool {
+	_, err := strconv.ParseInt(*(*string)(unsafe.Pointer(&byteSlice)), 10, 32)
+	return err == nil
+}
+
 func BytesIsValidBool(byteSlice []byte) bool {
 	_, err := strconv.ParseBool(*(*string)(unsafe.Pointer(&byteSlice)))
 	return err == nil

--- a/internal/pkg/unsafebytes/unsafebytes_test.go
+++ b/internal/pkg/unsafebytes/unsafebytes_test.go
@@ -79,9 +79,20 @@ func TestBytesIsValidFloat32(t *testing.T) {
 
 func TestBytesIsValidInt64(t *testing.T) {
 	t.Run("valid int", testValidation(BytesIsValidInt64, []byte("123"), true))
-	t.Run("invalid int", testValidation(BytesIsValidInt64, []byte("1.23"), false))
-	t.Run("invalid int", testValidation(BytesIsValidInt64, []byte("true"), false))
-	t.Run("invalid int", testValidation(BytesIsValidInt64, []byte("\"123\""), false))
+	t.Run("valid big int", testValidation(BytesIsValidInt64, []byte("8293842938492834982"), true))
+	t.Run("invalid very big int", testValidation(BytesIsValidInt64, []byte("8293842938492834982394"), false))
+	t.Run("invalid float", testValidation(BytesIsValidInt64, []byte("1.23"), false))
+	t.Run("invalid bool", testValidation(BytesIsValidInt64, []byte("true"), false))
+	t.Run("invalid quoted int", testValidation(BytesIsValidInt64, []byte("\"123\""), false))
+}
+
+func TestBytesIsValidInt32(t *testing.T) {
+	t.Run("valid int", testValidation(BytesIsValidInt32, []byte("123"), true))
+	t.Run("invalid valid big int", testValidation(BytesIsValidInt32, []byte("8293842938492834982"), false))
+	t.Run("invalid very big int", testValidation(BytesIsValidInt32, []byte("829384293849283498239482938"), false))
+	t.Run("invalid float", testValidation(BytesIsValidInt32, []byte("1.23"), false))
+	t.Run("invalid bool", testValidation(BytesIsValidInt32, []byte("true"), false))
+	t.Run("invalid quoted int", testValidation(BytesIsValidInt32, []byte("\"123\""), false))
 }
 
 func TestBytesIsValidBool(t *testing.T) {

--- a/pkg/ast/ast_argument.go
+++ b/pkg/ast/ast_argument.go
@@ -16,9 +16,10 @@ type ArgumentList struct {
 }
 
 type Argument struct {
-	Name  ByteSliceReference // e.g. foo
-	Colon position.Position  // :
-	Value Value              // e.g. 100 or "Bar"
+	Name     ByteSliceReference // e.g. foo
+	Colon    position.Position  // :
+	Value    Value              // e.g. 100 or "Bar"
+	Position position.Position
 }
 
 func (d *Document) CopyArgument(ref int) int {

--- a/pkg/ast/ast_object_field.go
+++ b/pkg/ast/ast_object_field.go
@@ -11,9 +11,10 @@ import (
 // example:
 // lon: 12.43
 type ObjectField struct {
-	Name  ByteSliceReference // e.g. lon
-	Colon position.Position  // :
-	Value Value              // e.g. 12.43
+	Name     ByteSliceReference // e.g. lon
+	Colon    position.Position  // :
+	Value    Value              // e.g. 12.43
+	Position position.Position
 }
 
 func (d *Document) CopyObjectField(ref int) int {

--- a/pkg/ast/ast_val_int_value.go
+++ b/pkg/ast/ast_val_int_value.go
@@ -41,6 +41,11 @@ func (d *Document) IntValueAsInt32(ref int) (out int32) {
 	return
 }
 
+func (d *Document) IntValueValidInt32(ref int) bool {
+	in := d.Input.ByteSlice(d.IntValues[ref].Raw)
+	return unsafebytes.BytesIsValidInt32(in)
+}
+
 func (d *Document) IntValue(ref int) IntValue {
 	return d.IntValues[ref]
 }

--- a/pkg/ast/ast_value.go
+++ b/pkg/ast/ast_value.go
@@ -10,6 +10,7 @@ import (
 	"github.com/wundergraph/graphql-go-tools/internal/pkg/quotes"
 	"github.com/wundergraph/graphql-go-tools/internal/pkg/unsafebytes"
 	"github.com/wundergraph/graphql-go-tools/pkg/lexer/literal"
+	"github.com/wundergraph/graphql-go-tools/pkg/lexer/position"
 )
 
 type ValueKind int

--- a/pkg/ast/ast_value.go
+++ b/pkg/ast/ast_value.go
@@ -28,8 +28,9 @@ const (
 )
 
 type Value struct {
-	Kind ValueKind // e.g. 100 or "Bar"
-	Ref  int
+	Kind     ValueKind // e.g. 100 or "Bar"
+	Ref      int
+	Position position.Position
 }
 
 func (d *Document) CopyValue(ref int) int {

--- a/pkg/astparser/parser.go
+++ b/pkg/astparser/parser.go
@@ -389,9 +389,10 @@ Loop:
 		value := p.ParseValue()
 
 		argument := ast.Argument{
-			Name:  name.Literal,
-			Colon: colon.TextPosition,
-			Value: value,
+			Name:     name.Literal,
+			Colon:    colon.TextPosition,
+			Value:    value,
+			Position: name.TextPosition,
 		}
 
 		p.document.Arguments = append(p.document.Arguments, argument)

--- a/pkg/astparser/parser.go
+++ b/pkg/astparser/parser.go
@@ -490,13 +490,16 @@ func (p *Parser) parseObjectValue() (ref int, pos position.Position) {
 }
 
 func (p *Parser) parseObjectField() int {
+	nameToken := p.mustRead(keyword.IDENT)
+
 	objectField := ast.ObjectField{
-		Name:  p.mustRead(keyword.IDENT).Literal,
-		Colon: p.mustRead(keyword.COLON).TextPosition,
-		Value: p.ParseValue(),
+		Name:     nameToken.Literal,
+		Colon:    p.mustRead(keyword.COLON).TextPosition,
+		Value:    p.ParseValue(),
+		Position: nameToken.TextPosition,
 	}
-	p.document.ObjectFields = append(p.document.ObjectFields, objectField)
-	return len(p.document.ObjectFields) - 1
+
+	return p.document.AddObjectField(objectField)
 }
 
 func (p *Parser) parseValueList() int {

--- a/pkg/astparser/parser.go
+++ b/pkg/astparser/parser.go
@@ -743,7 +743,7 @@ func (p *Parser) parseImplementsInterfaces() (list ast.TypeList) {
 				acceptIdent = false
 				acceptAnd = true
 				name := p.read()
-				ref := p.document.AddNamedTypeByNameRef(name.Literal)
+				ref := p.document.AddNamedTypeWithPosition(name.Literal, name.TextPosition)
 				if cap(list.Refs) == 0 {
 					list.Refs = p.document.Refs[p.document.NextRefIndex()][:0]
 				}
@@ -837,7 +837,7 @@ func (p *Parser) parseFieldDefinition() int {
 func (p *Parser) parseNamedType() (ref int) {
 	ident := p.mustRead(keyword.IDENT)
 
-	return p.document.AddNamedTypeByNameRef(ident.Literal)
+	return p.document.AddNamedTypeWithPosition(ident.Literal, ident.TextPosition)
 }
 
 func (p *Parser) ParseType() (ref int) {
@@ -845,7 +845,8 @@ func (p *Parser) ParseType() (ref int) {
 	first := p.peek()
 
 	if first == keyword.IDENT {
-		ref = p.document.AddNamedTypeByNameRef(p.read().Literal)
+		tok := p.read()
+		ref = p.document.AddNamedTypeWithPosition(tok.Literal, tok.TextPosition)
 	} else if first == keyword.LBRACK {
 
 		openList := p.read()
@@ -866,7 +867,7 @@ func (p *Parser) ParseType() (ref int) {
 			return
 		}
 
-		ref = p.document.AddNonNullTypeWithPosition(ref, bangPosition)
+		ref = p.document.AddNonNullTypeWithBangPosition(ref, bangPosition)
 	}
 
 	return
@@ -1077,7 +1078,7 @@ func (p *Parser) parseUnionMemberTypes() (list ast.TypeList) {
 
 				ident := p.read()
 
-				ref := p.document.AddNamedTypeByNameRef(ident.Literal)
+				ref := p.document.AddNamedTypeWithPosition(ident.Literal, ident.TextPosition)
 
 				if cap(list.Refs) == 0 {
 					list.Refs = p.document.Refs[p.document.NextRefIndex()][:0]

--- a/pkg/astparser/parser.go
+++ b/pkg/astparser/parser.go
@@ -280,7 +280,7 @@ func (p *Parser) parseRootOperationTypeDefinitionList(list *ast.RootOperationTyp
 				NamedType: ast.Type{
 					TypeKind: ast.TypeKindNamed,
 					Name:     namedType.Literal,
-					OfType:   -1,
+					OfType:   ast.InvalidRef,
 				},
 			}
 
@@ -524,7 +524,7 @@ func (p *Parser) parseValueList() int {
 		}
 
 		if p.report.HasErrors() {
-			return -1
+			return ast.InvalidRef
 		}
 	}
 }
@@ -573,7 +573,7 @@ func (p *Parser) parseIntegerValue(negativeSign *position.Position) (ref int, po
 
 	if negativeSign != nil && negativeSign.CharEnd != value.TextPosition.CharStart {
 		p.errUnexpectedToken(value)
-		return -1, position.Position{}
+		return ast.InvalidRef, position.Position{}
 	}
 
 	intValue := ast.IntValue{
@@ -810,13 +810,13 @@ func (p *Parser) parseFieldDefinition() int {
 		break
 	default:
 		p.errUnexpectedToken(p.read())
-		return -1
+		return ast.InvalidRef
 	}
 
 	nameToken := p.read()
 	if nameToken.Keyword != keyword.IDENT {
 		p.errUnexpectedToken(nameToken, keyword.IDENT)
-		return -1
+		return ast.InvalidRef
 	}
 
 	fieldDefinition.Name = nameToken.Literal
@@ -923,7 +923,7 @@ func (p *Parser) parseInputValueDefinition() int {
 		break
 	default:
 		p.errUnexpectedToken(p.read())
-		return -1
+		return ast.InvalidRef
 	}
 
 	inputValueDefinition.Name = p.read().Literal
@@ -1165,7 +1165,7 @@ func (p *Parser) parseEnumValueDefinition() int {
 		break
 	default:
 		p.errUnexpectedToken(p.read())
-		return -1
+		return ast.InvalidRef
 	}
 
 	enumValueDefinition.EnumValue = p.mustRead(keyword.IDENT).Literal
@@ -1300,7 +1300,7 @@ func (p *Parser) parseSelectionSet() (int, bool) {
 		}
 
 		if p.report.HasErrors() {
-			return -1, false
+			return ast.InvalidRef, false
 		}
 	}
 }
@@ -1320,7 +1320,7 @@ func (p *Parser) parseSelection() int {
 	default:
 		nextToken := p.read()
 		p.errUnexpectedToken(nextToken, keyword.IDENT, keyword.SPREAD)
-		return -1
+		return ast.InvalidRef
 	}
 }
 
@@ -1404,7 +1404,7 @@ func (p *Parser) parseFragmentSpread(spread position.Position) int {
 func (p *Parser) parseInlineFragment(spread position.Position) int {
 	fragment := ast.InlineFragment{
 		TypeCondition: ast.TypeCondition{
-			Type: -1,
+			Type: ast.InvalidRef,
 		},
 	}
 	fragment.Spread = spread

--- a/pkg/astvalidation/operation_rule_fragments.go
+++ b/pkg/astvalidation/operation_rule_fragments.go
@@ -65,7 +65,9 @@ func (f *fragmentsVisitor) EnterInlineFragment(ref int) {
 
 	node, exists := f.definition.Index.FirstNonExtensionNodeByNameBytes(typeName)
 	if !exists {
-		f.StopWithExternalErr(operationreport.ErrTypeUndefined(typeName))
+		typePosition := f.operation.Types[f.operation.InlineFragments[ref].TypeCondition.Type].Position
+		f.Report.AddExternalError(operationreport.ErrUnknownType(typeName, typePosition))
+		f.SkipNode() // skipping node cause otherwise visitor will not be able to get enclosing type and will stop with error but error is already added here
 		return
 	}
 
@@ -94,7 +96,8 @@ func (f *fragmentsVisitor) EnterFragmentDefinition(ref int) {
 
 	node, exists := f.definition.Index.FirstNodeByNameBytes(typeName)
 	if !exists {
-		f.StopWithExternalErr(operationreport.ErrTypeUndefined(typeName))
+		typePosition := f.operation.Types[f.operation.FragmentDefinitions[ref].TypeCondition.Type].Position
+		f.StopWithExternalErr(operationreport.ErrUnknownType(typeName, typePosition))
 		return
 	}
 

--- a/pkg/astvalidation/operation_rule_known_arguments.go
+++ b/pkg/astvalidation/operation_rule_known_arguments.go
@@ -1,0 +1,39 @@
+package astvalidation
+
+import (
+	"github.com/jensneuse/graphql-go-tools/pkg/ast"
+	"github.com/jensneuse/graphql-go-tools/pkg/astvisitor"
+	"github.com/jensneuse/graphql-go-tools/pkg/operationreport"
+)
+
+// KnownArguments validates if all arguments are known
+func KnownArguments() Rule {
+	return func(walker *astvisitor.Walker) {
+		visitor := knownArgumentsVisitor{
+			Walker: walker,
+		}
+		walker.RegisterEnterDocumentVisitor(&visitor)
+		walker.RegisterEnterArgumentVisitor(&visitor)
+	}
+}
+
+type knownArgumentsVisitor struct {
+	*astvisitor.Walker
+	operation, definition *ast.Document
+}
+
+func (v *knownArgumentsVisitor) EnterDocument(operation, definition *ast.Document) {
+	v.operation = operation
+	v.definition = definition
+}
+
+func (v *knownArgumentsVisitor) EnterArgument(ref int) {
+	definitionRef, exists := v.ArgumentInputValueDefinition(ref)
+	_ = definitionRef // TODO: provide location for this error
+
+	if !exists {
+		argumentName := v.operation.ArgumentNameBytes(ref)
+		ancestorName := v.AncestorNameBytes()
+		v.StopWithExternalErr(operationreport.ErrArgumentNotDefinedOnNode(argumentName, ancestorName))
+	}
+}

--- a/pkg/astvalidation/operation_rule_known_arguments.go
+++ b/pkg/astvalidation/operation_rule_known_arguments.go
@@ -1,9 +1,9 @@
 package astvalidation
 
 import (
-	"github.com/jensneuse/graphql-go-tools/pkg/ast"
-	"github.com/jensneuse/graphql-go-tools/pkg/astvisitor"
-	"github.com/jensneuse/graphql-go-tools/pkg/operationreport"
+	"github.com/wundergraph/graphql-go-tools/pkg/ast"
+	"github.com/wundergraph/graphql-go-tools/pkg/astvisitor"
+	"github.com/wundergraph/graphql-go-tools/pkg/operationreport"
 )
 
 // KnownArguments validates if all arguments are known

--- a/pkg/astvalidation/operation_rule_valid_arguments.go
+++ b/pkg/astvalidation/operation_rule_valid_arguments.go
@@ -128,7 +128,8 @@ func (v *validArgumentsVisitor) intValueSatisfiesInputValueDefinition(value ast.
 	if inputType.TypeKind != ast.TypeKindNamed {
 		return false
 	}
-	if !bytes.Equal(v.definition.Input.ByteSlice(inputType.Name), literal.INT) {
+	if !(bytes.Equal(v.definition.Input.ByteSlice(inputType.Name), literal.INT) ||
+		bytes.Equal(v.definition.Input.ByteSlice(inputType.Name), literal.ID)) {
 		return false
 	}
 	return true

--- a/pkg/astvalidation/operation_rule_valid_arguments.go
+++ b/pkg/astvalidation/operation_rule_valid_arguments.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/wundergraph/graphql-go-tools/pkg/ast"
 	"github.com/wundergraph/graphql-go-tools/pkg/astvisitor"
-	"github.com/wundergraph/graphql-go-tools/pkg/lexer/literal"
 	"github.com/wundergraph/graphql-go-tools/pkg/operationreport"
 )
 

--- a/pkg/astvalidation/operation_rule_valid_arguments.go
+++ b/pkg/astvalidation/operation_rule_valid_arguments.go
@@ -10,7 +10,7 @@ import (
 	"github.com/wundergraph/graphql-go-tools/pkg/operationreport"
 )
 
-// ValidArguments validates if arguments are valid: arguments names are known and variables has compatible types
+// ValidArguments validates if arguments are valid: values and variables has compatible types
 // deep variables comparison is handled by Values
 func ValidArguments() Rule {
 	return func(walker *astvisitor.Walker) {

--- a/pkg/astvalidation/operation_rule_values.go
+++ b/pkg/astvalidation/operation_rule_values.go
@@ -275,6 +275,8 @@ func (v *valuesVisitor) valueSatisfiesScalar(value ast.Value, scalar int) bool {
 		return scalarName == typeName
 	}
 	switch scalarName {
+	case "ID":
+		return value.Kind == ast.ValueKindString || value.Kind == ast.ValueKindInteger
 	case "Boolean":
 		return value.Kind == ast.ValueKindBoolean
 	case "Int":

--- a/pkg/astvalidation/operation_rule_values.go
+++ b/pkg/astvalidation/operation_rule_values.go
@@ -69,7 +69,7 @@ func (v *valuesVisitor) EnterArgument(ref int) {
 			return
 		}
 
-		v.StopWithExternalErr(operationreport.ErrValueDoesntSatisfyInputValueDefinition(printedValue, printedType))
+		v.StopWithExternalErr(operationreport.ErrValueDoesntSatisfyInputValueDefinition(printedValue, printedType, value.Position))
 		return
 	}
 }

--- a/pkg/astvalidation/operation_rule_values.go
+++ b/pkg/astvalidation/operation_rule_values.go
@@ -73,7 +73,7 @@ func (v *valuesVisitor) valueSatisfiesInputValueDefinitionType(value ast.Value, 
 func (v *valuesVisitor) valuesSatisfiesNonNullType(value ast.Value, definitionTypeRef int) {
 	switch value.Kind {
 	case ast.ValueKindNull:
-		v.handleTypeError(value, definitionTypeRef)
+		v.handleUnexpectedNullError(value, definitionTypeRef)
 		return
 	case ast.ValueKindVariable:
 		variableTypeRef, _, ok := v.operationVariableType(value.Ref)
@@ -297,4 +297,13 @@ func (v *valuesVisitor) handleTypeError(value ast.Value, definitionTypeRef int) 
 	}
 
 	v.Report.AddExternalError(operationreport.ErrValueDoesntSatisfyInputValueDefinition(printedValue, printedType, value.Position))
+}
+
+func (v *valuesVisitor) handleUnexpectedNullError(value ast.Value, definitionTypeRef int) {
+	printedType, err := v.definition.PrintTypeBytes(definitionTypeRef, nil)
+	if v.HandleInternalErr(err) {
+		return
+	}
+
+	v.Report.AddExternalError(operationreport.ErrNullValueDoesntSatisfyInputValueDefinition(printedType, value.Position))
 }

--- a/pkg/astvalidation/operation_rule_values.go
+++ b/pkg/astvalidation/operation_rule_values.go
@@ -161,10 +161,11 @@ func (v *valuesVisitor) valueSatisfiesTypeDefinitionNode(value ast.Value, defini
 	case ast.NodeKindEnumTypeDefinition:
 		return v.valueSatisfiesEnum(value, definitionTypeRef, node)
 	case ast.NodeKindScalarTypeDefinition:
-		if !v.valueSatisfiesScalar(value, node.Ref) {
+		satisfiesScalar := v.valueSatisfiesScalar(value, node.Ref)
+		if !satisfiesScalar {
 			v.handleTypeError(value, definitionTypeRef)
-			return false
 		}
+		return satisfiesScalar
 	case ast.NodeKindInputObjectTypeDefinition:
 		return v.valueSatisfiesInputObjectTypeDefinition(value, definitionTypeRef, node.Ref)
 	}

--- a/pkg/astvalidation/operation_rule_values.go
+++ b/pkg/astvalidation/operation_rule_values.go
@@ -350,10 +350,10 @@ func (v *valuesVisitor) valueSatisfiesInputObjectTypeDefinition(value ast.Value,
 
 	for _, i := range v.operation.ObjectValues[value.Ref].Refs {
 		if !v.objectFieldDefined(i, inputObjectTypeDefinition) {
-			objectFieldName := string(v.operation.ObjectFieldNameBytes(i))
-			def := string(v.definition.Input.ByteSlice(v.definition.InputObjectTypeDefinitions[inputObjectTypeDefinition].Name))
-			_, _ = objectFieldName, def
-			v.handleTypeError(value, definitionTypeRef)
+			objectFieldName := v.operation.ObjectFieldNameBytes(i)
+			def := v.definition.Input.ByteSlice(v.definition.InputObjectTypeDefinitions[inputObjectTypeDefinition].Name)
+
+			v.Report.AddExternalError(operationreport.ErrUnknownFieldOfInputObject(objectFieldName, def, v.operation.ObjectField(i).Position))
 			valid = false
 		}
 	}

--- a/pkg/astvalidation/operation_rule_values.go
+++ b/pkg/astvalidation/operation_rule_values.go
@@ -126,8 +126,12 @@ func (v *valuesVisitor) valueSatisfiesListType(value ast.Value, definitionTypeRe
 		}
 	}
 
+	if value.Kind == ast.ValueKindNull {
+		return
+	}
+
 	if value.Kind != ast.ValueKindList {
-		v.handleTypeError(value, definitionTypeRef)
+		v.valueSatisfiesInputValueDefinitionType(value, listItemType)
 		return
 	}
 

--- a/pkg/astvalidation/operation_rule_values.go
+++ b/pkg/astvalidation/operation_rule_values.go
@@ -244,9 +244,8 @@ func (v *valuesVisitor) valueSatisfiesListType(value ast.Value, definitionTypeRe
 
 	if v.definition.Types[listItemType].TypeKind == ast.TypeKindNonNull {
 		if len(v.operation.ListValues[value.Ref].Refs) == 0 {
-			v.handleTypeError(value, definitionTypeRef)
-			// TODO: check error format when list should not be empty
-			return false
+			// [] empty list is a valid input for [item!] lists
+			return true
 		}
 		listItemType = v.definition.Types[listItemType].OfType
 	}

--- a/pkg/astvalidation/operation_rule_values.go
+++ b/pkg/astvalidation/operation_rule_values.go
@@ -579,8 +579,13 @@ func (v *valuesVisitor) handleNotExistingEnumValueError(value ast.Value, definit
 }
 
 func (v *valuesVisitor) handleVariableHasIncompatibleTypeError(value ast.Value, definitionTypeRef int) {
-	printedValue, expectedTypeName, ok := v.printValueAndUnderlyingType(value, definitionTypeRef)
+	printedValue, ok := v.printOperationValue(value)
 	if !ok {
+		return
+	}
+
+	expectedTypeName, err := v.definition.PrintTypeBytes(definitionTypeRef, nil)
+	if v.HandleInternalErr(err) {
 		return
 	}
 

--- a/pkg/astvalidation/operation_rule_values.go
+++ b/pkg/astvalidation/operation_rule_values.go
@@ -6,6 +6,7 @@ import (
 	"github.com/wundergraph/graphql-go-tools/pkg/ast"
 	"github.com/wundergraph/graphql-go-tools/pkg/astimport"
 	"github.com/wundergraph/graphql-go-tools/pkg/astvisitor"
+	"github.com/wundergraph/graphql-go-tools/pkg/lexer/literal"
 	"github.com/wundergraph/graphql-go-tools/pkg/operationreport"
 )
 
@@ -301,16 +302,16 @@ func (v *valuesVisitor) valueSatisfiesScalar(value ast.Value, definitionTypeRef 
 		return v.variableValueHasMatchingTypeName(value, definitionTypeRef, scalarName)
 	}
 
-	switch string(scalarName) {
-	case "ID":
+	switch {
+	case bytes.Equal(scalarName, literal.ID):
 		return v.valueSatisfiesScalarID(value, definitionTypeRef)
-	case "Boolean":
+	case bytes.Equal(scalarName, literal.BOOLEAN):
 		return v.valueSatisfiesScalarBoolean(value, definitionTypeRef)
-	case "Int":
+	case bytes.Equal(scalarName, literal.INT):
 		return v.valueSatisfiesScalarInt(value, definitionTypeRef)
-	case "Float":
+	case bytes.Equal(scalarName, literal.FLOAT):
 		return v.valueSatisfiesScalarFloat(value, definitionTypeRef)
-	case "String":
+	case bytes.Equal(scalarName, literal.STRING):
 		return v.valueSatisfiesScalarString(value, definitionTypeRef, true)
 	default:
 		return v.valueSatisfiesScalarString(value, definitionTypeRef, false)
@@ -388,7 +389,7 @@ func (v *valuesVisitor) valueSatisfiesScalarFloat(value ast.Value, definitionTyp
 	return false
 }
 
-func (v *valuesVisitor) valueSatisfiesScalarString(value ast.Value, definitionTypeRef int, stringScalar bool) bool {
+func (v *valuesVisitor) valueSatisfiesScalarString(value ast.Value, definitionTypeRef int, builtInStringScalar bool) bool {
 	if value.Kind == ast.ValueKindString {
 		return true
 	}
@@ -398,7 +399,7 @@ func (v *valuesVisitor) valueSatisfiesScalarString(value ast.Value, definitionTy
 		return false
 	}
 
-	if stringScalar {
+	if builtInStringScalar {
 		v.Report.AddExternalError(operationreport.ErrValueDoesntSatisfyString(printedValue, printedType, value.Position))
 	} else {
 		v.Report.AddExternalError(operationreport.ErrValueDoesntSatisfyType(printedValue, printedType, value.Position))

--- a/pkg/astvalidation/operation_rule_variables_are_input_types.go
+++ b/pkg/astvalidation/operation_rule_variables_are_input_types.go
@@ -30,7 +30,12 @@ func (v *variablesAreInputTypesVisitor) EnterDocument(operation, definition *ast
 func (v *variablesAreInputTypesVisitor) EnterVariableDefinition(ref int) {
 
 	typeName := v.operation.ResolveTypeNameBytes(v.operation.VariableDefinitions[ref].Type)
-	typeDefinitionNode, _ := v.definition.Index.FirstNodeByNameBytes(typeName)
+	typeDefinitionNode, ok := v.definition.Index.FirstNodeByNameBytes(typeName)
+	if !ok {
+		v.Report.AddExternalError(operationreport.ErrUnknownType(typeName, v.operation.Types[v.operation.VariableDefinitions[ref].Type].Position))
+		return
+	}
+
 	switch typeDefinitionNode.Kind {
 	case ast.NodeKindInputObjectTypeDefinition, ast.NodeKindScalarTypeDefinition, ast.NodeKindEnumTypeDefinition:
 		return

--- a/pkg/astvalidation/operation_rule_variables_are_input_types.go
+++ b/pkg/astvalidation/operation_rule_variables_are_input_types.go
@@ -36,7 +36,14 @@ func (v *variablesAreInputTypesVisitor) EnterVariableDefinition(ref int) {
 		return
 	default:
 		variableName := v.operation.VariableDefinitionNameBytes(ref)
-		v.StopWithExternalErr(operationreport.ErrVariableOfTypeIsNoValidInputValue(variableName, typeName))
+		variableTypePos := v.operation.Types[v.operation.VariableDefinitions[ref].Type].Position
+
+		printedType, err := v.operation.PrintTypeBytes(v.operation.VariableDefinitions[ref].Type, nil)
+		if v.HandleInternalErr(err) {
+			return
+		}
+
+		v.Report.AddExternalError(operationreport.ErrVariableOfTypeIsNoValidInputValue(variableName, printedType, variableTypePos))
 		return
 	}
 }

--- a/pkg/astvalidation/operation_validation.go
+++ b/pkg/astvalidation/operation_validation.go
@@ -20,6 +20,7 @@ func DefaultOperationValidator() *OperationValidator {
 	validator.RegisterRule(SubscriptionSingleRootField())
 	validator.RegisterRule(FieldSelections())
 	validator.RegisterRule(FieldSelectionMerging())
+	validator.RegisterRule(KnownArguments())
 	validator.RegisterRule(ValidArguments())
 	validator.RegisterRule(Values())
 	validator.RegisterRule(ArgumentUniqueness())

--- a/pkg/astvalidation/operation_validation_test.go
+++ b/pkg/astvalidation/operation_validation_test.go
@@ -2248,6 +2248,16 @@ func TestExecutionValidation(t *testing.T) {
 					}`,
 					Valid, ValidArguments(), Values())
 			})
+			t.Run("ID as arg given as integer", func(t *testing.T) {
+				runManyRulesWithDefinition(countriesDefinition, `{
+						country(code: 11) {
+							code
+							name
+						}
+					}`,
+					Valid, ValidArguments(), Values())
+			})
+
 		})
 		t.Run("5.4.2 Argument Uniqueness", func(t *testing.T) {
 			t.Run("121 variant", func(t *testing.T) {

--- a/pkg/astvalidation/operation_validation_test.go
+++ b/pkg/astvalidation/operation_validation_test.go
@@ -2201,7 +2201,7 @@ func TestExecutionValidation(t *testing.T) {
 							fragment invalidArgName on Dog {
 								doesKnowCommand(command: CLEAN_UP_HOUSE)
 							}`,
-					ValidArguments(), Invalid)
+					KnownArguments(), Invalid)
 			})
 			t.Run("118 variant", func(t *testing.T) {
 				run(`	
@@ -2220,7 +2220,7 @@ func TestExecutionValidation(t *testing.T) {
 									fragment invalidArgName on Dog {
 										isHousetrained(atOtherHomes: true) @include(unless: false)
 									}`,
-					ValidArguments(), Invalid)
+					KnownArguments(), Invalid)
 			})
 			t.Run("121", func(t *testing.T) {
 				run(`	fragment multipleArgs on ValidArguments {
@@ -2237,7 +2237,7 @@ func TestExecutionValidation(t *testing.T) {
 									name
 								}
 							}`,
-					ValidArguments(), Invalid)
+					KnownArguments(), Invalid)
 			})
 			t.Run("ID as arg given as string", func(t *testing.T) {
 				runManyRulesWithDefinition(countriesDefinition, `{

--- a/pkg/astvalidation/operation_validation_test.go
+++ b/pkg/astvalidation/operation_validation_test.go
@@ -2160,7 +2160,7 @@ func TestExecutionValidation(t *testing.T) {
 					KnownArguments(), Invalid)
 			})
 			t.Run("118 variant", func(t *testing.T) {
-				run(`	
+				run(t, `	
 							{
 								dog { ...invalidArgName}
 							}
@@ -2733,7 +2733,7 @@ func TestExecutionValidation(t *testing.T) {
 							Fragments(), Valid)
 					})
 					t.Run("143 variant", func(t *testing.T) {
-						run(`
+						run(t, `
 									{
 										dog {
 											...interfaceWithUnion

--- a/pkg/astvalidation/operation_validation_test.go
+++ b/pkg/astvalidation/operation_validation_test.go
@@ -3723,6 +3723,28 @@ func TestExecutionValidation(t *testing.T) {
 					}
 					`, Values(), Valid)
 			})
+			t.Run("with boolean input", func(t *testing.T) {
+				runWithDefinition(wundergraphSchema, `
+					query QueryWithBooleanInput($a: Boolean) {
+						findFirstnodepool(
+							where: { shared: { equals: $a } }
+						) {
+							id
+						}
+					}
+					`, Values(), Valid)
+			})
+			t.Run("with nested boolean where clause", func(t *testing.T) {
+				runWithDefinition(wundergraphSchema, `
+					query QueryWithNestedBooleanClause($a: String) {
+						findFirstnodepool(
+							where: { id: { equals: $a }, AND: { shared: { equals: true } } }
+						) {
+							id
+						}
+					}
+					`, Values(), Valid)
+			})
 		})
 	})
 }

--- a/pkg/astvalidation/operation_validation_test.go
+++ b/pkg/astvalidation/operation_validation_test.go
@@ -2859,14 +2859,12 @@ func TestExecutionValidation(t *testing.T) {
 							}`,
 					Values(), Valid)
 			})
-			t.Run("145 variant variable non null", func(t *testing.T) {
-				t.Errorf("TODO: invalid result")
-
+			t.Run("145 variant variable non null into required field", func(t *testing.T) {
 				run(t, `
 							query goodComplexDefaultValue($name: String ) {
 								findDogNonOptional(complex: { name: $name })
 							}`,
-					Values(), Invalid, withValidationErrors(`Variable "$name" of type "String" used in position expecting type "String"`))
+					Values(), Invalid, withValidationErrors(`Variable "$name" of type "String" used in position expecting type "String!"`))
 			})
 			t.Run("145 variant", func(t *testing.T) {
 				run(t, `
@@ -2910,14 +2908,12 @@ func TestExecutionValidation(t *testing.T) {
 					Values(), Invalid, withValidationErrors(`Value "MEOW" does not exist in "DogCommand" enum`))
 			})
 			t.Run("145 variant", func(t *testing.T) {
-				t.Errorf("TODO: check result")
-
 				run(t, `	{
 								dog {
 									doesKnowCommand(dogCommand: [true])
 								}
 							}`,
-					Values(), Invalid, withValidationErrors(`Boolean cannot represent a non boolean value: [true]`))
+					Values(), Invalid, withValidationErrors(`Enum "DogCommand" cannot represent non-enum value: [true]`))
 			})
 			t.Run("145 variant", func(t *testing.T) {
 				run(t, `	{
@@ -3835,6 +3831,19 @@ func TestExecutionValidation(t *testing.T) {
 						`Variable "$b" of type "Boolean" used in position expecting type "String"`,
 					))
 			})
+
+			t.Run("with variables inside an input object", func(t *testing.T) {
+				run(t, `
+					query booleanIntoStringList($a: Boolean) {
+						findDog(complex: {optionalListOfOptionalStrings: $a}) {
+							id
+						}
+					}
+					`, Values(), Invalid,
+					withValidationErrors(
+						`Variable "$a" of type "Boolean" used in position expecting type "[String]"`,
+					))
+			})
 		})
 	})
 }
@@ -4404,7 +4413,7 @@ type Mutation {
 	mutateDog: Dog
 }
 
-input ComplexInput { name: String, owner: String }
+input ComplexInput { name: String, owner: String, optionalListOfOptionalStrings: [String]}
 input ComplexNestedInput { complex: ComplexInput }
 input ComplexNonOptionalInput { name: String! }
 

--- a/pkg/astvalidation/operation_validation_test.go
+++ b/pkg/astvalidation/operation_validation_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/wundergraph/graphql-go-tools/internal/pkg/unsafeparser"
 	"github.com/wundergraph/graphql-go-tools/pkg/ast"
 	"github.com/wundergraph/graphql-go-tools/pkg/astnormalization"
@@ -57,7 +59,9 @@ func TestExecutionValidation(t *testing.T) {
 		return str
 	}
 
-	runWithDefinition := func(definitionInput, operationInput string, rule Rule, expectation ValidationState, opts ...option) {
+	runWithDefinition := func(t *testing.T, definitionInput, operationInput string, rule Rule, expectation ValidationState, opts ...option) {
+		t.Helper()
+
 		var options options
 		for _, opt := range opts {
 			opt(&options)
@@ -81,19 +85,19 @@ func TestExecutionValidation(t *testing.T) {
 
 		printedOperation := mustString(astprinter.PrintString(&operation, &definition))
 
-		if expectation != result {
-			panic(fmt.Errorf("want expectation: %s, got: %s\nreason: %v\noperation:\n%s\n", expectation, result, report.Error(), printedOperation))
-		}
+		require.Equal(t, expectation, result, "wrong validation result expected: %v got: %v\nreason: %v\noperation:\n%s\n", expectation, result, report.Error(), printedOperation)
 	}
 
-	runManyRulesWithDefinition := func(definitionInput, operationInput string, expectation ValidationState, rules ...Rule) {
+	runManyRulesWithDefinition := func(t *testing.T, definitionInput, operationInput string, expectation ValidationState, rules ...Rule) {
 		for _, rule := range rules {
-			runWithDefinition(definitionInput, operationInput, rule, expectation)
+			runWithDefinition(t, definitionInput, operationInput, rule, expectation)
 		}
 	}
+	_ = runManyRulesWithDefinition
 
-	run := func(operationInput string, rule Rule, expectation ValidationState, opts ...option) {
-		runWithDefinition(testDefinition, operationInput, rule, expectation, opts...)
+	run := func(t *testing.T, operationInput string, rule Rule, expectation ValidationState, opts ...option) {
+		t.Helper()
+		runWithDefinition(t, testDefinition, operationInput, rule, expectation, opts...)
 	}
 
 	// 5.1 Documents
@@ -105,7 +109,7 @@ func TestExecutionValidation(t *testing.T) {
 		t.Run("5.2.1 Named Operation Definitions", func(t *testing.T) {
 			t.Run("5.2.1.1 Operation Name Uniqueness", func(t *testing.T) {
 				t.Run("92", func(t *testing.T) {
-					run(`
+					run(t, `
 								query getDogName {
   									dog {
     									name
@@ -121,7 +125,7 @@ func TestExecutionValidation(t *testing.T) {
 						OperationNameUniqueness(), Valid)
 				})
 				t.Run("93", func(t *testing.T) {
-					run(`
+					run(t, `
 								query getName {
 									dog {
     									name
@@ -137,7 +141,7 @@ func TestExecutionValidation(t *testing.T) {
 						OperationNameUniqueness(), Invalid)
 				})
 				t.Run("94", func(t *testing.T) {
-					run(`	
+					run(t, `	
 								query dogOperation {
   									dog {
   										name
@@ -155,7 +159,7 @@ func TestExecutionValidation(t *testing.T) {
 		t.Run("5.2.2 Anonymous Operation Definitions", func(t *testing.T) {
 			t.Run("5.2.2.1 Lone Anonymous Operation", func(t *testing.T) {
 				t.Run("95", func(t *testing.T) {
-					run(`	{
+					run(t, `	{
   							  		dog {
       									name
     								}
@@ -163,7 +167,7 @@ func TestExecutionValidation(t *testing.T) {
 						LoneAnonymousOperation(), Valid)
 				})
 				t.Run("96", func(t *testing.T) {
-					run(`	{
+					run(t, `	{
   									dog {
   										name
   									}
@@ -178,7 +182,7 @@ func TestExecutionValidation(t *testing.T) {
 						LoneAnonymousOperation(), Invalid)
 				})
 				t.Run("96 variant", func(t *testing.T) {
-					run(`	query getDogName {
+					run(t, `	query getDogName {
   									dog {
   										name
   									}
@@ -197,7 +201,7 @@ func TestExecutionValidation(t *testing.T) {
 		t.Run("5.2.3 Subscription Operation Definitions", func(t *testing.T) {
 			t.Run("5.2.3.1 Single root field", func(t *testing.T) {
 				t.Run("97", func(t *testing.T) {
-					run(`
+					run(t, `
 							subscription sub {
 								newMessage {
 									body
@@ -207,7 +211,7 @@ func TestExecutionValidation(t *testing.T) {
 						SubscriptionSingleRootField(), Valid)
 				})
 				t.Run("97 variant", func(t *testing.T) {
-					run(`	
+					run(t, `	
 								query sub {
   									foo
 									bar
@@ -215,7 +219,7 @@ func TestExecutionValidation(t *testing.T) {
 						SubscriptionSingleRootField(), Valid)
 				})
 				t.Run("97 variant", func(t *testing.T) {
-					run(`	
+					run(t, `	
 								subscription sub {
   									... { foo }
   									... { bar }
@@ -223,7 +227,7 @@ func TestExecutionValidation(t *testing.T) {
 						SubscriptionSingleRootField(), Invalid)
 				})
 				t.Run("98", func(t *testing.T) {
-					run(`	subscription sub {
+					run(t, `	subscription sub {
   									...newMessageFields
 								}
 								fragment newMessageFields on Subscription {
@@ -235,7 +239,7 @@ func TestExecutionValidation(t *testing.T) {
 						SubscriptionSingleRootField(), Valid)
 				})
 				t.Run("99", func(t *testing.T) {
-					run(`	
+					run(t, `	
 								subscription sub {
   									newMessage {
     									body
@@ -246,7 +250,7 @@ func TestExecutionValidation(t *testing.T) {
 						SubscriptionSingleRootField(), Invalid)
 				})
 				t.Run("100", func(t *testing.T) {
-					run(`	
+					run(t, `	
 								subscription sub {
   									...multipleSubscriptions
 								}
@@ -260,7 +264,7 @@ func TestExecutionValidation(t *testing.T) {
 						SubscriptionSingleRootField(), Invalid)
 				})
 				t.Run("101", func(t *testing.T) {
-					run(`
+					run(t, `
 							subscription sub {
 								newMessage {
 									body
@@ -276,7 +280,7 @@ func TestExecutionValidation(t *testing.T) {
 	t.Run("5.3 FieldSelections", func(t *testing.T) {
 		t.Run("5.3.1 Field Selections on Objects, Interfaces, and Unions Types", func(t *testing.T) {
 			t.Run("104", func(t *testing.T) {
-				run(`
+				run(t, `
 							{
 								dog {
 									...aliasedLyingFieldTargetNotDefined
@@ -288,7 +292,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelections(), Invalid, withExpectNormalizationError())
 			})
 			t.Run("104 variant", func(t *testing.T) {
-				run(`
+				run(t, `
 							{
 								dog {
 									barkVolume: kawVolume
@@ -297,7 +301,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelections(), Invalid, withExpectNormalizationError())
 			})
 			t.Run("103", func(t *testing.T) {
-				run(`	{
+				run(t, `	{
 								dog {
 									...interfaceFieldSelection
 								}
@@ -308,7 +312,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelections(), Valid)
 			})
 			t.Run("104", func(t *testing.T) {
-				run(`
+				run(t, `
 							{
 								dog {
 									...definedOnImplementorsButNotInterface
@@ -320,7 +324,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelections(), Invalid, withExpectNormalizationError())
 			})
 			t.Run("105", func(t *testing.T) {
-				run(`	fragment inDirectFieldSelectionOnUnion on CatOrDog {
+				run(t, `	fragment inDirectFieldSelectionOnUnion on CatOrDog {
 								__typename
 	  							... on Pet {
 	    							name
@@ -332,7 +336,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelections(), Valid)
 			})
 			t.Run("105 variant", func(t *testing.T) {
-				run(`
+				run(t, `
 							fragment inDirectFieldSelectionOnUnion on CatOrDog {
 								__typename
 	  							... on Pet {
@@ -345,7 +349,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelections(), Valid)
 			})
 			t.Run("105 variant", func(t *testing.T) {
-				run(`
+				run(t, `
 							fragment inDirectFieldSelectionOnUnion on CatOrDog {
 								__typename
 	  							... on Pet {
@@ -358,7 +362,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelections(), Invalid, withExpectNormalizationError())
 			})
 			t.Run("106", func(t *testing.T) {
-				run(`
+				run(t, `
 							fragment directFieldSelectionOnUnion on CatOrDog {
 								name
 								barkVolume
@@ -366,7 +370,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelections(), Invalid, withExpectNormalizationError())
 			})
 			t.Run("106 variant", func(t *testing.T) {
-				run(`
+				run(t, `
 							fragment directFieldSelectionOnUnion on Cat {
 								name {
 									name
@@ -377,7 +381,7 @@ func TestExecutionValidation(t *testing.T) {
 		})
 		t.Run("5.3.2 Field Selection Merging", func(t *testing.T) {
 			t.Run("introspection query", func(t *testing.T) {
-				run(`query IntrospectionQuery {
+				run(t, `query IntrospectionQuery {
 						__schema {
 							queryType {
 								name
@@ -622,7 +626,7 @@ func TestExecutionValidation(t *testing.T) {
 			})
 			t.Run("reference implementation tests", func(t *testing.T) {
 				t.Run("Same aliases allowed on non-overlapping fields", func(t *testing.T) {
-					run(`
+					run(t, `
 							fragment sameAliasesWithDifferentFieldTargets on Pet {
 								... on Dog {
 								  name
@@ -633,7 +637,7 @@ func TestExecutionValidation(t *testing.T) {
 						  	}`, FieldSelectionMerging(), Valid)
 				})
 				t.Run("allows different args where no conflict is possible", func(t *testing.T) {
-					run(`
+					run(t, `
 							fragment conflictingArgs on Pet {
 								... on Dog {
 								  name(surname: true)
@@ -644,7 +648,7 @@ func TestExecutionValidation(t *testing.T) {
 						 	 }`, FieldSelectionMerging(), Valid)
 				})
 				t.Run("encounters conflict in fragments", func(t *testing.T) {
-					run(`
+					run(t, `
 							{
 								...A
 								...B
@@ -657,7 +661,7 @@ func TestExecutionValidation(t *testing.T) {
 							}`, FieldSelectionMerging(), Invalid)
 				})
 				t.Run("reports each conflict once", func(t *testing.T) {
-					run(`
+					run(t, `
 							{
 								f1 {
 								  ...A
@@ -681,7 +685,7 @@ func TestExecutionValidation(t *testing.T) {
 							  }`, FieldSelectionMerging(), Invalid)
 				})
 				t.Run("deep conflict", func(t *testing.T) {
-					run(`
+					run(t, `
 							{
 								field {
 								  x: a
@@ -692,7 +696,7 @@ func TestExecutionValidation(t *testing.T) {
 						 	 }`, FieldSelectionMerging(), Invalid)
 				})
 				t.Run("deep conflict with multiple issues", func(t *testing.T) {
-					run(`
+					run(t, `
 							{
 								field {
 								  x: a
@@ -705,7 +709,7 @@ func TestExecutionValidation(t *testing.T) {
 						 	}`, FieldSelectionMerging(), Invalid)
 				})
 				t.Run("very deep conflict", func(t *testing.T) {
-					run(`
+					run(t, `
 							{
 								field {
 								  deepField {
@@ -720,7 +724,7 @@ func TestExecutionValidation(t *testing.T) {
 						 	 }`, FieldSelectionMerging(), Invalid)
 				})
 				t.Run("very deep conflict validated", func(t *testing.T) {
-					run(`
+					run(t, `
 							{
 								field {
 								  deepField {
@@ -735,7 +739,7 @@ func TestExecutionValidation(t *testing.T) {
 						 	 }`, FieldSelectionMerging(), Valid)
 				})
 				t.Run("reports deep conflict to nearest common ancestor", func(t *testing.T) {
-					run(`
+					run(t, `
 						{
 							field {
 							  deepField {
@@ -753,7 +757,7 @@ func TestExecutionValidation(t *testing.T) {
 						}`, FieldSelectionMerging(), Invalid)
 				})
 				t.Run("reports deep conflict to nearest common ancestor in fragments", func(t *testing.T) {
-					run(`
+					run(t, `
 						{
 							field {
 							  ...F
@@ -779,7 +783,7 @@ func TestExecutionValidation(t *testing.T) {
 					  	}`, FieldSelectionMerging(), Invalid)
 				})
 				t.Run("reports deep conflict in nested fragments", func(t *testing.T) {
-					run(`
+					run(t, `
 							{
 								field {
 								  ...F
@@ -806,7 +810,7 @@ func TestExecutionValidation(t *testing.T) {
 				/*
 					Why ignore when this still will result in an error because T is undefined?
 					t.Run("ignores unknown fragments", func(t *testing.T) {
-						run(`
+						run(t,`
 								{
 									field
 									...Unknown
@@ -823,7 +827,7 @@ func TestExecutionValidation(t *testing.T) {
 						type IntBox and the interface type NonNullStringBox1. While that
 						condition does not exist in the current schema, the schema could
 						expand in the future to allow this. Thus it is invalid.*/
-						runWithDefinition(boxDefinition, `
+						runWithDefinition(t, boxDefinition, `
 							{
 								someBox {
 							  		...on IntBox {
@@ -836,7 +840,7 @@ func TestExecutionValidation(t *testing.T) {
 							}`, FieldSelectionMerging(), Invalid)
 					})
 					t.Run("compatible return shapes on different return types", func(t *testing.T) {
-						runWithDefinition(boxDefinition, `
+						runWithDefinition(t, boxDefinition, `
 							{
 								someBox {
 						  			... on SomeBox {
@@ -853,7 +857,7 @@ func TestExecutionValidation(t *testing.T) {
 							}`, FieldSelectionMerging(), Valid)
 					})
 					t.Run("disallows differing return types despite no overlap", func(t *testing.T) {
-						runWithDefinition(boxDefinition, `
+						runWithDefinition(t, boxDefinition, `
 								{
 									someBox {
 								  		... on IntBox {
@@ -866,7 +870,7 @@ func TestExecutionValidation(t *testing.T) {
 								}`, FieldSelectionMerging(), Invalid)
 					})
 					t.Run("disallows differing return types despite no overlap", func(t *testing.T) {
-						runWithDefinition(boxDefinition, `
+						runWithDefinition(t, boxDefinition, `
 								{
 									someBox {
 										... on IntBox {
@@ -883,7 +887,7 @@ func TestExecutionValidation(t *testing.T) {
 					})
 					t.Run("deeply nested", func(t *testing.T) {
 						// reports correctly when a non-exclusive follows an exclusive
-						runWithDefinition(boxDefinition, `
+						runWithDefinition(t, boxDefinition, `
 								{
 									someBox {
 								  		... on IntBox {
@@ -928,7 +932,7 @@ func TestExecutionValidation(t *testing.T) {
 								}`, FieldSelectionMerging(), Invalid)
 					})
 					t.Run("disallows differing return type nullability despite no overlap", func(t *testing.T) {
-						runWithDefinition(boxDefinition, `
+						runWithDefinition(t, boxDefinition, `
 								{
 									someBox {
 								  		... on NonNullStringBox1 {
@@ -941,7 +945,7 @@ func TestExecutionValidation(t *testing.T) {
 								}`, FieldSelectionMerging(), Invalid)
 					})
 					t.Run("disallows differing return type list despite no overlap", func(t *testing.T) {
-						runWithDefinition(boxDefinition, `
+						runWithDefinition(t, boxDefinition, `
 								{
 									someBox {
 									  ... on IntBox {
@@ -956,7 +960,7 @@ func TestExecutionValidation(t *testing.T) {
 									  }
 									}
 							 	}`, FieldSelectionMerging(), Invalid)
-						runWithDefinition(boxDefinition, `
+						runWithDefinition(t, boxDefinition, `
 								{
 									someBox {
 									  ... on IntBox {
@@ -973,7 +977,7 @@ func TestExecutionValidation(t *testing.T) {
 								  }`, FieldSelectionMerging(), Invalid)
 					})
 					t.Run("disallows differing subfields", func(t *testing.T) {
-						runWithDefinition(boxDefinition, `
+						runWithDefinition(t, boxDefinition, `
 								{
 									someBox {
 									  ... on IntBox {
@@ -991,7 +995,7 @@ func TestExecutionValidation(t *testing.T) {
 								}`, FieldSelectionMerging(), Invalid)
 					})
 					t.Run("disallows differing deep return types despite no overlap", func(t *testing.T) {
-						runWithDefinition(boxDefinition, `
+						runWithDefinition(t, boxDefinition, `
 								{
 								someBox {
 								  ... on IntBox {
@@ -1008,7 +1012,7 @@ func TestExecutionValidation(t *testing.T) {
 							}`, FieldSelectionMerging(), Invalid)
 					})
 					t.Run("allows non-conflicting overlapping types", func(t *testing.T) {
-						runWithDefinition(boxDefinition, `
+						runWithDefinition(t, boxDefinition, `
 							{
 								someBox {
 								  ... on IntBox {
@@ -1021,7 +1025,7 @@ func TestExecutionValidation(t *testing.T) {
 							}`, FieldSelectionMerging(), Valid)
 					})
 					t.Run("same wrapped scalar return types", func(t *testing.T) {
-						runWithDefinition(boxDefinition, `
+						runWithDefinition(t, boxDefinition, `
 							{
 								someBox {
 								  ...on NonNullStringBox1 {
@@ -1034,7 +1038,7 @@ func TestExecutionValidation(t *testing.T) {
 							}`, FieldSelectionMerging(), Valid)
 					})
 					t.Run("allows inline typeless fragments", func(t *testing.T) {
-						run(`
+						run(t, `
 							{
 								a
 								... {
@@ -1043,7 +1047,7 @@ func TestExecutionValidation(t *testing.T) {
 							  }`, FieldSelectionMerging(), Valid)
 					})
 					t.Run("compares deep types including list", func(t *testing.T) {
-						runWithDefinition(boxDefinition, `
+						runWithDefinition(t, boxDefinition, `
 							{
 							connection {
 							  ...edgeID
@@ -1065,7 +1069,7 @@ func TestExecutionValidation(t *testing.T) {
 					/*
 						Why ignore?
 						t.Run("ignores unknown types", func(t *testing.T) {
-							runWithDefinition(boxDefinition, `
+							runWithDefinition(t,boxDefinition, `
 								{
 								someBox {
 								  ...on UnknownType {
@@ -1080,7 +1084,7 @@ func TestExecutionValidation(t *testing.T) {
 				})
 			})
 			t.Run("107", func(t *testing.T) {
-				run(`
+				run(t, `
 							fragment mergeIdenticalFields on Dog {
   								name
   								name
@@ -1092,7 +1096,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("107 variant", func(t *testing.T) {
-				run(`	
+				run(t, `	
 							query mergeIdenticalFields {
   								dog {
 									name
@@ -1108,7 +1112,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("108", func(t *testing.T) {
-				run(`
+				run(t, `
 							fragment conflictingBecauseAlias on Dog {
   								name: nickname
   								name
@@ -1116,7 +1120,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("108 variant", func(t *testing.T) {
-				run(`	
+				run(t, `	
 							query conflictingBecauseAlias {
 								dog {
   									name: nickname
@@ -1126,7 +1130,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("108 variant", func(t *testing.T) {
-				run(`	query conflictingBecauseAlias {
+				run(t, `	query conflictingBecauseAlias {
 								dog {
   									extra { string }
   									extra { string }
@@ -1135,7 +1139,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("108 variant", func(t *testing.T) {
-				run(`
+				run(t, `
 							query conflictingBecauseAlias {
 								dog {
   									extra { string }
@@ -1145,7 +1149,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("108 variant", func(t *testing.T) {
-				run(`
+				run(t, `
 							query conflictingBecauseAlias {
 								dog {
   									extra { string }
@@ -1155,7 +1159,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("108 variant", func(t *testing.T) {
-				run(`	
+				run(t, `	
 							query conflictingBecauseAlias {
 								dog {
   									extra { string }
@@ -1165,7 +1169,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("108 variant", func(t *testing.T) {
-				run(`	
+				run(t, `	
 							query conflictingBecauseAlias {
 								dog {
   									extra { string }
@@ -1175,7 +1179,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("108 variant", func(t *testing.T) {
-				run(`	query conflictingBecauseAlias {
+				run(t, `	query conflictingBecauseAlias {
 								dog {
   									extra { string }
   									extra: extras { string }
@@ -1184,7 +1188,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("108 variant", func(t *testing.T) {
-				run(`	query conflictingBecauseAlias {
+				run(t, `	query conflictingBecauseAlias {
 								dog {
   									extras { string }
   									extras: mustExtras { string }
@@ -1193,7 +1197,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("108 variant", func(t *testing.T) {
-				run(`	
+				run(t, `	
 							query conflictingBecauseAlias {
 								dog {
   									x: extras { string }
@@ -1203,7 +1207,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("108 variant", func(t *testing.T) {
-				run(`	
+				run(t, `	
 							query conflictingBecauseAlias {
 								dog {
   									extras { string,string2: string }
@@ -1213,7 +1217,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("108 variant", func(t *testing.T) {
-				run(`	
+				run(t, `	
 							query conflictingBecauseAlias {
 								dog {
   									extras { string,string2: string }
@@ -1223,7 +1227,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("108 variant", func(t *testing.T) {
-				run(`	
+				run(t, `	
 							query conflictingBecauseAlias {
 								dog {
   									extras { string,string2: string2 }
@@ -1233,7 +1237,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("108 variant", func(t *testing.T) {
-				run(`	
+				run(t, `	
 							query conflictingBecauseAlias {
 								dog {
   									extras { ... { string },string2: string }
@@ -1243,7 +1247,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("108 variant", func(t *testing.T) {
-				run(`	query conflictingBecauseAlias {
+				run(t, `	query conflictingBecauseAlias {
 								dog {
   									extras { ... { string },string: string1 }
   									extras { ... { string1: string },string2: string }
@@ -1252,7 +1256,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("108 variant", func(t *testing.T) {
-				run(`	
+				run(t, `	
 							query conflictingBecauseAlias {
 								dog {
   									extras { ...frag, ...frag }
@@ -1263,7 +1267,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("108 variant", func(t *testing.T) {
-				run(`	query conflictingBecauseAlias {
+				run(t, `	query conflictingBecauseAlias {
 								dog {
   									extras {
 										... {
@@ -1280,7 +1284,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("108 variant", func(t *testing.T) {
-				run(`	
+				run(t, `	
 							query conflictingBecauseAlias {
 								dog {
   									extras { ...frag }
@@ -1292,7 +1296,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("108 variant", func(t *testing.T) {
-				run(`	query conflictingBecauseAlias {
+				run(t, `	query conflictingBecauseAlias {
 								dog {
   									extra { looksLikeString: string }
   									extra { looksLikeString: bool }
@@ -1301,7 +1305,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("108 variant", func(t *testing.T) {
-				run(`	query conflictingBecauseAlias {
+				run(t, `	query conflictingBecauseAlias {
 								dog {
   									name: nickname
   									...nameFrag
@@ -1313,7 +1317,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("108 variant", func(t *testing.T) {
-				run(`	query conflictingBecauseAlias {
+				run(t, `	query conflictingBecauseAlias {
 								dog {
   									name: nickname
   									...nameFrag
@@ -1328,7 +1332,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("108 variant", func(t *testing.T) {
-				run(`	query conflictingBecauseAlias {
+				run(t, `	query conflictingBecauseAlias {
 								dog {
   									name: nickname
   									... on Dog {
@@ -1342,7 +1346,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("108 variant", func(t *testing.T) {
-				run(`	query conflictingBecauseAlias {
+				run(t, `	query conflictingBecauseAlias {
 								dog {
   									name: nickname
   									... {
@@ -1353,7 +1357,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("108 variant", func(t *testing.T) {
-				run(`	query conflictingBecauseAlias {
+				run(t, `	query conflictingBecauseAlias {
 											dog {
 			  									name: nickname
 			  									... @include(if: true) {
@@ -1364,7 +1368,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("108 variant", func(t *testing.T) {
-				run(`	query conflictingBecauseAlias {
+				run(t, `	query conflictingBecauseAlias {
 											dog {
 			  									name: nickname
 			  									... @include(if: false) {
@@ -1375,7 +1379,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("109", func(t *testing.T) {
-				run(`
+				run(t, `
 							fragment mergeIdenticalFieldsWithIdenticalArgs on Dog {
   								doesKnowCommand(dogCommand: SIT)
   								doesKnowCommand(dogCommand: SIT)
@@ -1387,14 +1391,14 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("109 variant", func(t *testing.T) {
-				run(`	fragment mergeIdenticalFieldsWithIdenticalValues on Dog {
+				run(t, `	fragment mergeIdenticalFieldsWithIdenticalValues on Dog {
   								doesKnowCommand(dogCommand: 1)
     							doesKnowCommand(dogCommand: 1)
   							}`,
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("109 variant", func(t *testing.T) {
-				run(`	
+				run(t, `	
 							fragment mergeIdenticalFieldsWithIdenticalValues on Dog {
   								doesKnowCommand(dogCommand: 1)
     							doesKnowCommand(dogCommand: 0)
@@ -1402,70 +1406,70 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("109 variant", func(t *testing.T) {
-				run(`	fragment mergeIdenticalFieldsWithIdenticalValues on Dog {
+				run(t, `	fragment mergeIdenticalFieldsWithIdenticalValues on Dog {
   								doesKnowCommand(dogCommand: 1.1)
     							doesKnowCommand(dogCommand: 1.1)
   							}`,
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("109 variant", func(t *testing.T) {
-				run(`	fragment mergeIdenticalFieldsWithIdenticalValues on Dog {
+				run(t, `	fragment mergeIdenticalFieldsWithIdenticalValues on Dog {
   								doesKnowCommand(dogCommand: 1.1)
     							doesKnowCommand(dogCommand: 0.1)
   							}`,
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("109 variant", func(t *testing.T) {
-				run(`	fragment mergeIdenticalFieldsWithIdenticalValues on Dog {
+				run(t, `	fragment mergeIdenticalFieldsWithIdenticalValues on Dog {
   								doesKnowCommand(dogCommand: "foo")
     							doesKnowCommand(dogCommand: "foo")
   							}`,
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("109 variant", func(t *testing.T) {
-				run(`	fragment mergeIdenticalFieldsWithIdenticalValues on Dog {
+				run(t, `	fragment mergeIdenticalFieldsWithIdenticalValues on Dog {
   								doesKnowCommand(dogCommand: "foo")
     							doesKnowCommand(dogCommand: "bar")
   							}`,
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("109 variant", func(t *testing.T) {
-				run(`	fragment mergeIdenticalFieldsWithIdenticalValues on Dog {
+				run(t, `	fragment mergeIdenticalFieldsWithIdenticalValues on Dog {
   								doesKnowCommand(dogCommand: null)
     							doesKnowCommand(dogCommand: null)
   							}`,
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("109 variant", func(t *testing.T) {
-				run(`	fragment mergeIdenticalFieldsWithIdenticalValues on Dog {
+				run(t, `	fragment mergeIdenticalFieldsWithIdenticalValues on Dog {
   								doesKnowCommand(dogCommand: null)
     							doesKnowCommand(dogCommand: 0)
   							}`,
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("109 variant", func(t *testing.T) {
-				run(`	fragment mergeIdenticalFieldsWithIdenticalValues on Dog {
+				run(t, `	fragment mergeIdenticalFieldsWithIdenticalValues on Dog {
   								doesKnowCommand(dogCommand: [1.1])
     							doesKnowCommand(dogCommand: [1.1])
   							}`,
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("109 variant", func(t *testing.T) {
-				run(`	fragment mergeIdenticalFieldsWithIdenticalValues on Dog {
+				run(t, `	fragment mergeIdenticalFieldsWithIdenticalValues on Dog {
   								doesKnowCommand(dogCommand: [1.1])
     							doesKnowCommand(dogCommand: [0.1])
   							}`,
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("109 variant", func(t *testing.T) {
-				run(`	fragment mergeIdenticalFieldsWithIdenticalValues on Dog {
+				run(t, `	fragment mergeIdenticalFieldsWithIdenticalValues on Dog {
   								doesKnowCommand(dogCommand: [1.1])
     							doesKnowCommand(dogCommand: [1.1,1.1])
   							}`,
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("109 variant", func(t *testing.T) {
-				run(`	
+				run(t, `	
 							fragment mergeIdenticalFieldsWithIdenticalValues on Dog {
   								doesKnowCommand(dogCommand: {foo: "bar"})
     							doesKnowCommand(dogCommand: {foo: "bar"})
@@ -1473,7 +1477,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("109 variant", func(t *testing.T) {
-				run(`	
+				run(t, `	
 							fragment mergeIdenticalFieldsWithIdenticalValues on Dog {
   								doesKnowCommand(dogCommand: {foo: "bar"})
     							doesKnowCommand(dogCommand: {bar: "bar"})
@@ -1481,7 +1485,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("109 variant", func(t *testing.T) {
-				run(`	fragment mergeIdenticalFieldsWithIdenticalValues on Dog {
+				run(t, `	fragment mergeIdenticalFieldsWithIdenticalValues on Dog {
   								doesKnowCommand(dogCommand: {foo: "bar"})
     							doesKnowCommand(dogCommand: {foo: "baz"})
     							doesKnowCommand(dogCommand: {bar: "baz"})
@@ -1489,41 +1493,41 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("109 variant", func(t *testing.T) {
-				run(`	fragment mergeIdenticalFieldsWithIdenticalValues on Dog {
+				run(t, `	fragment mergeIdenticalFieldsWithIdenticalValues on Dog {
   								doesKnowCommand(dogCommand: {foo: "bar"})
     							doesKnowCommand(dogCommand: {foo: "baz",bar: "bat"})
   							}`,
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("110", func(t *testing.T) {
-				run(`	fragment conflictingArgsOnValues on Dog {
+				run(t, `	fragment conflictingArgsOnValues on Dog {
 								doesKnowCommand(dogCommand: SIT)
 								doesKnowCommand(dogCommand: HEEL)
 							}`,
 					FieldSelectionMerging(), Invalid)
-				run(`	fragment conflictingArgsOnValues on Dog {
+				run(t, `	fragment conflictingArgsOnValues on Dog {
 								doesKnowCommand(dogCommand: SIT)
 								doesKnowCommand(dogCommand1: HEEL)
 							}`,
 					FieldSelectionMerging(), Invalid)
-				run(`	fragment conflictingArgsValueAndVar on Dog {
+				run(t, `	fragment conflictingArgsValueAndVar on Dog {
 								doesKnowCommand(dogCommand: SIT)
 								doesKnowCommand(dogCommand: $dogCommand)
 							}`,
 					FieldSelectionMerging(), Invalid)
-				run(`	fragment conflictingArgsWithVars on Dog {
+				run(t, `	fragment conflictingArgsWithVars on Dog {
 								doesKnowCommand(dogCommand: $varOne)
 								doesKnowCommand(dogCommand: $varTwo)
 							}`,
 					FieldSelectionMerging(), Invalid)
-				run(`	fragment differingArgs on Dog {
+				run(t, `	fragment differingArgs on Dog {
 								doesKnowCommand(dogCommand: SIT)
 								doesKnowCommand
 							}`,
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("111", func(t *testing.T) {
-				run(`	
+				run(t, `	
 							fragment safeDifferingFields on Pet {
 								... on Dog {
 									volume: barkVolume
@@ -1543,7 +1547,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("112", func(t *testing.T) {
-				run(`
+				run(t, `
 							fragment conflictingDifferingResponses on Pet {
 								... on Dog {
 									someValue: nickname
@@ -1555,7 +1559,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("112 variant", func(t *testing.T) {
-				run(`	
+				run(t, `	
 							fragment conflictingDifferingResponses on Pet {
 								... on Dog {
 									extra {
@@ -1571,7 +1575,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("112 variant", func(t *testing.T) {
-				run(`
+				run(t, `
 							fragment conflictingDifferingResponses on Pet {
 								... on Dog {
 									extra {
@@ -1587,7 +1591,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("112 variant", func(t *testing.T) {
-				run(`	fragment conflictingDifferingResponses on Pet {
+				run(t, `	fragment conflictingDifferingResponses on Pet {
 								... on Dog {
 									extra {
 										string
@@ -1602,7 +1606,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("112 variant", func(t *testing.T) {
-				run(`	fragment conflictingDifferingResponses on Pet {
+				run(t, `	fragment conflictingDifferingResponses on Pet {
 								... on Dog {
 									extra {
 										string
@@ -1617,7 +1621,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("112 variant", func(t *testing.T) {
-				run(`	fragment conflictingDifferingResponses on Pet {
+				run(t, `	fragment conflictingDifferingResponses on Pet {
 								... on Dog {
 									extra {
 										string
@@ -1632,7 +1636,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("112 variant", func(t *testing.T) {
-				run(`
+				run(t, `
 							fragment conflictingDifferingResponses on Pet {
 								... on Dog {
 									extra {
@@ -1648,7 +1652,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("112 variant", func(t *testing.T) {
-				run(`	fragment conflictingDifferingResponses on Pet {
+				run(t, `	fragment conflictingDifferingResponses on Pet {
 								... on Dog {
 									extra {
 										string
@@ -1663,7 +1667,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("112 variant", func(t *testing.T) {
-				run(`	fragment conflictingDifferingResponses on Pet {
+				run(t, `	fragment conflictingDifferingResponses on Pet {
 								... on Dog {
 									extra {
 										string
@@ -1680,7 +1684,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("112 variant", func(t *testing.T) {
-				run(`	fragment conflictingDifferingResponses on Pet {
+				run(t, `	fragment conflictingDifferingResponses on Pet {
 								... on Dog {
 									extra {
 										string
@@ -1697,7 +1701,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("112 variant", func(t *testing.T) {
-				run(`	fragment conflictingDifferingResponses on Pet {
+				run(t, `	fragment conflictingDifferingResponses on Pet {
 								... on Dog {
 									extra {
 										string
@@ -1714,7 +1718,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("112 variant", func(t *testing.T) {
-				run(`	fragment conflictingDifferingResponses on Pet {
+				run(t, `	fragment conflictingDifferingResponses on Pet {
 								... on Dog {
 									extra {
 										string
@@ -1731,7 +1735,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid, withExpectNormalizationError())
 			})
 			t.Run("112 variant", func(t *testing.T) {
-				run(`
+				run(t, `
 							fragment conflictingDifferingResponses on Pet {
 								... on Dog {
 									extra {
@@ -1749,7 +1753,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("112 variant", func(t *testing.T) {
-				run(`	
+				run(t, `	
 							fragment conflictingDifferingResponses on Pet {
 								...dogFrag
 								...catFrag
@@ -1763,7 +1767,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("112 variant", func(t *testing.T) {
-				run(`	query conflictingDifferingResponses {
+				run(t, `	query conflictingDifferingResponses {
 								pet {
 									...dogFrag
 									...catFrag
@@ -1778,7 +1782,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("112 variant", func(t *testing.T) {
-				run(`	query conflictingDifferingResponses {
+				run(t, `	query conflictingDifferingResponses {
 								catOrDog {
 									...catDogFrag
 								}
@@ -1796,7 +1800,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("112 variant", func(t *testing.T) {
-				run(`	query conflictingDifferingResponses {
+				run(t, `	query conflictingDifferingResponses {
 								pet {
 									...pet1
 									...pet2
@@ -1811,7 +1815,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("112 variant", func(t *testing.T) {
-				run(`	query conflictingDifferingResponses {
+				run(t, `	query conflictingDifferingResponses {
 								pet {
 									...pet1
 									...pet2
@@ -1826,7 +1830,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid, withExpectNormalizationError())
 			})
 			t.Run("112 variant", func(t *testing.T) {
-				run(`	
+				run(t, `	
 							query conflictingDifferingResponses {
 								catOrDog {
 									...catDogFrag
@@ -1845,7 +1849,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("112 variant", func(t *testing.T) {
-				run(`	fragment conflictingDifferingResponses on Pet {
+				run(t, `	fragment conflictingDifferingResponses on Pet {
 								...dogFrag
 								...catFrag
 							}
@@ -1858,7 +1862,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("112 variant", func(t *testing.T) {
-				run(`	fragment conflictingDifferingResponses on Pet {
+				run(t, `	fragment conflictingDifferingResponses on Pet {
 								...dogFrag
 								...catFrag
 							}
@@ -1871,7 +1875,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid)
 			})
 			t.Run("112 variant", func(t *testing.T) {
-				run(`
+				run(t, `
 							fragment conflictingDifferingResponses on Pet {
 								...dogFrag
 								...catFrag
@@ -1885,7 +1889,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("112 variant", func(t *testing.T) {
-				run(`	
+				run(t, `	
 							fragment conflictingDifferingResponses on Pet {
 								...dogFrag
 								... on Cat {
@@ -1898,7 +1902,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("112 variant", func(t *testing.T) {
-				run(`	query conflictingDifferingResponses {
+				run(t, `	query conflictingDifferingResponses {
 								pet {
 									...dogFrag
 									...catFrag
@@ -1913,7 +1917,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("112 variant", func(t *testing.T) {
-				run(`	query conflictingDifferingResponses {
+				run(t, `	query conflictingDifferingResponses {
 								pet {
 									...dogFrag
 									... on Cat {
@@ -1927,7 +1931,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Valid)
 			})
 			t.Run("112 variant", func(t *testing.T) {
-				run(`
+				run(t, `
 							query conflictingDifferingResponses {
 								pet {
 									...dogFrag
@@ -1942,7 +1946,7 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelectionMerging(), Invalid, withExpectNormalizationError())
 			})
 			t.Run("112 variant", func(t *testing.T) {
-				run(`	query conflictingDifferingResponses {
+				run(t, `	query conflictingDifferingResponses {
 								extra {
 									... on CatExtra { value: bool }
 									... on DogExtra { value: bool }
@@ -1953,13 +1957,13 @@ func TestExecutionValidation(t *testing.T) {
 		})
 		t.Run("5.3.3 Leaf Field Selections", func(t *testing.T) {
 			t.Run("113", func(t *testing.T) {
-				run(`	fragment scalarSelection on Dog {
+				run(t, `	fragment scalarSelection on Dog {
 								barkVolume
 							}`,
 					FieldSelections(), Valid)
 			})
 			t.Run("114", func(t *testing.T) {
-				run(`
+				run(t, `
 							fragment scalarSelectionsNotAllowedOnInt on Dog {
 								barkVolume {
 									sinceWhen
@@ -1968,25 +1972,25 @@ func TestExecutionValidation(t *testing.T) {
 					FieldSelections(), Invalid, withExpectNormalizationError())
 			})
 			t.Run("116", func(t *testing.T) {
-				run(`	
+				run(t, `	
 							query directQueryOnObjectWithoutSubFields {
 								human
 							}`,
 					FieldSelections(), Invalid)
-				run(`	query directQueryOnInterfaceWithoutSubFields {
+				run(t, `	query directQueryOnInterfaceWithoutSubFields {
 								pet
 							}`,
 					FieldSelections(), Invalid)
-				run(`	query directQueryOnUnionWithoutSubFields {
+				run(t, `	query directQueryOnUnionWithoutSubFields {
 								catOrDog
 							}`,
 					FieldSelections(), Invalid)
-				run(`
+				run(t, `
 							mutation directQueryOnUnionWithoutSubFields {
 								catOrDog
 							}`,
 					FieldSelections(), Invalid, withExpectNormalizationError())
-				run(`
+				run(t, `
 							subscription directQueryOnUnionWithoutSubFields {
 								catOrDog
 							}`,
@@ -1997,17 +2001,17 @@ func TestExecutionValidation(t *testing.T) {
 	t.Run("5.4 Arguments", func(t *testing.T) {
 		t.Run("5.4.1 Argument Names", func(t *testing.T) {
 			t.Run("117", func(t *testing.T) {
-				run(`	
+				run(t, `	
 							fragment argOnRequiredArg on Dog {
 								doesKnowCommand(dogCommand: SIT)
 							}
 							fragment argOnOptional on Dog {
 								isHousetrained(atOtherHomes: true) @include(if: true)
 							}`,
-					ValidArguments(), Valid)
+					Values(), Valid)
 			})
 			t.Run("117 variant", func(t *testing.T) {
-				run(`	query argOnRequiredArg {
+				run(t, `	query argOnRequiredArg {
 								dog {
 									doesKnowCommand(dogCommand: SIT)
 									...argOnOptional
@@ -2016,10 +2020,10 @@ func TestExecutionValidation(t *testing.T) {
 							fragment argOnOptional on Dog {
 								isHousetrained(atOtherHomes: true) @include(if: true)
 							}`,
-					ValidArguments(), Valid)
+					Values(), Valid)
 			})
 			t.Run("117 variant", func(t *testing.T) {
-				run(`	query argOnRequiredArg($dogCommand: DogCommand!) {
+				run(t, `	query argOnRequiredArg($dogCommand: DogCommand!) {
 								dog {
 									doesKnowCommand(dogCommand: $dogCommand)
 									...argOnOptional
@@ -2028,10 +2032,10 @@ func TestExecutionValidation(t *testing.T) {
 							fragment argOnOptional on Dog {
 								isHousetrained(atOtherHomes: true) @include(if: true)
 							}`,
-					ValidArguments(), Valid)
+					Values(), Valid)
 			})
 			t.Run("117 variant", func(t *testing.T) {
-				run(`	
+				run(t, `	
 							query argOnRequiredArg($dogCommand: DogCommand = SIT) {
 								dog {
 									doesKnowCommand(dogCommand: $dogCommand)
@@ -2041,10 +2045,10 @@ func TestExecutionValidation(t *testing.T) {
 							fragment argOnOptional on Dog {
 								isHousetrained(atOtherHomes: true) @include(if: true)
 							}`,
-					ValidArguments(), Valid, withDisableNormalization())
+					Values(), Valid, withDisableNormalization())
 			})
 			t.Run("117 variant", func(t *testing.T) {
-				run(`
+				run(t, `
 							query argOnRequiredArg($catCommand: CatCommand) {
 								dog {
 									doesKnowCommand(dogCommand: $catCommand)
@@ -2053,7 +2057,7 @@ func TestExecutionValidation(t *testing.T) {
 					ValidArguments(), Invalid)
 			})
 			t.Run("117 variant", func(t *testing.T) {
-				run(`query argOnRequiredArg($dogCommand: CatCommand) {
+				run(t, `query argOnRequiredArg($dogCommand: CatCommand) {
 									dog {
 										... on Dog {
 											doesKnowCommand(dogCommand: $dogCommand)
@@ -2063,7 +2067,7 @@ func TestExecutionValidation(t *testing.T) {
 					ValidArguments(), Invalid)
 			})
 			t.Run("117 variant", func(t *testing.T) {
-				run(`	query argOnRequiredArg($booleanArg: Boolean) {
+				run(t, `	query argOnRequiredArg($booleanArg: Boolean) {
 								dog {
 									...argOnOptional
 								}
@@ -2073,56 +2077,8 @@ func TestExecutionValidation(t *testing.T) {
 							}`,
 					ValidArguments(), Valid)
 			})
-			t.Run("required String", func(t *testing.T) {
-				run(`	query requiredString {
-										args {
-											requiredString(s: "foo")
-										}
-									}`,
-					ValidArguments(), Valid)
-			})
-			t.Run("required String", func(t *testing.T) {
-				run(`	query requiredString {
-										args {
-											requiredString(s: foo)
-										}
-									}`,
-					ValidArguments(), Invalid)
-			})
-			t.Run("required String", func(t *testing.T) {
-				run(`	query requiredString {
-										args {
-											requiredString(s: null)
-										}
-									}`,
-					ValidArguments(), Invalid)
-			})
-			t.Run("required String", func(t *testing.T) {
-				run(`	query requiredFloat {
-										args {
-											requiredFloat(f: 1.1)
-										}
-									}`,
-					ValidArguments(), Valid)
-			})
-			t.Run("required String", func(t *testing.T) {
-				run(`	query requiredFloat {
-										args {
-											requiredFloat(f: "1.1")
-										}
-									}`,
-					ValidArguments(), Invalid)
-			})
-			t.Run("required String", func(t *testing.T) {
-				run(`	query requiredFloat {
-										args {
-											requiredFloat(f: null)
-										}
-									}`,
-					ValidArguments(), Invalid)
-			})
 			t.Run("117 variant", func(t *testing.T) {
-				run(`	
+				run(t, `	
 							query argOnRequiredArg($booleanArg: Boolean!) {
 								dog {
 									...argOnOptional
@@ -2134,7 +2090,7 @@ func TestExecutionValidation(t *testing.T) {
 					ValidArguments(), Valid)
 			})
 			t.Run("117 variant", func(t *testing.T) {
-				run(`	
+				run(t, `	
 							query argOnRequiredArg($booleanArg: Boolean) {
 								dog {
 									...argOnOptional
@@ -2146,7 +2102,7 @@ func TestExecutionValidation(t *testing.T) {
 					ValidArguments(), Invalid)
 			})
 			t.Run("117 variant", func(t *testing.T) {
-				run(`	query argOnRequiredArg($booleanArg: Boolean!) {
+				run(t, `	query argOnRequiredArg($booleanArg: Boolean!) {
 										dog {
 											...argOnOptional
 										}
@@ -2159,7 +2115,7 @@ func TestExecutionValidation(t *testing.T) {
 					ValidArguments(), Valid)
 			})
 			t.Run("117 variant", func(t *testing.T) {
-				run(`	query argOnRequiredArg($intArg: Integer) {
+				run(t, `	query argOnRequiredArg($intArg: Integer) {
 								dog {
 									...argOnOptional
 								}
@@ -2170,7 +2126,7 @@ func TestExecutionValidation(t *testing.T) {
 					ValidArguments(), Invalid)
 			})
 			t.Run("117 variant", func(t *testing.T) {
-				run(`	query argOnRequiredArg($intArg: Integer) {
+				run(t, `	query argOnRequiredArg($intArg: Integer) {
 								pet {
 									...argOnOptional
 								}
@@ -2181,7 +2137,7 @@ func TestExecutionValidation(t *testing.T) {
 					ValidArguments(), Invalid)
 			})
 			t.Run("117 variant", func(t *testing.T) {
-				run(`	query argOnRequiredArg($intArg: Integer) {
+				run(t, `	query argOnRequiredArg($intArg: Integer) {
 								pet {
 									...on Dog {
 										...argOnOptional
@@ -2194,7 +2150,7 @@ func TestExecutionValidation(t *testing.T) {
 					ValidArguments(), Invalid)
 			})
 			t.Run("118", func(t *testing.T) {
-				run(`	
+				run(t, `	
 							{
 								dog { ...invalidArgName}
 							}
@@ -2214,7 +2170,7 @@ func TestExecutionValidation(t *testing.T) {
 					ValidArguments(), Invalid)
 			})
 			t.Run("119", func(t *testing.T) {
-				run(` 	{
+				run(t, ` 	{
 										dog { ...invalidArgName }
 									}
 									fragment invalidArgName on Dog {
@@ -2222,8 +2178,8 @@ func TestExecutionValidation(t *testing.T) {
 									}`,
 					KnownArguments(), Invalid)
 			})
-			t.Run("121", func(t *testing.T) {
-				run(`	fragment multipleArgs on ValidArguments {
+			t.Run("121 args in reversed order", func(t *testing.T) {
+				run(t, `	fragment multipleArgs on ValidArguments {
 								multipleReqs(x: 1, y: 2)
 							}
 							fragment multipleArgsReverseOrder on ValidArguments {
@@ -2232,36 +2188,17 @@ func TestExecutionValidation(t *testing.T) {
 					ValidArguments(), Valid)
 			})
 			t.Run("undefined arg", func(t *testing.T) {
-				run(`	{
+				run(t, `	{
 								dog(name: "Goofy"){ 
 									name
 								}
 							}`,
 					KnownArguments(), Invalid)
 			})
-			t.Run("ID as arg given as string", func(t *testing.T) {
-				runManyRulesWithDefinition(countriesDefinition, `{
-						country(code: "DE") {
-							code
-							name
-						}
-					}`,
-					Valid, ValidArguments(), Values())
-			})
-			t.Run("ID as arg given as integer", func(t *testing.T) {
-				runManyRulesWithDefinition(countriesDefinition, `{
-						country(code: 11) {
-							code
-							name
-						}
-					}`,
-					Valid, ValidArguments(), Values())
-			})
-
 		})
 		t.Run("5.4.2 Argument Uniqueness", func(t *testing.T) {
 			t.Run("121 variant", func(t *testing.T) {
-				run(`
+				run(t, `
 								{
 									arguments { ... multipleArgs }
 								}
@@ -2271,7 +2208,7 @@ func TestExecutionValidation(t *testing.T) {
 					ArgumentUniqueness(), Invalid)
 			})
 			t.Run("121 variant", func(t *testing.T) {
-				run(`{
+				run(t, `{
 									arguments { ... multipleArgs }
 								}
 								fragment multipleArgs on ValidArguments {
@@ -2279,9 +2216,64 @@ func TestExecutionValidation(t *testing.T) {
 								}`,
 					ArgumentUniqueness(), Valid)
 			})
-			t.Run("5.4.2.1 Required ValidArguments", func(t *testing.T) {
-				t.Run("122", func(t *testing.T) {
-					run(`	{
+		})
+
+		t.Run("Required Invalid Arguments", func(t *testing.T) {
+			t.Run("required String", func(t *testing.T) {
+				run(t, `	query requiredString {
+										args {
+											requiredString(s: foo)
+										}
+									}`,
+					Values(), Invalid)
+			})
+			t.Run("required String", func(t *testing.T) {
+				run(t, `	query requiredString {
+										args {
+											requiredString(s: null)
+										}
+									}`,
+					Values(), Invalid)
+			})
+
+			t.Run("required Float", func(t *testing.T) {
+				run(t, `	query requiredFloat {
+										args {
+											requiredFloat(f: "1.1")
+										}
+									}`,
+					Values(), Invalid)
+			})
+			t.Run("required Float", func(t *testing.T) {
+				run(t, `	query requiredFloat {
+										args {
+											requiredFloat(f: null)
+										}
+									}`,
+					Values(), Invalid)
+			})
+		})
+
+		t.Run("5.4.2.1 Required ValidArguments", func(t *testing.T) {
+			t.Run("required String", func(t *testing.T) {
+				run(t, `	query requiredString {
+										args {
+											requiredString(s: "foo")
+										}
+									}`,
+					Values(), Valid)
+			})
+
+			t.Run("required Float", func(t *testing.T) {
+				run(t, `	query requiredFloat {
+										args {
+											requiredFloat(f: 1.1)
+										}
+									}`,
+					Values(), Valid)
+			})
+			t.Run("122", func(t *testing.T) {
+				run(t, `	{
 									arguments {
 										...goodBooleanArg
 										...goodNonNullArg
@@ -2293,10 +2285,10 @@ func TestExecutionValidation(t *testing.T) {
 								fragment goodNonNullArg on ValidArguments {
 									nonNullBooleanArgField(nonNullBooleanArg: true)
 								}`,
-						ValidArguments(), Valid)
-				})
-				t.Run("123", func(t *testing.T) {
-					run(`	{
+					RequiredArguments(), Valid)
+			})
+			t.Run("123", func(t *testing.T) {
+				run(t, `	{
 									arguments {
 										...goodBooleanArgDefault
 									}
@@ -2304,10 +2296,10 @@ func TestExecutionValidation(t *testing.T) {
 								fragment goodBooleanArgDefault on ValidArguments {
 									booleanArgField
 								}`,
-						ValidArguments(), Valid)
-				})
-				t.Run("124", func(t *testing.T) {
-					run(`
+					RequiredArguments(), Valid)
+			})
+			t.Run("124", func(t *testing.T) {
+				run(t, `
 								{
 									arguments {
 										...missingRequiredArg
@@ -2316,10 +2308,10 @@ func TestExecutionValidation(t *testing.T) {
 								fragment missingRequiredArg on ValidArguments {
 									nonNullBooleanArgField
 								}`,
-						RequiredArguments(), Invalid)
-				})
-				t.Run("125", func(t *testing.T) {
-					run(`	{
+					RequiredArguments(), Invalid)
+			})
+			t.Run("125", func(t *testing.T) {
+				run(t, `	{
 									arguments {
 										...missingRequiredArg
 									}
@@ -2327,10 +2319,10 @@ func TestExecutionValidation(t *testing.T) {
 								fragment missingRequiredArg on ValidArguments {
 									nonNullBooleanArgField(nonNullBooleanArg: null)
 								}`,
-						ValidArguments(), Invalid)
-				})
-				t.Run("125 variant", func(t *testing.T) {
-					run(`	{
+					RequiredArguments(), Invalid)
+			})
+			t.Run("125 variant", func(t *testing.T) {
+				run(t, `	{
 									arguments {
 										...missingRequiredArg
 									}
@@ -2338,14 +2330,13 @@ func TestExecutionValidation(t *testing.T) {
 								fragment missingRequiredArg on ValidArguments {
 									nonNullBooleanArgField(nonNullBooleanArg: true)
 								}`,
-						RequiredArguments(), Valid)
-				})
-				t.Run("125 variant", func(t *testing.T) {
-					run(`	{
+					RequiredArguments(), Valid)
+			})
+			t.Run("125 variant", func(t *testing.T) {
+				run(t, `	{
 									booleanList (booleanListArg: [true])
 								}`,
-						RequiredArguments(), Valid)
-				})
+					RequiredArguments(), Valid)
 			})
 		})
 	})
@@ -2353,7 +2344,7 @@ func TestExecutionValidation(t *testing.T) {
 		t.Run("5.5.1 Fragment Declarations", func(t *testing.T) {
 			t.Run("5.5.1.1 Fragment Name Uniqueness", func(t *testing.T) {
 				t.Run("126", func(t *testing.T) {
-					run(`
+					run(t, `
 								{
   									dog {
     									...fragmentOne
@@ -2371,7 +2362,7 @@ func TestExecutionValidation(t *testing.T) {
 						Fragments(), Valid)
 				})
 				t.Run("127", func(t *testing.T) {
-					run(`	
+					run(t, `	
 								{
   									dog {
     									...fragmentOne
@@ -2390,7 +2381,7 @@ func TestExecutionValidation(t *testing.T) {
 			})
 			t.Run("5.5.1.2 Fragment Spread Existence", func(t *testing.T) {
 				t.Run("128", func(t *testing.T) {
-					run(`
+					run(t, `
 							{
 								dog {
 									...inlineFragment
@@ -2413,13 +2404,13 @@ func TestExecutionValidation(t *testing.T) {
 							}`, Fragments(), Valid)
 				})
 				t.Run("129", func(t *testing.T) {
-					run(`	
+					run(t, `	
 								fragment notOnExistingType on NotInSchema {
   									name
 								}`, Fragments(), Invalid, withExpectNormalizationError())
 				})
 				t.Run("129", func(t *testing.T) {
-					run(`	
+					run(t, `	
 								fragment inlineNotExistingType on Dog {
   									... on NotInSchema {
     									name
@@ -2429,7 +2420,7 @@ func TestExecutionValidation(t *testing.T) {
 			})
 			t.Run("5.5.1.3 Fragments on Composite Types", func(t *testing.T) {
 				t.Run("130", func(t *testing.T) {
-					run(`
+					run(t, `
 								{
 									dog {
 										...fragOnObject
@@ -2451,14 +2442,14 @@ func TestExecutionValidation(t *testing.T) {
 						Fragments(), Valid)
 				})
 				t.Run("131", func(t *testing.T) {
-					run(`
+					run(t, `
 								fragment fragOnScalar on Int {
 									something
 								}`,
 						Fragments(), Invalid, withExpectNormalizationError())
 				})
 				t.Run("131", func(t *testing.T) {
-					run(`
+					run(t, `
 								fragment inlineFragOnScalar on Dog {
 									... on Boolean {
 										somethingElse
@@ -2469,7 +2460,7 @@ func TestExecutionValidation(t *testing.T) {
 			})
 			t.Run("5.5.1.4 Fragments must be used", func(t *testing.T) {
 				t.Run("132", func(t *testing.T) {
-					run(`
+					run(t, `
 								fragment nameFragment on Dog {
 									name
 									...nameFragment2
@@ -2490,7 +2481,7 @@ func TestExecutionValidation(t *testing.T) {
 						Fragments(), Invalid)
 				})
 				t.Run("132 variant", func(t *testing.T) {
-					run(`
+					run(t, `
 								fragment dogNames on Query {
 									dog { name }
 								}
@@ -2500,7 +2491,7 @@ func TestExecutionValidation(t *testing.T) {
 						Fragments(), Valid)
 				})
 				t.Run("132 variant", func(t *testing.T) {
-					run(`
+					run(t, `
 								fragment catNames on Query {
 									dog { name }
 								}
@@ -2510,7 +2501,7 @@ func TestExecutionValidation(t *testing.T) {
 						Fragments(), Invalid, withExpectNormalizationError())
 				})
 				t.Run("132 variant", func(t *testing.T) {
-					run(`	fragment dogNames on Query {
+					run(t, `	fragment dogNames on Query {
 									dog { name }
 								}
 								{
@@ -2523,7 +2514,7 @@ func TestExecutionValidation(t *testing.T) {
 		t.Run("5.5.2 Fragment Spreads", func(t *testing.T) {
 			t.Run("5.5.2.1 Fragment spread target defined", func(t *testing.T) {
 				t.Run("133", func(t *testing.T) {
-					run(`
+					run(t, `
 								{
 									dog {
 										...undefinedFragment
@@ -2534,7 +2525,7 @@ func TestExecutionValidation(t *testing.T) {
 			})
 			t.Run("5.5.2.2 Fragment spreads must not form cycles", func(t *testing.T) {
 				t.Run("134", func(t *testing.T) {
-					run(`
+					run(t, `
 					{
 						dog {
 							...nameFragment
@@ -2551,7 +2542,7 @@ func TestExecutionValidation(t *testing.T) {
 						Fragments(), Invalid)
 				})
 				t.Run("136", func(t *testing.T) {
-					run(`
+					run(t, `
 								{
 									dog {
 										...dogFragment
@@ -2572,7 +2563,7 @@ func TestExecutionValidation(t *testing.T) {
 						Fragments(), Invalid, withExpectNormalizationError())
 				})
 				t.Run("136 variant", func(t *testing.T) {
-					run(`
+					run(t, `
 								{
 									dog {
 										...dogFragment
@@ -2596,7 +2587,7 @@ func TestExecutionValidation(t *testing.T) {
 			t.Run("5.5.2.3 Fragment spread is possible", func(t *testing.T) {
 				t.Run("5.5.2.3.1 Object Spreads In Object Scope", func(t *testing.T) {
 					t.Run("137", func(t *testing.T) {
-						run(`
+						run(t, `
 									{
 										dog {
 											...dogFragment
@@ -2610,7 +2601,7 @@ func TestExecutionValidation(t *testing.T) {
 							Fragments(), Valid)
 					})
 					t.Run("137 variant", func(t *testing.T) {
-						run(`
+						run(t, `
 									{
 										dog {
 											...dogFragment
@@ -2624,7 +2615,7 @@ func TestExecutionValidation(t *testing.T) {
 							Fragments(), Invalid, withExpectNormalizationError())
 					})
 					t.Run("138", func(t *testing.T) {
-						run(`
+						run(t, `
 									{
 										dog {
 											...catInDogFragmentInvalid
@@ -2638,7 +2629,7 @@ func TestExecutionValidation(t *testing.T) {
 							Fragments(), Invalid)
 					})
 					t.Run("138 variant", func(t *testing.T) {
-						run(`
+						run(t, `
 									{
 										dog {
 											...catInDogFragmentInvalid
@@ -2654,7 +2645,7 @@ func TestExecutionValidation(t *testing.T) {
 				})
 				t.Run("5.5.2.3.2 Abstract Spreads in Object Scope", func(t *testing.T) {
 					t.Run("139", func(t *testing.T) {
-						run(` 	{
+						run(t, ` 	{
 										dog {
 											...interfaceWithinObjectFragment
 										}
@@ -2668,7 +2659,7 @@ func TestExecutionValidation(t *testing.T) {
 							Fragments(), Valid)
 					})
 					t.Run("140", func(t *testing.T) {
-						run(`
+						run(t, `
 									{
 										dog {
 											...unionWithObjectFragment
@@ -2687,7 +2678,7 @@ func TestExecutionValidation(t *testing.T) {
 				})
 				t.Run("5.5.2.3.3 Object Spreads In Abstract Scope", func(t *testing.T) {
 					t.Run("141", func(t *testing.T) {
-						run(` {
+						run(t, ` {
 										dog {
 											...petFragment
 											...catOrDogFragment
@@ -2707,7 +2698,7 @@ func TestExecutionValidation(t *testing.T) {
 							Fragments(), Valid)
 					})
 					t.Run("142", func(t *testing.T) {
-						run(` fragment sentientFragment on Sentient {
+						run(t, ` fragment sentientFragment on Sentient {
 										... on Dog {
 											barkVolume
 										}
@@ -2715,7 +2706,7 @@ func TestExecutionValidation(t *testing.T) {
 							Fragments(), Invalid)
 					})
 					t.Run("142 variant", func(t *testing.T) {
-						run(` fragment humanOrAlienFragment on HumanOrAlien {
+						run(t, ` fragment humanOrAlienFragment on HumanOrAlien {
 										... on Cat {
 											meowVolume
 										}
@@ -2725,7 +2716,7 @@ func TestExecutionValidation(t *testing.T) {
 				})
 				t.Run("5.5.2.3.4 Abstract Spreads in Abstract Scope", func(t *testing.T) {
 					t.Run("143", func(t *testing.T) {
-						run(`
+						run(t, `
 									{
 										dog {
 											...unionWithInterface
@@ -2759,7 +2750,7 @@ func TestExecutionValidation(t *testing.T) {
 							Fragments(), Valid)
 					})
 					t.Run("144", func(t *testing.T) {
-						run(`
+						run(t, `
 									{
 										dog {
 											...nonIntersectingInterfaces
@@ -2779,33 +2770,54 @@ func TestExecutionValidation(t *testing.T) {
 	})
 	t.Run("5.6 Values", func(t *testing.T) {
 		t.Run("5.6.1 Values of Correct Type", func(t *testing.T) {
+			t.Run("valid ID arguments", func(t *testing.T) {
+				t.Run("ID as arg given as string", func(t *testing.T) {
+					runWithDefinition(t, countriesDefinition, `{
+						country(code: "DE") {
+							code
+							name
+						}
+					}`,
+						Values(), Valid)
+				})
+				t.Run("ID as arg given as integer", func(t *testing.T) {
+					runWithDefinition(t, countriesDefinition, `{
+						country(code: 11) {
+							code
+							name
+						}
+					}`,
+						Values(), Valid)
+				})
+			})
+
 			t.Run("145", func(t *testing.T) {
-				run(`
+				run(t, `
 							query goodComplexDefaultValue($search: ComplexInput = { name: "Fido" }) {
 								findDog(complex: $search)
 							}`,
 					Values(), Valid)
-				run(`
+				run(t, `
 							query goodComplexDefaultValue($search: ComplexInput = { name: "Fido" }) {
 								...queryFragment
 							}
 							fragment queryFragment on Query { findDog(complex: $search) }`,
 					Values(), Valid)
-				run(`
+				run(t, `
 							query goodComplexDefaultValue {
 								arguments {
 									booleanArgField(booleanArg: true)
 								}
 							}`,
 					Values(), Valid)
-				run(`
+				run(t, `
 							query goodComplexDefaultValue() {
 								arguments {
 									floatArgField(floatArg: 123)
 								}
 							}`,
 					Values(), Valid)
-				run(`
+				run(t, `
 							query goodComplexDefaultValue() {
 								arguments {
 									floatArgField(floatArg: 1.23)
@@ -2814,46 +2826,46 @@ func TestExecutionValidation(t *testing.T) {
 					Values(), Valid)
 			})
 			t.Run("145 variant inline variable", func(t *testing.T) {
-				run(`
+				run(t, `
 							query goodComplexDefaultValue($name: String = "Fido" ) {
 								findDog(complex: { name: $name })
 							}`,
 					Values(), Valid)
 			})
 			t.Run("145 variant variable non null", func(t *testing.T) {
-				run(`
+				run(t, `
 							query goodComplexDefaultValue($name: String ) {
 								findDogNonOptional(complex: { name: $name })
 							}`,
 					Values(), Invalid)
 			})
 			t.Run("145 variant", func(t *testing.T) {
-				run(`
+				run(t, `
 							query goodComplexDefaultValue($search: ComplexInput = { name: 123 }) {
 								findDog(complex: $search)
 							}`,
 					Values(), Invalid, withDisableNormalization())
 			})
 			t.Run("145 variant", func(t *testing.T) {
-				run(`query goodComplexDefaultValue($search: ComplexInput = { name: "123" }) {
+				run(t, `query goodComplexDefaultValue($search: ComplexInput = { name: "123" }) {
 									findDog(complex: $search)
 								}`,
 					Values(), Valid)
 			})
 			t.Run("145 variant", func(t *testing.T) {
-				run(`	query goodComplexDefaultValue {
+				run(t, `	query goodComplexDefaultValue {
 										findDog(complex: { name: 123 })
 									}`,
 					Values(), Invalid)
 			})
 			t.Run("145 variant", func(t *testing.T) {
-				run(`	query goodComplexDefaultValue {
+				run(t, `	query goodComplexDefaultValue {
 										findDog(complex: { name: "123" })
 									}`,
 					Values(), Valid)
 			})
 			t.Run("145 variant", func(t *testing.T) {
-				run(`	{
+				run(t, `	{
 								dog {
 									doesKnowCommand(dogCommand: SIT)
 								}
@@ -2861,7 +2873,7 @@ func TestExecutionValidation(t *testing.T) {
 					Values(), Valid)
 			})
 			t.Run("145 variant", func(t *testing.T) {
-				run(`	{
+				run(t, `	{
 								dog {
 									doesKnowCommand(dogCommand: MEOW)
 								}
@@ -2869,7 +2881,7 @@ func TestExecutionValidation(t *testing.T) {
 					Values(), Invalid)
 			})
 			t.Run("145 variant", func(t *testing.T) {
-				run(`	{
+				run(t, `	{
 								dog {
 									doesKnowCommand(dogCommand: [true])
 								}
@@ -2877,7 +2889,7 @@ func TestExecutionValidation(t *testing.T) {
 					Values(), Invalid)
 			})
 			t.Run("145 variant", func(t *testing.T) {
-				run(`	{
+				run(t, `	{
 								dog {
 									doesKnowCommand(dogCommand: {foo: "bar"})
 								}
@@ -2885,7 +2897,7 @@ func TestExecutionValidation(t *testing.T) {
 					Values(), Invalid)
 			})
 			t.Run("146", func(t *testing.T) {
-				run(`
+				run(t, `
 							{
 								arguments { ...stringIntoInt }
 							}
@@ -2893,14 +2905,14 @@ func TestExecutionValidation(t *testing.T) {
 								intArgField(intArg: "123")
 							}`,
 					Values(), Invalid)
-				run(`
+				run(t, `
 							query badComplexValue {
 								findDog(complex: { name: 123 })
 							}`,
 					Values(), Invalid)
 			})
 			t.Run("146 variant", func(t *testing.T) {
-				run(`
+				run(t, `
 							query badComplexValue {
 								findDog(complex: { name: "123" })
 							}`,
@@ -2909,13 +2921,13 @@ func TestExecutionValidation(t *testing.T) {
 		})
 		t.Run("5.6.2 Input Object Field Names", func(t *testing.T) {
 			t.Run("147", func(t *testing.T) {
-				run(`{
+				run(t, `{
   									findDog(complex: { name: "Fido" })
 								}`,
 					Values(), Valid)
 			})
 			t.Run("148", func(t *testing.T) {
-				run(`{
+				run(t, `{
  									findDog(complex: { favoriteCookieFlavor: "Bacon" })
 								}`,
 					Values(), Invalid)
@@ -2923,7 +2935,7 @@ func TestExecutionValidation(t *testing.T) {
 		})
 		t.Run("5.6.3 Input Object Field Uniqueness", func(t *testing.T) {
 			t.Run("149", func(t *testing.T) {
-				run(`{
+				run(t, `{
 									findDog(complex: { name: "Fido", name: "Goofy"})
 								}`,
 					Values(), Invalid)
@@ -2931,37 +2943,37 @@ func TestExecutionValidation(t *testing.T) {
 		})
 		t.Run("5.6.4 Input Object Required Fields", func(t *testing.T) {
 			t.Run("145 variant", func(t *testing.T) {
-				run(`query goodComplexDefaultValue($search: ComplexNonOptionalInput = { name: "123" }) {
+				run(t, `query goodComplexDefaultValue($search: ComplexNonOptionalInput = { name: "123" }) {
 									findDogNonOptional(complex: $search)
 								}`,
 					Values(), Valid)
 			})
 			t.Run("145 variant", func(t *testing.T) {
-				run(`query goodComplexDefaultValue($search: ComplexNonOptionalInput = { name: null }) {
+				run(t, `query goodComplexDefaultValue($search: ComplexNonOptionalInput = { name: null }) {
 									findDogNonOptional(complex: $search)
 								}`,
 					Values(), Invalid, withDisableNormalization())
 			})
 			t.Run("145 variant", func(t *testing.T) {
-				run(`query goodComplexDefaultValue($search: ComplexNonOptionalInput = {}) {
+				run(t, `query goodComplexDefaultValue($search: ComplexNonOptionalInput = {}) {
 									findDogNonOptional(complex: $search)
 								}`,
 					Values(), Invalid, withDisableNormalization())
 			})
 			t.Run("145 variant", func(t *testing.T) {
-				run(`query goodComplexDefaultValue {
+				run(t, `query goodComplexDefaultValue {
 									findDogNonOptional(complex: {})
 								}`,
 					Values(), Invalid)
 			})
 			t.Run("145 variant", func(t *testing.T) {
-				run(`query goodComplexDefaultValue {
+				run(t, `query goodComplexDefaultValue {
 									findDogNonOptional(complex: { name: "Goofy" })
 								}`,
 					Values(), Valid)
 			})
 			t.Run("145 variant", func(t *testing.T) {
-				run(`query goodComplexDefaultValue {
+				run(t, `query goodComplexDefaultValue {
 									...viaFragment
 								}
 								fragment viaFragment on Query {
@@ -2970,7 +2982,7 @@ func TestExecutionValidation(t *testing.T) {
 					Values(), Valid)
 			})
 			t.Run("145 variant", func(t *testing.T) {
-				run(`query goodComplexDefaultValue {
+				run(t, `query goodComplexDefaultValue {
 									...viaFragment
 								}
 								fragment viaFragment on Query {
@@ -2981,14 +2993,14 @@ func TestExecutionValidation(t *testing.T) {
 		})
 		t.Run("complex nested validation", func(t *testing.T) {
 			t.Run("complex nested 1", func(t *testing.T) {
-				run(`
+				run(t, `
 						{
 							nested(input: {})
 						}
 						`, Values(), Invalid)
 			})
 			t.Run("complex nested ok", func(t *testing.T) {
-				run(`
+				run(t, `
 						{
 							nested(input: {
 								requiredString: "str",
@@ -2998,8 +3010,8 @@ func TestExecutionValidation(t *testing.T) {
 						}
 						`, Values(), Valid)
 			})
-			t.Run("complex nested 'notList' is not list of Strings", func(t *testing.T) {
-				run(`
+			t.Run("complex nested 'notList' is not list of Strings should be ok with coersion", func(t *testing.T) {
+				run(t, `
 						{
 							nested(input: {
 								requiredString: "str",
@@ -3007,10 +3019,10 @@ func TestExecutionValidation(t *testing.T) {
 								requiredListOfRequiredStrings: ["str"]
 							})
 						}
-						`, Values(), Invalid)
+						`, Values(), Valid)
 			})
 			t.Run("complex nested ok 3", func(t *testing.T) {
-				run(`
+				run(t, `
 						{
 							nested(input: {
 								requiredString: "str",
@@ -3022,7 +3034,7 @@ func TestExecutionValidation(t *testing.T) {
 						`, Values(), Valid)
 			})
 			t.Run("complex nested ok optional list of nested input", func(t *testing.T) {
-				run(`
+				run(t, `
 						{
 							nested(input: {
 								requiredString: "str",
@@ -3046,7 +3058,7 @@ func TestExecutionValidation(t *testing.T) {
 						`, Values(), Valid)
 			})
 			t.Run("complex nested ok optional list of nested input, required string missing", func(t *testing.T) {
-				run(`
+				run(t, `
 						{
 							nested(input: {
 								requiredString: "str",
@@ -3064,7 +3076,7 @@ func TestExecutionValidation(t *testing.T) {
 						`, Values(), Invalid)
 			})
 			t.Run("complex nested 'str' is not String", func(t *testing.T) {
-				run(`
+				run(t, `
 						{
 							nested(input: {
 								requiredString: "str",
@@ -3076,7 +3088,7 @@ func TestExecutionValidation(t *testing.T) {
 						`, Values(), Invalid)
 			})
 			t.Run("complex nested requiredListOfRequiredStrings must not be empty", func(t *testing.T) {
-				run(`
+				run(t, `
 						{
 							nested(input: {
 								requiredString: "str",
@@ -3087,7 +3099,7 @@ func TestExecutionValidation(t *testing.T) {
 						`, Values(), Invalid)
 			})
 			t.Run("complex 2x nested", func(t *testing.T) {
-				run(`
+				run(t, `
 						{
 							nested(input: {
 								requiredString: "str",
@@ -3103,7 +3115,7 @@ func TestExecutionValidation(t *testing.T) {
 						`, Values(), Valid)
 			})
 			t.Run("complex 2x nested required string missing", func(t *testing.T) {
-				run(`
+				run(t, `
 						{
 							nested(input: {
 								requiredString: "str",
@@ -3118,7 +3130,7 @@ func TestExecutionValidation(t *testing.T) {
 						`, Values(), Invalid)
 			})
 			t.Run("complex 2x nested '123' is no String", func(t *testing.T) {
-				run(`
+				run(t, `
 						{
 							nested(input: {
 								requiredString: "str",
@@ -3138,7 +3150,7 @@ func TestExecutionValidation(t *testing.T) {
 	t.Run("5.7 Directives", func(t *testing.T) {
 		t.Run("5.7.1 Directives Are Defined", func(t *testing.T) {
 			t.Run("145 variant", func(t *testing.T) {
-				run(`query definedDirective {
+				run(t, `query definedDirective {
 									arguments {
 										booleanArgField(booleanArg: true) @skip(if: true)
 									}
@@ -3146,7 +3158,7 @@ func TestExecutionValidation(t *testing.T) {
 					DirectivesAreDefined(), Valid)
 			})
 			t.Run("145 variant", func(t *testing.T) {
-				run(`query undefinedDirective {
+				run(t, `query undefinedDirective {
 									arguments {
 										booleanArgField(booleanArg: true) @noSkip(if: true)
 									}
@@ -3154,7 +3166,7 @@ func TestExecutionValidation(t *testing.T) {
 					DirectivesAreDefined(), Invalid)
 			})
 			t.Run("145 variant", func(t *testing.T) {
-				run(`query undefinedDirective {
+				run(t, `query undefinedDirective {
 									arguments {
 										...viaFragment
 									}
@@ -3167,19 +3179,19 @@ func TestExecutionValidation(t *testing.T) {
 		})
 		t.Run("5.7.2 Directives Are In Valid Locations", func(t *testing.T) {
 			t.Run("150 variant", func(t *testing.T) {
-				run(`query @skip(if: true) {
+				run(t, `query @skip(if: true) {
 									dog
 								}`,
 					DirectivesAreInValidLocations(), Invalid)
 			})
 			t.Run("150 variant", func(t *testing.T) {
-				run(`query {
+				run(t, `query {
 									dog @skip(if: true)
 								}`,
 					DirectivesAreInValidLocations(), Valid)
 			})
 			t.Run("150 variant", func(t *testing.T) {
-				run(`	{
+				run(t, `	{
 								... @inline {
 									dog
 								}
@@ -3187,7 +3199,7 @@ func TestExecutionValidation(t *testing.T) {
 					DirectivesAreInValidLocations(), Valid)
 			})
 			t.Run("150 variant", func(t *testing.T) {
-				run(`	{
+				run(t, `	{
 								... {
 									dog @inline
 								}
@@ -3195,7 +3207,7 @@ func TestExecutionValidation(t *testing.T) {
 					DirectivesAreInValidLocations(), Invalid)
 			})
 			t.Run("150 variant", func(t *testing.T) {
-				run(`
+				run(t, `
 							{
 								...frag @spread
 							}
@@ -3203,7 +3215,7 @@ func TestExecutionValidation(t *testing.T) {
 					DirectivesAreInValidLocations(), Valid)
 			})
 			t.Run("150 variant", func(t *testing.T) {
-				run(`	{
+				run(t, `	{
 								... {
 									dog @spread
 								}
@@ -3211,7 +3223,7 @@ func TestExecutionValidation(t *testing.T) {
 					DirectivesAreInValidLocations(), Invalid)
 			})
 			t.Run("150 variant", func(t *testing.T) {
-				run(`	{
+				run(t, `	{
 								... {
 									dog @fragmentDefinition
 								}
@@ -3219,67 +3231,67 @@ func TestExecutionValidation(t *testing.T) {
 					DirectivesAreInValidLocations(), Invalid)
 			})
 			t.Run("150 variant", func(t *testing.T) {
-				run(`	{
+				run(t, `	{
 								...frag
 							}
 							fragment frag on Query @fragmentDefinition {}`,
 					DirectivesAreInValidLocations(), Valid)
 			})
 			t.Run("150 variant", func(t *testing.T) {
-				run(`	query @onQuery {
+				run(t, `	query @onQuery {
 								dog
 							}`,
 					DirectivesAreInValidLocations(), Valid)
 			})
 			t.Run("150 variant", func(t *testing.T) {
-				run(`	query @onMutation {
+				run(t, `	query @onMutation {
 								dog
 							}`,
 					DirectivesAreInValidLocations(), Invalid)
 			})
 			t.Run("150 variant", func(t *testing.T) {
-				run(`	query @onSubscription {
+				run(t, `	query @onSubscription {
 								dog
 							}`,
 					DirectivesAreInValidLocations(), Invalid)
 			})
 			t.Run("150 variant", func(t *testing.T) {
-				run(`
+				run(t, `
 							mutation @onQuery {
 								mutateDog
 							}`,
 					DirectivesAreInValidLocations(), Invalid)
 			})
 			t.Run("150 variant", func(t *testing.T) {
-				run(`
+				run(t, `
 							mutation @onSubscription {
 								mutateDog
 							}`,
 					DirectivesAreInValidLocations(), Invalid)
 			})
 			t.Run("150 variant", func(t *testing.T) {
-				run(`
+				run(t, `
 							mutation @onMutation {
 								mutateDog
 							}`,
 					DirectivesAreInValidLocations(), Valid)
 			})
 			t.Run("150 variant", func(t *testing.T) {
-				run(`
+				run(t, `
 							subscription @onQuery {
 								subscribeDog
 							}`,
 					DirectivesAreInValidLocations(), Invalid)
 			})
 			t.Run("150 variant", func(t *testing.T) {
-				run(`
+				run(t, `
 							subscription @onMutation {
 								foo
 							}`,
 					DirectivesAreInValidLocations(), Invalid)
 			})
 			t.Run("150 variant", func(t *testing.T) {
-				run(`
+				run(t, `
 							subscription @onSubscription {
 								foo
 							}`,
@@ -3288,13 +3300,13 @@ func TestExecutionValidation(t *testing.T) {
 		})
 		t.Run("5.7.3 Directives Are Unique Per Location", func(t *testing.T) {
 			t.Run("151", func(t *testing.T) {
-				run(`query MyQuery($foo: Boolean = true, $bar: Boolean = false) {
+				run(t, `query MyQuery($foo: Boolean = true, $bar: Boolean = false) {
 									field @skip(if: $foo) @skip(if: $bar)
 								}`,
 					DirectivesAreUniquePerLocation(), Invalid)
 			})
 			t.Run("152", func(t *testing.T) {
-				run(`query MyQuery($foo: Boolean = true, $bar: Boolean = false) {
+				run(t, `query MyQuery($foo: Boolean = true, $bar: Boolean = false) {
 									field @skip(if: $foo) {
 										subfieldA
 									}
@@ -3309,7 +3321,7 @@ func TestExecutionValidation(t *testing.T) {
 	t.Run("5.8 Variables", func(t *testing.T) {
 		t.Run("5.8.1 VariableValue Uniqueness", func(t *testing.T) {
 			t.Run("153", func(t *testing.T) {
-				run(`query houseTrainedQuery($atOtherHomes: Boolean, $atOtherHomes: Boolean) {
+				run(t, `query houseTrainedQuery($atOtherHomes: Boolean, $atOtherHomes: Boolean) {
 									dog {
 										isHousetrained(atOtherHomes: $atOtherHomes)
 									}
@@ -3317,7 +3329,7 @@ func TestExecutionValidation(t *testing.T) {
 					VariableUniqueness(), Invalid)
 			})
 			t.Run("154", func(t *testing.T) {
-				run(`
+				run(t, `
 							query A($atOtherHomes: Boolean) {
 								...HouseTrainedFragment
 							}
@@ -3334,7 +3346,7 @@ func TestExecutionValidation(t *testing.T) {
 		})
 		t.Run("5.8.2 Variables Are Input Types", func(t *testing.T) {
 			t.Run("156", func(t *testing.T) {
-				run(`
+				run(t, `
 							query takesBoolean($atOtherHomes: Boolean) {
 								dog {
 									isHousetrained(atOtherHomes: $atOtherHomes)
@@ -3351,27 +3363,27 @@ func TestExecutionValidation(t *testing.T) {
 					VariablesAreInputTypes(), Valid)
 			})
 			t.Run("156", func(t *testing.T) {
-				run(`query TakesListOfBooleanBang($booleans: [Boolean!]) {
+				run(t, `query TakesListOfBooleanBang($booleans: [Boolean!]) {
 									booleanList(booleanListArg: $booleans)
 								}`,
 					VariablesAreInputTypes(), Valid)
 			})
 			t.Run("157", func(t *testing.T) {
-				run(`query takesCat($cat: Cat) {}`,
+				run(t, `query takesCat($cat: Cat) {}`,
 					VariablesAreInputTypes(), Invalid)
-				run(`query takesDogBang($dog: Dog!) {}`,
+				run(t, `query takesDogBang($dog: Dog!) {}`,
 					VariablesAreInputTypes(), Invalid)
-				run(`query takesListOfPet($pets: [Pet]) {}`,
+				run(t, `query takesListOfPet($pets: [Pet]) {}`,
 					VariablesAreInputTypes(), Invalid)
-				run(`query takesCatOrDog($catOrDog: CatOrDog) {}`,
+				run(t, `query takesCatOrDog($catOrDog: CatOrDog) {}`,
 					VariablesAreInputTypes(), Invalid)
-				run(`query takesCatOrDog($catCommand: CatCommand) {}`,
+				run(t, `query takesCatOrDog($catCommand: CatCommand) {}`,
 					VariablesAreInputTypes(), Valid)
 			})
 		})
 		t.Run("5.8.3 All VariableValue Uses Defined", func(t *testing.T) {
 			t.Run("158", func(t *testing.T) {
-				run(`query variableIsDefined($atOtherHomes: Boolean) {
+				run(t, `query variableIsDefined($atOtherHomes: Boolean) {
 									dog {
 										isHousetrained(atOtherHomes: $atOtherHomes)
 									}
@@ -3379,7 +3391,7 @@ func TestExecutionValidation(t *testing.T) {
 					AllVariableUsesDefined(), Valid)
 			})
 			t.Run("159", func(t *testing.T) {
-				run(`query variableIsNotDefined {
+				run(t, `query variableIsNotDefined {
 									dog {
 										isHousetrained(atOtherHomes: $atOtherHomes)
 									}
@@ -3387,7 +3399,7 @@ func TestExecutionValidation(t *testing.T) {
 					AllVariableUsesDefined(), Invalid)
 			})
 			t.Run("160", func(t *testing.T) {
-				run(`query variableIsDefinedUsedInSingleFragment($atOtherHomes: Boolean) {
+				run(t, `query variableIsDefinedUsedInSingleFragment($atOtherHomes: Boolean) {
 									dog {
 										...isHousetrainedFragment
 									}
@@ -3398,7 +3410,7 @@ func TestExecutionValidation(t *testing.T) {
 					AllVariableUsesDefined(), Valid)
 			})
 			t.Run("161", func(t *testing.T) {
-				run(`query variableIsNotDefinedUsedInSingleFragment {
+				run(t, `query variableIsNotDefinedUsedInSingleFragment {
 									dog {
 										...isHousetrainedFragment
 									}
@@ -3409,7 +3421,7 @@ func TestExecutionValidation(t *testing.T) {
 					AllVariableUsesDefined(), Invalid)
 			})
 			t.Run("162", func(t *testing.T) {
-				run(`query variableIsNotDefinedUsedInNestedFragment {
+				run(t, `query variableIsNotDefinedUsedInNestedFragment {
 									dog {
 										...outerHousetrainedFragment
 									}
@@ -3422,7 +3434,7 @@ func TestExecutionValidation(t *testing.T) {
 								}`,
 					AllVariableUsesDefined(), Invalid)
 				t.Run("163", func(t *testing.T) {
-					run(`query housetrainedQueryOne($atOtherHomes: Boolean) {
+					run(t, `query housetrainedQueryOne($atOtherHomes: Boolean) {
 										dog {
 											...isHousetrainedFragment
 										}
@@ -3438,7 +3450,7 @@ func TestExecutionValidation(t *testing.T) {
 						AllVariableUsesDefined(), Valid)
 				})
 				t.Run("164", func(t *testing.T) {
-					run(`query housetrainedQueryOne($atOtherHomes: Boolean) {
+					run(t, `query housetrainedQueryOne($atOtherHomes: Boolean) {
 										dog {
 											...isHousetrainedFragment
 										}
@@ -3457,19 +3469,19 @@ func TestExecutionValidation(t *testing.T) {
 		})
 		t.Run("5.8.4 All Variables Used", func(t *testing.T) {
 			t.Run("165", func(t *testing.T) {
-				run(`	query variableUnused($name: String) {
+				run(t, `	query variableUnused($name: String) {
 										findDog(complex: {name: $name})
 									}`,
 					AllVariablesUsed(), Valid)
 			})
 			t.Run("165 variant nested", func(t *testing.T) {
-				run(`	query variableUnused($name: String) {
+				run(t, `	query variableUnused($name: String) {
 										findNestedDog(complex: {nested: {name: $name}})
 									}`,
 					AllVariablesUsed(), Valid)
 			})
 			t.Run("165 variant - input object type variable", func(t *testing.T) {
-				run(`query variableUnused($atOtherHomes: Boolean) {
+				run(t, `query variableUnused($atOtherHomes: Boolean) {
 									dog {
 										isHousetrained
 									}
@@ -3477,7 +3489,7 @@ func TestExecutionValidation(t *testing.T) {
 					AllVariablesUsed(), Invalid)
 			})
 			t.Run("165 variant", func(t *testing.T) {
-				run(`query variableUnused($x: Int!) {
+				run(t, `query variableUnused($x: Int!) {
 									arguments {
 										multipleReqs(x: $x, y: 1)
 									}
@@ -3485,7 +3497,7 @@ func TestExecutionValidation(t *testing.T) {
 					AllVariablesUsed(), Valid)
 			})
 			t.Run("166", func(t *testing.T) {
-				run(`query variableUsedInFragment($atOtherHomes: Boolean) {
+				run(t, `query variableUsedInFragment($atOtherHomes: Boolean) {
 									dog {
 										...isHousetrainedFragment
 									}
@@ -3496,7 +3508,7 @@ func TestExecutionValidation(t *testing.T) {
 					AllVariablesUsed(), Valid)
 			})
 			t.Run("167", func(t *testing.T) {
-				run(`query variableNotUsedWithinFragment($atOtherHomes: Boolean) {
+				run(t, `query variableNotUsedWithinFragment($atOtherHomes: Boolean) {
 									dog {
 										...isHousetrainedWithoutVariableFragment
 									}
@@ -3507,7 +3519,7 @@ func TestExecutionValidation(t *testing.T) {
 					AllVariablesUsed(), Invalid)
 			})
 			t.Run("168", func(t *testing.T) {
-				run(`query queryWithUsedVar($atOtherHomes: Boolean) {
+				run(t, `query queryWithUsedVar($atOtherHomes: Boolean) {
 									dog {
 										...isHousetrainedFragment
 									}
@@ -3523,7 +3535,7 @@ func TestExecutionValidation(t *testing.T) {
 					AllVariablesUsed(), Invalid)
 			})
 			t.Run("variables in array object", func(t *testing.T) {
-				runWithDefinition(todoSchema, `mutation AddTak($title: String!, $completed: Boolean!, $name: String! @fromClaim(name: "sub")) {
+				runWithDefinition(t, todoSchema, `mutation AddTak($title: String!, $completed: Boolean!, $name: String! @fromClaim(name: "sub")) {
   									addTask(input: [{title: $title, completed: $completed, user: {name: $name}}]){
 										task {
 										  id
@@ -3534,52 +3546,10 @@ func TestExecutionValidation(t *testing.T) {
 								}`,
 					AllVariablesUsed(), Valid)
 			})
-			t.Run("variables in nested array object", func(t *testing.T) {
-				run(`query variableUnused($name: String) {
-					dog(where: {
-						AND: [
-						  { nestedDog: { nickname: { eq: "Scooby Doo" } } }
-						  { nestedDog: { name: { eq: $name } } }
-						  {
-							OR: [
-							  {
-								AND: [
-								  {
-									nestedDog: {
-									  birthday: { eq: "2021-07-29" }
-									}
-								  }
-								  {
-									nestedDog: { barkVolume: { eq: 20 } }
-								  }
-								]
-							  }
-							  {
-								AND: [
-								  {
-									nestedDog: {
-										birthday: { eq: "2021-08-02" }
-									}
-								  }
-								  {
-									nestedDog: { barkVolume: { eq: 35 } }
-								  }
-								]
-							  }
-							]
-						  }
-						]
-					  }) {
-						id
-						name
-					}
-				}`,
-					AllVariablesUsed(), Valid)
-			})
 		})
 		t.Run("5.8.5 All VariableValue Usages are Allowed", func(t *testing.T) {
 			t.Run("169", func(t *testing.T) {
-				run(`query intCannotGoIntoBoolean($intArg: Int) {
+				run(t, `query intCannotGoIntoBoolean($intArg: Int) {
 									arguments {
 										booleanArgField(booleanArg: $intArg)
 									}
@@ -3587,7 +3557,7 @@ func TestExecutionValidation(t *testing.T) {
 					ValidArguments(), Invalid)
 			})
 			t.Run("170", func(t *testing.T) {
-				run(`query booleanListCannotGoIntoBoolean($booleanListArg: [Boolean]) {
+				run(t, `query booleanListCannotGoIntoBoolean($booleanListArg: [Boolean]) {
 									arguments {
 										booleanArgField(booleanArg: $booleanListArg)
 									}
@@ -3595,7 +3565,7 @@ func TestExecutionValidation(t *testing.T) {
 					ValidArguments(), Invalid)
 			})
 			t.Run("171", func(t *testing.T) {
-				run(`query booleanArgQuery($booleanArg: Boolean) {
+				run(t, `query booleanArgQuery($booleanArg: Boolean) {
 									arguments {
 										nonNullBooleanArgField(nonNullBooleanArg: $booleanArg)
 									}
@@ -3604,7 +3574,7 @@ func TestExecutionValidation(t *testing.T) {
 			})
 			// Non-null types are compatible with nullable types.
 			t.Run("172", func(t *testing.T) {
-				run(`query nonNullListToList($nonNullListOfBoolean: [Boolean]!) {
+				run(t, `query nonNullListToList($nonNullListOfBoolean: [Boolean]!) {
 								arguments {
 									nonNullListOfBooleanArgField(nonNullListOfBooleanArg: $nonNullListOfBoolean)
 								}
@@ -3612,7 +3582,7 @@ func TestExecutionValidation(t *testing.T) {
 					ValidArguments(), Valid)
 			})
 			t.Run("172 variant", func(t *testing.T) {
-				run(`query listToList($listOfBoolean: [Boolean]) {
+				run(t, `query listToList($listOfBoolean: [Boolean]) {
 									arguments {
 										listOfBooleanArgField(listOfBooleanArg: $listOfBoolean)
 									}
@@ -3620,7 +3590,7 @@ func TestExecutionValidation(t *testing.T) {
 					ValidArguments(), Valid)
 			})
 			t.Run("172 variant", func(t *testing.T) {
-				run(`query listOfNonNullToList($listOfNonNullBoolean: [Boolean!]) {
+				run(t, `query listOfNonNullToList($listOfNonNullBoolean: [Boolean!]) {
 									arguments {
 										listOfBooleanArgField(listOfBooleanArg: $listOfNonNullBoolean)
 									}
@@ -3628,7 +3598,7 @@ func TestExecutionValidation(t *testing.T) {
 					ValidArguments(), Valid)
 			})
 			t.Run("172 variant", func(t *testing.T) {
-				run(`query nonNullListOfNonNullToList($nonNullListOfNonNullBoolean: [Boolean!]!) {
+				run(t, `query nonNullListOfNonNullToList($nonNullListOfNonNullBoolean: [Boolean!]!) {
 									arguments {
 										listOfBooleanArgField(listOfBooleanArg: $nonNullListOfNonNullBoolean)
 									}
@@ -3636,7 +3606,7 @@ func TestExecutionValidation(t *testing.T) {
 					ValidArguments(), Valid)
 			})
 			t.Run("172 variant", func(t *testing.T) {
-				run(`query nonNullListToListLiteral {
+				run(t, `query nonNullListToListLiteral {
 									arguments {
 										nonNullListOfBooleanArgField(nonNullListOfBooleanArg: [true,false,true])
 									}
@@ -3645,7 +3615,7 @@ func TestExecutionValidation(t *testing.T) {
 			})
 			// Types in lists must match
 			t.Run("172 variant", func(t *testing.T) {
-				run(`query listContainingIncorrectType {
+				run(t, `query listContainingIncorrectType {
 									arguments {
 										nonNullListOfBooleanArgField(nonNullListOfBooleanArg: [true,false,"123"])
 									}
@@ -3653,7 +3623,7 @@ func TestExecutionValidation(t *testing.T) {
 					Values(), Invalid)
 			})
 			t.Run("172 variant", func(t *testing.T) {
-				run(`query listContainingIncorrectType {
+				run(t, `query listContainingIncorrectType {
 									arguments {
 										nonNullListOfBooleanArgField(nonNullListOfBooleanArg: [true,false,123])
 									}
@@ -3662,7 +3632,7 @@ func TestExecutionValidation(t *testing.T) {
 			})
 			// Nullable types are NOT compatible with non-null types.
 			t.Run("172 variant", func(t *testing.T) {
-				run(`query listToListOfNonNull($listOfBoolean: [Boolean]) {
+				run(t, `query listToListOfNonNull($listOfBoolean: [Boolean]) {
 									arguments {
 										listOfNonNullBooleanArgField(listOfNonNullBooleanArg: $listOfBoolean)
 									}
@@ -3670,7 +3640,7 @@ func TestExecutionValidation(t *testing.T) {
 					ValidArguments(), Invalid)
 			})
 			t.Run("172 variant", func(t *testing.T) {
-				run(`query nonNullListToListOfNonNull($nonNullListOfBoolean: [Boolean]!) {
+				run(t, `query nonNullListToListOfNonNull($nonNullListOfBoolean: [Boolean]!) {
 									arguments {
 										listOfNonNullBooleanArgField(listOfNonNullBooleanArg: $nonNullListOfBoolean)
 									}
@@ -3678,7 +3648,7 @@ func TestExecutionValidation(t *testing.T) {
 					ValidArguments(), Invalid)
 			})
 			t.Run("172 variant", func(t *testing.T) {
-				run(`query listOfNonNullToNonNullList($listOfNonNullBoolean: [Boolean!]) {
+				run(t, `query listOfNonNullToNonNullList($listOfNonNullBoolean: [Boolean!]) {
 									arguments {
 										nonNullListOfBooleanArgField(nonNullListOfBooleanArg: $listOfNonNullBoolean)
 									}
@@ -3686,7 +3656,7 @@ func TestExecutionValidation(t *testing.T) {
 					ValidArguments(), Invalid)
 			})
 			t.Run("173", func(t *testing.T) {
-				run(`query listToNonNullList($listOfBoolean: [Boolean]) {
+				run(t, `query listToNonNullList($listOfBoolean: [Boolean]) {
 									arguments {
 										nonNullListOfBooleanArgField(nonNullListOfBooleanArg: $listOfBoolean)
 									}
@@ -3694,7 +3664,7 @@ func TestExecutionValidation(t *testing.T) {
 					ValidArguments(), Invalid)
 			})
 			t.Run("174", func(t *testing.T) {
-				run(`query booleanArgQueryWithDefault($booleanArg: Boolean) {
+				run(t, `query booleanArgQueryWithDefault($booleanArg: Boolean) {
 									arguments {
 										nonNullBooleanWithDefaultArgField(nonNullBooleanWithDefaultArg: $booleanArg)
 									}
@@ -3702,7 +3672,7 @@ func TestExecutionValidation(t *testing.T) {
 					ValidArguments(), Valid)
 			})
 			t.Run("175", func(t *testing.T) {
-				run(`query booleanArgQueryWithDefault($booleanArg: Boolean = true) {
+				run(t, `query booleanArgQueryWithDefault($booleanArg: Boolean = true) {
 									arguments {
 										nonNullBooleanArgField(nonNullBooleanArg: $booleanArg)
 									}
@@ -3710,7 +3680,7 @@ func TestExecutionValidation(t *testing.T) {
 					ValidArguments(), Valid, withDisableNormalization())
 			})
 			t.Run("complex values", func(t *testing.T) {
-				runWithDefinition(wundergraphSchema, `
+				runWithDefinition(t, wundergraphSchema, `
 					query FirstNamespace($id: String $mode: QueryMode) {
 						findFirstnamespace(where: {id: {equals: $id mode: $mode}}) {
 							id
@@ -3725,7 +3695,7 @@ func TestExecutionValidation(t *testing.T) {
 					`, ValidArguments(), Valid)
 			})
 			t.Run("complex values", func(t *testing.T) {
-				runWithDefinition(wundergraphSchema, `
+				runWithDefinition(t, wundergraphSchema, `
 					query FirstNamespace($id: String $mode: QueryMode) {
 						findFirstnamespace(where: {id: {equals: $id mode: $mode}}) {
 							id
@@ -3740,7 +3710,7 @@ func TestExecutionValidation(t *testing.T) {
 					`, Values(), Valid)
 			})
 			t.Run("complex values with input object", func(t *testing.T) {
-				runWithDefinition(wundergraphSchema, `
+				runWithDefinition(t, wundergraphSchema, `
 					query FirstAPI($a: String $b: StringFilter) {
 						findFirstapi(where: {id: {equals: $a} AND: {name: $b}}) {
 							id

--- a/pkg/astvalidation/operation_validation_test.go
+++ b/pkg/astvalidation/operation_validation_test.go
@@ -3114,9 +3114,7 @@ func TestExecutionValidation(t *testing.T) {
 						}
 						`, Values(), Invalid, withValidationErrors(`String cannot represent a non string value: str`))
 			})
-			t.Run("complex nested requiredListOfRequiredStrings must not be empty", func(t *testing.T) {
-				t.Errorf("TODO: Need support better error")
-
+			t.Run("complex nested requiredListOfRequiredStrings could be empty but not `null` or `[null]`", func(t *testing.T) {
 				run(t, `
 						{
 							nested(input: {
@@ -3125,7 +3123,7 @@ func TestExecutionValidation(t *testing.T) {
 								requiredListOfRequiredStrings: []
 							})
 						}
-						`, Values(), Invalid, withValidationErrors(`Field "NestedInput.requiredListOfRequiredStrings" of required type "[String!]!" must not be empty.`))
+						`, Values(), Valid)
 			})
 			t.Run("complex 2x nested", func(t *testing.T) {
 				run(t, `

--- a/pkg/astvalidation/operation_validation_test.go
+++ b/pkg/astvalidation/operation_validation_test.go
@@ -2173,7 +2173,7 @@ func TestExecutionValidation(t *testing.T) {
 							fragment invalidArgName on Dog {
 								doesKnowCommand(command: CLEAN_UP_HOUSE)
 							}`,
-					KnownArguments(), Invalid)
+					KnownArguments(), Invalid, withValidationErrors(`Unknown argument "command" on field "Dog.doesKnowCommand"`))
 			})
 			t.Run("118 variant", func(t *testing.T) {
 				run(t, `	
@@ -2183,7 +2183,9 @@ func TestExecutionValidation(t *testing.T) {
 							fragment invalidArgName on Dog {
 								doesKnowCommand(dogCommand: CLEAN_UP_HOUSE)
 							}`,
-					ValidArguments(), Invalid)
+					Values(),
+					Invalid,
+					withValidationErrors(`Value "CLEAN_UP_HOUSE" does not exist in "DogCommand" enum.`))
 			})
 			t.Run("119", func(t *testing.T) {
 				run(t, ` 	{

--- a/pkg/astvalidation/reference/testsgo/KnownArgumentNamesRule_test.go
+++ b/pkg/astvalidation/reference/testsgo/KnownArgumentNamesRule_test.go
@@ -77,7 +77,7 @@ func TestKnownArgumentNamesRule(t *testing.T) {
           doesKnowCommand(dogCommand: SIT)
         }
         human {
-          pet {
+          pets { # we are using pets instead of pet: to not fail in visitor with unknown field name on a type
             ... on Dog {
               doesKnowCommand(dogCommand: SIT)
             }
@@ -136,6 +136,21 @@ func TestKnownArgumentNamesRule(t *testing.T) {
       }
     `)([]Err{
 				{
+					message:   `Unknown argument "iff" on directive "@skip".`,
+					locations: []Loc{{line: 3, column: 19}},
+				},
+			})
+		})
+
+		t.Run("misspelled directive args are reported with suggestions", func(t *testing.T) {
+			t.Skip(NotSupportedSuggestionsSkipMsg)
+
+			ExpectErrors(t, `
+      {
+        dog @skip(iff: true)
+      }
+    `)([]Err{
+				{
 					message:   `Unknown argument "iff" on directive "@skip". Did you mean "if"?`,
 					locations: []Loc{{line: 3, column: 19}},
 				},
@@ -156,6 +171,21 @@ func TestKnownArgumentNamesRule(t *testing.T) {
 		})
 
 		t.Run("misspelled arg name is reported", func(t *testing.T) {
+			ExpectErrors(t, `
+      fragment invalidArgName on Dog {
+        doesKnowCommand(DogCommand: true)
+      }
+    `)([]Err{
+				{
+					message:   `Unknown argument "DogCommand" on field "Dog.doesKnowCommand".`,
+					locations: []Loc{{line: 3, column: 25}},
+				},
+			})
+		})
+
+		t.Run("misspelled arg name is reported with suggestions", func(t *testing.T) {
+			t.Skip(NotSupportedSuggestionsSkipMsg)
+
 			ExpectErrors(t, `
       fragment invalidArgName on Dog {
         doesKnowCommand(DogCommand: true)
@@ -192,7 +222,7 @@ func TestKnownArgumentNamesRule(t *testing.T) {
           doesKnowCommand(unknown: true)
         }
         human {
-          pet {
+          pets { # we are using pets instead of pet: to not fail in visitor with unknown field name on a type
             ... on Dog {
               doesKnowCommand(unknown: true)
             }
@@ -212,6 +242,8 @@ func TestKnownArgumentNamesRule(t *testing.T) {
 		})
 
 		t.Run("within SDL", func(t *testing.T) {
+			t.Skip("Definition directive args validation is not supported yet")
+
 			t.Run("known arg on directive defined inside SDL", func(t *testing.T) {
 				ExpectValidSDL(t, `
         type Query {

--- a/pkg/astvalidation/reference/testsgo/KnownArgumentNamesRule_test.go
+++ b/pkg/astvalidation/reference/testsgo/KnownArgumentNamesRule_test.go
@@ -5,8 +5,6 @@ import (
 )
 
 func TestKnownArgumentNamesRule(t *testing.T) {
-	t.Skip()
-
 	ExpectErrors := func(t *testing.T, queryStr string) ResultCompare {
 		return ExpectValidationErrors(t, KnownArgumentNamesRule, queryStr)
 	}

--- a/pkg/astvalidation/reference/testsgo/UniqueInputFieldNamesRule_test.go
+++ b/pkg/astvalidation/reference/testsgo/UniqueInputFieldNamesRule_test.go
@@ -5,19 +5,24 @@ import (
 )
 
 func TestUniqueInputFieldNamesRule(t *testing.T) {
-	t.Skip()
-
-	ExpectErrors := func(t *testing.T, queryStr string) ResultCompare {
-		return ExpectValidationErrors(t, UniqueInputFieldNamesRule, queryStr)
+	ExpectErrors := func(t *testing.T, schema, queryStr string) ResultCompare {
+		return ExpectValidationErrorsWithSchema(t, schema, UniqueInputFieldNamesRule, queryStr)
 	}
 
-	ExpectValid := func(t *testing.T, queryStr string) {
-		ExpectErrors(t, queryStr)([]Err{})
+	ExpectValid := func(t *testing.T, schemaStr, queryStr string) {
+		ExpectErrors(t, schemaStr, queryStr)([]Err{})
 	}
 
 	t.Run("Validate: Unique input field names", func(t *testing.T) {
 		t.Run("input object with fields", func(t *testing.T) {
 			ExpectValid(t, `
+		input Input {
+			f: Boolean
+		}
+
+		type Query {
+			field(arg: Input): String
+        }`, `
       {
         field(arg: { f: true })
       }
@@ -26,6 +31,13 @@ func TestUniqueInputFieldNamesRule(t *testing.T) {
 
 		t.Run("same input object within two args", func(t *testing.T) {
 			ExpectValid(t, `
+		input Input {
+			f: Boolean
+		}
+
+		type Query {
+			field(arg1: Input, arg2: Input): String
+        }`, `
       {
         field(arg1: { f: true }, arg2: { f: true })
       }
@@ -34,6 +46,15 @@ func TestUniqueInputFieldNamesRule(t *testing.T) {
 
 		t.Run("multiple input object fields", func(t *testing.T) {
 			ExpectValid(t, `
+		input Input {
+			f1: String
+			f2: String
+			f3: String
+		}
+
+		type Query {
+			field(arg: Input): String
+        }`, `
       {
         field(arg: { f1: "value", f2: "value", f3: "value" })
       }
@@ -42,6 +63,23 @@ func TestUniqueInputFieldNamesRule(t *testing.T) {
 
 		t.Run("allows for nested input objects with similar fields", func(t *testing.T) {
 			ExpectValid(t, `
+		input Nested1 {
+			id: ID
+			deep: Nested2
+		}
+
+		input Nested2 {
+			id: ID
+		}
+
+		input Input {
+			id: ID
+			deep: Nested1
+		}
+
+		type Query {
+			field(arg: Input): String
+        }`, `
       {
         field(arg: {
           deep: {
@@ -58,6 +96,13 @@ func TestUniqueInputFieldNamesRule(t *testing.T) {
 
 		t.Run("duplicate input object fields", func(t *testing.T) {
 			ExpectErrors(t, `
+		input Input {
+			f1: String
+		}
+
+		type Query {
+			field(arg: Input): String
+        }`, `
       {
         field(arg: { f1: "value", f1: "value" })
       }
@@ -74,6 +119,13 @@ func TestUniqueInputFieldNamesRule(t *testing.T) {
 
 		t.Run("many duplicate input object fields", func(t *testing.T) {
 			ExpectErrors(t, `
+		input Input {
+			f1: String
+		}
+
+		type Query {
+			field(arg: Input): String
+        }`, `
       {
         field(arg: { f1: "value", f1: "value", f1: "value" })
       }
@@ -97,6 +149,17 @@ func TestUniqueInputFieldNamesRule(t *testing.T) {
 
 		t.Run("nested duplicate input object fields", func(t *testing.T) {
 			ExpectErrors(t, `
+		input Nested {
+			f2: String
+		}
+
+		input Input {
+			f1: Nested
+		}
+
+		type Query {
+			field(arg: Input): String
+        }`, `
       {
         field(arg: { f1: {f2: "value", f2: "value" }})
       }

--- a/pkg/astvalidation/reference/testsgo/ValuesOfCorrectTypeRule_test.go
+++ b/pkg/astvalidation/reference/testsgo/ValuesOfCorrectTypeRule_test.go
@@ -941,6 +941,26 @@ func TestValuesOfCorrectTypeRule(t *testing.T) {
         }
       `)([]Err{
 					{
+						message:   `Field "invalidField" is not defined by type "ComplexInput".`,
+						locations: []Loc{{line: 6, column: 15}},
+					},
+				})
+			})
+
+			t.Run("Partial object, unknown field arg with suggestions", func(t *testing.T) {
+				t.Skip(NotSupportedSuggestionsSkipMsg)
+
+				ExpectErrors(t, `
+        {
+          complicatedArgs {
+            complexArgField(complexArg: {
+              requiredField: true,
+              invalidField: "value"
+            })
+          }
+        }
+      `)([]Err{
+					{
 						message:   `Field "invalidField" is not defined by type "ComplexInput". Did you mean "intField"?`,
 						locations: []Loc{{line: 6, column: 15}},
 					},

--- a/pkg/astvalidation/reference/testsgo/ValuesOfCorrectTypeRule_test.go
+++ b/pkg/astvalidation/reference/testsgo/ValuesOfCorrectTypeRule_test.go
@@ -5,8 +5,6 @@ import (
 )
 
 func TestValuesOfCorrectTypeRule(t *testing.T) {
-	t.Skip()
-
 	ExpectErrors := func(t *testing.T, queryStr string) ResultCompare {
 		return ExpectValidationErrors(t, ValuesOfCorrectTypeRule, queryStr)
 	}

--- a/pkg/astvalidation/reference/testsgo/ValuesOfCorrectTypeRule_test.go
+++ b/pkg/astvalidation/reference/testsgo/ValuesOfCorrectTypeRule_test.go
@@ -489,6 +489,23 @@ func TestValuesOfCorrectTypeRule(t *testing.T) {
         }
       `)([]Err{
 					{
+						message:   `Enum "DogCommand" cannot represent non-enum value: "SIT".`,
+						locations: []Loc{{line: 4, column: 41}},
+					},
+				})
+			})
+
+			t.Run("String into Enum with suggestions", func(t *testing.T) {
+				t.Skip(NotSupportedSuggestionsSkipMsg)
+
+				ExpectErrors(t, `
+        {
+          dog {
+            doesKnowCommand(dogCommand: "SIT")
+          }
+        }
+      `)([]Err{
+					{
 						message:   `Enum "DogCommand" cannot represent non-enum value: "SIT". Did you mean the enum value "SIT"?`,
 						locations: []Loc{{line: 4, column: 41}},
 					},
@@ -526,6 +543,23 @@ func TestValuesOfCorrectTypeRule(t *testing.T) {
 			})
 
 			t.Run("Different case Enum Value into Enum", func(t *testing.T) {
+				ExpectErrors(t, `
+        {
+          dog {
+            doesKnowCommand(dogCommand: sit)
+          }
+        }
+      `)([]Err{
+					{
+						message:   `Value "sit" does not exist in "DogCommand" enum.`,
+						locations: []Loc{{line: 4, column: 41}},
+					},
+				})
+			})
+
+			t.Run("Different case Enum Value into Enum with suggestions", func(t *testing.T) {
+				t.Skip(NotSupportedSuggestionsSkipMsg)
+
 				ExpectErrors(t, `
         {
           dog {

--- a/pkg/astvalidation/reference/testsgo/ValuesOfCorrectTypeRule_test.go
+++ b/pkg/astvalidation/reference/testsgo/ValuesOfCorrectTypeRule_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestValuesOfCorrectTypeRule(t *testing.T) {
+
 	ExpectErrors := func(t *testing.T, queryStr string) ResultCompare {
 		return ExpectValidationErrors(t, ValuesOfCorrectTypeRule, queryStr)
 	}

--- a/pkg/astvalidation/reference/testsgo/VariablesAreInputTypesRule_test.go
+++ b/pkg/astvalidation/reference/testsgo/VariablesAreInputTypesRule_test.go
@@ -5,8 +5,6 @@ import (
 )
 
 func TestVariablesAreInputTypesRule(t *testing.T) {
-	t.Skip()
-
 	ExpectErrors := func(t *testing.T, queryStr string) ResultCompare {
 		return ExpectValidationErrors(t, VariablesAreInputTypesRule, queryStr)
 	}

--- a/pkg/astvalidation/reference/testsgo/VariablesAreInputTypesRule_test.go
+++ b/pkg/astvalidation/reference/testsgo/VariablesAreInputTypesRule_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestVariablesAreInputTypesRule(t *testing.T) {
+
 	ExpectErrors := func(t *testing.T, queryStr string) ResultCompare {
 		return ExpectValidationErrors(t, VariablesAreInputTypesRule, queryStr)
 	}

--- a/pkg/astvalidation/reference/testsgo/VariablesInAllowedPositionRule_test.go
+++ b/pkg/astvalidation/reference/testsgo/VariablesInAllowedPositionRule_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestVariablesInAllowedPositionRule(t *testing.T) {
+
 	ExpectErrors := func(t *testing.T, queryStr string) ResultCompare {
 		return ExpectValidationErrors(t, VariablesInAllowedPositionRule, queryStr)
 	}

--- a/pkg/astvalidation/reference/testsgo/VariablesInAllowedPositionRule_test.go
+++ b/pkg/astvalidation/reference/testsgo/VariablesInAllowedPositionRule_test.go
@@ -5,8 +5,6 @@ import (
 )
 
 func TestVariablesInAllowedPositionRule(t *testing.T) {
-	t.Skip()
-
 	ExpectErrors := func(t *testing.T, queryStr string) ResultCompare {
 		return ExpectValidationErrors(t, VariablesInAllowedPositionRule, queryStr)
 	}

--- a/pkg/astvalidation/reference/testsgo/VariablesInAllowedPositionRule_test.go
+++ b/pkg/astvalidation/reference/testsgo/VariablesInAllowedPositionRule_test.go
@@ -193,8 +193,6 @@ func TestVariablesInAllowedPositionRule(t *testing.T) {
 		})
 
 		t.Run("Int => Int! within nested fragment", func(t *testing.T) {
-			t.Skip("Panic: possibly unsupported case")
-
 			ExpectErrors(t, `
       fragment outerFrag on ComplicatedArgs {
         ...nonNullIntArgFieldFrag

--- a/pkg/astvalidation/reference/testsgo/VariablesInAllowedPositionRule_test.go
+++ b/pkg/astvalidation/reference/testsgo/VariablesInAllowedPositionRule_test.go
@@ -138,7 +138,7 @@ func TestVariablesInAllowedPositionRule(t *testing.T) {
       query Query($boolVar: Boolean = false)
       {
         complicatedArgs {
-          complexArgField(complexArg: {requiredArg: $boolVar})
+          complexArgField(complexArg: {requiredField: $boolVar}) # requiredArg is not exists in complex input
         }
       }
     `)

--- a/pkg/astvalidation/reference/testsgo/harness_test.go
+++ b/pkg/astvalidation/reference/testsgo/harness_test.go
@@ -60,6 +60,44 @@ const (
 	PossibleTypeExtensionsRule = "PossibleTypeExtensionsRule"
 )
 
+const (
+	ExecutableDefinitionsRule        = "ExecutableDefinitionsRule"
+	FieldsOnCorrectTypeRule          = "FieldsOnCorrectTypeRule"
+	KnownArgumentNamesRule           = "KnownArgumentNamesRule"
+	KnownDirectivesRule              = "KnownDirectivesRule"
+	KnownTypeNamesRule               = "KnownTypeNamesRule"
+	LoneAnonymousOperationRule       = "LoneAnonymousOperationRule"
+	NoUndefinedVariablesRule         = "NoUndefinedVariablesRule"
+	NoUnusedVariablesRule            = "NoUnusedVariablesRule"
+	OverlappingFieldsCanBeMergedRule = "OverlappingFieldsCanBeMergedRule"
+	ProvidedRequiredArgumentsRule    = "ProvidedRequiredArgumentsRule"
+	SingleFieldSubscriptionsRule     = "SingleFieldSubscriptionsRule"
+	UniqueArgumentNamesRule          = "UniqueArgumentNamesRule"
+	UniqueDirectivesPerLocationRule  = "UniqueDirectivesPerLocationRule"
+	UniqueEnumValueNamesRule         = "UniqueEnumValueNamesRule"
+	UniqueFieldDefinitionNamesRule   = "UniqueFieldDefinitionNamesRule"
+	UniqueOperationNamesRule         = "UniqueOperationNamesRule"
+	UniqueOperationTypesRule         = "UniqueOperationTypesRule"
+	UniqueTypeNamesRule              = "UniqueTypeNamesRule"
+	UniqueVariableNamesRule          = "UniqueVariableNamesRule"
+	ValuesOfCorrectTypeRule          = "ValuesOfCorrectTypeRule"
+	VariablesAreInputTypesRule       = "VariablesAreInputTypesRule"
+	VariablesInAllowedPositionRule   = "VariablesInAllowedPositionRule"
+
+	FragmentsOnCompositeTypesRule = "FragmentsOnCompositeTypesRule"
+	KnownFragmentNamesRule        = "KnownFragmentNamesRule"
+	NoFragmentCyclesRule          = "NoFragmentCyclesRule"
+	NoUnusedFragmentsRule         = "NoUnusedFragmentsRule"
+	PossibleFragmentSpreadsRule   = "PossibleFragmentSpreadsRule"
+	UniqueFragmentNamesRule       = "UniqueFragmentNamesRule"
+
+	UniqueInputFieldNamesRule  = "UniqueInputFieldNamesRule"
+	UniqueDirectiveNamesRule   = "UniqueDirectiveNamesRule"
+	LoneSchemaDefinitionRule   = "LoneSchemaDefinitionRule"
+	ScalarLeafsRule            = "ScalarLeafsRule"
+	PossibleTypeExtensionsRule = "PossibleTypeExtensionsRule"
+)
+
 var rulesMap = map[string][]astvalidation.Rule{
 	ExecutableDefinitionsRule:                 {astvalidation.DocumentContainsExecutableOperation()},
 	FieldsOnCorrectTypeRule:                   {astvalidation.FieldSelections()},

--- a/pkg/astvalidation/reference/testsgo/harness_test.go
+++ b/pkg/astvalidation/reference/testsgo/harness_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	// NotSupportedSuggestionsSkipMsg = "Suggestions is not supported"
+	NotSupportedSuggestionsSkipMsg = "Suggestions is not supported"
 
 	RuleHasNoMapping = `Validation rule: "%s" has no mapped rule`
 )

--- a/pkg/astvalidation/reference/testsgo/harness_test.go
+++ b/pkg/astvalidation/reference/testsgo/harness_test.go
@@ -27,6 +27,7 @@ const (
 	KnownArgumentNamesOnDirectivesRule        = "KnownArgumentNamesOnDirectivesRule"
 	KnownDirectivesRule                       = "KnownDirectivesRule"
 	KnownTypeNamesRule                        = "KnownTypeNamesRule"
+	KnownTypeNamesOperationRule               = "KnownTypeNamesOperationRule"
 	LoneAnonymousOperationRule                = "LoneAnonymousOperationRule"
 	NoUndefinedVariablesRule                  = "NoUndefinedVariablesRule"
 	NoUnusedVariablesRule                     = "NoUnusedVariablesRule"
@@ -122,6 +123,7 @@ var rulesMap = map[string][]astvalidation.Rule{
 	UniqueVariableNamesRule:                   {astvalidation.VariableUniqueness()},
 	ValuesOfCorrectTypeRule:                   {astvalidation.Values()},
 	VariablesAreInputTypesRule:                {astvalidation.VariablesAreInputTypes()},
+	KnownTypeNamesOperationRule:               {astvalidation.VariablesAreInputTypes(), astvalidation.Fragments()},
 	VariablesInAllowedPositionRule:            {astvalidation.ValidArguments()},
 
 	// fragments rules

--- a/pkg/astvalidation/reference/testsgo/harness_test.go
+++ b/pkg/astvalidation/reference/testsgo/harness_test.go
@@ -86,7 +86,7 @@ var rulesMap = map[string][]astvalidation.Rule{
 	ValuesOfCorrectTypeRule:                   {astvalidation.Values()},
 	VariablesAreInputTypesRule:                {astvalidation.VariablesAreInputTypes()},
 	KnownTypeNamesOperationRule:               {astvalidation.VariablesAreInputTypes(), astvalidation.Fragments()},
-	VariablesInAllowedPositionRule:            {astvalidation.ValidArguments()},
+	VariablesInAllowedPositionRule:            {astvalidation.ValidArguments(), astvalidation.Values()},
 
 	// fragments rules
 	FragmentsOnCompositeTypesRule: {astvalidation.Fragments()},

--- a/pkg/astvalidation/reference/testsgo/harness_test.go
+++ b/pkg/astvalidation/reference/testsgo/harness_test.go
@@ -64,7 +64,7 @@ const (
 var rulesMap = map[string][]astvalidation.Rule{
 	ExecutableDefinitionsRule:                 {astvalidation.DocumentContainsExecutableOperation()},
 	FieldsOnCorrectTypeRule:                   {astvalidation.FieldSelections()},
-	KnownArgumentNamesRule:                    {}, // {astvalidation.KnownArguments()},
+	KnownArgumentNamesRule:                    {astvalidation.KnownArguments()},
 	KnownArgumentNamesOnDirectivesRule:        {},
 	KnownDirectivesRule:                       {astvalidation.DirectivesAreDefined()},
 	KnownTypeNamesRule:                        {astvalidation.KnownTypeNames()},

--- a/pkg/astvalidation/reference/testsgo/harness_test.go
+++ b/pkg/astvalidation/reference/testsgo/harness_test.go
@@ -61,44 +61,6 @@ const (
 	PossibleTypeExtensionsRule = "PossibleTypeExtensionsRule"
 )
 
-const (
-	ExecutableDefinitionsRule        = "ExecutableDefinitionsRule"
-	FieldsOnCorrectTypeRule          = "FieldsOnCorrectTypeRule"
-	KnownArgumentNamesRule           = "KnownArgumentNamesRule"
-	KnownDirectivesRule              = "KnownDirectivesRule"
-	KnownTypeNamesRule               = "KnownTypeNamesRule"
-	LoneAnonymousOperationRule       = "LoneAnonymousOperationRule"
-	NoUndefinedVariablesRule         = "NoUndefinedVariablesRule"
-	NoUnusedVariablesRule            = "NoUnusedVariablesRule"
-	OverlappingFieldsCanBeMergedRule = "OverlappingFieldsCanBeMergedRule"
-	ProvidedRequiredArgumentsRule    = "ProvidedRequiredArgumentsRule"
-	SingleFieldSubscriptionsRule     = "SingleFieldSubscriptionsRule"
-	UniqueArgumentNamesRule          = "UniqueArgumentNamesRule"
-	UniqueDirectivesPerLocationRule  = "UniqueDirectivesPerLocationRule"
-	UniqueEnumValueNamesRule         = "UniqueEnumValueNamesRule"
-	UniqueFieldDefinitionNamesRule   = "UniqueFieldDefinitionNamesRule"
-	UniqueOperationNamesRule         = "UniqueOperationNamesRule"
-	UniqueOperationTypesRule         = "UniqueOperationTypesRule"
-	UniqueTypeNamesRule              = "UniqueTypeNamesRule"
-	UniqueVariableNamesRule          = "UniqueVariableNamesRule"
-	ValuesOfCorrectTypeRule          = "ValuesOfCorrectTypeRule"
-	VariablesAreInputTypesRule       = "VariablesAreInputTypesRule"
-	VariablesInAllowedPositionRule   = "VariablesInAllowedPositionRule"
-
-	FragmentsOnCompositeTypesRule = "FragmentsOnCompositeTypesRule"
-	KnownFragmentNamesRule        = "KnownFragmentNamesRule"
-	NoFragmentCyclesRule          = "NoFragmentCyclesRule"
-	NoUnusedFragmentsRule         = "NoUnusedFragmentsRule"
-	PossibleFragmentSpreadsRule   = "PossibleFragmentSpreadsRule"
-	UniqueFragmentNamesRule       = "UniqueFragmentNamesRule"
-
-	UniqueInputFieldNamesRule  = "UniqueInputFieldNamesRule"
-	UniqueDirectiveNamesRule   = "UniqueDirectiveNamesRule"
-	LoneSchemaDefinitionRule   = "LoneSchemaDefinitionRule"
-	ScalarLeafsRule            = "ScalarLeafsRule"
-	PossibleTypeExtensionsRule = "PossibleTypeExtensionsRule"
-)
-
 var rulesMap = map[string][]astvalidation.Rule{
 	ExecutableDefinitionsRule:                 {astvalidation.DocumentContainsExecutableOperation()},
 	FieldsOnCorrectTypeRule:                   {astvalidation.FieldSelections()},

--- a/pkg/astvalidation/reference/testsgo/test_schema.graphql
+++ b/pkg/astvalidation/reference/testsgo/test_schema.graphql
@@ -114,6 +114,7 @@ type QueryRoot {
     dogOrHuman: DogOrHuman
     humanOrAlien: HumanOrAlien
     complicatedArgs: ComplicatedArgs
+    field(strArg: String, boolListArg: [Boolean!]!, inputArg: ComplexInput): String # need to be here to not have an error of not existing field in visitor
 }
 
 schema {

--- a/pkg/astvalidation/reference/testsgo/test_schema.graphql
+++ b/pkg/astvalidation/reference/testsgo/test_schema.graphql
@@ -114,7 +114,7 @@ type QueryRoot {
     dogOrHuman: DogOrHuman
     humanOrAlien: HumanOrAlien
     complicatedArgs: ComplicatedArgs
-    field(strArg: String, boolListArg: [Boolean!]!, inputArg: ComplexInput): String # need to be here to not have an error of not existing field in visitor
+    field(strArg: String, boolListArg: [Boolean!]!, inputArg: ComplexInput): String # need to be here to not have an error of not existing field in visitor in TestVariablesAreInputTypesRule
 }
 
 schema {

--- a/pkg/astvisitor/visitor.go
+++ b/pkg/astvisitor/visitor.go
@@ -3614,6 +3614,13 @@ func (w *Walker) FieldDefinition(field int) (definition int, exists bool) {
 	return w.definition.NodeFieldDefinitionByName(w.EnclosingTypeDefinition, fieldName)
 }
 
+func (w *Walker) Ancestor() ast.Node {
+	if len(w.Ancestors) == 0 {
+		return ast.InvalidNode
+	}
+	return w.Ancestors[len(w.Ancestors)-1]
+}
+
 func (w *Walker) AncestorNameBytes() ast.ByteSlice {
 	if len(w.Ancestors) == 0 {
 		return nil

--- a/pkg/execution/planning.go
+++ b/pkg/execution/planning.go
@@ -138,7 +138,15 @@ func (p *planningVisitor) EnterField(ref int) {
 
 	definition, exists := p.FieldDefinition(ref)
 	if !exists {
-		return
+		if fieldName != "__typename" {
+			return
+		}
+
+		// UGLY FIX
+		// Document.NodeFieldDefinitionByName was returning 0 as a definition index when it was not exists
+		// old implementation of Walker.FieldDefinition method was calculating exists = index != -1 which was always true
+		// this old wrong behaviour was allowing to plan __typename field resolving
+		definition = 0
 	}
 
 	typeName := p.definition.NodeResolverTypeNameString(p.EnclosingTypeDefinition, p.Path)

--- a/pkg/execution/planning.go
+++ b/pkg/execution/planning.go
@@ -138,15 +138,7 @@ func (p *planningVisitor) EnterField(ref int) {
 
 	definition, exists := p.FieldDefinition(ref)
 	if !exists {
-		if fieldName != "__typename" {
-			return
-		}
-
-		// UGLY FIX
-		// Document.NodeFieldDefinitionByName was returning 0 as a definition index when it was not exists
-		// old implementation of Walker.FieldDefinition method was calculating exists = index != -1 which was always true
-		// this old wrong behaviour was allowing to plan __typename field resolving
-		definition = 0
+		return
 	}
 
 	typeName := p.definition.NodeResolverTypeNameString(p.EnclosingTypeDefinition, p.Path)

--- a/pkg/operationreport/externalerror.go
+++ b/pkg/operationreport/externalerror.go
@@ -11,18 +11,19 @@ import (
 )
 
 const (
-	NotCompatibleTypeErrMsg          = "%s cannot represent value: %s"
-	NotStringErrMsg                  = "%s cannot represent a non string value: %s"
-	NotIntegerErrMsg                 = "%s cannot represent non-integer value: %s"
-	NotFloatErrMsg                   = "%s cannot represent non numeric value: %s"
-	NotBoolErrMsg                    = "%s cannot represent a non boolean value: %s"
-	NotIDErrMsg                      = "%s cannot represent a non-string and non-integer value: %s"
-	NotEnumErrMsg                    = `Enum "%s" cannot represent non-enum value: %s.`
-	NotAnEnumMemberErrMsg            = `Value "%s" does not exist in "%s" enum.`
-	NullValueErrMsg                  = `Expected value of type "%s", found null.`
-	UnknownArgumentOnDirectiveErrMsg = `Unknown argument "%s" on directive "@%s".`
-	UnknownArgumentOnFieldErrMsg     = `Unknown argument "%s" on field "%s.%s".`
-	VariableIsNotInputTypeErrMsg     = `Variable "$%s" cannot be non-input type "%s".`
+	NotCompatibleTypeErrMsg           = "%s cannot represent value: %s"
+	NotStringErrMsg                   = "%s cannot represent a non string value: %s"
+	NotIntegerErrMsg                  = "%s cannot represent non-integer value: %s"
+	NotFloatErrMsg                    = "%s cannot represent non numeric value: %s"
+	NotBoolErrMsg                     = "%s cannot represent a non boolean value: %s"
+	NotIDErrMsg                       = "%s cannot represent a non-string and non-integer value: %s"
+	NotEnumErrMsg                     = `Enum "%s" cannot represent non-enum value: %s.`
+	NotAnEnumMemberErrMsg             = `Value "%s" does not exist in "%s" enum.`
+	NullValueErrMsg                   = `Expected value of type "%s", found null.`
+	UnknownArgumentOnDirectiveErrMsg  = `Unknown argument "%s" on directive "@%s".`
+	UnknownArgumentOnFieldErrMsg      = `Unknown argument "%s" on field "%s.%s".`
+	VariableIsNotInputTypeErrMsg      = `Variable "$%s" cannot be non-input type "%s".`
+	MissingRequiredFieldOfInputObject = `Field "%s.%s" of required type "%s" was not provided.`
 )
 
 type ExternalError struct {
@@ -144,6 +145,17 @@ func ErrMissingFieldSelectionOnNonScalar(fieldName, enclosingTypeName ast.ByteSl
 
 func ErrArgumentNotDefinedOnDirective(argName, directiveName ast.ByteSlice, position position.Position) (err ExternalError) {
 	err.Message = fmt.Sprintf(UnknownArgumentOnDirectiveErrMsg, argName, directiveName)
+	err.Locations = []graphqlerrors.Location{
+		{
+			Line:   position.LineStart,
+			Column: position.CharStart,
+		},
+	}
+	return err
+}
+
+func ErrMissingRequiredFieldOfInputObject(objName, fieldName, typeName ast.ByteSlice, position position.Position) (err ExternalError) {
+	err.Message = fmt.Sprintf(MissingRequiredFieldOfInputObject, objName, fieldName, typeName)
 	err.Locations = []graphqlerrors.Location{
 		{
 			Line:   position.LineStart,

--- a/pkg/operationreport/externalerror.go
+++ b/pkg/operationreport/externalerror.go
@@ -132,32 +132,40 @@ func ErrArgumentNotDefinedOnNode(argName, node ast.ByteSlice) (err ExternalError
 	return err
 }
 
+const (
+	NotCompatibleTypeErrMsg = "%s cannot represent value: %s"
+	NotStringErrMsg         = "%s cannot represent a non string value: %s"
+	NotIntegerErrMsg        = "%s cannot represent non-integer value: %s"
+	NotFloatErrMsg          = "%s cannot represent non numeric value: %s"
+	NotBoolErrMsg           = "%s cannot represent a non boolean value: %s"
+	NotIDErrMsg             = "%s cannot represent a non-string and non-integer value: %s"
+	NotEnumErrMsg           = `Enum "%s" cannot represent non-enum value: %s.`
+	NotAnEnumMemberErrMsg   = `Value "JUGGLE" does not exist in "%s" enum.`
+
+	WrongEnumValueCase = `\"sit\" does not exist in \"DogCommand\" enum. Did you mean the enum value \"SIT\"?`
+)
+
 func ErrValueDoesntSatisfyInputValueDefinition(value, inputType ast.ByteSlice, position position.Position) (err ExternalError) {
 	var msg string
 
-	// TODO: temporary ugly solution
-
-	if bytes.Equal(inputType, literal.STRING) {
-		msg = "a non string"
-	}
-	if bytes.Equal(inputType, literal.INT) {
-		msg = "non-integer"
-	}
-	if bytes.Equal(inputType, literal.FLOAT) {
-		msg = "non numeric"
-	}
-	if bytes.Equal(inputType, literal.BOOLEAN) {
-		msg = "a non boolean"
-	}
-	if bytes.Equal(inputType, literal.BOOLEAN) {
-		msg = "a non boolean"
-	}
-
-	if bytes.Equal(inputType, literal.ID) {
-		msg = "a non-string and non-integer"
+	switch {
+	case bytes.Equal(literal.STRING, inputType):
+		msg = fmt.Sprintf(NotStringErrMsg, inputType, value)
+	case bytes.Equal(literal.INT, inputType):
+		msg = fmt.Sprintf(NotIntegerErrMsg, inputType, value)
+	case bytes.Equal(literal.FLOAT, inputType):
+		msg = fmt.Sprintf(NotFloatErrMsg, inputType, value)
+	case bytes.Equal(literal.BOOLEAN, inputType):
+		msg = fmt.Sprintf(NotBoolErrMsg, inputType, value)
+	case bytes.Equal(literal.ID, inputType):
+		msg = fmt.Sprintf(NotIDErrMsg, inputType, value)
+	case bytes.Equal(literal.ENUM, inputType):
+		msg = fmt.Sprintf(NotEnumErrMsg, inputType, value)
+	default:
+		msg = fmt.Sprintf(NotCompatibleTypeErrMsg, inputType, value)
 	}
 
-	err.Message = fmt.Sprintf("%s cannot represent %s value: %s", inputType, msg, value)
+	err.Message = msg
 	err.Locations = []graphqlerrors.Location{
 		{
 			Line:   position.LineStart,

--- a/pkg/operationreport/externalerror.go
+++ b/pkg/operationreport/externalerror.go
@@ -23,10 +23,12 @@ const (
 	NullValueErrMsg                         = `Expected value of type "%s", found null.`
 	UnknownArgumentOnDirectiveErrMsg        = `Unknown argument "%s" on directive "@%s".`
 	UnknownArgumentOnFieldErrMsg            = `Unknown argument "%s" on field "%s.%s".`
+	UnknownTypeErrMsg                       = `Unknown type "%s".`
 	VariableIsNotInputTypeErrMsg            = `Variable "$%s" cannot be non-input type "%s".`
 	MissingRequiredFieldOfInputObjectErrMsg = `Field "%s.%s" of required type "%s" was not provided.`
 	UnknownFieldOfInputObjectErrMsg         = `Field "%s" is not defined by type "%s".`
 	DuplicatedFieldInputObjectErrMsg        = `There can be only one input field named "%s".`
+	ValueIsNotAnInputObjectType             = `Expected value of type "%s", found %s.`
 )
 
 type ExternalError struct {
@@ -162,6 +164,13 @@ func ErrArgumentNotDefinedOnDirective(argName, directiveName ast.ByteSlice, posi
 	return err
 }
 
+func ErrUnknownType(typeName ast.ByteSlice, position position.Position) (err ExternalError) {
+	err.Message = fmt.Sprintf(UnknownTypeErrMsg, typeName)
+	err.Locations = LocationsFromPosition(position)
+
+	return err
+}
+
 func ErrMissingRequiredFieldOfInputObject(objName, fieldName, typeName ast.ByteSlice, position position.Position) (err ExternalError) {
 	err.Message = fmt.Sprintf(MissingRequiredFieldOfInputObjectErrMsg, objName, fieldName, typeName)
 	err.Locations = LocationsFromPosition(position)
@@ -223,6 +232,13 @@ func ErrValueDoesntExistsInEnum(value, inputType ast.ByteSlice, position positio
 
 func ErrValueDoesntSatisfyType(value, inputType ast.ByteSlice, position position.Position) (err ExternalError) {
 	err.Message = fmt.Sprintf(NotCompatibleTypeErrMsg, inputType, value)
+	err.Locations = LocationsFromPosition(position)
+
+	return err
+}
+
+func ErrValueIsNotAnInputObjectType(value, inputType ast.ByteSlice, position position.Position) (err ExternalError) {
+	err.Message = fmt.Sprintf(ValueIsNotAnInputObjectType, inputType, value)
 	err.Locations = LocationsFromPosition(position)
 
 	return err

--- a/pkg/operationreport/externalerror.go
+++ b/pkg/operationreport/externalerror.go
@@ -14,8 +14,9 @@ const (
 	NotCompatibleTypeErrMsg           = "%s cannot represent value: %s"
 	NotStringErrMsg                   = "%s cannot represent a non string value: %s"
 	NotIntegerErrMsg                  = "%s cannot represent non-integer value: %s"
+	BigIntegerErrMsg                  = "%s cannot represent non 32-bit signed integer value: %s"
 	NotFloatErrMsg                    = "%s cannot represent non numeric value: %s"
-	NotBoolErrMsg                     = "%s cannot represent a non boolean value: %s"
+	NotBooleanErrMsg                  = "%s cannot represent a non boolean value: %s"
 	NotIDErrMsg                       = "%s cannot represent a non-string and non-integer value: %s"
 	NotEnumErrMsg                     = `Enum "%s" cannot represent non-enum value: %s.`
 	NotAnEnumMemberErrMsg             = `Value "%s" does not exist in "%s" enum.`
@@ -215,6 +216,13 @@ func ErrValueDoesntSatisfyInt(value, inputType ast.ByteSlice, position position.
 	return err
 }
 
+func ErrBigIntValueDoesntSatisfyInt(value, inputType ast.ByteSlice, position position.Position) (err ExternalError) {
+	err.Message = fmt.Sprintf(BigIntegerErrMsg, inputType, value)
+	err.Locations = LocationsFromPosition(position)
+
+	return err
+}
+
 func ErrValueDoesntSatisfyFloat(value, inputType ast.ByteSlice, position position.Position) (err ExternalError) {
 	err.Message = fmt.Sprintf(NotFloatErrMsg, inputType, value)
 	err.Locations = LocationsFromPosition(position)
@@ -222,8 +230,8 @@ func ErrValueDoesntSatisfyFloat(value, inputType ast.ByteSlice, position positio
 	return err
 }
 
-func ErrValueDoesntSatisfyBool(value, inputType ast.ByteSlice, position position.Position) (err ExternalError) {
-	err.Message = fmt.Sprintf(NotBoolErrMsg, inputType, value)
+func ErrValueDoesntSatisfyBoolean(value, inputType ast.ByteSlice, position position.Position) (err ExternalError) {
+	err.Message = fmt.Sprintf(NotBooleanErrMsg, inputType, value)
 	err.Locations = LocationsFromPosition(position)
 
 	return err
@@ -245,7 +253,7 @@ func ErrValueDoesntSatisfyInputValueDefinition(value, inputType ast.ByteSlice, p
 	case bytes.Equal(literal.FLOAT, inputType):
 		return ErrValueDoesntSatisfyFloat(value, inputType, position)
 	case bytes.Equal(literal.BOOLEAN, inputType):
-		return ErrValueDoesntSatisfyBool(value, inputType, position)
+		return ErrValueDoesntSatisfyBoolean(value, inputType, position)
 	case bytes.Equal(literal.ID, inputType):
 		return ErrValueDoesntSatisfyID(value, inputType, position)
 	default:

--- a/pkg/operationreport/externalerror.go
+++ b/pkg/operationreport/externalerror.go
@@ -143,7 +143,21 @@ const (
 	NotAnEnumMemberErrMsg   = `Value "JUGGLE" does not exist in "%s" enum.`
 
 	WrongEnumValueCase = `\"sit\" does not exist in \"DogCommand\" enum. Did you mean the enum value \"SIT\"?`
+
+	NullValueErrMsg = `Expected value of type "%s", found null.`
 )
+
+func ErrNullValueDoesntSatisfyInputValueDefinition(inputType ast.ByteSlice, position position.Position) (err ExternalError) {
+	err.Message = fmt.Sprintf(NullValueErrMsg, inputType)
+	err.Locations = []graphqlerrors.Location{
+		{
+			Line:   position.LineStart,
+			Column: position.CharStart,
+		},
+	}
+
+	return err
+}
 
 func ErrValueDoesntSatisfyInputValueDefinition(value, inputType ast.ByteSlice, position position.Position) (err ExternalError) {
 	var msg string

--- a/pkg/operationreport/externalerror.go
+++ b/pkg/operationreport/externalerror.go
@@ -26,6 +26,7 @@ const (
 	VariableIsNotInputTypeErrMsg            = `Variable "$%s" cannot be non-input type "%s".`
 	MissingRequiredFieldOfInputObjectErrMsg = `Field "%s.%s" of required type "%s" was not provided.`
 	UnknownFieldOfInputObjectErrMsg         = `Field "%s" is not defined by type "%s".`
+	DuplicatedFieldInputObjectErrMsg        = `There can be only one input field named "%s".`
 )
 
 type ExternalError struct {
@@ -171,6 +172,23 @@ func ErrMissingRequiredFieldOfInputObject(objName, fieldName, typeName ast.ByteS
 func ErrUnknownFieldOfInputObject(objName, fieldName ast.ByteSlice, position position.Position) (err ExternalError) {
 	err.Message = fmt.Sprintf(UnknownFieldOfInputObjectErrMsg, objName, fieldName)
 	err.Locations = LocationsFromPosition(position)
+
+	return err
+}
+
+func ErrDuplicatedFieldInputObject(fieldName ast.ByteSlice, first, duplicated position.Position) (err ExternalError) {
+	err.Message = fmt.Sprintf(DuplicatedFieldInputObjectErrMsg, fieldName)
+
+	err.Locations = []graphqlerrors.Location{
+		{
+			Line:   first.LineStart,
+			Column: first.CharStart,
+		},
+		{
+			Line:   duplicated.LineStart,
+			Column: duplicated.CharStart,
+		},
+	}
 
 	return err
 }

--- a/pkg/operationreport/externalerror.go
+++ b/pkg/operationreport/externalerror.go
@@ -127,22 +127,40 @@ func ErrMissingFieldSelectionOnNonScalar(fieldName, enclosingTypeName ast.ByteSl
 	return err
 }
 
-func ErrArgumentNotDefinedOnNode(argName, node ast.ByteSlice) (err ExternalError) {
-	err.Message = fmt.Sprintf("argument: %s not defined on node: %s", argName, node)
+func ErrArgumentNotDefinedOnDirective(argName, directiveName ast.ByteSlice, position position.Position) (err ExternalError) {
+	err.Message = fmt.Sprintf(UnknownArgumentOnDirective, argName, directiveName)
+	err.Locations = []graphqlerrors.Location{
+		{
+			Line:   position.LineStart,
+			Column: position.CharStart,
+		},
+	}
+	return err
+}
+
+func ErrArgumentNotDefinedOnField(argName, typeName, fieldName ast.ByteSlice, position position.Position) (err ExternalError) {
+	err.Message = fmt.Sprintf(UnknownArgumentOnField, argName, typeName, fieldName)
+	err.Locations = []graphqlerrors.Location{
+		{
+			Line:   position.LineStart,
+			Column: position.CharStart,
+		},
+	}
 	return err
 }
 
 const (
-	NotCompatibleTypeErrMsg = "%s cannot represent value: %s"
-	NotStringErrMsg         = "%s cannot represent a non string value: %s"
-	NotIntegerErrMsg        = "%s cannot represent non-integer value: %s"
-	NotFloatErrMsg          = "%s cannot represent non numeric value: %s"
-	NotBoolErrMsg           = "%s cannot represent a non boolean value: %s"
-	NotIDErrMsg             = "%s cannot represent a non-string and non-integer value: %s"
-	NotEnumErrMsg           = `Enum "%s" cannot represent non-enum value: %s.`
-	NotAnEnumMemberErrMsg   = `Value "%s" does not exist in "%s" enum.`
-
-	NullValueErrMsg = `Expected value of type "%s", found null.`
+	NotCompatibleTypeErrMsg    = "%s cannot represent value: %s"
+	NotStringErrMsg            = "%s cannot represent a non string value: %s"
+	NotIntegerErrMsg           = "%s cannot represent non-integer value: %s"
+	NotFloatErrMsg             = "%s cannot represent non numeric value: %s"
+	NotBoolErrMsg              = "%s cannot represent a non boolean value: %s"
+	NotIDErrMsg                = "%s cannot represent a non-string and non-integer value: %s"
+	NotEnumErrMsg              = `Enum "%s" cannot represent non-enum value: %s.`
+	NotAnEnumMemberErrMsg      = `Value "%s" does not exist in "%s" enum.`
+	NullValueErrMsg            = `Expected value of type "%s", found null.`
+	UnknownArgumentOnDirective = `Unknown argument "%s" on directive "@%s".`
+	UnknownArgumentOnField     = `Unknown argument "%s" on field "%s.%s".`
 )
 
 func ErrNullValueDoesntSatisfyInputValueDefinition(inputType ast.ByteSlice, position position.Position) (err ExternalError) {

--- a/pkg/operationreport/externalerror.go
+++ b/pkg/operationreport/externalerror.go
@@ -32,6 +32,15 @@ type ExternalError struct {
 	Locations []graphqlerrors.Location `json:"locations"`
 }
 
+func LocationsFromPosition(position position.Position) []graphqlerrors.Location {
+	return []graphqlerrors.Location{
+		{
+			Line:   position.LineStart,
+			Column: position.CharStart,
+		},
+	}
+}
+
 func ErrDocumentDoesntContainExecutableOperation() (err ExternalError) {
 	err.Message = "document doesn't contain any executable operation"
 	return
@@ -145,100 +154,103 @@ func ErrMissingFieldSelectionOnNonScalar(fieldName, enclosingTypeName ast.ByteSl
 
 func ErrArgumentNotDefinedOnDirective(argName, directiveName ast.ByteSlice, position position.Position) (err ExternalError) {
 	err.Message = fmt.Sprintf(UnknownArgumentOnDirectiveErrMsg, argName, directiveName)
-	err.Locations = []graphqlerrors.Location{
-		{
-			Line:   position.LineStart,
-			Column: position.CharStart,
-		},
-	}
+	err.Locations = LocationsFromPosition(position)
+
 	return err
 }
 
 func ErrMissingRequiredFieldOfInputObject(objName, fieldName, typeName ast.ByteSlice, position position.Position) (err ExternalError) {
 	err.Message = fmt.Sprintf(MissingRequiredFieldOfInputObject, objName, fieldName, typeName)
-	err.Locations = []graphqlerrors.Location{
-		{
-			Line:   position.LineStart,
-			Column: position.CharStart,
-		},
-	}
+	err.Locations = LocationsFromPosition(position)
+
 	return err
 }
 
 func ErrArgumentNotDefinedOnField(argName, typeName, fieldName ast.ByteSlice, position position.Position) (err ExternalError) {
 	err.Message = fmt.Sprintf(UnknownArgumentOnFieldErrMsg, argName, typeName, fieldName)
-	err.Locations = []graphqlerrors.Location{
-		{
-			Line:   position.LineStart,
-			Column: position.CharStart,
-		},
-	}
+	err.Locations = LocationsFromPosition(position)
+
 	return err
 }
 
 func ErrNullValueDoesntSatisfyInputValueDefinition(inputType ast.ByteSlice, position position.Position) (err ExternalError) {
 	err.Message = fmt.Sprintf(NullValueErrMsg, inputType)
-	err.Locations = []graphqlerrors.Location{
-		{
-			Line:   position.LineStart,
-			Column: position.CharStart,
-		},
-	}
+	err.Locations = LocationsFromPosition(position)
 
 	return err
 }
 
 func ErrValueDoesntSatisfyEnum(value, inputType ast.ByteSlice, position position.Position) (err ExternalError) {
 	err.Message = fmt.Sprintf(NotEnumErrMsg, inputType, value)
-	err.Locations = []graphqlerrors.Location{
-		{
-			Line:   position.LineStart,
-			Column: position.CharStart,
-		},
-	}
+	err.Locations = LocationsFromPosition(position)
 
 	return err
 }
 
 func ErrValueDoesntExistsInEnum(value, inputType ast.ByteSlice, position position.Position) (err ExternalError) {
 	err.Message = fmt.Sprintf(NotAnEnumMemberErrMsg, value, inputType)
-	err.Locations = []graphqlerrors.Location{
-		{
-			Line:   position.LineStart,
-			Column: position.CharStart,
-		},
-	}
+	err.Locations = LocationsFromPosition(position)
+
+	return err
+}
+
+func ErrValueDoesntSatisfyType(value, inputType ast.ByteSlice, position position.Position) (err ExternalError) {
+	err.Message = fmt.Sprintf(NotCompatibleTypeErrMsg, inputType, value)
+	err.Locations = LocationsFromPosition(position)
+
+	return err
+}
+
+func ErrValueDoesntSatisfyString(value, inputType ast.ByteSlice, position position.Position) (err ExternalError) {
+	err.Message = fmt.Sprintf(NotStringErrMsg, inputType, value)
+	err.Locations = LocationsFromPosition(position)
+
+	return err
+}
+
+func ErrValueDoesntSatisfyInt(value, inputType ast.ByteSlice, position position.Position) (err ExternalError) {
+	err.Message = fmt.Sprintf(NotIntegerErrMsg, inputType, value)
+	err.Locations = LocationsFromPosition(position)
+
+	return err
+}
+
+func ErrValueDoesntSatisfyFloat(value, inputType ast.ByteSlice, position position.Position) (err ExternalError) {
+	err.Message = fmt.Sprintf(NotFloatErrMsg, inputType, value)
+	err.Locations = LocationsFromPosition(position)
+
+	return err
+}
+
+func ErrValueDoesntSatisfyBool(value, inputType ast.ByteSlice, position position.Position) (err ExternalError) {
+	err.Message = fmt.Sprintf(NotBoolErrMsg, inputType, value)
+	err.Locations = LocationsFromPosition(position)
+
+	return err
+}
+
+func ErrValueDoesntSatisfyID(value, inputType ast.ByteSlice, position position.Position) (err ExternalError) {
+	err.Message = fmt.Sprintf(NotIDErrMsg, inputType, value)
+	err.Locations = LocationsFromPosition(position)
 
 	return err
 }
 
 func ErrValueDoesntSatisfyInputValueDefinition(value, inputType ast.ByteSlice, position position.Position) (err ExternalError) {
-	var msg string
-
 	switch {
 	case bytes.Equal(literal.STRING, inputType):
-		msg = fmt.Sprintf(NotStringErrMsg, inputType, value)
+		return ErrValueDoesntSatisfyString(value, inputType, position)
 	case bytes.Equal(literal.INT, inputType):
-		msg = fmt.Sprintf(NotIntegerErrMsg, inputType, value)
+		return ErrValueDoesntSatisfyInt(value, inputType, position)
 	case bytes.Equal(literal.FLOAT, inputType):
-		msg = fmt.Sprintf(NotFloatErrMsg, inputType, value)
+		return ErrValueDoesntSatisfyFloat(value, inputType, position)
 	case bytes.Equal(literal.BOOLEAN, inputType):
-		msg = fmt.Sprintf(NotBoolErrMsg, inputType, value)
+		return ErrValueDoesntSatisfyBool(value, inputType, position)
 	case bytes.Equal(literal.ID, inputType):
-		msg = fmt.Sprintf(NotIDErrMsg, inputType, value)
+		return ErrValueDoesntSatisfyID(value, inputType, position)
 	default:
-		msg = fmt.Sprintf(NotCompatibleTypeErrMsg, inputType, value)
+		return ErrValueDoesntSatisfyType(value, inputType, position)
 	}
-
-	err.Message = msg
-	err.Locations = []graphqlerrors.Location{
-		{
-			Line:   position.LineStart,
-			Column: position.CharStart,
-		},
-	}
-
-	return err
 }
 
 func ErrVariableTypeDoesntSatisfyInputValueDefinition(value, inputType, expectedType ast.ByteSlice, valuePos, variableDefinitionPos position.Position) (err ExternalError) {
@@ -278,12 +290,7 @@ func ErrVariableNotDefinedOnArgument(variableName, argumentName ast.ByteSlice) (
 
 func ErrVariableOfTypeIsNoValidInputValue(variableName, ofTypeName ast.ByteSlice, position position.Position) (err ExternalError) {
 	err.Message = fmt.Sprintf(VariableIsNotInputTypeErrMsg, variableName, ofTypeName)
-	err.Locations = []graphqlerrors.Location{
-		{
-			Line:   position.LineStart,
-			Column: position.CharStart,
-		},
-	}
+	err.Locations = LocationsFromPosition(position)
 
 	return err
 }

--- a/pkg/operationreport/externalerror.go
+++ b/pkg/operationreport/externalerror.go
@@ -62,7 +62,7 @@ func ErrFieldNameMustBeUniqueOnType(fieldName, typeName ast.ByteSlice) (err Exte
 }
 
 func ErrTypeUndefined(typeName ast.ByteSlice) (err ExternalError) {
-	err.Message = fmt.Sprintf("type not defined: %s", typeName)
+	err.Message = fmt.Sprintf(UnknownTypeErrMsg, typeName)
 	return err
 }
 

--- a/pkg/operationreport/externalerror.go
+++ b/pkg/operationreport/externalerror.go
@@ -140,15 +140,37 @@ const (
 	NotBoolErrMsg           = "%s cannot represent a non boolean value: %s"
 	NotIDErrMsg             = "%s cannot represent a non-string and non-integer value: %s"
 	NotEnumErrMsg           = `Enum "%s" cannot represent non-enum value: %s.`
-	NotAnEnumMemberErrMsg   = `Value "JUGGLE" does not exist in "%s" enum.`
-
-	WrongEnumValueCase = `\"sit\" does not exist in \"DogCommand\" enum. Did you mean the enum value \"SIT\"?`
+	NotAnEnumMemberErrMsg   = `Value "%s" does not exist in "%s" enum.`
 
 	NullValueErrMsg = `Expected value of type "%s", found null.`
 )
 
 func ErrNullValueDoesntSatisfyInputValueDefinition(inputType ast.ByteSlice, position position.Position) (err ExternalError) {
 	err.Message = fmt.Sprintf(NullValueErrMsg, inputType)
+	err.Locations = []graphqlerrors.Location{
+		{
+			Line:   position.LineStart,
+			Column: position.CharStart,
+		},
+	}
+
+	return err
+}
+
+func ErrValueDoesntSatisfyEnum(value, inputType ast.ByteSlice, position position.Position) (err ExternalError) {
+	err.Message = fmt.Sprintf(NotEnumErrMsg, inputType, value)
+	err.Locations = []graphqlerrors.Location{
+		{
+			Line:   position.LineStart,
+			Column: position.CharStart,
+		},
+	}
+
+	return err
+}
+
+func ErrValueDoesntExistsInEnum(value, inputType ast.ByteSlice, position position.Position) (err ExternalError) {
+	err.Message = fmt.Sprintf(NotAnEnumMemberErrMsg, value, inputType)
 	err.Locations = []graphqlerrors.Location{
 		{
 			Line:   position.LineStart,
@@ -173,8 +195,6 @@ func ErrValueDoesntSatisfyInputValueDefinition(value, inputType ast.ByteSlice, p
 		msg = fmt.Sprintf(NotBoolErrMsg, inputType, value)
 	case bytes.Equal(literal.ID, inputType):
 		msg = fmt.Sprintf(NotIDErrMsg, inputType, value)
-	case bytes.Equal(literal.ENUM, inputType):
-		msg = fmt.Sprintf(NotEnumErrMsg, inputType, value)
 	default:
 		msg = fmt.Sprintf(NotCompatibleTypeErrMsg, inputType, value)
 	}

--- a/pkg/operationreport/externalerror.go
+++ b/pkg/operationreport/externalerror.go
@@ -134,6 +134,11 @@ func ErrValueDoesntSatisfyInputValueDefinition(value, inputType ast.ByteSlice) (
 	return err
 }
 
+func ErrVariableTypeDoesntSatisfyInputValueDefinition(value, inputType ast.ByteSlice) (err ExternalError) {
+	err.Message = fmt.Sprintf("value: %s doesn't satisfy inputType: %s", value, inputType)
+	return err
+}
+
 func ErrVariableNotDefinedOnOperation(variableName, operationName ast.ByteSlice) (err ExternalError) {
 	err.Message = fmt.Sprintf("variable: %s not defined on operation: %s", variableName, operationName)
 	return err

--- a/pkg/operationreport/externalerror.go
+++ b/pkg/operationreport/externalerror.go
@@ -11,20 +11,21 @@ import (
 )
 
 const (
-	NotCompatibleTypeErrMsg           = "%s cannot represent value: %s"
-	NotStringErrMsg                   = "%s cannot represent a non string value: %s"
-	NotIntegerErrMsg                  = "%s cannot represent non-integer value: %s"
-	BigIntegerErrMsg                  = "%s cannot represent non 32-bit signed integer value: %s"
-	NotFloatErrMsg                    = "%s cannot represent non numeric value: %s"
-	NotBooleanErrMsg                  = "%s cannot represent a non boolean value: %s"
-	NotIDErrMsg                       = "%s cannot represent a non-string and non-integer value: %s"
-	NotEnumErrMsg                     = `Enum "%s" cannot represent non-enum value: %s.`
-	NotAnEnumMemberErrMsg             = `Value "%s" does not exist in "%s" enum.`
-	NullValueErrMsg                   = `Expected value of type "%s", found null.`
-	UnknownArgumentOnDirectiveErrMsg  = `Unknown argument "%s" on directive "@%s".`
-	UnknownArgumentOnFieldErrMsg      = `Unknown argument "%s" on field "%s.%s".`
-	VariableIsNotInputTypeErrMsg      = `Variable "$%s" cannot be non-input type "%s".`
-	MissingRequiredFieldOfInputObject = `Field "%s.%s" of required type "%s" was not provided.`
+	NotCompatibleTypeErrMsg                 = "%s cannot represent value: %s"
+	NotStringErrMsg                         = "%s cannot represent a non string value: %s"
+	NotIntegerErrMsg                        = "%s cannot represent non-integer value: %s"
+	BigIntegerErrMsg                        = "%s cannot represent non 32-bit signed integer value: %s"
+	NotFloatErrMsg                          = "%s cannot represent non numeric value: %s"
+	NotBooleanErrMsg                        = "%s cannot represent a non boolean value: %s"
+	NotIDErrMsg                             = "%s cannot represent a non-string and non-integer value: %s"
+	NotEnumErrMsg                           = `Enum "%s" cannot represent non-enum value: %s.`
+	NotAnEnumMemberErrMsg                   = `Value "%s" does not exist in "%s" enum.`
+	NullValueErrMsg                         = `Expected value of type "%s", found null.`
+	UnknownArgumentOnDirectiveErrMsg        = `Unknown argument "%s" on directive "@%s".`
+	UnknownArgumentOnFieldErrMsg            = `Unknown argument "%s" on field "%s.%s".`
+	VariableIsNotInputTypeErrMsg            = `Variable "$%s" cannot be non-input type "%s".`
+	MissingRequiredFieldOfInputObjectErrMsg = `Field "%s.%s" of required type "%s" was not provided.`
+	UnknownFieldOfInputObjectErrMsg         = `Field "%s" is not defined by type "%s".`
 )
 
 type ExternalError struct {
@@ -161,7 +162,14 @@ func ErrArgumentNotDefinedOnDirective(argName, directiveName ast.ByteSlice, posi
 }
 
 func ErrMissingRequiredFieldOfInputObject(objName, fieldName, typeName ast.ByteSlice, position position.Position) (err ExternalError) {
-	err.Message = fmt.Sprintf(MissingRequiredFieldOfInputObject, objName, fieldName, typeName)
+	err.Message = fmt.Sprintf(MissingRequiredFieldOfInputObjectErrMsg, objName, fieldName, typeName)
+	err.Locations = LocationsFromPosition(position)
+
+	return err
+}
+
+func ErrUnknownFieldOfInputObject(objName, fieldName ast.ByteSlice, position position.Position) (err ExternalError) {
+	err.Message = fmt.Sprintf(UnknownFieldOfInputObjectErrMsg, objName, fieldName)
 	err.Locations = LocationsFromPosition(position)
 
 	return err

--- a/pkg/operationreport/externalerror.go
+++ b/pkg/operationreport/externalerror.go
@@ -1,12 +1,10 @@
 package operationreport
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/wundergraph/graphql-go-tools/pkg/ast"
 	"github.com/wundergraph/graphql-go-tools/pkg/graphqlerrors"
-	"github.com/wundergraph/graphql-go-tools/pkg/lexer/literal"
 	"github.com/wundergraph/graphql-go-tools/pkg/lexer/position"
 )
 
@@ -28,7 +26,7 @@ const (
 	MissingRequiredFieldOfInputObjectErrMsg = `Field "%s.%s" of required type "%s" was not provided.`
 	UnknownFieldOfInputObjectErrMsg         = `Field "%s" is not defined by type "%s".`
 	DuplicatedFieldInputObjectErrMsg        = `There can be only one input field named "%s".`
-	ValueIsNotAnInputObjectType             = `Expected value of type "%s", found %s.`
+	ValueIsNotAnInputObjectTypeErrMsg       = `Expected value of type "%s", found %s.`
 )
 
 type ExternalError struct {
@@ -238,7 +236,7 @@ func ErrValueDoesntSatisfyType(value, inputType ast.ByteSlice, position position
 }
 
 func ErrValueIsNotAnInputObjectType(value, inputType ast.ByteSlice, position position.Position) (err ExternalError) {
-	err.Message = fmt.Sprintf(ValueIsNotAnInputObjectType, inputType, value)
+	err.Message = fmt.Sprintf(ValueIsNotAnInputObjectTypeErrMsg, inputType, value)
 	err.Locations = LocationsFromPosition(position)
 
 	return err
@@ -284,23 +282,6 @@ func ErrValueDoesntSatisfyID(value, inputType ast.ByteSlice, position position.P
 	err.Locations = LocationsFromPosition(position)
 
 	return err
-}
-
-func ErrValueDoesntSatisfyInputValueDefinition(value, inputType ast.ByteSlice, position position.Position) (err ExternalError) {
-	switch {
-	case bytes.Equal(literal.STRING, inputType):
-		return ErrValueDoesntSatisfyString(value, inputType, position)
-	case bytes.Equal(literal.INT, inputType):
-		return ErrValueDoesntSatisfyInt(value, inputType, position)
-	case bytes.Equal(literal.FLOAT, inputType):
-		return ErrValueDoesntSatisfyFloat(value, inputType, position)
-	case bytes.Equal(literal.BOOLEAN, inputType):
-		return ErrValueDoesntSatisfyBoolean(value, inputType, position)
-	case bytes.Equal(literal.ID, inputType):
-		return ErrValueDoesntSatisfyID(value, inputType, position)
-	default:
-		return ErrValueDoesntSatisfyType(value, inputType, position)
-	}
 }
 
 func ErrVariableTypeDoesntSatisfyInputValueDefinition(value, inputType, expectedType ast.ByteSlice, valuePos, variableDefinitionPos position.Position) (err ExternalError) {

--- a/pkg/operationreport/externalerror.go
+++ b/pkg/operationreport/externalerror.go
@@ -10,6 +10,21 @@ import (
 	"github.com/wundergraph/graphql-go-tools/pkg/lexer/position"
 )
 
+const (
+	NotCompatibleTypeErrMsg          = "%s cannot represent value: %s"
+	NotStringErrMsg                  = "%s cannot represent a non string value: %s"
+	NotIntegerErrMsg                 = "%s cannot represent non-integer value: %s"
+	NotFloatErrMsg                   = "%s cannot represent non numeric value: %s"
+	NotBoolErrMsg                    = "%s cannot represent a non boolean value: %s"
+	NotIDErrMsg                      = "%s cannot represent a non-string and non-integer value: %s"
+	NotEnumErrMsg                    = `Enum "%s" cannot represent non-enum value: %s.`
+	NotAnEnumMemberErrMsg            = `Value "%s" does not exist in "%s" enum.`
+	NullValueErrMsg                  = `Expected value of type "%s", found null.`
+	UnknownArgumentOnDirectiveErrMsg = `Unknown argument "%s" on directive "@%s".`
+	UnknownArgumentOnFieldErrMsg     = `Unknown argument "%s" on field "%s.%s".`
+	VariableIsNotInputTypeErrMsg     = `Variable "$%s" cannot be non-input type "%s".`
+)
+
 type ExternalError struct {
 	Message   string                   `json:"message"`
 	Path      ast.Path                 `json:"path"`
@@ -128,7 +143,7 @@ func ErrMissingFieldSelectionOnNonScalar(fieldName, enclosingTypeName ast.ByteSl
 }
 
 func ErrArgumentNotDefinedOnDirective(argName, directiveName ast.ByteSlice, position position.Position) (err ExternalError) {
-	err.Message = fmt.Sprintf(UnknownArgumentOnDirective, argName, directiveName)
+	err.Message = fmt.Sprintf(UnknownArgumentOnDirectiveErrMsg, argName, directiveName)
 	err.Locations = []graphqlerrors.Location{
 		{
 			Line:   position.LineStart,
@@ -139,7 +154,7 @@ func ErrArgumentNotDefinedOnDirective(argName, directiveName ast.ByteSlice, posi
 }
 
 func ErrArgumentNotDefinedOnField(argName, typeName, fieldName ast.ByteSlice, position position.Position) (err ExternalError) {
-	err.Message = fmt.Sprintf(UnknownArgumentOnField, argName, typeName, fieldName)
+	err.Message = fmt.Sprintf(UnknownArgumentOnFieldErrMsg, argName, typeName, fieldName)
 	err.Locations = []graphqlerrors.Location{
 		{
 			Line:   position.LineStart,
@@ -148,20 +163,6 @@ func ErrArgumentNotDefinedOnField(argName, typeName, fieldName ast.ByteSlice, po
 	}
 	return err
 }
-
-const (
-	NotCompatibleTypeErrMsg    = "%s cannot represent value: %s"
-	NotStringErrMsg            = "%s cannot represent a non string value: %s"
-	NotIntegerErrMsg           = "%s cannot represent non-integer value: %s"
-	NotFloatErrMsg             = "%s cannot represent non numeric value: %s"
-	NotBoolErrMsg              = "%s cannot represent a non boolean value: %s"
-	NotIDErrMsg                = "%s cannot represent a non-string and non-integer value: %s"
-	NotEnumErrMsg              = `Enum "%s" cannot represent non-enum value: %s.`
-	NotAnEnumMemberErrMsg      = `Value "%s" does not exist in "%s" enum.`
-	NullValueErrMsg            = `Expected value of type "%s", found null.`
-	UnknownArgumentOnDirective = `Unknown argument "%s" on directive "@%s".`
-	UnknownArgumentOnField     = `Unknown argument "%s" on field "%s.%s".`
-)
 
 func ErrNullValueDoesntSatisfyInputValueDefinition(inputType ast.ByteSlice, position position.Position) (err ExternalError) {
 	err.Message = fmt.Sprintf(NullValueErrMsg, inputType)
@@ -263,8 +264,15 @@ func ErrVariableNotDefinedOnArgument(variableName, argumentName ast.ByteSlice) (
 	return err
 }
 
-func ErrVariableOfTypeIsNoValidInputValue(variableName, ofTypeName ast.ByteSlice) (err ExternalError) {
-	err.Message = fmt.Sprintf("variable: %s of type: %s is no valid input value type", variableName, ofTypeName)
+func ErrVariableOfTypeIsNoValidInputValue(variableName, ofTypeName ast.ByteSlice, position position.Position) (err ExternalError) {
+	err.Message = fmt.Sprintf(VariableIsNotInputTypeErrMsg, variableName, ofTypeName)
+	err.Locations = []graphqlerrors.Location{
+		{
+			Line:   position.LineStart,
+			Column: position.CharStart,
+		},
+	}
+
 	return err
 }
 


### PR DESCRIPTION
# Changes

## packages `astparser`, `ast`:
- position support were added to Argument, ObjectField, Type, Values
- astparser now using `ast.InvalidRef` constant instead of -1

## package `astvalidation`:
- bunch of changes to operation validation rules
- part of tests with invalid queries now includes error messages assertions
- reference tests related to updated rules were enabled 

### `Values` rule:
- nested Boolean values is now properly validated (closes #431)
- List values coersion is allowed by validation
- `ID` scalar accepts string and int values
- `[String!]!` accepts empty list `[]` as an allowed value
- Rule is rewritten to provide precise errors with messages in format of `graphl-js` implementation with included locations

### `KnownArguments` rule:
- is now a separate tiny rule

### `ValidArguments` rule:
- is not doing anymore similar deep checks as `Values` rule
- now responsible only for top level arguments validation with variable values


closes #437
fixes ENG-725