### PR TITLE
fix: bug in astprinter that prints schema with erroneous extra brace

### DIFF
--- a/v2/pkg/astprinter/astprinter.go
+++ b/v2/pkg/astprinter/astprinter.go
@@ -1024,7 +1024,9 @@ func (p *printVisitor) LeaveSchemaExtension(ref int) {
 	if p.indent != nil {
 		p.write(literal.LINETERMINATOR)
 	}
-	p.write(literal.RBRACE)
+	if len(p.document.SchemaExtensions[ref].SchemaDefinition.RootOperationTypeDefinitions.Refs) > 0 {
+		p.write(literal.RBRACE)
+	}
 	if !p.document.NodeIsLastRootNode(ast.Node{Kind: ast.NodeKindSchemaExtension, Ref: ref}) {
 		if p.indent != nil {
 			p.write(literal.LINETERMINATOR)

--- a/v2/pkg/astprinter/astprinter_test.go
+++ b/v2/pkg/astprinter/astprinter_test.go
@@ -209,6 +209,11 @@ vary: [String]! = []) on QUERY directive @include(if: Boolean!) repeatable on FI
 					subscription: Subscription
 				}`, `extend schema @foo {query: Query mutation: Mutation subscription: Subscription}`)
 	})
+
+	t.Run("schema extension only directives", func(t *testing.T) {
+		run(t, `extend schema @foo `, `extend schema @foo `)
+	})
+
 	t.Run("object type definition", func(t *testing.T) {
 		run(t, `
 				type Foo {


### PR DESCRIPTION
### Description:

A schema extension with no fields and only directives prints an invalid schema.

e.g. 

```graphql 
extend schema @foo
```

ends up printing to this
```graphql
extend schema @foo }
```

This change makes the printer only write a closing brace if their are fields in the schema extension.