### PR TITLE
Bug when converting triple quoted descriptions with quotes inside.

### DIFF
--- a/pkg/ast/ast_description.go
+++ b/pkg/ast/ast_description.go
@@ -84,9 +84,11 @@ func (d *Document) ImportDescription(desc string) (description Description) {
 		return
 	}
 
+	isBlockString := strings.Contains(desc, "\n") || strings.Contains(desc, `"`)
+
 	return Description{
 		IsDefined:     true,
-		IsBlockString: strings.Contains(desc, "\n"),
+		IsBlockString: isBlockString,
 		Content:       d.Input.AppendInputString(desc),
 	}
 }

--- a/pkg/introspection/fixtures/starwars.golden
+++ b/pkg/introspection/fixtures/starwars.golden
@@ -175,7 +175,9 @@ scalar String
 "The `Boolean` scalar type represents `true` or `false` ."
 scalar Boolean
 
-"The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `4`) or integer (such as 4) input value will be accepted as an ID."
+"""
+The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as "4") or integer (such as 4) input value will be accepted as an ID.
+"""
 scalar ID
 
 "Directs the executor to include this field or fragment only when the argument is true."


### PR DESCRIPTION
Hello 👋🏻 Great library you have here, good work!

## The problem 

`JsonConverter` will incorrectly convert a description if the description contains a quote `"` inside a triple quoted description if the description does not contain a newline. 

If the description contains a newline it will be rendered as a "block" description inside triple quotes and everything is fine. However if there's no newline it will be rendered as description inside a single quote pair which is _not_ fine.

This happened to us while converting a schema produced by https://github.com/99designs/gqlgen. If you look at their `scalar ID` description you'll see that it is a triple quoted description with quotes inside.

## Example

```graphql
"""
The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as "4") or integer (such as 4) input value will be accepted as an ID.
"""
```

Once converted to JSON, converted via `JsonConverter` and printed will result in:

```graphql
"The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as "4") or integer (such as 4) input value will be accepted as an ID."
```

Note the quotes around `4`.

## The fix

Descriptions with quotes inside of them should also be "block" descriptions, not just descriptions with new lines.
