### PR TITLE
fix leak in planner

### DIFF
--- a/pkg/engine/plan/plan.go
+++ b/pkg/engine/plan/plan.go
@@ -272,6 +272,10 @@ func (p *Planner) Plan(operation, definition *ast.Document, operationName string
 
 	config := p.config
 
+	// clean objects and current fields from previous invocation
+	p.planningVisitor.objects = p.planningVisitor.objects[:0]
+	p.planningVisitor.currentFields = p.planningVisitor.currentFields[:0]
+
 	// select operation
 
 	p.selectOperation(operation, operationName, report)


### PR DESCRIPTION
We found excessive memory usage when using the library on scale with huge requests. The following fix cleans the planner visitor fields so that they do not grow excessively..