### PR TITLE
fix for handling non existing field of input type in astnormalization

### DIFF
--- a/pkg/astnormalization/astnormalization_test.go
+++ b/pkg/astnormalization/astnormalization_test.go
@@ -460,6 +460,42 @@ var run = func(normalizeFunc registerNormalizeFunc, definition, operation, expec
 	}
 }
 
+var runWithExpectedErrors = func(t *testing.T, normalizeFunc registerNormalizeVariablesFunc, definition, operation, expectedError string, additionalNormalizers ...registerNormalizeFunc) {
+	t.Helper()
+
+	definitionDocument := unsafeparser.ParseGraphqlDocumentString(definition)
+	err := asttransform.MergeDefinitionWithBaseSchema(&definitionDocument)
+	if err != nil {
+		panic(err)
+	}
+
+	operationDocument := unsafeparser.ParseGraphqlDocumentString(operation)
+	report := operationreport.Report{}
+	walker := astvisitor.NewWalker(48)
+
+	normalizeFunc(&walker)
+
+	for _, fn := range additionalNormalizers {
+		fn(&walker)
+	}
+
+	walker.Walk(&operationDocument, &definitionDocument, &report)
+	// we run this walker twice because some normalizers may depend on other normalizers
+	// walking twice ensures that all prerequisites are met
+	// additionally, walking twice also ensures that the normalizers are idempotent
+	walker.Walk(&operationDocument, &definitionDocument, &report)
+
+	assert.True(t, report.HasErrors())
+	assert.Condition(t, func() bool {
+		for i := range report.InternalErrors {
+			if report.InternalErrors[i].Error() == expectedError {
+				return true
+			}
+		}
+		return false
+	})
+}
+
 func runMany(definition, operation, expectedOutput string, normalizeFuncs ...registerNormalizeFunc) {
 	var runManyNormalizers = func(walker *astvisitor.Walker) {
 		for _, normalizeFunc := range normalizeFuncs {

--- a/pkg/astnormalization/input_coercion_for_list.go
+++ b/pkg/astnormalization/input_coercion_for_list.go
@@ -1,6 +1,7 @@
 package astnormalization
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -193,6 +194,10 @@ func (i *inputCoercionForListVisitor) walkJsonObject(inputObjDefTypeRef int, dat
 		defer i.popQuery()
 
 		inputValueDefRef := i.definition.InputObjectTypeDefinitionInputValueDefinitionByName(inputObjDefTypeRef, key)
+		if inputValueDefRef == ast.InvalidRef {
+			return fmt.Errorf("nested field %s is not defined in any subfield of type %s", string(key), i.definition.InputObjectTypeDefinitionNameBytes(inputObjDefTypeRef))
+		}
+
 		typeRef := i.definition.ResolveListOrNameType(i.definition.InputValueDefinitionType(inputValueDefRef))
 
 		switch i.definition.Types[typeRef].TypeKind {

--- a/pkg/astnormalization/input_coercion_for_list_test.go
+++ b/pkg/astnormalization/input_coercion_for_list_test.go
@@ -776,5 +776,17 @@ func TestInputCoercionForList(t *testing.T) {
 				`{}`,
 				`{"a":{"list":[{"foo":"bar","list":[{"foo":"bar2","list":[{"nested":{"foo":"bar3","list":[{"foo":"bar4"}]}}]}]}]}}`, inputCoercionForList)
 		})
+		t.Run("walk into nested non existing object", func(t *testing.T) {
+			runWithExpectedErrors(t, extractVariables, inputCoercionForListDefinition, `
+				query {
+				  inputWithListNestedList(input: {
+				    nested: {non_existing_field: true},
+				  }) {
+ 				   id
+ 				   name
+ 				 }
+				}
+`, "nested field non_existing_field is not defined in any subfield of type InputWithList", inputCoercionForList)
+		})
 	})
 }


### PR DESCRIPTION
This fix is for normalization of request where one of nested subfields of input type does not exist.

This can be checked by running such a query in input_coercion_for_list_test.go

```
query {
  inputWithListNestedList(input: {
    nested: {non_existing_field: true},
  }) {
    id
    name
  }
}
```

fixes https://github.com/wundergraph/graphql-go-tools/pull/559