### PR TITLE
fix(edfs): stable sort subject

### DIFF
--- a/v2/pkg/engine/datasource/pubsub_datasource/kafka_event_manager.go
+++ b/v2/pkg/engine/datasource/pubsub_datasource/kafka_event_manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+	"slices"
 )
 
 type KafkaSubscriptionEventConfiguration struct {
@@ -60,6 +61,8 @@ func (p *KafkaEventManager) handleSubscriptionEvent(ref int) {
 		p.visitor.Walker.StopWithInternalErr(fmt.Errorf("expected at least one subscription topic but received %d", len(p.eventConfiguration.Topics)))
 		return
 	}
+
+	slices.Sort(p.eventConfiguration.Topics)
 
 	p.subscriptionEventConfiguration = &KafkaSubscriptionEventConfiguration{
 		ProviderID: p.eventMetadata.ProviderID,

--- a/v2/pkg/engine/datasource/pubsub_datasource/nats_event_manager.go
+++ b/v2/pkg/engine/datasource/pubsub_datasource/nats_event_manager.go
@@ -6,6 +6,7 @@ import (
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+	"slices"
 )
 
 type NatsSubscriptionEventConfiguration struct {
@@ -110,6 +111,8 @@ func (p *NatsEventManager) handleSubscriptionEvent(ref int) {
 		}
 		extractedSubjects = append(extractedSubjects, extractedSubject)
 	}
+
+	slices.Sort(extractedSubjects)
 
 	p.subscriptionEventConfiguration = &NatsSubscriptionEventConfiguration{
 		ProviderID:          p.eventMetadata.ProviderID,


### PR DESCRIPTION
Avoid creating multiple triggers when the topics are defined in different orders in the schema.