### PR TITLE
feat: add named type info to field and usage info

### DIFF
--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource_federation_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource_federation_test.go
@@ -519,6 +519,7 @@ func TestGraphQLDataSourceFederation(t *testing.T) {
 								Info: &resolve.FieldInfo{
 									Name:            "user",
 									ParentTypeNames: []string{"Query"},
+									NamedType:       "User",
 									Source: resolve.TypeFieldSource{
 										IDs: []string{"user.service"},
 									},
@@ -531,6 +532,7 @@ func TestGraphQLDataSourceFederation(t *testing.T) {
 											Name: []byte("account"),
 											Info: &resolve.FieldInfo{
 												Name:            "account",
+												NamedType:       "Account",
 												ParentTypeNames: []string{"User"},
 												Source: resolve.TypeFieldSource{
 													IDs: []string{"user.service"},
@@ -544,6 +546,7 @@ func TestGraphQLDataSourceFederation(t *testing.T) {
 														Name: []byte("name"),
 														Info: &resolve.FieldInfo{
 															Name:            "name",
+															NamedType:       "String",
 															ParentTypeNames: []string{"Account"},
 															Source: resolve.TypeFieldSource{
 																IDs: []string{"account.service"},
@@ -557,6 +560,7 @@ func TestGraphQLDataSourceFederation(t *testing.T) {
 														Name: []byte("shippingInfo"),
 														Info: &resolve.FieldInfo{
 															Name:            "shippingInfo",
+															NamedType:       "ShippingInfo",
 															ParentTypeNames: []string{"Account"},
 															Source: resolve.TypeFieldSource{
 																IDs: []string{"account.service"},
@@ -570,6 +574,7 @@ func TestGraphQLDataSourceFederation(t *testing.T) {
 																	Name: []byte("zip"),
 																	Info: &resolve.FieldInfo{
 																		Name:            "zip",
+																		NamedType:       "String",
 																		ParentTypeNames: []string{"ShippingInfo"},
 																		Source: resolve.TypeFieldSource{
 																			IDs: []string{"account.service"},

--- a/v2/pkg/engine/plan/schemausageinfo.go
+++ b/v2/pkg/engine/plan/schemausageinfo.go
@@ -12,6 +12,7 @@ type SchemaUsageInfo struct {
 
 type TypeFieldUsageInfo struct {
 	FieldName string
+	NamedType string
 	TypeNames []string
 	Path      []string
 	Source    TypeFieldSource
@@ -54,6 +55,7 @@ func (p *planVisitor) visitNode(node resolve.Node, path []string) {
 			p.usage.TypeFields = append(p.usage.TypeFields, TypeFieldUsageInfo{
 				FieldName: field.Info.Name,
 				TypeNames: field.Info.ParentTypeNames,
+				NamedType: field.Info.NamedType,
 				Path:      newPath,
 				Source: TypeFieldSource{
 					IDs: field.Info.Source.IDs,

--- a/v2/pkg/engine/plan/schemausageinfo_test.go
+++ b/v2/pkg/engine/plan/schemausageinfo_test.go
@@ -23,6 +23,7 @@ func TestGetSchemaUsageInfo(t *testing.T) {
 					Name: []byte("searchResults"),
 					Info: &resolve.FieldInfo{
 						Name:            "searchResults",
+						NamedType:       "SearchResults",
 						ParentTypeNames: []string{"Query"},
 						Source:          source,
 					},
@@ -41,6 +42,7 @@ func TestGetSchemaUsageInfo(t *testing.T) {
 									},
 									Info: &resolve.FieldInfo{
 										Name:            "__typename",
+										NamedType:       "String",
 										ParentTypeNames: []string{"Human", "Droid"},
 										Source:          source,
 									},
@@ -54,6 +56,7 @@ func TestGetSchemaUsageInfo(t *testing.T) {
 									OnTypeNames: [][]byte{[]byte("Human"), []byte("Droid")},
 									Info: &resolve.FieldInfo{
 										Name:            "name",
+										NamedType:       "String",
 										ParentTypeNames: []string{"Human", "Droid"},
 										Source:          source,
 									},
@@ -67,6 +70,7 @@ func TestGetSchemaUsageInfo(t *testing.T) {
 									OnTypeNames: [][]byte{[]byte("Starship")},
 									Info: &resolve.FieldInfo{
 										Name:            "length",
+										NamedType:       "String",
 										ParentTypeNames: []string{"Starship"},
 										Source:          source,
 									},
@@ -75,7 +79,8 @@ func TestGetSchemaUsageInfo(t *testing.T) {
 									Name: []byte("user"),
 									Info: &resolve.FieldInfo{
 										Name:            "user",
-										ParentTypeNames: []string{"searchResults"},
+										NamedType:       "User",
+										ParentTypeNames: []string{"SearchResults"},
 										Source:          source,
 									},
 									Value: &resolve.Object{
@@ -86,7 +91,8 @@ func TestGetSchemaUsageInfo(t *testing.T) {
 												Name: []byte("account"),
 												Info: &resolve.FieldInfo{
 													Name:            "account",
-													ParentTypeNames: []string{"user"},
+													NamedType:       "Account",
+													ParentTypeNames: []string{"User"},
 													Source:          source,
 												},
 												Value: &resolve.Object{
@@ -97,7 +103,8 @@ func TestGetSchemaUsageInfo(t *testing.T) {
 															Name: []byte("name"),
 															Info: &resolve.FieldInfo{
 																Name:            "name",
-																ParentTypeNames: []string{"account"},
+																NamedType:       "String",
+																ParentTypeNames: []string{"Account"},
 																Source:          source,
 															},
 															Value: &resolve.String{
@@ -108,18 +115,20 @@ func TestGetSchemaUsageInfo(t *testing.T) {
 															Name: []byte("shippingInfo"),
 															Info: &resolve.FieldInfo{
 																Name:            "shippingInfo",
-																ParentTypeNames: []string{"account"},
+																NamedType:       "ShippingInfo",
+																ParentTypeNames: []string{"Account"},
 																Source:          source,
 															},
 															Value: &resolve.Object{
-																Path:     []string{"shippingInfo"},
+																Path:     []string{"ShippingInfo"},
 																Nullable: true,
 																Fields: []*resolve.Field{
 																	{
 																		Name: []byte("zip"),
 																		Info: &resolve.FieldInfo{
 																			Name:            "zip",
-																			ParentTypeNames: []string{"shippingInfo"},
+																			NamedType:       "String",
+																			ParentTypeNames: []string{"ShippingInfo"},
 																			Source:          source,
 																		},
 																		Value: &resolve.String{
@@ -157,6 +166,7 @@ func TestGetSchemaUsageInfo(t *testing.T) {
 				FieldName: "searchResults",
 				TypeNames: []string{"Query"},
 				Path:      []string{"searchResults"},
+				NamedType: "SearchResults",
 				Source: TypeFieldSource{
 					IDs: []string{"https://swapi.dev/api"},
 				},
@@ -165,6 +175,7 @@ func TestGetSchemaUsageInfo(t *testing.T) {
 				Path:      []string{"searchResults", "__typename"},
 				TypeNames: []string{"Human", "Droid"},
 				FieldName: "__typename",
+				NamedType: "String",
 				Source: TypeFieldSource{
 					IDs: []string{"https://swapi.dev/api"},
 				},
@@ -173,6 +184,7 @@ func TestGetSchemaUsageInfo(t *testing.T) {
 				Path:      []string{"searchResults", "name"},
 				TypeNames: []string{"Human", "Droid"},
 				FieldName: "name",
+				NamedType: "String",
 				Source: TypeFieldSource{
 					IDs: []string{"https://swapi.dev/api"},
 				},
@@ -180,6 +192,7 @@ func TestGetSchemaUsageInfo(t *testing.T) {
 			{
 				Path:      []string{"searchResults", "length"},
 				TypeNames: []string{"Starship"},
+				NamedType: "String",
 				FieldName: "length",
 				Source: TypeFieldSource{
 					IDs: []string{"https://swapi.dev/api"},
@@ -187,7 +200,8 @@ func TestGetSchemaUsageInfo(t *testing.T) {
 			},
 			{
 				Path:      []string{"searchResults", "user"},
-				TypeNames: []string{"searchResults"},
+				NamedType: "User",
+				TypeNames: []string{"SearchResults"},
 				FieldName: "user",
 				Source: TypeFieldSource{
 					IDs: []string{"https://swapi.dev/api"},
@@ -195,7 +209,8 @@ func TestGetSchemaUsageInfo(t *testing.T) {
 			},
 			{
 				Path:      []string{"searchResults", "user", "account"},
-				TypeNames: []string{"user"},
+				TypeNames: []string{"User"},
+				NamedType: "Account",
 				FieldName: "account",
 				Source: TypeFieldSource{
 					IDs: []string{"https://swapi.dev/api"},
@@ -203,7 +218,8 @@ func TestGetSchemaUsageInfo(t *testing.T) {
 			},
 			{
 				Path:      []string{"searchResults", "user", "account", "name"},
-				TypeNames: []string{"account"},
+				TypeNames: []string{"Account"},
+				NamedType: "String",
 				FieldName: "name",
 				Source: TypeFieldSource{
 					IDs: []string{"https://swapi.dev/api"},
@@ -211,7 +227,8 @@ func TestGetSchemaUsageInfo(t *testing.T) {
 			},
 			{
 				Path:      []string{"searchResults", "user", "account", "shippingInfo"},
-				TypeNames: []string{"account"},
+				NamedType: "ShippingInfo",
+				TypeNames: []string{"Account"},
 				FieldName: "shippingInfo",
 				Source: TypeFieldSource{
 					IDs: []string{"https://swapi.dev/api"},
@@ -219,7 +236,8 @@ func TestGetSchemaUsageInfo(t *testing.T) {
 			},
 			{
 				Path:      []string{"searchResults", "user", "account", "shippingInfo", "zip"},
-				TypeNames: []string{"shippingInfo"},
+				TypeNames: []string{"ShippingInfo"},
+				NamedType: "String",
 				FieldName: "zip",
 				Source: TypeFieldSource{
 					IDs: []string{"https://swapi.dev/api"},

--- a/v2/pkg/engine/resolve/node_object.go
+++ b/v2/pkg/engine/resolve/node_object.go
@@ -68,9 +68,14 @@ type FieldInfo struct {
 	// E.g. for a root field, this will be Query, Mutation, Subscription.
 	// For a field on an object type, this will be the name of that object type.
 	// For a field on an interface type, this will be the name of that interface type and all of its possible implementations.
-	// For a field on a union type, this will be the name of that union type and all of its possible members.
 	ParentTypeNames []string
-	Source          TypeFieldSource
+	// NamedType is the underlying node type of the field.
+	// E.g. for a field of type Hobby! this will be Hobby.
+	// For a field of type [Hobby] this will be Hobby.
+	// For a field of type [Hobby!]! this will be Hobby.
+	// For scalar fields, this will return string, int, float, boolean, ID.
+	NamedType string
+	Source    TypeFieldSource
 }
 
 type TypeFieldSource struct {


### PR DESCRIPTION
In order to understand certain schema changes, we need to extend `TypeFieldUsageInfo` with the named type of the requested field.  `TypeNames` is not enough to understand the usage of the enum.