### PR TITLE
propose simpler version to skip child fields

### DIFF
--- a/pkg/engine/plan/plan.go
+++ b/pkg/engine/plan/plan.go
@@ -456,7 +456,7 @@ func (v *Visitor) AllowVisitor(kind astvisitor.VisitorKind, ref int, visitor int
 		return true
 	}
 	if skipRef, ok := v.skipVisitors[visitor]; ok {
-		if skipRef == ref {
+		if kind == astvisitor.LeaveSelectionSet && skipRef == ref {
 			// delete the visitor from the skip list
 			// as skipRef is our exit point of the skip
 			delete(v.skipVisitors, visitor)


### PR DESCRIPTION
this PR didn't remove the existing skip fields logic and might not be complete yet, but proposes a simpler version to skip all child fields for a given visitor until we "leave" a specific ref again.