### PR TITLE
feat: use NewRequestWithContext instead of NewRequest

### DIFF
--- a/pkg/execution/datasource/datasource_graphql.go
+++ b/pkg/execution/datasource/datasource_graphql.go
@@ -418,9 +418,9 @@ func (g *GraphQLDataSource) Resolve(ctx context.Context, args ResolverArgs, out 
 		log.ByteString("data", gqlRequestData),
 	)
 
-	request, err := http.NewRequest(http.MethodPost, parsedURL.String(), bytes.NewBuffer(gqlRequestData))
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, parsedURL.String(), bytes.NewBuffer(gqlRequestData))
 	if err != nil {
-		g.Log.Error("GraphQLDataSource.http.NewRequest",
+		g.Log.Error("GraphQLDataSource.http.NewRequestWithContext",
 			log.Error(err),
 		)
 		return n, err

--- a/pkg/execution/datasource/datasource_http_json.go
+++ b/pkg/execution/datasource/datasource_http_json.go
@@ -314,9 +314,9 @@ func (r *HttpJsonDataSource) Resolve(ctx context.Context, args ResolverArgs, out
 		bodyReader = bytes.NewReader(bodyArg)
 	}
 
-	request, err := http.NewRequest(httpMethod, parsedURL.String(), bodyReader)
+	request, err := http.NewRequestWithContext(ctx, httpMethod, parsedURL.String(), bodyReader)
 	if err != nil {
-		r.Log.Error("HttpJsonDataSource.Resolve.NewRequest",
+		r.Log.Error("HttpJsonDataSource.Resolve.NewRequestWithContext",
 			log.Error(err),
 		)
 		return

--- a/pkg/execution/datasource/datasource_http_polling_stream.go
+++ b/pkg/execution/datasource/datasource_http_polling_stream.go
@@ -136,7 +136,7 @@ func (s *HttpPollingStreamDataSource) isClosed() bool {
 func (h *HttpPollingStreamDataSource) Resolve(ctx context.Context, args ResolverArgs, out io.Writer) (n int, err error) {
 	h.once.Do(func() {
 		h.ch = make(chan []byte)
-		h.request = h.generateRequest(args)
+		h.request = h.generateRequest(ctx, args)
 		h.client = &http.Client{
 			Timeout: time.Second * 5,
 			Transport: &http.Transport{
@@ -210,7 +210,7 @@ func (h *HttpPollingStreamDataSource) startPolling(ctx context.Context) {
 	}
 }
 
-func (h *HttpPollingStreamDataSource) generateRequest(args ResolverArgs) *http.Request {
+func (h *HttpPollingStreamDataSource) generateRequest(ctx context.Context, args ResolverArgs) *http.Request {
 	hostArg := args.ByKey(literal.HOST)
 	urlArg := args.ByKey(literal.URL)
 
@@ -256,7 +256,7 @@ func (h *HttpPollingStreamDataSource) generateRequest(args ResolverArgs) *http.R
 		log.String("url", url),
 	)
 
-	request, err := http.NewRequest(http.MethodGet, url, nil)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		h.Log.Error("HttpPollingStreamDataSource.generateRequest.Resolve.NewRequest",
 			log.Error(err),

--- a/pkg/testing/federationtesting/gateway/datasource_poller.go
+++ b/pkg/testing/federationtesting/gateway/datasource_poller.go
@@ -27,7 +27,7 @@ type DatasourcePollerConfig struct {
 }
 
 const ServiceDefinitionQuery = `
-	{ 
+	{
 		"query": "query __ApolloGetServiceDefinition__ { _service { sdl } }",
 		"operationName": "__ApolloGetServiceDefinition__",
 		"variables": {}

--- a/pkg/testing/federationtesting/graphql_client_test.go
+++ b/pkg/testing/federationtesting/graphql_client_test.go
@@ -59,7 +59,7 @@ type GraphqlClient struct {
 
 func (g *GraphqlClient) Query(ctx context.Context, addr, queryFilePath string, variables queryVariables, t *testing.T) []byte {
 	reqBody := loadQuery(t, queryFilePath, variables)
-	req, err := http.NewRequest(http.MethodPost, addr, bytes.NewBuffer(reqBody))
+	req, err := http.NewRequest(ctx, http.MethodPost, addr, bytes.NewBuffer(reqBody))
 	require.NoError(t, err)
 	req = req.WithContext(ctx)
 	resp, err := g.httpClient.Do(req)


### PR DESCRIPTION
This PR changes `http.NewRequest` to `http.NewRequestWithContext` where upper `ctx` is available.