### PR TITLE
Handle three character strings

### DIFF
--- a/pkg/engine/resolve/variable.go
+++ b/pkg/engine/resolve/variable.go
@@ -634,6 +634,10 @@ func extractStringWithQuotes(rootValueType JsonRootType, data []byte) ([]byte, j
 		}
 	}
 	if desiredType == jsonparser.String {
+		if len(data) == 3 {
+			// For a string like '"1"', return just '1'
+			return string(data[1]), desiredType
+	    	}
 		return data[1 : len(data)-1], desiredType
 	}
 	return data, desiredType


### PR DESCRIPTION
To reproduce, create a BigInt primary key column in a postgres database and query it using a graphql operation for findUnique. If the id is less than 10 and therefore a single character, ex: "1". This function fails to parse it.