### PR TITLE
feat: custom resolve map

### DIFF
--- a/pkg/engine/plan/plan.go
+++ b/pkg/engine/plan/plan.go
@@ -36,6 +36,7 @@ type Configuration struct {
 	// This setting removes position information from all fields
 	// In production, this should be set to false so that error messages are easier to understand
 	DisableResolveFieldPositions bool
+	CustomResolveMap             map[string]resolve.CustomResolve
 }
 
 type DirectiveConfigurations []DirectiveConfiguration
@@ -730,6 +731,13 @@ func (v *Visitor) resolveFieldValue(fieldRef, typeRef int, nullable bool, path [
 		}
 	case ast.TypeKindNamed:
 		typeName := v.Definition.ResolveTypeNameString(typeRef)
+		customResolve, ok := v.Config.CustomResolveMap[typeName]
+		if ok {
+			return &resolve.CustomNode{
+				CustomResolve: customResolve,
+				Path:          path,
+			}
+		}
 		typeDefinitionNode, ok := v.Definition.Index.FirstNodeByNameStr(typeName)
 		if !ok {
 			return &resolve.Null{}

--- a/pkg/engine/resolve/resolve.go
+++ b/pkg/engine/resolve/resolve.go
@@ -95,6 +95,7 @@ const (
 	NodeKindBoolean
 	NodeKindInteger
 	NodeKindFloat
+	NodeKindCustom
 
 	FetchKindSingle FetchKind = iota + 1
 	FetchKindParallel
@@ -432,6 +433,8 @@ func (r *Resolver) resolveNode(ctx *Context, node Node, data []byte, bufPair *Bu
 	case *EmptyArray:
 		r.resolveEmptyArray(bufPair.Data)
 		return
+	case *CustomNode:
+		return n.Resolve(ctx, data, n.Path, n.Nullable, bufPair)
 	default:
 		return
 	}
@@ -1478,6 +1481,20 @@ type String struct {
 
 func (_ *String) NodeKind() NodeKind {
 	return NodeKindString
+}
+
+type CustomResolve interface {
+	Resolve(ctx *Context, data []byte, path []string, nullable bool, customBuf *BufPair) error
+}
+
+type CustomNode struct {
+	CustomResolve
+	Nullable bool
+	Path     []string
+}
+
+func (_ *CustomNode) NodeKind() NodeKind {
+	return NodeKindCustom
 }
 
 type Boolean struct {

--- a/pkg/graphql/config_factory_federation.go
+++ b/pkg/graphql/config_factory_federation.go
@@ -17,9 +17,16 @@ type federationEngineConfigFactoryOptions struct {
 	streamingClient           *http.Client
 	subscriptionClientFactory graphqlDataSource.GraphQLSubscriptionClientFactory
 	subscriptionType          SubscriptionType
+	customResolveMap          map[string]resolve.CustomResolve
 }
 
 type FederationEngineConfigFactoryOption func(options *federationEngineConfigFactoryOptions)
+
+func WithCustomResolveMap(customResolveMap map[string]resolve.CustomResolve) FederationEngineConfigFactoryOption {
+	return func(options *federationEngineConfigFactoryOptions) {
+		options.customResolveMap = customResolveMap
+	}
+}
 
 func WithFederationHttpClient(client *http.Client) FederationEngineConfigFactoryOption {
 	return func(options *federationEngineConfigFactoryOptions) {
@@ -72,6 +79,7 @@ func NewFederationEngineConfigFactory(dataSourceConfigs []graphqlDataSource.Conf
 		batchFactory:              batchFactory,
 		subscriptionClientFactory: options.subscriptionClientFactory,
 		subscriptionType:          options.subscriptionType,
+		customResolveMap:          options.customResolveMap,
 	}
 }
 
@@ -84,6 +92,7 @@ type FederationEngineConfigFactory struct {
 	batchFactory              resolve.DataSourceBatchFactory
 	subscriptionClientFactory graphqlDataSource.GraphQLSubscriptionClientFactory
 	subscriptionType          SubscriptionType
+	customResolveMap          map[string]resolve.CustomResolve
 }
 
 func (f *FederationEngineConfigFactory) SetMergedSchemaFromString(mergedSchema string) (err error) {
@@ -136,6 +145,10 @@ func (f *FederationEngineConfigFactory) EngineV2Configuration() (conf EngineV2Co
 
 	conf.SetFieldConfigurations(fieldConfigs)
 	conf.SetDataSources(dataSources)
+
+	if f.customResolveMap != nil {
+		conf.SetCustomResolveMap(f.customResolveMap)
+	}
 
 	return conf, nil
 }

--- a/pkg/graphql/engine_config_v2.go
+++ b/pkg/graphql/engine_config_v2.go
@@ -41,6 +41,10 @@ type dataLoaderConfig struct {
 	EnableDataLoader         bool
 }
 
+func (e *EngineV2Configuration) SetCustomResolveMap(customResolveMap map[string]resolve.CustomResolve) {
+	e.plannerConfig.CustomResolveMap = customResolveMap
+}
+
 func (e *EngineV2Configuration) AddDataSource(dataSource plan.DataSourceConfiguration) {
 	e.plannerConfig.DataSources = append(e.plannerConfig.DataSources, dataSource)
 }

--- a/pkg/graphql/execution_engine_v2_test.go
+++ b/pkg/graphql/execution_engine_v2_test.go
@@ -819,7 +819,8 @@ func TestExecutionEngineV2_Execute(t *testing.T) {
 					Variables:     nil,
 				}
 				jsonBytes, _ := json.Marshal(body)
-				UnmarshalRequest(bytes.NewBuffer(jsonBytes), &request)
+				err := UnmarshalRequest(bytes.NewBuffer(jsonBytes), &request)
+				require.NoError(t, err)
 				return request
 			},
 			dataSources: []plan.DataSourceConfiguration{

--- a/pkg/graphql/execution_engine_v2_test.go
+++ b/pkg/graphql/execution_engine_v2_test.go
@@ -1,9 +1,11 @@
 package graphql
 
 import (
+	"bytes"
 	"compress/flate"
 	"compress/gzip"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -21,6 +23,7 @@ import (
 	"github.com/wundergraph/graphql-go-tools/pkg/engine/datasource/staticdatasource"
 	"github.com/wundergraph/graphql-go-tools/pkg/engine/plan"
 	"github.com/wundergraph/graphql-go-tools/pkg/engine/resolve"
+	"github.com/wundergraph/graphql-go-tools/pkg/execution"
 	"github.com/wundergraph/graphql-go-tools/pkg/operationreport"
 	"github.com/wundergraph/graphql-go-tools/pkg/starwars"
 	"github.com/wundergraph/graphql-go-tools/pkg/testing/federationtesting"
@@ -28,6 +31,12 @@ import (
 	products "github.com/wundergraph/graphql-go-tools/pkg/testing/federationtesting/products/graph"
 	reviews "github.com/wundergraph/graphql-go-tools/pkg/testing/federationtesting/reviews/graph"
 )
+
+type customResolver struct{}
+
+func (customResolver) Resolve(value []byte) ([]byte, error) {
+	return value, nil
+}
 
 func TestEngineResponseWriter_AsHTTPResponse(t *testing.T) {
 	t.Run("no compression", func(t *testing.T) {
@@ -148,6 +157,7 @@ type ExecutionEngineV2TestCase struct {
 	fields                            plan.FieldConfigurations
 	engineOptions                     []ExecutionOptionsV2
 	expectedResponse                  string
+	customResolveMap                  map[string]resolve.CustomResolve
 }
 
 func TestExecutionEngineV2_Execute(t *testing.T) {
@@ -172,6 +182,7 @@ func TestExecutionEngineV2_Execute(t *testing.T) {
 			}
 			engineConf.SetDataSources(testCase.dataSources)
 			engineConf.SetFieldConfigurations(testCase.fields)
+			engineConf.SetCustomResolveMap(testCase.customResolveMap)
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			engine, err := NewExecutionEngineV2(ctx, abstractlogger.Noop{}, engineConf)
@@ -785,6 +796,67 @@ func TestExecutionEngineV2_Execute(t *testing.T) {
 			},
 			fields:           []plan.FieldConfiguration{},
 			expectedResponse: `{"data":{"hero":{"name":"Luke Skywalker"}}}`,
+		},
+	))
+
+	schemaWithCustomScalar, _ := NewSchemaFromString(string(`
+    scalar Long
+    type Asset {
+      id: Long!
+    }
+    type Query {
+      asset: Asset
+    }
+  `))
+	t.Run("query with custom scalar", runWithoutError(
+		ExecutionEngineV2TestCase{
+			schema: schemaWithCustomScalar,
+			operation: func(t *testing.T) Request {
+				request := Request{}
+				body := execution.GraphqlRequest{
+					Query:         `{asset{id}}`,
+					OperationName: "",
+					Variables:     nil,
+				}
+				jsonBytes, _ := json.Marshal(body)
+				UnmarshalRequest(bytes.NewBuffer(jsonBytes), &request)
+				return request
+			},
+			dataSources: []plan.DataSourceConfiguration{
+				{
+					RootNodes: []plan.TypeField{
+						{
+							TypeName:   "Query",
+							FieldNames: []string{"asset"},
+						},
+					},
+					ChildNodes: []plan.TypeField{
+						{
+							TypeName:   "Asset",
+							FieldNames: []string{"id"},
+						},
+					},
+					Factory: &graphql_datasource.Factory{
+						HTTPClient: testNetHttpClient(t, roundTripperTestCase{
+							expectedHost:     "example.com",
+							expectedPath:     "/",
+							expectedBody:     "",
+							sendResponseBody: `{"data":{"asset":{"id":1}}}`,
+							sendStatusCode:   200,
+						}),
+					},
+					Custom: graphql_datasource.ConfigJson(graphql_datasource.Configuration{
+						Fetch: graphql_datasource.FetchConfiguration{
+							URL:    "https://example.com/",
+							Method: "GET",
+						},
+					}),
+				},
+			},
+			customResolveMap: map[string]resolve.CustomResolve{
+				"Long": &customResolver{},
+			},
+			expectedResponse: `{"data":{"asset":{"id":1}}}`,
 		},
 	))
 


### PR DESCRIPTION
This PR allows users to register a map which allows to parse/validate/resolve custom types.
This should allow to pass through any custom scalar to the federated gql apis.

Related issues:
- https://github.com/wundergraph/graphql-go-tools/issues/179
- https://github.com/wundergraph/graphql-go-tools/issues/530
- https://github.com/wundergraph/graphql-go-tools/issues/457
- https://github.com/wundergraph/graphql-go-tools/issues/454