### PR TITLE
feat: Use complete channel for callbacks

### DIFF
--- a/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
@@ -1421,7 +1421,7 @@ func (s *Source) Load(ctx context.Context, input []byte, writer io.Writer) (err 
 }
 
 type GraphQLSubscriptionClient interface {
-	Subscribe(ctx context.Context, options GraphQLSubscriptionOptions, next chan<- []byte) error
+	Subscribe(ctx context.Context, options GraphQLSubscriptionOptions, next chan<- []byte, complete chan<- bool) error
 }
 
 type GraphQLSubscriptionOptions struct {
@@ -1443,7 +1443,7 @@ type SubscriptionSource struct {
 	client GraphQLSubscriptionClient
 }
 
-func (s *SubscriptionSource) Start(ctx context.Context, input []byte, next chan<- []byte) error {
+func (s *SubscriptionSource) Start(ctx context.Context, input []byte, next chan<- []byte, complete chan<- bool) error {
 	var options GraphQLSubscriptionOptions
 	err := json.Unmarshal(input, &options)
 	if err != nil {
@@ -1452,5 +1452,5 @@ func (s *SubscriptionSource) Start(ctx context.Context, input []byte, next chan<
 	if options.Body.Query == "" {
 		return resolve.ErrUnableToResolve
 	}
-	return s.client.Subscribe(ctx, options, next)
+	return s.client.Subscribe(ctx, options, next, complete)
 }

--- a/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
@@ -326,6 +326,7 @@ func (p *Planner) ConfigureSubscription() plan.SubscriptionConfiguration {
 	input := httpclient.SetInputBodyWithPath(nil, p.upstreamVariables, "variables")
 	input = httpclient.SetInputBodyWithPath(input, p.printOperation(), "query")
 	input = httpclient.SetInputURL(input, []byte(p.config.Subscription.URL))
+
 	if p.config.Subscription.UseSSE {
 		input = httpclient.SetInputFlag(input, httpclient.USESSE)
 		if p.config.Subscription.SSEMethodPost {

--- a/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
@@ -3596,7 +3596,9 @@ func TestGraphQLDataSource(t *testing.T) {
 											IsTypeName: true,
 										},
 									},
-								}}},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -7747,7 +7749,7 @@ var errSubscriptionClientFail = errors.New("subscription client fail error")
 
 type FailingSubscriptionClient struct{}
 
-func (f FailingSubscriptionClient) Subscribe(_ context.Context, _ GraphQLSubscriptionOptions, _ chan<- []byte) error {
+func (f FailingSubscriptionClient) Subscribe(_ context.Context, _ GraphQLSubscriptionOptions, _ chan<- []byte, _ chan<- bool) error {
 	return errSubscriptionClientFail
 }
 
@@ -7794,13 +7796,13 @@ func TestSubscriptionSource_Start(t *testing.T) {
 
 	t.Run("should return error when input is invalid", func(t *testing.T) {
 		source := SubscriptionSource{client: FailingSubscriptionClient{}}
-		err := source.Start(context.Background(), []byte(`{"url": "", "body": "", "header": null}`), nil)
+		err := source.Start(context.Background(), []byte(`{"url": "", "body": "", "header": null}`), nil, nil)
 		assert.Error(t, err)
 	})
 
 	t.Run("should return error when subscription client returns an error", func(t *testing.T) {
 		source := SubscriptionSource{client: FailingSubscriptionClient{}}
-		err := source.Start(context.Background(), []byte(`{"url": "", "body": {}, "header": null}`), nil)
+		err := source.Start(context.Background(), []byte(`{"url": "", "body": {}, "header": null}`), nil, nil)
 		assert.Error(t, err)
 		assert.Equal(t, resolve.ErrUnableToResolve, err)
 	})
@@ -7812,7 +7814,7 @@ func TestSubscriptionSource_Start(t *testing.T) {
 
 		source := newSubscriptionSource(ctx.Context())
 		chatSubscriptionOptions := chatServerSubscriptionOptions(t, `{"variables": {}, "extensions": {}, "operationName": "LiveMessages", "query": "subscription LiveMessages { messageAdded(roomName: "#test") { text createdBy } }"}`)
-		err := source.Start(ctx.Context(), chatSubscriptionOptions, next)
+		err := source.Start(ctx.Context(), chatSubscriptionOptions, next, nil)
 		require.ErrorIs(t, err, resolve.ErrUnableToResolve)
 	})
 
@@ -7823,7 +7825,7 @@ func TestSubscriptionSource_Start(t *testing.T) {
 
 		source := newSubscriptionSource(ctx.Context())
 		chatSubscriptionOptions := chatServerSubscriptionOptions(t, `{"variables": {}, "extensions": {}, "operationName": "LiveMessages", "query": "subscription LiveMessages { messageAdded(roomNam: \"#test\") { text createdBy } }"}`)
-		err := source.Start(ctx.Context(), chatSubscriptionOptions, next)
+		err := source.Start(ctx.Context(), chatSubscriptionOptions, next, nil)
 		require.NoError(t, err)
 
 		msg, ok := <-next
@@ -7841,7 +7843,7 @@ func TestSubscriptionSource_Start(t *testing.T) {
 
 		source := newSubscriptionSource(resolverLifecycle)
 		chatSubscriptionOptions := chatServerSubscriptionOptions(t, `{"variables": {}, "extensions": {}, "operationName": "LiveMessages", "query": "subscription LiveMessages { messageAdded(roomName: \"#test\") { text createdBy } }"}`)
-		err := source.Start(subscriptionLifecycle, chatSubscriptionOptions, next)
+		err := source.Start(subscriptionLifecycle, chatSubscriptionOptions, next, nil)
 		require.NoError(t, err)
 
 		username := "myuser"
@@ -7862,7 +7864,7 @@ func TestSubscriptionSource_Start(t *testing.T) {
 
 		source := newSubscriptionSource(ctx.Context())
 		chatSubscriptionOptions := chatServerSubscriptionOptions(t, `{"variables": {}, "extensions": {}, "operationName": "LiveMessages", "query": "subscription LiveMessages { messageAdded(roomName: \"#test\") { text createdBy } }"}`)
-		err := source.Start(ctx.Context(), chatSubscriptionOptions, next)
+		err := source.Start(ctx.Context(), chatSubscriptionOptions, next, nil)
 		require.NoError(t, err)
 
 		username := "myuser"
@@ -7924,7 +7926,7 @@ func TestSubscription_GTWS_SubProtocol(t *testing.T) {
 
 		source := newSubscriptionSource(ctx.Context())
 		chatSubscriptionOptions := chatServerSubscriptionOptions(t, `{"variables": {}, "extensions": {}, "operationName": "LiveMessages", "query": "subscription LiveMessages { messageAdded(roomNam: \"#test\") { text createdBy } }"}`)
-		err := source.Start(ctx.Context(), chatSubscriptionOptions, next)
+		err := source.Start(ctx.Context(), chatSubscriptionOptions, next, nil)
 		require.NoError(t, err)
 
 		msg, ok := <-next
@@ -7942,7 +7944,7 @@ func TestSubscription_GTWS_SubProtocol(t *testing.T) {
 
 		source := newSubscriptionSource(resolverLifecycle)
 		chatSubscriptionOptions := chatServerSubscriptionOptions(t, `{"variables": {}, "extensions": {}, "operationName": "LiveMessages", "query": "subscription LiveMessages { messageAdded(roomName: \"#test\") { text createdBy } }"}`)
-		err := source.Start(subscriptionLifecycle, chatSubscriptionOptions, next)
+		err := source.Start(subscriptionLifecycle, chatSubscriptionOptions, next, nil)
 		require.NoError(t, err)
 
 		username := "myuser"
@@ -7963,7 +7965,7 @@ func TestSubscription_GTWS_SubProtocol(t *testing.T) {
 
 		source := newSubscriptionSource(ctx.Context())
 		chatSubscriptionOptions := chatServerSubscriptionOptions(t, `{"variables": {}, "extensions": {}, "operationName": "LiveMessages", "query": "subscription LiveMessages { messageAdded(roomName: \"#test\") { text createdBy } }"}`)
-		err := source.Start(ctx.Context(), chatSubscriptionOptions, next)
+		err := source.Start(ctx.Context(), chatSubscriptionOptions, next, nil)
 		require.NoError(t, err)
 
 		username := "myuser"
@@ -8343,7 +8345,6 @@ func BenchmarkFederationBatching(b *testing.B) {
 								},
 							},
 							{
-
 								HasBuffer: true,
 								BufferID:  1,
 								Name:      []byte("reviews"),

--- a/pkg/engine/datasource/graphql_datasource/graphql_sse_handler.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_sse_handler.go
@@ -52,7 +52,9 @@ func (h *gqlSSEConnectionHandler) StartBlocking(sub Subscription) {
 		}
 	}()
 
-	go h.subscribe(reqCtx, sub, dataCh, errCh, sub.complete)
+	complete := make(chan bool)
+
+	go h.subscribe(reqCtx, sub, dataCh, errCh, complete)
 
 	for {
 		select {
@@ -62,6 +64,11 @@ func (h *gqlSSEConnectionHandler) StartBlocking(sub Subscription) {
 			sub.next <- err
 			return
 		case <-reqCtx.Done():
+			return
+		case <-complete:
+			if sub.complete != nil {
+				sub.complete <- true
+			}
 			return
 		}
 	}
@@ -95,6 +102,9 @@ func (h *gqlSSEConnectionHandler) subscribe(ctx context.Context, sub Subscriptio
 		msg, err := reader.ReadEvent()
 		if err != nil {
 			if err == io.EOF {
+				if complete != nil {
+					complete <- true
+				}
 				return
 			}
 

--- a/pkg/engine/datasource/graphql_datasource/graphql_sse_handler_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_sse_handler_test.go
@@ -55,7 +55,7 @@ func TestGraphQLSubscriptionClientSubscribe_SSE(t *testing.T) {
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},
 		UseSSE: true,
-	}, next)
+	}, next, nil)
 	assert.NoError(t, err)
 
 	first := <-next
@@ -91,7 +91,7 @@ func TestGraphQLSubscriptionClientSubscribe_SSE_RequestAbort(t *testing.T) {
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},
 		UseSSE: true,
-	}, next)
+	}, next, nil)
 	assert.NoError(t, err)
 
 	assert.Eventuallyf(t, func() bool {
@@ -149,7 +149,7 @@ func TestGraphQLSubscriptionClientSubscribe_SSE_POST(t *testing.T) {
 		Body:          postReqBody,
 		UseSSE:        true,
 		SSEMethodPost: true,
-	}, next)
+	}, next, nil)
 	assert.NoError(t, err)
 
 	first := <-next
@@ -200,20 +200,23 @@ func TestGraphQLSubscriptionClientSubscribe_SSE_WithEvents(t *testing.T) {
 	)
 
 	next := make(chan []byte)
+	complete := make(chan bool)
 	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
 		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},
 		UseSSE: true,
-	}, next)
+	}, next, complete)
 	assert.NoError(t, err)
 
 	first := <-next
 	second := <-next
+	c := <-complete
 
 	assert.Equal(t, `{"data":{"messageAdded":{"text":"first"}}}`, string(first))
 	assert.Equal(t, `{"data":{"messageAdded":{"text":"second"}}}`, string(second))
+	assert.Equal(t, true, c)
 
 	clientCancel()
 	assert.Eventuallyf(t, func() bool {
@@ -258,7 +261,7 @@ func TestGraphQLSubscriptionClientSubscribe_SSE_Error(t *testing.T) {
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},
 		UseSSE: true,
-	}, next)
+	}, next, nil)
 	assert.NoError(t, err)
 
 	first := <-next
@@ -308,7 +311,7 @@ func TestGraphQLSubscriptionClientSubscribe_SSE_Error_Without_Header(t *testing.
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},
 		UseSSE: true,
-	}, next)
+	}, next, nil)
 	assert.NoError(t, err)
 
 	first := <-next
@@ -366,7 +369,7 @@ func TestGraphQLSubscriptionClientSubscribe_QueryParams(t *testing.T) {
 			Extensions:    []byte(`{"persistedQuery":{"version":1,"sha256Hash":"d41d8cd98f00b204e9800998ecf8427e"}}`),
 		},
 		UseSSE: true,
-	}, next)
+	}, next, nil)
 	assert.NoError(t, err)
 
 	first := <-next
@@ -483,7 +486,7 @@ func TestGraphQLSubscriptionClientSubscribe_SSE_Upstream_Dies(t *testing.T) {
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},
 		UseSSE: true,
-	}, next)
+	}, next, nil)
 	assert.NoError(t, err)
 
 	first := <-next

--- a/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
@@ -165,7 +165,7 @@ func TestWebsocketSubscriptionClientDeDuplication(t *testing.T) {
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},
-	}, next)
+	}, next, nil)
 	assert.NoError(t, err)
 	assertReceiveMessages(next)
 
@@ -180,7 +180,7 @@ func TestWebsocketSubscriptionClientDeDuplication(t *testing.T) {
 			Body: GraphQLBody{
 				Query: `subscription {messageAdded(roomName: "room"){text}}`,
 			},
-		}, next)
+		}, next, nil)
 		assert.NoError(t, err)
 		go func(next chan []byte, cancel func()) {
 			assertReceiveMessages(next)
@@ -219,7 +219,7 @@ func TestWebsocketSubscriptionClientImmediateClientCancel(t *testing.T) {
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},
-	}, next)
+	}, next, nil)
 	assert.Error(t, err)
 	assert.Eventuallyf(t, func() bool {
 		return serverInvocations.Load() == 0
@@ -274,7 +274,7 @@ func TestWebsocketSubscriptionClientWithServerDisconnect(t *testing.T) {
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},
-	}, next)
+	}, next, nil)
 	assert.NoError(t, err)
 	first := <-next
 	second := <-next

--- a/pkg/engine/datasource/graphql_datasource/graphql_tws_handler_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_tws_handler_test.go
@@ -63,7 +63,7 @@ func TestWebsocketSubscriptionClient_GQLTWS(t *testing.T) {
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},
-	}, next)
+	}, next, nil)
 	assert.NoError(t, err)
 
 	first := <-next
@@ -140,7 +140,7 @@ func TestWebsocketSubscriptionClientPing_GQLTWS(t *testing.T) {
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},
-	}, next)
+	}, next, nil)
 	assert.NoError(t, err)
 
 	first := <-next
@@ -203,7 +203,7 @@ func TestWebsocketSubscriptionClientError_GQLTWS(t *testing.T) {
 		Body: GraphQLBody{
 			Query: `wrongQuery {messageAdded(roomName: "room"){text}}`,
 		},
-	}, next)
+	}, next, nil)
 	assert.NoError(t, err)
 
 	message := <-next
@@ -286,7 +286,7 @@ func TestWebSocketSubscriptionClientInitIncludePing_GQLTWS(t *testing.T) {
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},
-	}, next)
+	}, next, nil)
 	assertion.NoError(err)
 
 	first := <-next
@@ -359,7 +359,7 @@ func TestWebsocketSubscriptionClient_GQLTWS_Upstream_Dies(t *testing.T) {
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},
-	}, next)
+	}, next, nil)
 	assert.NoError(t, err)
 
 	first := <-next

--- a/pkg/engine/datasource/graphql_datasource/graphql_ws_handler_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_ws_handler_test.go
@@ -74,7 +74,7 @@ func TestWebSocketSubscriptionClientInitIncludeKA_GQLWS(t *testing.T) {
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},
-	}, next)
+	}, next, nil)
 	assertion.NoError(err)
 	first := <-next
 	second := <-next
@@ -139,7 +139,7 @@ func TestWebsocketSubscriptionClient_GQLWS(t *testing.T) {
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},
-	}, next)
+	}, next, nil)
 	assert.NoError(t, err)
 	first := <-next
 	second := <-next
@@ -200,7 +200,7 @@ func TestWebsocketSubscriptionClientErrorArray(t *testing.T) {
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomNam: "room"){text}}`,
 		},
-	}, next)
+	}, next, nil)
 	assert.NoError(t, err)
 	message := <-next
 	assert.Equal(t, `{"errors":[{"message":"error"},{"message":"error"}]}`, string(message))
@@ -253,7 +253,7 @@ func TestWebsocketSubscriptionClientErrorObject(t *testing.T) {
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomNam: "room"){text}}`,
 		},
-	}, next)
+	}, next, nil)
 	assert.NoError(t, err)
 	message := <-next
 	assert.Equal(t, `{"errors":[{"message":"error"}]}`, string(message))
@@ -314,7 +314,7 @@ func TestWebsocketSubscriptionClient_GQLWS_Upstream_Dies(t *testing.T) {
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
 		},
-	}, next)
+	}, next, nil)
 	assert.NoError(t, err)
 	first := <-next
 	assert.Equal(t, `{"data":{"messageAdded":{"text":"first"}}}`, string(first))

--- a/pkg/engine/resolve/resolve.go
+++ b/pkg/engine/resolve/resolve.go
@@ -587,7 +587,6 @@ func (r *Resolver) ResolveGraphQLSubscription(ctx *Context, subscription *GraphQ
 	}
 
 	completed := make(chan bool)
-
 	err = subscription.Trigger.Source.Start(c, subscriptionInput, next, completed)
 	if err != nil {
 		if errors.Is(err, ErrUnableToResolve) {

--- a/pkg/engine/resolve/resolve.go
+++ b/pkg/engine/resolve/resolve.go
@@ -331,7 +331,7 @@ type DataSource interface {
 }
 
 type SubscriptionDataSource interface {
-	Start(ctx context.Context, input []byte, next chan<- []byte) error
+	Start(ctx context.Context, input []byte, next chan<- []byte, complete chan<- bool) error
 }
 
 type Resolver struct {
@@ -586,7 +586,9 @@ func (r *Resolver) ResolveGraphQLSubscription(ctx *Context, subscription *GraphQ
 		return writeAndFlush(writer, msg)
 	}
 
-	err = subscription.Trigger.Source.Start(c, subscriptionInput, next)
+	completed := make(chan bool)
+
+	err = subscription.Trigger.Source.Start(c, subscriptionInput, next, completed)
 	if err != nil {
 		if errors.Is(err, ErrUnableToResolve) {
 			msg := []byte(`{"errors":[{"message":"unable to resolve"}]}`)
@@ -601,6 +603,11 @@ func (r *Resolver) ResolveGraphQLSubscription(ctx *Context, subscription *GraphQ
 	for {
 		select {
 		case <-resolverDone:
+			return nil
+		case <-completed:
+			if close, ok := writer.(io.WriteCloser); ok {
+				return close.Close()
+			}
 			return nil
 		default:
 			data, ok := <-next

--- a/pkg/engine/resolve/resolve.go
+++ b/pkg/engine/resolve/resolve.go
@@ -605,8 +605,8 @@ func (r *Resolver) ResolveGraphQLSubscription(ctx *Context, subscription *GraphQ
 		case <-resolverDone:
 			return nil
 		case <-completed:
-			if close, ok := writer.(io.WriteCloser); ok {
-				return close.Close()
+			if f, ok := writer.(CompleteFlushWriter); ok {
+				return f.Complete()
 			}
 			return nil
 		default:
@@ -1646,6 +1646,10 @@ type GraphQLSubscriptionTrigger struct {
 type FlushWriter interface {
 	io.Writer
 	Flush()
+}
+
+type CompleteFlushWriter interface {
+	Complete() error
 }
 
 type GraphQLResponse struct {

--- a/pkg/engine/resolve/resolve.go
+++ b/pkg/engine/resolve/resolve.go
@@ -605,12 +605,11 @@ func (r *Resolver) ResolveGraphQLSubscription(ctx *Context, subscription *GraphQ
 		case <-resolverDone:
 			return nil
 		case <-completed:
-			if f, ok := writer.(CompleteFlushWriter); ok {
-				return f.Complete()
+			if close, ok := writer.(io.WriteCloser); ok {
+				return close.Close()
 			}
 			return nil
-		default:
-			data, ok := <-next
+		case data, ok := <-next:
 			if !ok {
 				return nil
 			}
@@ -1646,10 +1645,6 @@ type GraphQLSubscriptionTrigger struct {
 type FlushWriter interface {
 	io.Writer
 	Flush()
-}
-
-type CompleteFlushWriter interface {
-	Complete() error
 }
 
 type GraphQLResponse struct {

--- a/pkg/engine/resolve/resolve_test.go
+++ b/pkg/engine/resolve/resolve_test.go
@@ -4131,7 +4131,7 @@ func (t *TestFlushWriter) Flush() {
 	t.buf.Reset()
 }
 
-func (t *TestFlushWriter) Close() error {
+func (t *TestFlushWriter) Complete() error {
 	t.closed = true
 	return nil
 }

--- a/pkg/engine/resolve/resolve_test.go
+++ b/pkg/engine/resolve/resolve_test.go
@@ -4131,7 +4131,7 @@ func (t *TestFlushWriter) Flush() {
 	t.buf.Reset()
 }
 
-func (t *TestFlushWriter) Complete() error {
+func (t *TestFlushWriter) Close() error {
 	t.closed = true
 	return nil
 }

--- a/pkg/graphql/execution_engine_v2.go
+++ b/pkg/graphql/execution_engine_v2.go
@@ -26,8 +26,9 @@ import (
 )
 
 type EngineResultWriter struct {
-	buf           *bytes.Buffer
-	flushCallback func(data []byte)
+	buf              *bytes.Buffer
+	flushCallback    func(data []byte)
+	completeCallback func()
 }
 
 func NewEngineResultWriter() EngineResultWriter {
@@ -46,6 +47,10 @@ func (e *EngineResultWriter) SetFlushCallback(flushCb func(data []byte)) {
 	e.flushCallback = flushCb
 }
 
+func (e *EngineResultWriter) SetCompleteCallback(completeCb func()) {
+	e.completeCallback = completeCb
+}
+
 func (e *EngineResultWriter) Write(p []byte) (n int, err error) {
 	return e.buf.Write(p)
 }
@@ -60,6 +65,14 @@ func (e *EngineResultWriter) Flush() {
 	}
 
 	e.Reset()
+}
+
+func (e *EngineResultWriter) Close() error {
+	if e.completeCallback != nil {
+		e.completeCallback()
+	}
+	e.Reset()
+	return nil
 }
 
 func (e *EngineResultWriter) Len() int {

--- a/pkg/graphql/execution_engine_v2.go
+++ b/pkg/graphql/execution_engine_v2.go
@@ -67,7 +67,7 @@ func (e *EngineResultWriter) Flush() {
 	e.Reset()
 }
 
-func (e *EngineResultWriter) Close() error {
+func (e *EngineResultWriter) Complete() error {
 	if e.completeCallback != nil {
 		e.completeCallback()
 	}

--- a/pkg/graphql/execution_engine_v2.go
+++ b/pkg/graphql/execution_engine_v2.go
@@ -67,7 +67,7 @@ func (e *EngineResultWriter) Flush() {
 	e.Reset()
 }
 
-func (e *EngineResultWriter) Complete() error {
+func (e *EngineResultWriter) Close() error {
 	if e.completeCallback != nil {
 		e.completeCallback()
 	}


### PR DESCRIPTION
The GraphQL SSE spec includes a complete event when the stream finishes, the current implementation keeps running even when the event is received. 

This PR adds support for receiving a callback when the complete event is received. I changed the API to include a channel to receive the complete event, wasn't sure if it was the right way or if we should add another method to the interfaces including the channel