### PR TITLE
fix: shareable planning

### DIFF
--- a/v2/pkg/engine/plan/datasource_filter_visitor.go
+++ b/v2/pkg/engine/plan/datasource_filter_visitor.go
@@ -155,23 +155,21 @@ func appendSuggestionWithPresenceCheck(nodes NodeSuggestions, node NodeSuggestio
 	return append(nodes, node)
 }
 
-func (f NodeSuggestions) SuggestionForPath(typeName, fieldName, path string) (suggestion NodeSuggestion, ok bool) {
-	if len(f) == 0 {
-		return NodeSuggestion{}, false
-	}
-
+func (f NodeSuggestions) SuggestionsForPath(typeName, fieldName, path string) (dsHashes []DSHash) {
 	for i := range f {
 		if typeName == f[i].TypeName && fieldName == f[i].FieldName && path == f[i].Path {
-			return f[i], true
+			dsHashes = append(dsHashes, f[i].DataSourceHash)
 		}
 	}
-	return NodeSuggestion{}, false
+
+	return dsHashes
 }
 
 func (f NodeSuggestions) HasSuggestionForPath(typeName, fieldName, path string) (dsHash DSHash, ok bool) {
-	suggestion, ok := f.SuggestionForPath(typeName, fieldName, path)
-	if ok {
-		return suggestion.DataSourceHash, true
+	for i := range f {
+		if typeName == f[i].TypeName && fieldName == f[i].FieldName && path == f[i].Path {
+			return f[i].DataSourceHash, true
+		}
 	}
 
 	return 0, false

--- a/v2/pkg/engine/plan/planner.go
+++ b/v2/pkg/engine/plan/planner.go
@@ -195,17 +195,19 @@ func (p *Planner) findPlanningPaths(operation, definition *ast.Document, report 
 	for p.configurationVisitor.hasNewFields || p.configurationVisitor.hasMissingPaths() {
 		p.configurationVisitor.secondaryRun = true
 
-		// update suggestions for the new required fields
-		p.configurationVisitor.dataSources, p.configurationVisitor.nodeSuggestions =
-			dsFilter.FilterDataSources(p.config.DataSources, p.configurationVisitor.nodeSuggestions)
-		if report.HasErrors() {
-			return
-		}
+		if p.configurationVisitor.hasNewFields {
+			// update suggestions for the new required fields
+			p.configurationVisitor.dataSources, p.configurationVisitor.nodeSuggestions =
+				dsFilter.FilterDataSources(p.config.DataSources, p.configurationVisitor.nodeSuggestions)
+			if report.HasErrors() {
+				return
+			}
 
-		if p.config.Debug.PrintNodeSuggestions {
-			p.debugMessage("Recalculated node suggestions:")
-			for i := range p.configurationVisitor.nodeSuggestions {
-				fmt.Println(p.configurationVisitor.nodeSuggestions[i].String())
+			if p.config.Debug.PrintNodeSuggestions {
+				p.debugMessage("Recalculated node suggestions:")
+				for i := range p.configurationVisitor.nodeSuggestions {
+					fmt.Println(p.configurationVisitor.nodeSuggestions[i].String())
+				}
 			}
 		}
 
@@ -222,12 +224,6 @@ func (p *Planner) findPlanningPaths(operation, definition *ast.Document, report 
 
 		if p.config.Debug.PrintPlanningPaths {
 			p.debugMessage(fmt.Sprintf("After run #%d. Planning paths", i))
-			if p.configurationVisitor.hasMissingPaths() {
-				p.debugMessage("Missing paths:")
-				for path := range p.configurationVisitor.missingPathTracker {
-					fmt.Println(path)
-				}
-			}
 			p.printPlanningPaths()
 		}
 		i++
@@ -304,6 +300,13 @@ func (p *Planner) printPlanningPaths() {
 		fmt.Println("Paths for planner", i+1)
 		fmt.Println("Planner parent path", planner.parentPath)
 		for _, path := range planner.paths {
+			fmt.Println(path.String())
+		}
+	}
+
+	if p.configurationVisitor.hasMissingPaths() {
+		p.debugMessage("Missing paths:")
+		for _, path := range p.configurationVisitor.missingPathTracker {
 			fmt.Println(path.String())
 		}
 	}

--- a/v2/pkg/engine/plan/planner_configuration.go
+++ b/v2/pkg/engine/plan/planner_configuration.go
@@ -115,7 +115,6 @@ type pathConfiguration struct {
 	fieldRef      int
 	enclosingNode ast.Node
 
-	depth      int
 	dsHash     DSHash
 	isRootNode bool
 	pathType   PathType


### PR DESCRIPTION
properly check multiple node suggestions for the same path, not depending on order of ds
track all added path by planner
do not recalculate suggestions if we don't have new fields