### PR TITLE
fix introspection not working for custom root operation types (#356)

### DIFF
--- a/pkg/engine/datasource/introspection_datasource/config_factory.go
+++ b/pkg/engine/datasource/introspection_datasource/config_factory.go
@@ -56,7 +56,7 @@ func (f *IntrospectionConfigFactory) BuildDataSourceConfiguration() plan.DataSou
 	return plan.DataSourceConfiguration{
 		RootNodes: []plan.TypeField{
 			{
-				TypeName:   "Query",
+				TypeName:   f.dataSourceConfigQueryTypeName(),
 				FieldNames: []string{"__schema", "__type"},
 			},
 			{
@@ -67,4 +67,11 @@ func (f *IntrospectionConfigFactory) BuildDataSourceConfiguration() plan.DataSou
 		Factory: NewFactory(f.introspectionData),
 		Custom:  json.RawMessage{},
 	}
+}
+
+func (f *IntrospectionConfigFactory) dataSourceConfigQueryTypeName() string {
+	if f.introspectionData.Schema.QueryType == nil || len(f.introspectionData.Schema.QueryType.Name) == 0 {
+		return "Query"
+	}
+	return f.introspectionData.Schema.QueryType.Name
 }

--- a/pkg/engine/datasource/introspection_datasource/fixtures/schema_introspection_with_custom_root_operation_types.golden
+++ b/pkg/engine/datasource/introspection_datasource/fixtures/schema_introspection_with_custom_root_operation_types.golden
@@ -1,0 +1,319 @@
+{
+  "queryType": {
+    "name": "CustomQuery"
+  },
+  "mutationType": {
+    "name": "CustomMutation"
+  },
+  "subscriptionType": {
+    "name": "CustomSubscription"
+  },
+  "types": [
+    {
+      "kind": "OBJECT",
+      "name": "CustomQuery",
+      "description": "",
+      "fields": [
+        {
+          "name": "me",
+          "description": "",
+          "args": [],
+          "type": {
+            "kind": "OBJECT",
+            "name": "Droid",
+            "ofType": null
+          },
+          "isDeprecated": true,
+          "deprecationReason": "No longer supported"
+        },
+        {
+          "name": "droid",
+          "description": "",
+          "args": [
+            {
+              "name": "id",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "type": {
+            "kind": "OBJECT",
+            "name": "Droid",
+            "ofType": null
+          },
+          "isDeprecated": false,
+          "deprecationReason": null
+        }
+      ],
+      "inputFields": [],
+      "interfaces": [],
+      "enumValues": [],
+      "possibleTypes": []
+    },
+    {
+      "kind": "OBJECT",
+      "name": "CustomMutation",
+      "description": "",
+      "fields": [
+        {
+          "name": "destroyDroid",
+          "description": "",
+          "args": [
+            {
+              "name": "id",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "type": {
+            "kind": "NON_NULL",
+            "name": null,
+            "ofType": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            }
+          },
+          "isDeprecated": false,
+          "deprecationReason": null
+        }
+      ],
+      "inputFields": [],
+      "interfaces": [],
+      "enumValues": [],
+      "possibleTypes": []
+    },
+    {
+      "kind": "OBJECT",
+      "name": "CustomSubscription",
+      "description": "",
+      "fields": [
+        {
+          "name": "destroyedDroid",
+          "description": "",
+          "args": [],
+          "type": {
+            "kind": "OBJECT",
+            "name": "Droid",
+            "ofType": null
+          },
+          "isDeprecated": false,
+          "deprecationReason": null
+        }
+      ],
+      "inputFields": [],
+      "interfaces": [],
+      "enumValues": [],
+      "possibleTypes": []
+    },
+    {
+      "kind": "ENUM",
+      "name": "Episode",
+      "description": "",
+      "fields": [],
+      "inputFields": [],
+      "interfaces": [],
+      "enumValues": [
+        {
+          "name": "NEWHOPE",
+          "description": "",
+          "isDeprecated": false,
+          "deprecationReason": null
+        },
+        {
+          "name": "EMPIRE",
+          "description": "",
+          "isDeprecated": false,
+          "deprecationReason": null
+        },
+        {
+          "name": "JEDI",
+          "description": "",
+          "isDeprecated": true,
+          "deprecationReason": "No longer supported"
+        }
+      ],
+      "possibleTypes": []
+    },
+    {
+      "kind": "OBJECT",
+      "name": "Droid",
+      "description": "",
+      "fields": [
+        {
+          "name": "name",
+          "description": "",
+          "args": [],
+          "type": {
+            "kind": "NON_NULL",
+            "name": null,
+            "ofType": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            }
+          },
+          "isDeprecated": false,
+          "deprecationReason": null
+        }
+      ],
+      "inputFields": [],
+      "interfaces": [],
+      "enumValues": [],
+      "possibleTypes": []
+    },
+    {
+      "kind": "SCALAR",
+      "name": "Int",
+      "description": "The 'Int' scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
+      "fields": [],
+      "inputFields": [],
+      "interfaces": [],
+      "enumValues": [],
+      "possibleTypes": []
+    },
+    {
+      "kind": "SCALAR",
+      "name": "Float",
+      "description": "The 'Float' scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).",
+      "fields": [],
+      "inputFields": [],
+      "interfaces": [],
+      "enumValues": [],
+      "possibleTypes": []
+    },
+    {
+      "kind": "SCALAR",
+      "name": "String",
+      "description": "The 'String' scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+      "fields": [],
+      "inputFields": [],
+      "interfaces": [],
+      "enumValues": [],
+      "possibleTypes": []
+    },
+    {
+      "kind": "SCALAR",
+      "name": "Boolean",
+      "description": "The 'Boolean' scalar type represents 'true' or 'false' .",
+      "fields": [],
+      "inputFields": [],
+      "interfaces": [],
+      "enumValues": [],
+      "possibleTypes": []
+    },
+    {
+      "kind": "SCALAR",
+      "name": "ID",
+      "description": "The 'ID' scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as '4') or integer (such as 4) input value will be accepted as an ID.",
+      "fields": [],
+      "inputFields": [],
+      "interfaces": [],
+      "enumValues": [],
+      "possibleTypes": []
+    }
+  ],
+  "directives": [
+    {
+      "name": "include",
+      "description": "Directs the executor to include this field or fragment only when the argument is true.",
+      "locations": [
+        "FIELD",
+        "FRAGMENT_SPREAD",
+        "INLINE_FRAGMENT"
+      ],
+      "args": [
+        {
+          "name": "if",
+          "description": "Included when true.",
+          "type": {
+            "kind": "NON_NULL",
+            "name": null,
+            "ofType": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            }
+          },
+          "defaultValue": null
+        }
+      ],
+      "isRepeatable": false
+    },
+    {
+      "name": "skip",
+      "description": "Directs the executor to skip this field or fragment when the argument is true.",
+      "locations": [
+        "FIELD",
+        "FRAGMENT_SPREAD",
+        "INLINE_FRAGMENT"
+      ],
+      "args": [
+        {
+          "name": "if",
+          "description": "Skipped when true.",
+          "type": {
+            "kind": "NON_NULL",
+            "name": null,
+            "ofType": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            }
+          },
+          "defaultValue": null
+        }
+      ],
+      "isRepeatable": false
+    },
+    {
+      "name": "deprecated",
+      "description": "Marks an element of a GraphQL schema as no longer supported.",
+      "locations": [
+        "FIELD_DEFINITION",
+        "ENUM_VALUE"
+      ],
+      "args": [
+        {
+          "name": "reason",
+          "description": "Explains why this element was deprecated, usually also including a suggestion\n    for how to access supported similar data. Formatted in\n    [Markdown](https://daringfireball.net/projects/markdown/).",
+          "type": {
+            "kind": "SCALAR",
+            "name": "String",
+            "ofType": null
+          },
+          "defaultValue": "\"No longer supported\""
+        }
+      ],
+      "isRepeatable": false
+    },
+    {
+      "name": "removeNullVariables",
+      "description": "The @removeNullVariables directive allows you to remove variables with null value from your GraphQL Query or Mutation Operations.\n\nA potential use-case could be that you have a graphql upstream which is not accepting null values for variables.\nBy enabling this directive all variables with null values will be removed from upstream query.\n\nquery ($say: String, $name: String) @removeNullVariables {\n\thello(say: $say, name: $name)\n}\n\nDirective will transform variables json and remove top level null values.\n{ \"say\": null, \"name\": \"world\" }\n\nSo upstream will receive the following variables:\n\n{ \"name\": \"world\" }",
+      "locations": [
+        "QUERY",
+        "MUTATION"
+      ],
+      "args": [],
+      "isRepeatable": false
+    }
+  ]
+}

--- a/pkg/engine/datasource/introspection_datasource/planner_test.go
+++ b/pkg/engine/datasource/introspection_datasource/planner_test.go
@@ -3,16 +3,41 @@ package introspection_datasource
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/internal/pkg/unsafeparser"
+	"github.com/wundergraph/graphql-go-tools/pkg/asttransform"
 	"github.com/wundergraph/graphql-go-tools/pkg/engine/datasourcetesting"
 	"github.com/wundergraph/graphql-go-tools/pkg/engine/plan"
 	"github.com/wundergraph/graphql-go-tools/pkg/engine/resolve"
 	"github.com/wundergraph/graphql-go-tools/pkg/introspection"
+	"github.com/wundergraph/graphql-go-tools/pkg/operationreport"
 )
 
 const (
 	schema = `
 		type Query {
 			friend: String
+		}
+	`
+
+	schemaWithCustomRootOperationTypes = `
+		schema {
+			query: CustomQuery
+			mutation: CustomMutation
+			subscription: CustomSubscription
+		}
+
+		type CustomQuery {
+			friend: String
+		}
+
+		type CustomMutation {
+			addFriend: Boolean
+		}
+
+		type CustomSubscription {
+			lastAddedFriend: String
 		}
 	`
 
@@ -35,6 +60,22 @@ const (
 		}
 	`
 
+	schemaIntrospectionForAllRootOperationTypeNames = `
+		query typeIntrospection {
+			__schema {
+				queryType {
+					name
+				}
+				mutationType {
+					name
+				}
+				subscriptionType {
+					name
+				}
+			}
+		}
+	`
+
 	typeIntrospectionWithArgs = `
 		query typeIntrospection {
 			__type(name: "Query") {
@@ -50,21 +91,39 @@ const (
 )
 
 func TestIntrospectionDataSourcePlanning(t *testing.T) {
-	dataSourceIdentifier := []byte("introspection_datasource.Source")
+	runTest := func(schema string, introspectionQuery string, expectedPlan plan.Plan) func(t *testing.T) {
+		return func(t *testing.T) {
+			t.Helper()
 
-	introspectionData := &introspection.Data{}
-	introspectionData.Schema.QueryType = &introspection.TypeName{Name: "Query"}
+			def := unsafeparser.ParseGraphqlDocumentString(schema)
+			err := asttransform.MergeDefinitionWithBaseSchema(&def)
+			require.NoError(t, err)
 
-	cfgFactory := IntrospectionConfigFactory{introspectionData: introspectionData}
-	introspectionDataSource := cfgFactory.BuildDataSourceConfiguration()
-	introspectionDataSource.Factory = &Factory{}
+			var (
+				introspectionData introspection.Data
+				report            operationreport.Report
+			)
 
-	planConfiguration := plan.Configuration{
-		DataSources: []plan.DataSourceConfiguration{introspectionDataSource},
-		Fields:      cfgFactory.BuildFieldConfigurations(),
+			gen := introspection.NewGenerator()
+			gen.Generate(&def, &report, &introspectionData)
+			require.False(t, report.HasErrors())
+
+			cfgFactory := IntrospectionConfigFactory{introspectionData: &introspectionData}
+			introspectionDataSource := cfgFactory.BuildDataSourceConfiguration()
+			introspectionDataSource.Factory = &Factory{}
+
+			planConfiguration := plan.Configuration{
+				DataSources: []plan.DataSourceConfiguration{introspectionDataSource},
+				Fields:      cfgFactory.BuildFieldConfigurations(),
+			}
+
+			datasourcetesting.RunTest(schema, introspectionQuery, "", expectedPlan, planConfiguration)(t)
+		}
 	}
 
-	t.Run("type introspection request", datasourcetesting.RunTest(schema, typeIntrospection, "",
+	dataSourceIdentifier := []byte("introspection_datasource.Source")
+
+	t.Run("type introspection request", runTest(schema, typeIntrospection,
 		&plan.SynchronousResponsePlan{
 			Response: &resolve.GraphQLResponse{
 				Data: &resolve.Object{
@@ -120,10 +179,9 @@ func TestIntrospectionDataSourcePlanning(t *testing.T) {
 				},
 			},
 		},
-		planConfiguration,
 	))
 
-	t.Run("schema introspection request", datasourcetesting.RunTest(schema, schemaIntrospection, "",
+	t.Run("schema introspection request", runTest(schema, schemaIntrospection,
 		&plan.SynchronousResponsePlan{
 			Response: &resolve.GraphQLResponse{
 				Data: &resolve.Object{
@@ -174,10 +232,110 @@ func TestIntrospectionDataSourcePlanning(t *testing.T) {
 				},
 			},
 		},
-		planConfiguration,
 	))
 
-	t.Run("type introspection request with fields args", datasourcetesting.RunTest(schema, typeIntrospectionWithArgs, "",
+	t.Run("schema introspection request with custom root operation types", runTest(schemaWithCustomRootOperationTypes, schemaIntrospectionForAllRootOperationTypeNames,
+		&plan.SynchronousResponsePlan{
+			Response: &resolve.GraphQLResponse{
+				Data: &resolve.Object{
+					Fetch: &resolve.SingleFetch{
+						BufferId:             0,
+						Input:                `{"request_type":1}`,
+						DataSource:           &Source{},
+						DataSourceIdentifier: dataSourceIdentifier,
+					},
+					Fields: []*resolve.Field{
+						{
+							BufferID:  0,
+							HasBuffer: true,
+							Name:      []byte("__schema"),
+							Position: resolve.Position{
+								Line:   3,
+								Column: 4,
+							},
+							Value: &resolve.Object{
+								Fields: []*resolve.Field{
+									{
+										Name: []byte("queryType"),
+										Value: &resolve.Object{
+											Path: []string{"queryType"},
+											Fields: []*resolve.Field{
+												{
+													Name: []byte("name"),
+													Value: &resolve.String{
+														Path:     []string{"name"},
+														Nullable: true,
+													},
+													Position: resolve.Position{
+														Line:   5,
+														Column: 6,
+													},
+												},
+											},
+										},
+										Position: resolve.Position{
+											Line:   4,
+											Column: 5,
+										},
+									},
+									{
+										Name: []byte("mutationType"),
+										Value: &resolve.Object{
+											Path:     []string{"mutationType"},
+											Nullable: true,
+											Fields: []*resolve.Field{
+												{
+													Name: []byte("name"),
+													Value: &resolve.String{
+														Path:     []string{"name"},
+														Nullable: true,
+													},
+													Position: resolve.Position{
+														Line:   8,
+														Column: 6,
+													},
+												},
+											},
+										},
+										Position: resolve.Position{
+											Line:   7,
+											Column: 5,
+										},
+									},
+									{
+										Name: []byte("subscriptionType"),
+										Value: &resolve.Object{
+											Path:     []string{"subscriptionType"},
+											Nullable: true,
+											Fields: []*resolve.Field{
+												{
+													Name: []byte("name"),
+													Value: &resolve.String{
+														Path:     []string{"name"},
+														Nullable: true,
+													},
+													Position: resolve.Position{
+														Line:   11,
+														Column: 6,
+													},
+												},
+											},
+										},
+										Position: resolve.Position{
+											Line:   10,
+											Column: 5,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	))
+
+	t.Run("type introspection request with fields args", runTest(schema, typeIntrospectionWithArgs,
 		&plan.SynchronousResponsePlan{
 			Response: &resolve.GraphQLResponse{
 				Data: &resolve.Object{
@@ -298,6 +456,5 @@ func TestIntrospectionDataSourcePlanning(t *testing.T) {
 				},
 			},
 		},
-		planConfiguration,
 	))
 }

--- a/pkg/engine/datasource/introspection_datasource/source_test.go
+++ b/pkg/engine/datasource/introspection_datasource/source_test.go
@@ -15,18 +15,18 @@ import (
 )
 
 func TestSource_Load(t *testing.T) {
-	def, report := astparser.ParseGraphqlDocumentString(testSchema)
-	require.False(t, report.HasErrors())
-	require.NoError(t, asttransform.MergeDefinitionWithBaseSchema(&def))
-
-	var data introspection.Data
-	gen := introspection.NewGenerator()
-	gen.Generate(&def, &report, &data)
-	require.False(t, report.HasErrors())
-
-	run := func(input string, fixtureName string) func(t *testing.T) {
+	run := func(schema string, input string, fixtureName string) func(t *testing.T) {
 		t.Helper()
 		return func(t *testing.T) {
+			def, report := astparser.ParseGraphqlDocumentString(schema)
+			require.False(t, report.HasErrors())
+			require.NoError(t, asttransform.MergeDefinitionWithBaseSchema(&def))
+
+			var data introspection.Data
+			gen := introspection.NewGenerator()
+			gen.Generate(&def, &report, &data)
+			require.False(t, report.HasErrors())
+
 			buf := &bytes.Buffer{}
 			source := &Source{introspectionData: &data}
 			require.NoError(t, source.Load(context.Background(), []byte(input), buf))
@@ -37,24 +37,25 @@ func TestSource_Load(t *testing.T) {
 		}
 	}
 
-	t.Run("schema introspection", run(`{"request_type":1}`, `schema_introspection`))
-	t.Run("type introspection", run(`{"request_type":2,"type_name":"Query"}`, `type_introspection`))
-	t.Run("type introspection of not existing type", run(`{"request_type":2,"type_name":"NotExisting"}`, `not_existing_type`))
+	t.Run("schema introspection", run(testSchema, `{"request_type":1}`, `schema_introspection`))
+	t.Run("schema introspection with custom root operation types", run(testSchemaWithCustomRootOperationTypes, `{"request_type":1}`, `schema_introspection_with_custom_root_operation_types`))
+	t.Run("type introspection", run(testSchema, `{"request_type":2,"type_name":"Query"}`, `type_introspection`))
+	t.Run("type introspection of not existing type", run(testSchema, `{"request_type":2,"type_name":"NotExisting"}`, `not_existing_type`))
 
 	t.Run("type fields", func(t *testing.T) {
-		t.Run("include deprecated", run(`{"request_type":3,"on_type_name":"Query","include_deprecated":true}`, `fields_with_deprecated`))
+		t.Run("include deprecated", run(testSchema, `{"request_type":3,"on_type_name":"Query","include_deprecated":true}`, `fields_with_deprecated`))
 
-		t.Run("no deprecated", run(`{"request_type":3,"on_type_name":"Query","include_deprecated":false}`, `fields_without_deprecated`))
+		t.Run("no deprecated", run(testSchema, `{"request_type":3,"on_type_name":"Query","include_deprecated":false}`, `fields_without_deprecated`))
 
-		t.Run("of not existing type", run(`{"request_type":3,"on_type_name":"NotExisting","include_deprecated":true}`, `not_existing_type`))
+		t.Run("of not existing type", run(testSchema, `{"request_type":3,"on_type_name":"NotExisting","include_deprecated":true}`, `not_existing_type`))
 	})
 
 	t.Run("type enum values", func(t *testing.T) {
-		t.Run("include deprecated", run(`{"request_type":4,"on_type_name":"Episode","include_deprecated":true}`, `enum_values_with_deprecated`))
+		t.Run("include deprecated", run(testSchema, `{"request_type":4,"on_type_name":"Episode","include_deprecated":true}`, `enum_values_with_deprecated`))
 
-		t.Run("no deprecated", run(`{"request_type":4,"on_type_name":"Episode","include_deprecated":false}`, `enum_values_without_deprecated`))
+		t.Run("no deprecated", run(testSchema, `{"request_type":4,"on_type_name":"Episode","include_deprecated":false}`, `enum_values_without_deprecated`))
 
-		t.Run("of not existing type", run(`{"request_type":4,"on_type_name":"NotExisting","include_deprecated":true}`, `not_existing_type`))
+		t.Run("of not existing type", run(testSchema, `{"request_type":4,"on_type_name":"NotExisting","include_deprecated":true}`, `not_existing_type`))
 	})
 }
 
@@ -78,3 +79,33 @@ type Droid {
     name: String!
 }
 `
+
+const testSchemaWithCustomRootOperationTypes = `
+schema {
+    query: CustomQuery
+	mutation: CustomMutation
+	subscription: CustomSubscription
+}
+
+type CustomQuery {
+    me: Droid @deprecated
+    droid(id: ID!): Droid
+}
+
+type CustomMutation {
+	destroyDroid(id: ID!): Boolean!
+}
+
+type CustomSubscription {
+	destroyedDroid: Droid
+}
+
+enum Episode {
+    NEWHOPE
+    EMPIRE
+    JEDI @deprecated
+}
+
+type Droid {
+    name: String!
+}`


### PR DESCRIPTION
This PR fixes an introspection issue when custom root operation types are defined, e.g.
```
schema {
	query: CustomQuery
	mutation: CustomMutation
	subscription: CustomSubscription
}

type CustomQuery {
	friend: String
}

type CustomMutation {
	addFriend: Boolean
}

type CustomSubscription {
	lastAddedFriend: String
}
```

In those cases, the engine returns an "unable to resolve" error message.