### PR TITLE
Fix potential panic

### DIFF
--- a/pkg/astnormalization/input_coercion_for_list_test.go
+++ b/pkg/astnormalization/input_coercion_for_list_test.go
@@ -786,8 +786,8 @@ func TestInputCoercionForList(t *testing.T) {
 					inputWithNestedScalar(input: {
 						stringList: null,
 						intList: null,
-                        unknownField: null
-					}) 
+						unknownField: null
+					})
 				}`, `Q`,
 				`
 				query Q($a: InputWithNestedScalarList) {

--- a/pkg/astnormalization/input_coercion_for_list_test.go
+++ b/pkg/astnormalization/input_coercion_for_list_test.go
@@ -177,7 +177,7 @@ func TestInputCoercionForList(t *testing.T) {
 				query Q {
 					inputWithNestedScalar(input: {
 						stringList: null,
-						intList: null,
+						intList: null
 					}) 
 				}`, `Q`,
 				`


### PR DESCRIPTION
This PR fixes a potential panic that exists in the specification of variables to the query.

For example, in cases where a field that does not exist in the definition, but does exist in a variable.

Details:

If an undefined field of input type is in the given variable, `walkJsonObject()` returns -1.
```Go
func (i *inputCoercionForListVisitor) walkJsonObject(inputObjDefTypeRef int, data []byte) {
... snip
		inputValueDefRef := i.definition.InputObjectTypeDefinitionInputValueDefinitionByName(inputObjDefTypeRef, key)
		typeRef := i.definition.ResolveListOrNameType(i.definition.InputValueDefinitionType(inputValueDefRef))

```

This causes a panic by referencing the `InputValueDefinitions` array with a index of -1.

```Go
func (d *Document) InputValueDefinitionType(ref int) int {
	return d.InputValueDefinitions[ref].Type     // ← ★ ref=-1 !!! cause panic.
}
```

