### PR TITLE
[Fix] variables_default_value_extraction sets type as not nullable when variable is provided

### DIFF
--- a/examples/federation/products/graph/entity.resolvers.go
+++ b/examples/federation/products/graph/entity.resolvers.go
@@ -9,10 +9,11 @@ import (
 
 	"github.com/wundergraph/graphql-go-tools/examples/federation/products/graph/generated"
 	"github.com/wundergraph/graphql-go-tools/examples/federation/products/graph/model"
+	"github.com/99designs/gqlgen/plugin/federation/fedruntime"
 )
 
 // FindProductByUpc is the resolver for the findProductByUpc field.
-func (r *entityResolver) FindProductByUpc(ctx context.Context, upc string) (*model.Product, error) {
+func (r *entityResolver) FindProductByUpc(ctx context.Context, obj fedruntime.Entity, upc string) (*model.Product, error) {
 	for _, h := range hats {
 		if h.Upc == upc {
 			return h, nil

--- a/examples/federation/products/graph/generated/federation.go
+++ b/examples/federation/products/graph/generated/federation.go
@@ -92,7 +92,7 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 				if err != nil {
 					return fmt.Errorf(`unmarshalling param 0 for findProductByUpc(): %w`, err)
 				}
-				entity, err := ec.resolvers.Entity().FindProductByUpc(ctx, id0)
+				entity, err := ec.resolvers.Entity().FindProductByUpc(ctx, nil, id0)
 				if err != nil {
 					return fmt.Errorf(`resolving Entity "Product": %w`, err)
 				}

--- a/examples/federation/products/graph/schema.graphqls
+++ b/examples/federation/products/graph/schema.graphqls
@@ -1,5 +1,5 @@
 extend type Query {
-    topProducts(first: Int = 5): [Product]
+    topProducts(first: Int! = 5): [Product]
 }
 
 extend type Subscription {

--- a/examples/federation/products/graph/schema.resolvers.go
+++ b/examples/federation/products/graph/schema.resolvers.go
@@ -15,7 +15,7 @@ import (
 )
 
 // TopProducts is the resolver for the topProducts field.
-func (r *queryResolver) TopProducts(ctx context.Context, first *int) ([]*model.Product, error) {
+func (r *queryResolver) TopProducts(ctx context.Context, first int) ([]*model.Product, error) {
 	return hats, nil
 }
 

--- a/pkg/astnormalization/variables_default_value_extraction_test.go
+++ b/pkg/astnormalization/variables_default_value_extraction_test.go
@@ -14,6 +14,8 @@ const (
 			objectInNestedList(input: [[Nested]]): String
 			stringInNestedList(input: [[String!]]): String
 			nullableStringInNestedList(input: [[String]]): String
+			notNullableInt(input: Int! = 5): String
+			notNullableString(input: String! = "DefaultInSchema"): String
 		}
 		input Nested {
 			NotNullable: String!
@@ -182,14 +184,14 @@ func TestVariablesDefaultValueExtraction(t *testing.T) {
 				runWithVariablesDefaultValues(t, extractVariablesDefaultValue, variablesDefaultValueExtractionDefinition, `
 					query q(
 						$nullable: String = "a",
-						$notNullable: String = "b",	
+						$notNullable: String = "b",
 					) {
 						objectInList(input: [{NotNullable: $notNullable, Nullable: $nullable}])
 					}`, "", `
-					query q(	
+					query q(
 						$nullable: String,
 						$notNullable: String!,
-					) {	
+					) {
 						objectInList(input: [{NotNullable: $notNullable, Nullable: $nullable}])
 					}`, ``, `{"notNullable":"b","nullable":"a"}`)
 			})
@@ -198,14 +200,14 @@ func TestVariablesDefaultValueExtraction(t *testing.T) {
 				runWithVariablesDefaultValues(t, extractVariablesDefaultValue, variablesDefaultValueExtractionDefinition, `
 					query q(
 						$nullable: String = "a",
-						$notNullable: String = "b",	
+						$notNullable: String = "b",
 					) {
 						objectInNestedList(input: [[{NotNullable: $notNullable, Nullable: $nullable}]])
 					}`, "", `
-					query q(	
+					query q(
 						$nullable: String,
 						$notNullable: String!,
-					) {	
+					) {
 						objectInNestedList(input: [[{NotNullable: $notNullable, Nullable: $nullable}]])
 					}`, ``, `{"notNullable":"b","nullable":"a"}`)
 			})
@@ -219,7 +221,7 @@ func TestVariablesDefaultValueExtraction(t *testing.T) {
 					}`, "", `
 					query q(
 						$notNullable: String!,
-					) {	
+					) {
 						stringInNestedList(input: [["a", $notNullable]])
 					}`, ``, `{"notNullable":"foo"}`)
 			})
@@ -233,7 +235,7 @@ func TestVariablesDefaultValueExtraction(t *testing.T) {
 					}`, "", `
 					query q(
 						$nullable: String,
-					) {	
+					) {
 						nullableStringInNestedList(input: [["a", null, $nullable]])
 					}`, ``, `{"nullable":"foo"}`)
 			})
@@ -264,6 +266,61 @@ func TestVariablesDefaultValueExtraction(t *testing.T) {
 			mutation simple($a: String, $b: String, $c: String, $d: String!) {
 				mixed(a: $a, b: $b, input: $c, nonNullInput: $d)
 			}`, `{"a":"aaa"}`, `{"d":"bar","c":"foo","b":"bazz","a":"aaa"}`)
+	})
 
+	t.Run("Not nullable int with default value", func(t *testing.T) {
+		runWithVariablesDefaultValues(t, extractVariablesDefaultValue, variablesDefaultValueExtractionDefinition, `
+			query q(
+				$input: Int = 4,
+			) {
+				notNullableInt(input: $input)
+			}`, "", `
+			query q(
+				$input: Int!,
+			) {
+				notNullableInt(input: $input)
+			}`, ``, `{"input":4}`)
+	})
+
+	t.Run("not nullable int with default value and variable overwrite", func(t *testing.T) {
+		runWithVariablesDefaultValues(t, extractVariablesDefaultValue, variablesDefaultValueExtractionDefinition, `
+			query q(
+				$input: Int = 4,
+			) {
+				notNullableInt(input: $input)
+			}`, "", `
+			query q(
+				$input: Int!,
+			) {
+				notNullableInt(input: $input)
+			}`, `{"input":6}`, `{"input":6}`)
+	})
+
+	t.Run("not nullable string with default value", func(t *testing.T) {
+		runWithVariablesDefaultValues(t, extractVariablesDefaultValue, variablesDefaultValueExtractionDefinition, `
+			query q(
+				$input: String = "DefaultInOperation",
+			) {
+				notNullableString(input: $input)
+			}`, "", `
+			query q(
+				$input: String!,
+			) {
+				notNullableString(input: $input)
+			}`, ``, `{"input":"DefaultInOperation"}`)
+	})
+
+	t.Run("not nullable string with default value and variable overwrite", func(t *testing.T) {
+		runWithVariablesDefaultValues(t, extractVariablesDefaultValue, variablesDefaultValueExtractionDefinition, `
+			query q(
+				$input: String = "DefaultInOperation",
+			) {
+				notNullableString(input: $input)
+			}`, "", `
+			query q(
+				$input: String!,
+			) {
+				notNullableString(input: $input)
+			}`, `{"input":"ValueInVariable"}`, `{"input":"ValueInVariable"}`)
 	})
 }

--- a/v2/pkg/astnormalization/variables_default_value_extraction.go
+++ b/v2/pkg/astnormalization/variables_default_value_extraction.go
@@ -6,6 +6,7 @@ import (
 	"github.com/buger/jsonparser"
 	"github.com/tidwall/sjson"
 
+	"github.com/wundergraph/graphql-go-tools/v2/internal/pkg/quotes"
 	"github.com/wundergraph/graphql-go-tools/v2/internal/pkg/unsafebytes"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/astimport"
@@ -76,30 +77,41 @@ func (v *variablesDefaultValueExtractionVisitor) EnterVariableDefinition(ref int
 		return
 	}
 
+	// Add not null type for variable
+	if !v.operation.TypeIsNonNull(v.operation.VariableDefinitions[ref].Type) {
+		v.operation.VariableDefinitions[ref].Type = v.operation.AddNonNullType(v.operation.VariableDefinitions[ref].Type)
+	}
+
 	variableName := v.operation.VariableDefinitionNameString(ref)
 
 	// remove variable DefaultValue from operation
 	v.operation.VariableDefinitions[ref].DefaultValue.IsDefined = false
 
-	// skip when variable was provided
-	_, _, _, err := jsonparser.Get(v.operation.Input.Variables, variableName)
-	if err == nil {
-		return
-	}
-
 	// store extracted variable ref
 	v.extractedVariablesRefs = append(v.extractedVariablesRefs, ref)
 
-	valueBytes, err := v.operation.ValueToJSON(v.operation.VariableDefinitionDefaultValue(ref))
-	if err != nil {
-		return
+	// Use the provided value for the variable if present, otherwise, use the default value
+	valueBytes, dataType, _, _ := jsonparser.Get(v.operation.Input.Variables, variableName)
+	if valueBytes == nil {
+		jsonVal, err := v.operation.ValueToJSON(v.operation.VariableDefinitionDefaultValue(ref))
+		if err != nil {
+			return
+		}
+
+		valueBytes = jsonVal
+	} else {
+		if dataType == jsonparser.String {
+			valueBytes = quotes.WrapBytes(valueBytes)
+		}
 	}
 
-	v.operation.Input.Variables, err = sjson.SetRawBytes(v.operation.Input.Variables, variableName, valueBytes)
+	inputVars, err := sjson.SetRawBytes(v.operation.Input.Variables, variableName, valueBytes)
 	if err != nil {
 		v.StopWithInternalErr(err)
 		return
 	}
+
+	v.operation.Input.Variables = inputVars
 }
 
 func (v *variablesDefaultValueExtractionVisitor) EnterOperationDefinition(ref int) {


### PR DESCRIPTION
I think this fixes https://github.com/wundergraph/graphql-go-tools/issues/640

It seems like `pkg/astnormalization/variables_default_value_extraction.go` removed default values for variables that had a value assigned explicitly, but it wasn't setting the variable as not nullable which resulted in an invalid operation. I believe this should fix it.