### PR TITLE
fix: nil pointer on operation rule valid argument

### DIFF
--- a/pkg/astvalidation/operation_rule_valid_arguments.go
+++ b/pkg/astvalidation/operation_rule_valid_arguments.go
@@ -71,6 +71,11 @@ func (v *validArgumentsVisitor) validateIfValueSatisfiesInputFieldDefinition(val
 		return
 	}
 
+	if operationTypeRef == ast.InvalidRef {
+		// variable is not defined on operation
+		return
+	}
+
 	printedValue, err := v.operation.PrintValueBytes(value, nil)
 	if v.HandleInternalErr(err) {
 		return

--- a/pkg/astvalidation/operation_rule_values.go
+++ b/pkg/astvalidation/operation_rule_values.go
@@ -53,7 +53,7 @@ func (v *valuesVisitor) EnterArgument(ref int) {
 		variableName := v.operation.VariableValueNameBytes(value.Ref)
 		variableDefinition, exists := v.operation.VariableDefinitionByNameAndOperation(v.Ancestors[0].Ref, variableName)
 		if !exists {
-			operationName := v.operation.NodeNameBytes(v.Ancestors[0])
+			operationName := v.operation.OperationDefinitionNameBytes(v.Ancestors[0].Ref)
 			v.StopWithExternalErr(operationreport.ErrVariableNotDefinedOnOperation(variableName, operationName))
 			return
 		}

--- a/pkg/astvalidation/operation_validation.go
+++ b/pkg/astvalidation/operation_validation.go
@@ -14,6 +14,8 @@ func DefaultOperationValidator() *OperationValidator {
 		walker: astvisitor.NewWalker(48),
 	}
 
+	validator.RegisterRule(AllVariablesUsed())
+	validator.RegisterRule(AllVariableUsesDefined())
 	validator.RegisterRule(DocumentContainsExecutableOperation())
 	validator.RegisterRule(OperationNameUniqueness())
 	validator.RegisterRule(LoneAnonymousOperation())
@@ -31,8 +33,6 @@ func DefaultOperationValidator() *OperationValidator {
 	validator.RegisterRule(VariableUniqueness())
 	validator.RegisterRule(DirectivesAreUniquePerLocation())
 	validator.RegisterRule(VariablesAreInputTypes())
-	validator.RegisterRule(AllVariableUsesDefined())
-	validator.RegisterRule(AllVariablesUsed())
 
 	return &validator
 }

--- a/v2/pkg/astvalidation/operation_rule_valid_arguments.go
+++ b/v2/pkg/astvalidation/operation_rule_valid_arguments.go
@@ -71,6 +71,11 @@ func (v *validArgumentsVisitor) validateIfValueSatisfiesInputFieldDefinition(val
 		return
 	}
 
+	if operationTypeRef == ast.InvalidRef {
+		// variable is not defined
+		return
+	}
+
 	printedValue, err := v.operation.PrintValueBytes(value, nil)
 	if v.HandleInternalErr(err) {
 		return
@@ -79,11 +84,6 @@ func (v *validArgumentsVisitor) validateIfValueSatisfiesInputFieldDefinition(val
 	typeRef := v.definition.InputValueDefinitionType(inputValueDefinitionRef)
 	expectedTypeName, err := v.definition.PrintTypeBytes(typeRef, nil)
 	if v.HandleInternalErr(err) {
-		return
-	}
-
-	if operationTypeRef == ast.InvalidRef {
-		// variable is not defined
 		return
 	}
 

--- a/v2/pkg/astvalidation/operation_rule_values.go
+++ b/v2/pkg/astvalidation/operation_rule_values.go
@@ -53,7 +53,7 @@ func (v *valuesVisitor) EnterArgument(ref int) {
 		variableName := v.operation.VariableValueNameBytes(value.Ref)
 		variableDefinition, exists := v.operation.VariableDefinitionByNameAndOperation(v.Ancestors[0].Ref, variableName)
 		if !exists {
-			operationName := v.operation.NodeNameBytes(v.Ancestors[0])
+			operationName := v.operation.OperationDefinitionNameBytes(v.Ancestors[0].Ref)
 			v.StopWithExternalErr(operationreport.ErrVariableNotDefinedOnOperation(variableName, operationName))
 			return
 		}

--- a/v2/pkg/astvalidation/operation_validation.go
+++ b/v2/pkg/astvalidation/operation_validation.go
@@ -14,6 +14,8 @@ func DefaultOperationValidator() *OperationValidator {
 		walker: astvisitor.NewWalker(48),
 	}
 
+	validator.RegisterRule(AllVariablesUsed())
+	validator.RegisterRule(AllVariableUsesDefined())
 	validator.RegisterRule(DocumentContainsExecutableOperation())
 	validator.RegisterRule(OperationNameUniqueness())
 	validator.RegisterRule(LoneAnonymousOperation())
@@ -31,8 +33,6 @@ func DefaultOperationValidator() *OperationValidator {
 	validator.RegisterRule(VariableUniqueness())
 	validator.RegisterRule(DirectivesAreUniquePerLocation())
 	validator.RegisterRule(VariablesAreInputTypes())
-	validator.RegisterRule(AllVariableUsesDefined())
-	validator.RegisterRule(AllVariablesUsed())
 
 	return &validator
 }


### PR DESCRIPTION
## Background

Addressing the following issues:

* resolve a panic case on `operation_rule_valid_arguments.go`
* resolve issue extracting operation name on `operation_rule_values.go`
* reorder validator order for a more logical validation


### An example query to reproduce panic
```graphql
query first {
  characters(size: $size) {
    collection {
      id
    }
  }
}
```

```
runtime error: index out of range [-1]
```
