### PR TITLE
fix(edfs): filter only when type matches

### DIFF
--- a/v2/pkg/engine/resolve/inputtemplate.go
+++ b/v2/pkg/engine/resolve/inputtemplate.go
@@ -26,6 +26,7 @@ type TemplateSegment struct {
 	VariableSourcePath []string
 	Renderer           VariableRenderer
 	Segments           []TemplateSegment
+	VariableValueType  jsonparser.ValueType
 }
 
 type InputTemplate struct {
@@ -113,6 +114,9 @@ func (i *InputTemplate) renderObjectVariable(ctx context.Context, variables []by
 		_, _ = preparedInput.Write(literal.NULL)
 		return nil
 	}
+
+	segment.VariableValueType = valueType
+
 	if valueType == jsonparser.String {
 		value = variables[offset-len(value)-2 : offset]
 		switch segment.Renderer.GetKind() {
@@ -140,6 +144,9 @@ func (i *InputTemplate) renderContextVariable(ctx *Context, segment TemplateSegm
 		}
 		return false, segment.Renderer.RenderVariable(ctx.Context(), value, preparedInput)
 	}
+
+	segment.VariableValueType = valueType
+
 	if valueType == jsonparser.String {
 		value = ctx.Variables[offset-len(value)-2 : offset]
 		switch segment.Renderer.GetKind() {
@@ -149,6 +156,7 @@ func (i *InputTemplate) renderContextVariable(ctx *Context, segment TemplateSegm
 			}
 		}
 	}
+
 	return false, segment.Renderer.RenderVariable(ctx.Context(), value, preparedInput)
 }
 

--- a/v2/pkg/engine/resolve/inputtemplate.go
+++ b/v2/pkg/engine/resolve/inputtemplate.go
@@ -113,7 +113,6 @@ func (i *InputTemplate) renderObjectVariable(ctx context.Context, variables []by
 		_, _ = preparedInput.Write(literal.NULL)
 		return nil
 	}
-
 	if valueType == jsonparser.String {
 		value = variables[offset-len(value)-2 : offset]
 		switch segment.Renderer.GetKind() {
@@ -141,7 +140,6 @@ func (i *InputTemplate) renderContextVariable(ctx *Context, segment TemplateSegm
 		}
 		return false, segment.Renderer.RenderVariable(ctx.Context(), value, preparedInput)
 	}
-
 	if valueType == jsonparser.String {
 		value = ctx.Variables[offset-len(value)-2 : offset]
 		switch segment.Renderer.GetKind() {
@@ -151,7 +149,6 @@ func (i *InputTemplate) renderContextVariable(ctx *Context, segment TemplateSegm
 			}
 		}
 	}
-
 	return false, segment.Renderer.RenderVariable(ctx.Context(), value, preparedInput)
 }
 

--- a/v2/pkg/engine/resolve/inputtemplate.go
+++ b/v2/pkg/engine/resolve/inputtemplate.go
@@ -26,7 +26,6 @@ type TemplateSegment struct {
 	VariableSourcePath []string
 	Renderer           VariableRenderer
 	Segments           []TemplateSegment
-	VariableValueType  jsonparser.ValueType
 }
 
 type InputTemplate struct {
@@ -115,8 +114,6 @@ func (i *InputTemplate) renderObjectVariable(ctx context.Context, variables []by
 		return nil
 	}
 
-	segment.VariableValueType = valueType
-
 	if valueType == jsonparser.String {
 		value = variables[offset-len(value)-2 : offset]
 		switch segment.Renderer.GetKind() {
@@ -144,8 +141,6 @@ func (i *InputTemplate) renderContextVariable(ctx *Context, segment TemplateSegm
 		}
 		return false, segment.Renderer.RenderVariable(ctx.Context(), value, preparedInput)
 	}
-
-	segment.VariableValueType = valueType
 
 	if valueType == jsonparser.String {
 		value = ctx.Variables[offset-len(value)-2 : offset]

--- a/v2/pkg/engine/resolve/resolve_test.go
+++ b/v2/pkg/engine/resolve/resolve_test.go
@@ -4870,7 +4870,7 @@ func Test_ResolveGraphQLSubscriptionWithFilter(t *testing.T) {
 		resolver := newResolver(c)
 
 		ctx := &Context{
-			Variables: []byte(`{"ids":[2,3]}`),
+			Variables: []byte(`{"ids":["2","3"]}`),
 		}
 
 		err := resolver.AsyncResolveGraphQLSubscription(ctx, plan, out, id)

--- a/v2/pkg/engine/resolve/subscription_filter.go
+++ b/v2/pkg/engine/resolve/subscription_filter.go
@@ -98,15 +98,16 @@ func (f *SubscriptionFieldFilter) SkipEvent(ctx *Context, data []byte, buf *byte
 		actualRawBytes := buf.Bytes()
 		// cheap pre-check to see if we can skip the more expensive array check
 		if !bytes.Contains(actualRawBytes, literal.LBRACK) || !bytes.Contains(actualRawBytes, literal.RBRACK) {
-			actual, actualDataType, _, err := jsonparser.Get(actualRawBytes)
-			if err != nil {
-				return false, nil
+			// type is only set when a proper variable rendering is used.
+			// if more than one segment is used, the result is always a string and we compare byte by byte
+			if len(f.Values[i].Segments) == 1 {
+				vt := f.Values[i].Segments[0].VariableValueType
+				if vt != jsonparser.NotExist && expectedDataType != vt {
+					return true, nil
+				}
 			}
-			// type must match
-			if expectedDataType != actualDataType {
-				continue
-			}
-			if bytes.Equal(expected, actual) {
+
+			if bytes.Equal(expected, actualRawBytes) {
 				return false, nil
 			}
 		}

--- a/v2/pkg/engine/resolve/subscription_filter.go
+++ b/v2/pkg/engine/resolve/subscription_filter.go
@@ -100,7 +100,7 @@ func (f *SubscriptionFieldFilter) SkipEvent(ctx *Context, data []byte, buf *byte
 		if !bytes.Contains(actualRawBytes, literal.LBRACK) || !bytes.Contains(actualRawBytes, literal.RBRACK) {
 			// We only try to compare the types if a variable segment is used otherwise we just compare the bytes
 			// This requires that not more than one segment is used, because the use of multiple segments
-			// always result in a byte by byte comparison
+			// always result in a string and where byte by byte comparison is needed
 			if len(f.Values[i].Segments) == 1 && f.Values[i].Segments[0].SegmentType == VariableSegmentType {
 				_, valueType, _, err := jsonparser.Get(ctx.Variables, f.Values[i].Segments[0].VariableSourcePath...)
 				if err != nil {

--- a/v2/pkg/engine/resolve/subscription_filter.go
+++ b/v2/pkg/engine/resolve/subscription_filter.go
@@ -98,11 +98,15 @@ func (f *SubscriptionFieldFilter) SkipEvent(ctx *Context, data []byte, buf *byte
 		actualRawBytes := buf.Bytes()
 		// cheap pre-check to see if we can skip the more expensive array check
 		if !bytes.Contains(actualRawBytes, literal.LBRACK) || !bytes.Contains(actualRawBytes, literal.RBRACK) {
-			// type is only set when a proper variable rendering is used.
-			// if more than one segment is used, the result is always a string and we compare byte by byte
-			if len(f.Values[i].Segments) == 1 {
-				vt := f.Values[i].Segments[0].VariableValueType
-				if vt != jsonparser.NotExist && expectedDataType != vt {
+			// We only try to compare the types if a variable segment is used otherwise we just compare the bytes
+			// This requires that not more than one segment is used, because the use of multiple segments
+			// always result in a byte by byte comparison
+			if len(f.Values[i].Segments) == 1 && f.Values[i].Segments[0].SegmentType == VariableSegmentType {
+				_, valueType, _, err := jsonparser.Get(ctx.Variables, f.Values[i].Segments[0].VariableSourcePath...)
+				if err != nil {
+					return true, nil
+				}
+				if valueType != jsonparser.NotExist && expectedDataType != valueType {
 					return true, nil
 				}
 			}

--- a/v2/pkg/engine/resolve/subscription_filter_test.go
+++ b/v2/pkg/engine/resolve/subscription_filter_test.go
@@ -823,7 +823,7 @@ func TestSubscriptionFilter(t *testing.T) {
 		assert.Equal(t, false, skip)
 	})
 
-	t.Run("or: multiple predicates with multiple is true and will always be compared byte-to-byte", func(t *testing.T) {
+	t.Run("or: multiple segments with multiple is true and will always be compared byte-to-byte", func(t *testing.T) {
 		filter := &SubscriptionFilter{
 			Or: []SubscriptionFilter{
 				{

--- a/v2/pkg/engine/resolve/subscription_filter_test.go
+++ b/v2/pkg/engine/resolve/subscription_filter_test.go
@@ -170,7 +170,7 @@ func TestSubscriptionFilter(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, true, skip)
 	})
-	t.Run("in: predicate is false (string)", func(t *testing.T) {
+	t.Run("in: predicate is true (boolean)", func(t *testing.T) {
 		filter := &SubscriptionFilter{
 			In: &SubscriptionFieldFilter{
 				FieldPath: []string{"event"},
@@ -189,10 +189,37 @@ func TestSubscriptionFilter(t *testing.T) {
 			},
 		}
 		c := &Context{
-			Variables: []byte(`{"var":"b"}`),
+			Variables: []byte(`{"var":"true"}`),
 		}
 		buf := &bytes.Buffer{}
-		data := []byte(`{"event":"c"}`)
+		data := []byte(`{"event":true}`)
+		skip, err := filter.SkipEvent(c, data, buf)
+		assert.NoError(t, err)
+		assert.Equal(t, false, skip)
+	})
+	t.Run("in: predicate is false due to type mismatch", func(t *testing.T) {
+		filter := &SubscriptionFilter{
+			In: &SubscriptionFieldFilter{
+				FieldPath: []string{"event"},
+				Values: []InputTemplate{
+					{
+						Segments: []TemplateSegment{
+							{
+								SegmentType:        VariableSegmentType,
+								VariableKind:       ContextVariableKind,
+								VariableSourcePath: []string{"var"},
+								Renderer:           NewPlainVariableRenderer(),
+							},
+						},
+					},
+				},
+			},
+		}
+		c := &Context{
+			Variables: []byte(`{"var":321}`),
+		}
+		buf := &bytes.Buffer{}
+		data := []byte(`{"event":"321"}`)
 		skip, err := filter.SkipEvent(c, data, buf)
 		assert.NoError(t, err)
 		assert.Equal(t, true, skip)
@@ -220,6 +247,33 @@ func TestSubscriptionFilter(t *testing.T) {
 		}
 		buf := &bytes.Buffer{}
 		data := []byte(`{"event":"c"}`)
+		skip, err := filter.SkipEvent(c, data, buf)
+		assert.NoError(t, err)
+		assert.Equal(t, true, skip)
+	})
+	t.Run("in: array predicate is false due to type mismatch", func(t *testing.T) {
+		filter := &SubscriptionFilter{
+			In: &SubscriptionFieldFilter{
+				FieldPath: []string{"event"},
+				Values: []InputTemplate{
+					{
+						Segments: []TemplateSegment{
+							{
+								SegmentType:        VariableSegmentType,
+								VariableKind:       ContextVariableKind,
+								VariableSourcePath: []string{"var"},
+								Renderer:           NewPlainVariableRenderer(),
+							},
+						},
+					},
+				},
+			},
+		}
+		c := &Context{
+			Variables: []byte(`{"var":[1,"2"]}`),
+		}
+		buf := &bytes.Buffer{}
+		data := []byte(`{"event":2}`)
 		skip, err := filter.SkipEvent(c, data, buf)
 		assert.NoError(t, err)
 		assert.Equal(t, true, skip)

--- a/v2/pkg/engine/resolve/subscription_filter_test.go
+++ b/v2/pkg/engine/resolve/subscription_filter_test.go
@@ -2,7 +2,6 @@ package resolve
 
 import (
 	"bytes"
-	"github.com/buger/jsonparser"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,7 +19,6 @@ func TestSubscriptionFilter(t *testing.T) {
 								SegmentType:        VariableSegmentType,
 								VariableKind:       ContextVariableKind,
 								VariableSourcePath: []string{"var"},
-								VariableValueType:  jsonparser.Boolean,
 								Renderer:           NewPlainVariableRenderer(),
 							},
 						},
@@ -48,7 +46,6 @@ func TestSubscriptionFilter(t *testing.T) {
 								SegmentType:        VariableSegmentType,
 								VariableKind:       ContextVariableKind,
 								VariableSourcePath: []string{"var"},
-								VariableValueType:  jsonparser.String,
 								Renderer:           NewPlainVariableRenderer(),
 							},
 						},
@@ -76,7 +73,6 @@ func TestSubscriptionFilter(t *testing.T) {
 								SegmentType:        VariableSegmentType,
 								VariableKind:       ContextVariableKind,
 								VariableSourcePath: []string{"var"},
-								VariableValueType:  jsonparser.String,
 								Renderer:           NewPlainVariableRenderer(),
 							},
 						},
@@ -112,7 +108,6 @@ func TestSubscriptionFilter(t *testing.T) {
 							{
 								SegmentType:        VariableSegmentType,
 								VariableKind:       ContextVariableKind,
-								VariableValueType:  jsonparser.Number,
 								VariableSourcePath: []string{"var"},
 								Renderer:           NewPlainVariableRenderer(),
 							},
@@ -141,7 +136,6 @@ func TestSubscriptionFilter(t *testing.T) {
 								SegmentType:        VariableSegmentType,
 								VariableKind:       ContextVariableKind,
 								VariableSourcePath: []string{"var"},
-								VariableValueType:  jsonparser.String,
 								Renderer:           NewPlainVariableRenderer(),
 							},
 						},
@@ -177,7 +171,6 @@ func TestSubscriptionFilter(t *testing.T) {
 							{
 								SegmentType:        VariableSegmentType,
 								VariableKind:       ContextVariableKind,
-								VariableValueType:  jsonparser.Number,
 								VariableSourcePath: []string{"var"},
 								Renderer:           NewPlainVariableRenderer(),
 							},
@@ -206,7 +199,6 @@ func TestSubscriptionFilter(t *testing.T) {
 								SegmentType:        VariableSegmentType,
 								VariableKind:       ContextVariableKind,
 								VariableSourcePath: []string{"var"},
-								VariableValueType:  jsonparser.String,
 								Renderer:           NewPlainVariableRenderer(),
 							},
 						},
@@ -242,7 +234,6 @@ func TestSubscriptionFilter(t *testing.T) {
 							{
 								SegmentType:        VariableSegmentType,
 								VariableKind:       ContextVariableKind,
-								VariableValueType:  jsonparser.String,
 								VariableSourcePath: []string{"var"},
 								Renderer:           NewPlainVariableRenderer(),
 							},
@@ -270,7 +261,6 @@ func TestSubscriptionFilter(t *testing.T) {
 							{
 								SegmentType:        VariableSegmentType,
 								VariableKind:       ContextVariableKind,
-								VariableValueType:  jsonparser.Number,
 								VariableSourcePath: []string{"var"},
 								Renderer:           NewPlainVariableRenderer(),
 							},
@@ -298,7 +288,6 @@ func TestSubscriptionFilter(t *testing.T) {
 							{
 								SegmentType:        VariableSegmentType,
 								VariableKind:       ContextVariableKind,
-								VariableValueType:  jsonparser.Boolean,
 								VariableSourcePath: []string{"var"},
 								Renderer:           NewPlainVariableRenderer(),
 							},
@@ -326,7 +315,6 @@ func TestSubscriptionFilter(t *testing.T) {
 							{
 								SegmentType:        VariableSegmentType,
 								VariableKind:       ContextVariableKind,
-								VariableValueType:  jsonparser.Array,
 								VariableSourcePath: []string{"var"},
 								Renderer:           NewPlainVariableRenderer(),
 							},
@@ -354,7 +342,6 @@ func TestSubscriptionFilter(t *testing.T) {
 							{
 								SegmentType:        VariableSegmentType,
 								VariableKind:       ContextVariableKind,
-								VariableValueType:  jsonparser.Array,
 								VariableSourcePath: []string{"var"},
 								Renderer:           NewPlainVariableRenderer(),
 							},
@@ -382,7 +369,6 @@ func TestSubscriptionFilter(t *testing.T) {
 							{
 								SegmentType:        VariableSegmentType,
 								VariableKind:       ContextVariableKind,
-								VariableValueType:  jsonparser.Array,
 								VariableSourcePath: []string{"var"},
 								Renderer:           NewPlainVariableRenderer(),
 							},
@@ -411,7 +397,6 @@ func TestSubscriptionFilter(t *testing.T) {
 								{
 									SegmentType:        VariableSegmentType,
 									VariableKind:       ContextVariableKind,
-									VariableValueType:  jsonparser.String,
 									VariableSourcePath: []string{"var"},
 									Renderer:           NewPlainVariableRenderer(),
 								},
@@ -441,7 +426,6 @@ func TestSubscriptionFilter(t *testing.T) {
 								{
 									SegmentType:        VariableSegmentType,
 									VariableKind:       ContextVariableKind,
-									VariableValueType:  jsonparser.String,
 									VariableSourcePath: []string{"var"},
 									Renderer:           NewPlainVariableRenderer(),
 								},
@@ -472,7 +456,6 @@ func TestSubscriptionFilter(t *testing.T) {
 									{
 										SegmentType:        VariableSegmentType,
 										VariableKind:       ContextVariableKind,
-										VariableValueType:  jsonparser.String,
 										VariableSourcePath: []string{"first"},
 										Renderer:           NewPlainVariableRenderer(),
 									},
@@ -490,7 +473,6 @@ func TestSubscriptionFilter(t *testing.T) {
 									{
 										SegmentType:        VariableSegmentType,
 										VariableKind:       ContextVariableKind,
-										VariableValueType:  jsonparser.String,
 										VariableSourcePath: []string{"second"},
 										Renderer:           NewPlainVariableRenderer(),
 									},
@@ -564,7 +546,6 @@ func TestSubscriptionFilter(t *testing.T) {
 									{
 										SegmentType:        VariableSegmentType,
 										VariableKind:       ContextVariableKind,
-										VariableValueType:  jsonparser.String,
 										VariableSourcePath: []string{"first"},
 										Renderer:           NewPlainVariableRenderer(),
 									},
@@ -582,7 +563,6 @@ func TestSubscriptionFilter(t *testing.T) {
 									{
 										SegmentType:        VariableSegmentType,
 										VariableKind:       ContextVariableKind,
-										VariableValueType:  jsonparser.String,
 										VariableSourcePath: []string{"second"},
 										Renderer:           NewPlainVariableRenderer(),
 									},
@@ -614,7 +594,6 @@ func TestSubscriptionFilter(t *testing.T) {
 									{
 										SegmentType:        VariableSegmentType,
 										VariableKind:       ContextVariableKind,
-										VariableValueType:  jsonparser.String,
 										VariableSourcePath: []string{"first"},
 										Renderer:           NewPlainVariableRenderer(),
 									},
@@ -632,7 +611,6 @@ func TestSubscriptionFilter(t *testing.T) {
 									{
 										SegmentType:        VariableSegmentType,
 										VariableKind:       ContextVariableKind,
-										VariableValueType:  jsonparser.String,
 										VariableSourcePath: []string{"second"},
 										Renderer:           NewPlainVariableRenderer(),
 									},
@@ -664,7 +642,6 @@ func TestSubscriptionFilter(t *testing.T) {
 									{
 										SegmentType:        VariableSegmentType,
 										VariableKind:       ContextVariableKind,
-										VariableValueType:  jsonparser.String,
 										VariableSourcePath: []string{"first"},
 										Renderer:           NewPlainVariableRenderer(),
 									},
@@ -682,7 +659,6 @@ func TestSubscriptionFilter(t *testing.T) {
 									{
 										SegmentType:        VariableSegmentType,
 										VariableKind:       ContextVariableKind,
-										VariableValueType:  jsonparser.String,
 										VariableSourcePath: []string{"second"},
 										Renderer:           NewPlainVariableRenderer(),
 									},
@@ -714,7 +690,6 @@ func TestSubscriptionFilter(t *testing.T) {
 									{
 										SegmentType:        VariableSegmentType,
 										VariableKind:       ContextVariableKind,
-										VariableValueType:  jsonparser.String,
 										VariableSourcePath: []string{"first"},
 										Renderer:           NewPlainVariableRenderer(),
 									},
@@ -732,7 +707,6 @@ func TestSubscriptionFilter(t *testing.T) {
 									{
 										SegmentType:        VariableSegmentType,
 										VariableKind:       ContextVariableKind,
-										VariableValueType:  jsonparser.NotExist,
 										VariableSourcePath: []string{"second"},
 										Renderer:           NewPlainVariableRenderer(),
 									},
@@ -764,7 +738,6 @@ func TestSubscriptionFilter(t *testing.T) {
 									{
 										SegmentType:        VariableSegmentType,
 										VariableKind:       ContextVariableKind,
-										VariableValueType:  jsonparser.NotExist,
 										VariableSourcePath: []string{"first"},
 										Renderer:           NewPlainVariableRenderer(),
 									},
@@ -782,7 +755,6 @@ func TestSubscriptionFilter(t *testing.T) {
 									{
 										SegmentType:        VariableSegmentType,
 										VariableKind:       ContextVariableKind,
-										VariableValueType:  jsonparser.String,
 										VariableSourcePath: []string{"second"},
 										Renderer:           NewPlainVariableRenderer(),
 									},
@@ -814,7 +786,6 @@ func TestSubscriptionFilter(t *testing.T) {
 									{
 										SegmentType:        VariableSegmentType,
 										VariableKind:       ContextVariableKind,
-										VariableValueType:  jsonparser.NotExist,
 										VariableSourcePath: []string{"first"},
 										Renderer:           NewPlainVariableRenderer(),
 									},
@@ -832,7 +803,6 @@ func TestSubscriptionFilter(t *testing.T) {
 									{
 										SegmentType:        VariableSegmentType,
 										VariableKind:       ContextVariableKind,
-										VariableValueType:  jsonparser.String,
 										VariableSourcePath: []string{"second"},
 										Renderer:           NewPlainVariableRenderer(),
 									},
@@ -865,7 +835,6 @@ func TestSubscriptionFilter(t *testing.T) {
 									{
 										SegmentType:        VariableSegmentType,
 										VariableKind:       ContextVariableKind,
-										VariableValueType:  jsonparser.NotExist,
 										VariableSourcePath: []string{"first"},
 										Renderer:           NewPlainVariableRenderer(),
 									},
@@ -883,14 +852,12 @@ func TestSubscriptionFilter(t *testing.T) {
 									{
 										SegmentType:        VariableSegmentType,
 										VariableKind:       ContextVariableKind,
-										VariableValueType:  jsonparser.String,
 										VariableSourcePath: []string{"second"},
 										Renderer:           NewPlainVariableRenderer(),
 									},
 									{
 										SegmentType:        VariableSegmentType,
 										VariableKind:       ContextVariableKind,
-										VariableValueType:  jsonparser.String,
 										VariableSourcePath: []string{"fourth"},
 										Renderer:           NewPlainVariableRenderer(),
 									},


### PR DESCRIPTION
This PR ensures that we respect the value type when comparing the argument value with the event payload. Before this PR, we treated "1" as 1 and vice versa, as well as "true" = true.

Changes in a nutshell: When we have one segment we can extract the type. If we have more than one it will always result in a byte value comparison. In case of array values, we can always get the type and compare it with the argument type.