### PR TITLE
fix: if subgraph does not have type then ignore `__typename` field

### DIFF
--- a/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
@@ -523,8 +523,11 @@ func (p *Planner) EnterField(ref int) {
 	}
 
 	fieldConfiguration := p.visitor.Config.Fields.ForTypeField(enclosingTypeName, fieldName)
-	if fieldConfiguration == nil && fieldName != "__typename" {
-		p.addField(ref)
+	// if subgraph does not have type then ignore `__typename` field
+	if fieldConfiguration == nil {
+		if fieldName != "__typename" {
+			p.addField(ref)
+		}
 		return
 	}
 


### PR DESCRIPTION
This occurs when using Federation and Fragment with the `__typename` problem.

Example

SubGraphA
```
type Group {
  :
}
type Query {
  group(id: ID!) Group
}
```

SubGraphB
```
type Employee {
  :
}
type Query {
  employee(id: ID!) Group
}
```

Query
```
{
  group(id: "xxx") {
     :
  }
  employee(id: "xxx") {
     ... EmployeeItem
    __typename // <-- This would be an error
  }
}

fragment EmployeeItem on Employee {
 :
}
```

Then, Federation queries SubGraphA for the Employee type, which results in an error.
