### PR TITLE
chore: improve error messages when base schema is not merged

### DIFF
--- a/pkg/ast/ast_operation_definition.go
+++ b/pkg/ast/ast_operation_definition.go
@@ -17,6 +17,8 @@ const (
 	OperationTypeSubscription
 )
 
+// Name returns a human-readable operation name for the given OperationType.
+// If the operation is not one of the OperationType constants, it panics.
 func (t OperationType) Name() string {
 	switch t {
 	case OperationTypeUnknown:
@@ -28,7 +30,7 @@ func (t OperationType) Name() string {
 	case OperationTypeSubscription:
 		return "subscription"
 	}
-	return fmt.Sprintf("unknown operation type %d", int(t))
+	panic(fmt.Errorf("unknown operation type %d", int(t)))
 }
 
 type OperationDefinition struct {

--- a/pkg/ast/ast_operation_definition.go
+++ b/pkg/ast/ast_operation_definition.go
@@ -1,6 +1,7 @@
 package ast
 
 import (
+	"fmt"
 	"math"
 
 	"github.com/wundergraph/graphql-go-tools/internal/pkg/unsafebytes"
@@ -15,6 +16,20 @@ const (
 	OperationTypeMutation
 	OperationTypeSubscription
 )
+
+func (t OperationType) Name() string {
+	switch t {
+	case OperationTypeUnknown:
+		return "unknown"
+	case OperationTypeQuery:
+		return "query"
+	case OperationTypeMutation:
+		return "mutation"
+	case OperationTypeSubscription:
+		return "subscription"
+	}
+	return fmt.Sprintf("unknown operation type %d", int(t))
+}
 
 type OperationDefinition struct {
 	OperationType          OperationType      // one of query, mutation, subscription

--- a/pkg/astvisitor/visitor.go
+++ b/pkg/astvisitor/visitor.go
@@ -1348,6 +1348,7 @@ func (w *Walker) appendAncestor(ref int, kind ast.NodeKind) {
 				FieldName: literal.SUBSCRIPTION,
 			})
 		default:
+			w.StopWithExternalErr(operationreport.ErrInvalidOperationType(operationType))
 			return
 		}
 		if len(typeName) == 0 {

--- a/pkg/astvisitor/visitor.go
+++ b/pkg/astvisitor/visitor.go
@@ -1327,7 +1327,8 @@ func (w *Walker) appendAncestor(ref int, kind ast.NodeKind) {
 
 	switch kind {
 	case ast.NodeKindOperationDefinition:
-		switch w.document.OperationDefinitions[ref].OperationType {
+		operationType := w.document.OperationDefinitions[ref].OperationType
+		switch operationType {
 		case ast.OperationTypeQuery:
 			typeName = w.definition.Index.QueryTypeName
 			w.Path = append(w.Path, ast.PathItem{
@@ -1347,6 +1348,10 @@ func (w *Walker) appendAncestor(ref int, kind ast.NodeKind) {
 				FieldName: literal.SUBSCRIPTION,
 			})
 		default:
+			return
+		}
+		if len(typeName) == 0 {
+			w.StopWithExternalErr(operationreport.ErrOperationTypeUndefined(operationType))
 			return
 		}
 	case ast.NodeKindInlineFragment:

--- a/pkg/operationreport/externalerror.go
+++ b/pkg/operationreport/externalerror.go
@@ -64,6 +64,11 @@ func ErrTypeUndefined(typeName ast.ByteSlice) (err ExternalError) {
 	return err
 }
 
+func ErrInvalidOperationType(operationType ast.OperationType) (err ExternalError) {
+	err.Message = fmt.Sprintf("invalid operation type %d", int(operationType))
+	return err
+}
+
 func ErrOperationTypeUndefined(operationType ast.OperationType) (err ExternalError) {
 	err.Message = fmt.Sprintf("operation type %s is not defined; did you forget to merge the base schema?", operationType.Name())
 	return err

--- a/pkg/operationreport/externalerror.go
+++ b/pkg/operationreport/externalerror.go
@@ -65,7 +65,7 @@ func ErrTypeUndefined(typeName ast.ByteSlice) (err ExternalError) {
 }
 
 func ErrOperationTypeUndefined(operationType ast.OperationType) (err ExternalError) {
-	err.Message = fmt.Sprintf("operation type %s is not defined, did you forget to merge the base schema?", operationType.Name())
+	err.Message = fmt.Sprintf("operation type %s is not defined; did you forget to merge the base schema?", operationType.Name())
 	return err
 }
 

--- a/pkg/operationreport/externalerror.go
+++ b/pkg/operationreport/externalerror.go
@@ -64,6 +64,11 @@ func ErrTypeUndefined(typeName ast.ByteSlice) (err ExternalError) {
 	return err
 }
 
+func ErrOperationTypeUndefined(operationType ast.OperationType) (err ExternalError) {
+	err.Message = fmt.Sprintf("operation type %s is not defined, did you forget to merge the base schema?", operationType.Name())
+	return err
+}
+
 func ErrScalarTypeUndefined(scalarName ast.ByteSlice) (err ExternalError) {
 	err.Message = fmt.Sprintf("scalar not defined: %s", scalarName)
 	return err


### PR DESCRIPTION
Now the error message says "operation type %s is not defined; did you forget to merge the base schema?"
where the placeholder is replaced by query/mutation/subscription
