### PR TITLE
chore: add __typename field to trigger bad datasource config

### DIFF
--- a/v2/pkg/engine/plan/planner_test.go
+++ b/v2/pkg/engine/plan/planner_test.go
@@ -268,6 +268,7 @@ func TestPlanner_Plan(t *testing.T) {
 		t.Run("should successfully plan unnamed query with fragment", test(testDefinition, `
 				fragment CharacterFields on Character {
 					name
+					__typename
 				}
 				query {
 					hero {


### PR DESCRIPTION
Reproduction-test for #830 