### PR TITLE
fix: crash when requesting trace info without initializing it

### DIFF
--- a/v2/pkg/engine/resolve/context.go
+++ b/v2/pkg/engine/resolve/context.go
@@ -138,5 +138,7 @@ func SetPlannerStats(ctx context.Context, stats PlannerStats) {
 }
 
 func GetTraceInfo(ctx context.Context) *TraceInfo {
-	return ctx.Value(traceStartKey{}).(*TraceInfo)
+	// The context might not have trace info, in that case we return nil
+	info, _ := ctx.Value(traceStartKey{}).(*TraceInfo)
+	return info
 }


### PR DESCRIPTION
If the trace info was not initialized (e.g. we want to always print it
if it's available, but it is not always available), we might get into
this scenario.
