### PR TITLE
feat: Needs to improve file upload, add tests to demo the failure with complex input

### DIFF
--- a/v2/pkg/variablesvalidation/variablesvalidation_test.go
+++ b/v2/pkg/variablesvalidation/variablesvalidation_test.go
@@ -698,6 +698,26 @@ func TestVariablesValidation(t *testing.T) {
 		err := runTest(t, tc)
 		require.NoError(t, err)
 	})
+
+	t.Run("required field argument of scalar Upload can be null", func(t *testing.T) {
+		tc := testCase{
+			schema:    `type Mutation { singleUpload(file: Upload!): Boolean } scalar Upload`,
+			operation: `mutation($file: Upload!){singleUpload(file: $file)}`,
+			variables: `{"file":null}`,
+		}
+		err := runTest(t, tc)
+		assert.Nil(t, err)
+	})
+
+	t.Run("required field argument of scalar Upload can be null in a leaf", func(t *testing.T) {
+		tc := testCase{
+			schema:    `type Mutation { singleUpload(file: FileInput!): Boolean } scalar Upload input FileInput { file: Upload!, fileName: String!}`,
+			operation: `mutation($file: FileInput!){singleUpload(file: $file)}`,
+			variables: `{"file": {"file": null, "fileName": "test"}}`,
+		}
+		err := runTest(t, tc)
+		assert.Nil(t, err)
+	})
 }
 
 type testCase struct {


### PR DESCRIPTION
I added 2 tests. The first one is the regular scenario where one have a variable for normal uploads. The second is a failing test which show a validation problem when you have a complex input in GQL, an input which the `Upload` scalar is an internal field from the input.

I am debugging the internal to solve this. I'm afraid my past solution was not ideal. I introduced a fix that solved the problem earlier, but it feels like a hack:

https://github.com/wundergraph/graphql-go-tools/pull/758/files#diff-8a6f211adbdd8b7c97282d713fa1eb60e673f77b26464efd67bc27e7ddde5460L133

Any guidance here is much appreciated.
