### PR TITLE
feat: take client request headers into account when deciding whether to reuse WS conns

### DIFF
--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
@@ -369,7 +369,7 @@ func (p *Planner) ConfigureFetch() resolve.FetchConfiguration {
 	input = httpclient.SetInputBodyWithPath(input, p.printOperation(), "query")
 
 	if p.unnulVariables {
-		input = httpclient.SetInputFlag(input, httpclient.UNNULLVARIABLES)
+		input = httpclient.SetInputFlag(input, httpclient.UNNULL_VARIABLES)
 	}
 
 	header, err := json.Marshal(p.config.Fetch.Header)
@@ -437,9 +437,9 @@ func (p *Planner) ConfigureSubscription() plan.SubscriptionConfiguration {
 	input = httpclient.SetInputBodyWithPath(input, p.printOperation(), "query")
 	input = httpclient.SetInputURL(input, []byte(p.config.Subscription.URL))
 	if p.config.Subscription.UseSSE {
-		input = httpclient.SetInputFlag(input, httpclient.USESSE)
+		input = httpclient.SetInputFlag(input, httpclient.USE_SSE)
 		if p.config.Subscription.SSEMethodPost {
-			input = httpclient.SetInputFlag(input, httpclient.SSEMETHODPOST)
+			input = httpclient.SetInputFlag(input, httpclient.SSE_METHOD_POST)
 		}
 	}
 
@@ -1651,7 +1651,7 @@ func (s *Source) compactAndUnNullVariables(input []byte) []byte {
 		variables = buf.Bytes()
 	}
 
-	removeNullVariables := httpclient.IsInputFlagSet(input, httpclient.UNNULLVARIABLES)
+	removeNullVariables := httpclient.IsInputFlagSet(input, httpclient.UNNULL_VARIABLES)
 	variables = s.cleanupVariables(variables, removeNullVariables, undefinedVariables)
 
 	input, _ = jsonparser.Set(input, variables, "body", "variables")
@@ -1722,7 +1722,7 @@ func (s *Source) Load(ctx context.Context, input []byte, writer io.Writer) (err 
 }
 
 type GraphQLSubscriptionClient interface {
-	Subscribe(ctx context.Context, options GraphQLSubscriptionOptions, next chan<- []byte) error
+	Subscribe(ctx *resolve.Context, options GraphQLSubscriptionOptions, next chan<- []byte) error
 }
 
 type GraphQLSubscriptionOptions struct {
@@ -1744,7 +1744,7 @@ type SubscriptionSource struct {
 	client GraphQLSubscriptionClient
 }
 
-func (s *SubscriptionSource) Start(ctx context.Context, input []byte, next chan<- []byte) error {
+func (s *SubscriptionSource) Start(ctx *resolve.Context, input []byte, next chan<- []byte) error {
 	var options GraphQLSubscriptionOptions
 	err := json.Unmarshal(input, &options)
 	if err != nil {

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
@@ -7996,7 +7996,7 @@ var errSubscriptionClientFail = errors.New("subscription client fail error")
 
 type FailingSubscriptionClient struct{}
 
-func (f FailingSubscriptionClient) Subscribe(_ context.Context, _ GraphQLSubscriptionOptions, _ chan<- []byte) error {
+func (f FailingSubscriptionClient) Subscribe(_ *resolve.Context, _ GraphQLSubscriptionOptions, _ chan<- []byte) error {
 	return errSubscriptionClientFail
 }
 
@@ -8043,13 +8043,13 @@ func TestSubscriptionSource_Start(t *testing.T) {
 
 	t.Run("should return error when input is invalid", func(t *testing.T) {
 		source := SubscriptionSource{client: FailingSubscriptionClient{}}
-		err := source.Start(context.Background(), []byte(`{"url": "", "body": "", "header": null}`), nil)
+		err := source.Start(resolve.NewContext(context.Background()), []byte(`{"url": "", "body": "", "header": null}`), nil)
 		assert.Error(t, err)
 	})
 
 	t.Run("should return error when subscription client returns an error", func(t *testing.T) {
 		source := SubscriptionSource{client: FailingSubscriptionClient{}}
-		err := source.Start(context.Background(), []byte(`{"url": "", "body": {}, "header": null}`), nil)
+		err := source.Start(resolve.NewContext(context.Background()), []byte(`{"url": "", "body": {}, "header": null}`), nil)
 		assert.Error(t, err)
 		assert.Equal(t, resolve.ErrUnableToResolve, err)
 	})
@@ -8061,7 +8061,7 @@ func TestSubscriptionSource_Start(t *testing.T) {
 
 		source := newSubscriptionSource(ctx.Context())
 		chatSubscriptionOptions := chatServerSubscriptionOptions(t, `{"variables": {}, "extensions": {}, "operationName": "LiveMessages", "query": "subscription LiveMessages { messageAdded(roomName: "#test") { text createdBy } }"}`)
-		err := source.Start(ctx.Context(), chatSubscriptionOptions, next)
+		err := source.Start(ctx, chatSubscriptionOptions, next)
 		require.ErrorIs(t, err, resolve.ErrUnableToResolve)
 	})
 
@@ -8072,7 +8072,7 @@ func TestSubscriptionSource_Start(t *testing.T) {
 
 		source := newSubscriptionSource(ctx.Context())
 		chatSubscriptionOptions := chatServerSubscriptionOptions(t, `{"variables": {}, "extensions": {}, "operationName": "LiveMessages", "query": "subscription LiveMessages { messageAdded(roomNam: \"#test\") { text createdBy } }"}`)
-		err := source.Start(ctx.Context(), chatSubscriptionOptions, next)
+		err := source.Start(ctx, chatSubscriptionOptions, next)
 		require.NoError(t, err)
 
 		msg, ok := <-next
@@ -8090,7 +8090,7 @@ func TestSubscriptionSource_Start(t *testing.T) {
 
 		source := newSubscriptionSource(resolverLifecycle)
 		chatSubscriptionOptions := chatServerSubscriptionOptions(t, `{"variables": {}, "extensions": {}, "operationName": "LiveMessages", "query": "subscription LiveMessages { messageAdded(roomName: \"#test\") { text createdBy } }"}`)
-		err := source.Start(subscriptionLifecycle, chatSubscriptionOptions, next)
+		err := source.Start(resolve.NewContext(subscriptionLifecycle), chatSubscriptionOptions, next)
 		require.NoError(t, err)
 
 		username := "myuser"
@@ -8111,7 +8111,7 @@ func TestSubscriptionSource_Start(t *testing.T) {
 
 		source := newSubscriptionSource(ctx.Context())
 		chatSubscriptionOptions := chatServerSubscriptionOptions(t, `{"variables": {}, "extensions": {}, "operationName": "LiveMessages", "query": "subscription LiveMessages { messageAdded(roomName: \"#test\") { text createdBy } }"}`)
-		err := source.Start(ctx.Context(), chatSubscriptionOptions, next)
+		err := source.Start(ctx, chatSubscriptionOptions, next)
 		require.NoError(t, err)
 
 		username := "myuser"
@@ -8173,7 +8173,7 @@ func TestSubscription_GTWS_SubProtocol(t *testing.T) {
 
 		source := newSubscriptionSource(ctx.Context())
 		chatSubscriptionOptions := chatServerSubscriptionOptions(t, `{"variables": {}, "extensions": {}, "operationName": "LiveMessages", "query": "subscription LiveMessages { messageAdded(roomNam: \"#test\") { text createdBy } }"}`)
-		err := source.Start(ctx.Context(), chatSubscriptionOptions, next)
+		err := source.Start(ctx, chatSubscriptionOptions, next)
 		require.NoError(t, err)
 
 		msg, ok := <-next
@@ -8191,7 +8191,7 @@ func TestSubscription_GTWS_SubProtocol(t *testing.T) {
 
 		source := newSubscriptionSource(resolverLifecycle)
 		chatSubscriptionOptions := chatServerSubscriptionOptions(t, `{"variables": {}, "extensions": {}, "operationName": "LiveMessages", "query": "subscription LiveMessages { messageAdded(roomName: \"#test\") { text createdBy } }"}`)
-		err := source.Start(subscriptionLifecycle, chatSubscriptionOptions, next)
+		err := source.Start(resolve.NewContext(subscriptionLifecycle), chatSubscriptionOptions, next)
 		require.NoError(t, err)
 
 		username := "myuser"
@@ -8212,7 +8212,7 @@ func TestSubscription_GTWS_SubProtocol(t *testing.T) {
 
 		source := newSubscriptionSource(ctx.Context())
 		chatSubscriptionOptions := chatServerSubscriptionOptions(t, `{"variables": {}, "extensions": {}, "operationName": "LiveMessages", "query": "subscription LiveMessages { messageAdded(roomName: \"#test\") { text createdBy } }"}`)
-		err := source.Start(ctx.Context(), chatSubscriptionOptions, next)
+		err := source.Start(ctx, chatSubscriptionOptions, next)
 		require.NoError(t, err)
 
 		username := "myuser"
@@ -8364,7 +8364,7 @@ func TestSource_Load(t *testing.T) {
 			var input []byte
 			input = httpclient.SetInputBodyWithPath(input, variables, "variables")
 			input = httpclient.SetInputURL(input, []byte(serverUrl))
-			input = httpclient.SetInputFlag(input, httpclient.UNNULLVARIABLES)
+			input = httpclient.SetInputFlag(input, httpclient.UNNULL_VARIABLES)
 			buf := bytes.NewBuffer(nil)
 
 			require.NoError(t, src.Load(context.Background(), input, buf))

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_sse_handler.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_sse_handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/buger/jsonparser"
 	log "github.com/jensneuse/abstractlogger"
 	"github.com/r3labs/sse/v2"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 )
 
 var (
@@ -29,10 +30,10 @@ type gqlSSEConnectionHandler struct {
 	options GraphQLSubscriptionOptions
 }
 
-func newSSEConnectionHandler(ctx context.Context, conn *http.Client, opts GraphQLSubscriptionOptions, l log.Logger) *gqlSSEConnectionHandler {
+func newSSEConnectionHandler(ctx *resolve.Context, conn *http.Client, opts GraphQLSubscriptionOptions, l log.Logger) *gqlSSEConnectionHandler {
 	return &gqlSSEConnectionHandler{
 		conn:    conn,
-		ctx:     ctx,
+		ctx:     ctx.Context(),
 		log:     l,
 		options: opts,
 	}

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_sse_handler_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_sse_handler_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 )
 
 func TestGraphQLSubscriptionClientSubscribe_SSE(t *testing.T) {
@@ -51,7 +52,8 @@ func TestGraphQLSubscriptionClientSubscribe_SSE(t *testing.T) {
 	)
 
 	next := make(chan []byte)
-	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+
+	err := client.Subscribe(resolve.NewContext(ctx), GraphQLSubscriptionOptions{
 		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
@@ -89,7 +91,7 @@ func TestGraphQLSubscriptionClientSubscribe_SSE_RequestAbort(t *testing.T) {
 	)
 
 	next := make(chan []byte)
-	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+	err := client.Subscribe(resolve.NewContext(ctx), GraphQLSubscriptionOptions{
 		URL: "http://dummy",
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
@@ -150,7 +152,7 @@ func TestGraphQLSubscriptionClientSubscribe_SSE_POST(t *testing.T) {
 	)
 
 	next := make(chan []byte)
-	err = client.Subscribe(ctx, GraphQLSubscriptionOptions{
+	err = client.Subscribe(resolve.NewContext(ctx), GraphQLSubscriptionOptions{
 		URL:           server.URL,
 		Body:          postReqBody,
 		UseSSE:        true,
@@ -208,7 +210,7 @@ func TestGraphQLSubscriptionClientSubscribe_SSE_WithEvents(t *testing.T) {
 	)
 
 	next := make(chan []byte)
-	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+	err := client.Subscribe(resolve.NewContext(ctx), GraphQLSubscriptionOptions{
 		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
@@ -262,7 +264,7 @@ func TestGraphQLSubscriptionClientSubscribe_SSE_Error(t *testing.T) {
 	)
 
 	next := make(chan []byte)
-	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+	err := client.Subscribe(resolve.NewContext(ctx), GraphQLSubscriptionOptions{
 		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
@@ -314,7 +316,7 @@ func TestGraphQLSubscriptionClientSubscribe_SSE_Error_Without_Header(t *testing.
 	)
 
 	next := make(chan []byte)
-	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+	err := client.Subscribe(resolve.NewContext(ctx), GraphQLSubscriptionOptions{
 		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
@@ -371,7 +373,7 @@ func TestGraphQLSubscriptionClientSubscribe_QueryParams(t *testing.T) {
 	)
 
 	next := make(chan []byte)
-	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+	err := client.Subscribe(resolve.NewContext(ctx), GraphQLSubscriptionOptions{
 		URL: server.URL,
 		Body: GraphQLBody{
 			Query:         `subscription($a: Int!){countdown(from: $a)}`,
@@ -497,7 +499,7 @@ func TestGraphQLSubscriptionClientSubscribe_SSE_Upstream_Dies(t *testing.T) {
 	)
 
 	next := make(chan []byte)
-	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+	err := client.Subscribe(resolve.NewContext(ctx), GraphQLSubscriptionOptions{
 		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/buger/jsonparser"
 	"github.com/cespare/xxhash/v2"
 	"github.com/jensneuse/abstractlogger"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 	"nhooyr.io/websocket"
 )
 
@@ -107,7 +108,7 @@ func NewGraphQLSubscriptionClient(httpClient, streamingClient *http.Client, engi
 // If an existing WS connection with the same ID (Hash) exists, it is being re-used
 // If connection protocol is SSE, a new connection is always created
 // If no connection exists, the client initiates a new one
-func (c *SubscriptionClient) Subscribe(reqCtx context.Context, options GraphQLSubscriptionOptions, next chan<- []byte) error {
+func (c *SubscriptionClient) Subscribe(reqCtx *resolve.Context, options GraphQLSubscriptionOptions, next chan<- []byte) error {
 	if options.UseSSE {
 		return c.subscribeSSE(reqCtx, options, next)
 	}
@@ -115,13 +116,13 @@ func (c *SubscriptionClient) Subscribe(reqCtx context.Context, options GraphQLSu
 	return c.subscribeWS(reqCtx, options, next)
 }
 
-func (c *SubscriptionClient) subscribeSSE(reqCtx context.Context, options GraphQLSubscriptionOptions, next chan<- []byte) error {
+func (c *SubscriptionClient) subscribeSSE(reqCtx *resolve.Context, options GraphQLSubscriptionOptions, next chan<- []byte) error {
 	if c.streamingClient == nil {
 		return fmt.Errorf("streaming http client is nil")
 	}
 
 	sub := Subscription{
-		ctx:     reqCtx,
+		ctx:     reqCtx.Context(),
 		options: options,
 		next:    next,
 	}
@@ -135,19 +136,19 @@ func (c *SubscriptionClient) subscribeSSE(reqCtx context.Context, options GraphQ
 	return nil
 }
 
-func (c *SubscriptionClient) subscribeWS(reqCtx context.Context, options GraphQLSubscriptionOptions, next chan<- []byte) error {
+func (c *SubscriptionClient) subscribeWS(reqCtx *resolve.Context, options GraphQLSubscriptionOptions, next chan<- []byte) error {
 	if c.httpClient == nil {
 		return fmt.Errorf("http client is nil")
 	}
 
 	sub := Subscription{
-		ctx:     reqCtx,
+		ctx:     reqCtx.Context(),
 		options: options,
 		next:    next,
 	}
 
 	// each WS connection to an origin is uniquely identified by the Hash(URL,Headers,Body)
-	handlerID, err := c.generateHandlerIDHash(options)
+	handlerID, err := c.generateHandlerIDHash(reqCtx, options)
 	if err != nil {
 		return err
 	}
@@ -158,12 +159,12 @@ func (c *SubscriptionClient) subscribeWS(reqCtx context.Context, options GraphQL
 	if exists {
 		select {
 		case handler.SubscribeCH() <- sub:
-		case <-reqCtx.Done():
+		case <-reqCtx.Context().Done():
 		}
 		return nil
 	}
 
-	handler, err = c.newWSConnectionHandler(reqCtx, options)
+	handler, err = c.newWSConnectionHandler(reqCtx.Context(), options)
 	if err != nil {
 		return err
 	}
@@ -181,7 +182,7 @@ func (c *SubscriptionClient) subscribeWS(reqCtx context.Context, options GraphQL
 }
 
 // generateHandlerIDHash generates a Hash based on: URL and Headers to uniquely identify Upgrade Requests
-func (c *SubscriptionClient) generateHandlerIDHash(options GraphQLSubscriptionOptions) (uint64, error) {
+func (c *SubscriptionClient) generateHandlerIDHash(ctx *resolve.Context, options GraphQLSubscriptionOptions) (uint64, error) {
 	var (
 		err error
 	)
@@ -189,13 +190,29 @@ func (c *SubscriptionClient) generateHandlerIDHash(options GraphQLSubscriptionOp
 	defer c.hashPool.Put(xxh)
 	xxh.Reset()
 
-	_, err = xxh.WriteString(options.URL)
-	if err != nil {
+	if _, err = xxh.WriteString(options.URL); err != nil {
 		return 0, err
 	}
-	err = options.Header.Write(xxh)
-	if err != nil {
+	if err := options.Header.Write(xxh); err != nil {
 		return 0, err
+	}
+	// The client request headers might be propagated to the outgoing
+	// request by the caller. We need to take them into account as well.
+	// However, to improve the changes of connection reuse we do skip
+	// some headers that are very likely to be different but very unlikely
+	// to cause different responses, otherwise no connections would be reused.
+	for key, values := range ctx.Request.Header {
+		if key == "Sec-Websocket-Key" || key == "Content-Length" {
+			continue
+		}
+		if _, err := xxh.WriteString(key); err != nil {
+			return 0, err
+		}
+		for _, val := range values {
+			if _, err := xxh.WriteString(val); err != nil {
+				return 0, err
+			}
+		}
 	}
 
 	return xxh.Sum64(), nil

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 
 	"github.com/buger/jsonparser"
 	ll "github.com/jensneuse/abstractlogger"
@@ -160,7 +161,7 @@ func TestWebsocketSubscriptionClientDeDuplication(t *testing.T) {
 
 	next := make(chan []byte)
 	ctx, clientCancel := context.WithCancel(context.Background())
-	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+	err := client.Subscribe(resolve.NewContext(ctx), GraphQLSubscriptionOptions{
 		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
@@ -175,7 +176,7 @@ func TestWebsocketSubscriptionClientDeDuplication(t *testing.T) {
 
 		ctx, cancel := context.WithCancel(context.Background())
 
-		err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+		err := client.Subscribe(resolve.NewContext(ctx), GraphQLSubscriptionOptions{
 			URL: server.URL,
 			Body: GraphQLBody{
 				Query: `subscription {messageAdded(roomName: "room"){text}}`,
@@ -214,7 +215,7 @@ func TestWebsocketSubscriptionClientImmediateClientCancel(t *testing.T) {
 		WithWSSubProtocol(ProtocolGraphQLWS),
 	)
 	next := make(chan []byte)
-	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+	err := client.Subscribe(resolve.NewContext(ctx), GraphQLSubscriptionOptions{
 		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
@@ -269,7 +270,7 @@ func TestWebsocketSubscriptionClientWithServerDisconnect(t *testing.T) {
 		WithWSSubProtocol(ProtocolGraphQLWS),
 	)
 	next := make(chan []byte)
-	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+	err := client.Subscribe(resolve.NewContext(ctx), GraphQLSubscriptionOptions{
 		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_tws_handler_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_tws_handler_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 
 	"github.com/stretchr/testify/assert"
 	"nhooyr.io/websocket"
@@ -60,7 +61,7 @@ func TestWebsocketSubscriptionClient_GQLTWS(t *testing.T) {
 	)
 
 	next := make(chan []byte)
-	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+	err := client.Subscribe(resolve.NewContext(ctx), GraphQLSubscriptionOptions{
 		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
@@ -139,7 +140,7 @@ func TestWebsocketSubscriptionClientPing_GQLTWS(t *testing.T) {
 	)
 
 	next := make(chan []byte)
-	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+	err := client.Subscribe(resolve.NewContext(ctx), GraphQLSubscriptionOptions{
 		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
@@ -204,7 +205,7 @@ func TestWebsocketSubscriptionClientError_GQLTWS(t *testing.T) {
 	)
 
 	next := make(chan []byte)
-	err := client.Subscribe(clientCtx, GraphQLSubscriptionOptions{
+	err := client.Subscribe(resolve.NewContext(clientCtx), GraphQLSubscriptionOptions{
 		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `wrongQuery {messageAdded(roomName: "room"){text}}`,
@@ -289,7 +290,7 @@ func TestWebSocketSubscriptionClientInitIncludePing_GQLTWS(t *testing.T) {
 		WithWSSubProtocol(ProtocolGraphQLTWS),
 	)
 	next := make(chan []byte)
-	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+	err := client.Subscribe(resolve.NewContext(ctx), GraphQLSubscriptionOptions{
 		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
@@ -364,7 +365,7 @@ func TestWebsocketSubscriptionClient_GQLTWS_Upstream_Dies(t *testing.T) {
 	)
 
 	next := make(chan []byte)
-	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+	err := client.Subscribe(resolve.NewContext(ctx), GraphQLSubscriptionOptions{
 		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_ws_handler_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_ws_handler_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 
 	"github.com/stretchr/testify/assert"
 	"nhooyr.io/websocket"
@@ -71,7 +72,7 @@ func TestWebSocketSubscriptionClientInitIncludeKA_GQLWS(t *testing.T) {
 		WithWSSubProtocol(ProtocolGraphQLWS),
 	)
 	next := make(chan []byte)
-	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+	err := client.Subscribe(resolve.NewContext(ctx), GraphQLSubscriptionOptions{
 		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
@@ -138,7 +139,7 @@ func TestWebsocketSubscriptionClient_GQLWS(t *testing.T) {
 		WithWSSubProtocol(ProtocolGraphQLWS),
 	)
 	next := make(chan []byte)
-	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+	err := client.Subscribe(resolve.NewContext(ctx), GraphQLSubscriptionOptions{
 		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,
@@ -201,7 +202,7 @@ func TestWebsocketSubscriptionClientErrorArray(t *testing.T) {
 		WithWSSubProtocol(ProtocolGraphQLWS),
 	)
 	next := make(chan []byte)
-	err := client.Subscribe(clientCtx, GraphQLSubscriptionOptions{
+	err := client.Subscribe(resolve.NewContext(clientCtx), GraphQLSubscriptionOptions{
 		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomNam: "room"){text}}`,
@@ -256,7 +257,7 @@ func TestWebsocketSubscriptionClientErrorObject(t *testing.T) {
 		WithWSSubProtocol(ProtocolGraphQLWS),
 	)
 	next := make(chan []byte)
-	err := client.Subscribe(clientCtx, GraphQLSubscriptionOptions{
+	err := client.Subscribe(resolve.NewContext(clientCtx), GraphQLSubscriptionOptions{
 		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomNam: "room"){text}}`,
@@ -319,7 +320,7 @@ func TestWebsocketSubscriptionClient_GQLWS_Upstream_Dies(t *testing.T) {
 		WithWSSubProtocol(ProtocolGraphQLWS),
 	)
 	next := make(chan []byte)
-	err := client.Subscribe(ctx, GraphQLSubscriptionOptions{
+	err := client.Subscribe(resolve.NewContext(ctx), GraphQLSubscriptionOptions{
 		URL: server.URL,
 		Body: GraphQLBody{
 			Query: `subscription {messageAdded(roomName: "room"){text}}`,

--- a/v2/pkg/engine/datasource/httpclient/httpclient.go
+++ b/v2/pkg/engine/datasource/httpclient/httpclient.go
@@ -18,17 +18,17 @@ import (
 const (
 	PATH                = "path"
 	URL                 = "url"
-	URLENCODEBODY       = "url_encode_body"
+	URLENCODE_BODY      = "url_encode_body"
 	BASEURL             = "base_url"
 	METHOD              = "method"
 	BODY                = "body"
 	HEADER              = "header"
 	QUERYPARAMS         = "query_params"
-	USESSE              = "use_sse"
-	SSEMETHODPOST       = "sse_method_post"
+	USE_SSE             = "use_sse"
+	SSE_METHOD_POST     = "sse_method_post"
 	SCHEME              = "scheme"
 	HOST                = "host"
-	UNNULLVARIABLES     = "unnull_variables"
+	UNNULL_VARIABLES    = "unnull_variables"
 	UNDEFINED_VARIABLES = "undefined"
 )
 
@@ -105,7 +105,7 @@ func SetInputURLEncodeBody(input []byte, urlEncodeBody bool) []byte {
 	if !urlEncodeBody {
 		return input
 	}
-	out, _ := sjson.SetRawBytes(input, URLENCODEBODY, []byte("true"))
+	out, _ := sjson.SetRawBytes(input, URLENCODE_BODY, []byte("true"))
 	return out
 }
 

--- a/v2/pkg/engine/resolve/datasource.go
+++ b/v2/pkg/engine/resolve/datasource.go
@@ -10,5 +10,5 @@ type DataSource interface {
 }
 
 type SubscriptionDataSource interface {
-	Start(ctx context.Context, input []byte, next chan<- []byte) error
+	Start(ctx *Context, input []byte, next chan<- []byte) error
 }

--- a/v2/pkg/engine/resolve/resolve_test.go
+++ b/v2/pkg/engine/resolve/resolve_test.go
@@ -3903,7 +3903,7 @@ type _fakeStream struct {
 	messageFunc func(counter int) (message string, ok bool)
 }
 
-func (f *_fakeStream) Start(ctx context.Context, input []byte, next chan<- []byte) error {
+func (f *_fakeStream) Start(ctx *Context, input []byte, next chan<- []byte) error {
 	go func() {
 		time.Sleep(time.Millisecond)
 		count := 0


### PR DESCRIPTION
Otherwise it's not possible for the client to route headers through the engine because
a connection with different headers might be reused instead of creating a new one.
Instead, now we only reuse connections if the headers except Sec-Websocket-Key
and Content-Length match.
