### PR TITLE
Adding Optional Argument Type Replacement

### DIFF
--- a/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
@@ -766,7 +766,7 @@ func (p *Planner) configureArgument(upstreamFieldRef, downstreamFieldRef int, fi
 
 	switch argumentConfiguration.SourceType {
 	case plan.FieldArgumentSource:
-		p.configureFieldArgumentSource(upstreamFieldRef, downstreamFieldRef, argumentConfiguration.Name, argumentConfiguration.SourcePath)
+		p.configureFieldArgumentSource(upstreamFieldRef, downstreamFieldRef, argumentConfiguration.Name, argumentConfiguration.SourcePath, argumentConfiguration.CustomOriginTypeReplacement)
 	case plan.ObjectFieldSource:
 		p.configureObjectFieldSource(upstreamFieldRef, downstreamFieldRef, fieldConfig, argumentConfiguration)
 	}
@@ -775,7 +775,7 @@ func (p *Planner) configureArgument(upstreamFieldRef, downstreamFieldRef int, fi
 }
 
 // configureFieldArgumentSource - creates variables for a plain argument types, in case object or list types goes deep and calls applyInlineFieldArgument
-func (p *Planner) configureFieldArgumentSource(upstreamFieldRef, downstreamFieldRef int, argumentName string, sourcePath []string) {
+func (p *Planner) configureFieldArgumentSource(upstreamFieldRef, downstreamFieldRef int, argumentName string, sourcePath []string, argumentTypeNameOverride string) {
 	fieldArgument, ok := p.visitor.Operation.FieldArgument(downstreamFieldRef, []byte(argumentName))
 	if !ok {
 		return
@@ -821,6 +821,9 @@ func (p *Planner) configureFieldArgumentSource(upstreamFieldRef, downstreamField
 		}
 		typeName := p.visitor.Operation.ResolveTypeNameString(p.visitor.Operation.VariableDefinitions[i].Type)
 		typeName = p.visitor.Config.Types.RenameTypeNameOnMatchStr(typeName)
+		if argumentTypeNameOverride != "" {
+			typeName = argumentTypeNameOverride
+		}
 		importedType := p.visitor.Importer.ImportTypeWithRename(p.visitor.Operation.VariableDefinitions[i].Type, p.visitor.Operation, p.upstreamOperation, typeName)
 		p.upstreamOperation.AddVariableDefinitionToOperationDefinition(p.nodes[0].Ref, variableValueRef, importedType)
 

--- a/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
@@ -775,7 +775,7 @@ func (p *Planner) configureArgument(upstreamFieldRef, downstreamFieldRef int, fi
 }
 
 // configureFieldArgumentSource - creates variables for a plain argument types, in case object or list types goes deep and calls applyInlineFieldArgument
-func (p *Planner) configureFieldArgumentSource(upstreamFieldRef, downstreamFieldRef int, argumentName string, sourcePath []string, argumentTypeNameOverride string) {
+func (p *Planner) configureFieldArgumentSource(upstreamFieldRef, downstreamFieldRef int, argumentName string, sourcePath []string, argumentTypeNameReplacement string) {
 	fieldArgument, ok := p.visitor.Operation.FieldArgument(downstreamFieldRef, []byte(argumentName))
 	if !ok {
 		return
@@ -821,8 +821,8 @@ func (p *Planner) configureFieldArgumentSource(upstreamFieldRef, downstreamField
 		}
 		typeName := p.visitor.Operation.ResolveTypeNameString(p.visitor.Operation.VariableDefinitions[i].Type)
 		typeName = p.visitor.Config.Types.RenameTypeNameOnMatchStr(typeName)
-		if argumentTypeNameOverride != "" {
-			typeName = argumentTypeNameOverride
+		if argumentTypeNameReplacement != "" {
+			typeName = argumentTypeNameReplacement
 		}
 		importedType := p.visitor.Importer.ImportTypeWithRename(p.visitor.Operation.VariableDefinitions[i].Type, p.visitor.Operation, p.upstreamOperation, typeName)
 		p.upstreamOperation.AddVariableDefinitionToOperationDefinition(p.nodes[0].Ref, variableValueRef, importedType)

--- a/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
@@ -5430,7 +5430,7 @@ func TestGraphQLDataSource(t *testing.T) {
 			},
 		}))
 		t.Run("custom scalar replacement query", RunTest(starWarsSchema, `
-		query MyQuery($droidId: ID!, $reviewId: Int!){
+		query MyQuery($droidId: ID!, $reviewId: ID!){
 			droid(id: $droidId){
 				name
 				aliased: name
@@ -5457,7 +5457,7 @@ func TestGraphQLDataSource(t *testing.T) {
 						},
 						&resolve.ContextVariable{
 							Path:     []string{"reviewId"},
-							Renderer: resolve.NewJSONVariableRendererWithValidation(`{"type":["integer"]}`),
+							Renderer: resolve.NewJSONVariableRendererWithValidation(`{"type":["string","integer"]}`),
 						},
 						&resolve.HeaderVariable{
 							Path: []string{"Authorization"},
@@ -6420,7 +6420,7 @@ schema {
 type Query {
     hero: Character
     droid(id: ID!): Droid
-    review(id: Int!): Review
+    review(id: ID!): Review
     search(name: String!): SearchResult
     searchWithInput(input: SearchInput!): SearchResult
 	stringList: [String]

--- a/pkg/engine/plan/plan.go
+++ b/pkg/engine/plan/plan.go
@@ -151,6 +151,7 @@ type ArgumentConfiguration struct {
 	SourceType   SourceType
 	SourcePath   []string
 	RenderConfig ArgumentRenderConfig
+	CustomOriginTypeReplacement string
 }
 
 type DataSourceConfiguration struct {


### PR DESCRIPTION
In relation to the Wundergraph issue found here: https://github.com/wundergraph/wundergraph/issues/284, we require the ability to provide an override on a GraphQL argument's type. This PR adds in this functionality.

@jensneuse, let me know if you're happy with the naming conventions.