### PR TITLE
Fix validation for unknown non-nill field types

### DIFF
--- a/pkg/astvalidation/rule_known_type_names.go
+++ b/pkg/astvalidation/rule_known_type_names.go
@@ -58,6 +58,9 @@ func (u *knownTypeNamesVisitor) EnterRootOperationTypeDefinition(ref int) {
 
 func (u *knownTypeNamesVisitor) EnterFieldDefinition(ref int) {
 	referencedTypeRef := u.definition.FieldDefinitions[ref].Type
+	if ofType := u.definition.Types[referencedTypeRef].OfType; ofType >= 0 {
+		referencedTypeRef = ofType
+	}
 	referencedTypeName := u.definition.TypeNameBytes(referencedTypeRef)
 	u.saveReferencedTypeName(referencedTypeName)
 }

--- a/pkg/astvalidation/rule_known_type_names_test.go
+++ b/pkg/astvalidation/rule_known_type_names_test.go
@@ -162,6 +162,24 @@ func TestKnownTypeNames(t *testing.T) {
 			)
 		})
 
+		t.Run("unknown type references: field", func(t *testing.T) {
+			runDefinitionValidation(t, `
+					type Review {
+						author: User
+					}
+				`, Invalid, KnownTypeNames(),
+			)
+		})
+
+		t.Run("unknown type references: non-null field", func(t *testing.T) {
+			runDefinitionValidation(t, `
+					type Review {
+						author: User!
+					}
+				`, Invalid, KnownTypeNames(),
+			)
+		})
+
 		t.Run("does not consider non-type definitions", func(t *testing.T) {
 			runDefinitionValidation(t, `
 					fragment Foo on Query { __typename }


### PR DESCRIPTION
Validation did not work for invalid schemas with fields of undefined type when the type was specified as non-null. 
see. [0a97177](https://github.com/wundergraph/graphql-go-tools/pull/497/commits/0a971770faa3fc0d06550c87b978c70ef367f499)

Field types specified as non-null are registered as TypeKindNonNull. The field type names of these fields must be referenced by ofType. However, this process was missing from the collection of  referenced types, so non-null types passed validation even though there were inconsistencies in the references.