### PR TITLE
fix: goroutine leak and deadlock in ws event loop

### DIFF
--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
@@ -1731,7 +1731,7 @@ func (s *Source) Load(ctx context.Context, input []byte, out *bytes.Buffer) (err
 }
 
 type GraphQLSubscriptionClient interface {
-	// Subscribes to the origin source. The implementation must not block the calling goroutine.
+	// Subscribe to the origin source. The implementation must not block the calling goroutine.
 	Subscribe(ctx *resolve.Context, options GraphQLSubscriptionOptions, updater resolve.SubscriptionUpdater) error
 	UniqueRequestID(ctx *resolve.Context, options GraphQLSubscriptionOptions, hash *xxhash.Digest) (err error)
 }

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
@@ -61,12 +61,6 @@ func WithReadTimeout(timeout time.Duration) Options {
 	}
 }
 
-func WithOnWsConnectionInitCallback(callback *OnWsConnectionInitCallback) Options {
-	return func(options *opts) {
-		options.onWsConnectionInitCallback = callback
-	}
-}
-
 type opts struct {
 	readTimeout                time.Duration
 	log                        abstractlogger.Logger
@@ -346,7 +340,6 @@ func (c *subscriptionClient) getConnectionInitMessage(ctx context.Context, url s
 
 type ConnectionHandler interface {
 	StartBlocking(sub Subscription)
-	SubscribeCH() chan<- Subscription
 }
 
 type Subscription struct {

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_ws_handler.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_ws_handler.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net"
 	"strconv"
 	"time"
 
@@ -32,33 +34,32 @@ func newGQLWSConnectionHandler(ctx context.Context, conn *websocket.Conn, readTi
 		conn:               conn,
 		ctx:                ctx,
 		log:                log,
-		subscribeCh:        make(chan Subscription),
 		nextSubscriptionID: 0,
 		subscriptions:      map[string]Subscription{},
 		readTimeout:        readTimeout,
 	}
 }
 
-func (h *gqlWSConnectionHandler) SubscribeCH() chan<- Subscription {
-	return h.subscribeCh
-}
-
 // StartBlocking starts the single threaded event loop of the handler
 // if the global context returns or the websocket connection is terminated, it will stop
 func (h *gqlWSConnectionHandler) StartBlocking(sub Subscription) {
+	dataCh := make(chan []byte)
+	errCh := make(chan error)
 	readCtx, cancel := context.WithCancel(h.ctx)
+
 	defer func() {
 		h.unsubscribeAllAndCloseConn()
 		cancel()
 	}()
+
 	h.subscribe(sub)
-	dataCh := make(chan []byte)
-	errCh := make(chan error)
+
 	go h.readBlocking(readCtx, dataCh, errCh)
+
 	for {
 		err := h.ctx.Err()
 		if err != nil {
-			if !errors.Is(err, context.Canceled) {
+			if !errors.Is(err, context.Canceled) && !errors.Is(err, io.EOF) {
 				h.log.Error("gqlWSConnectionHandler.StartBlocking", abstractlogger.Error(err))
 			}
 			h.broadcastErrorMessage(err)
@@ -69,12 +70,12 @@ func (h *gqlWSConnectionHandler) StartBlocking(sub Subscription) {
 			return
 		}
 		select {
+		case <-readCtx.Done():
+			return
 		case <-time.After(h.readTimeout):
 			continue
-		case sub = <-h.subscribeCh:
-			h.subscribe(sub)
 		case err = <-errCh:
-			if !errors.Is(err, context.Canceled) {
+			if !errors.Is(err, context.Canceled) && !errors.Is(err, io.EOF) && !errors.Is(err, net.ErrClosed) {
 				h.log.Error("gqlWSConnectionHandler.StartBlocking", abstractlogger.Error(err))
 			}
 			h.broadcastErrorMessage(err)
@@ -114,12 +115,11 @@ func (h *gqlWSConnectionHandler) StartBlocking(sub Subscription) {
 func (h *gqlWSConnectionHandler) readBlocking(ctx context.Context, dataCh chan []byte, errCh chan error) {
 	for {
 		msgType, data, err := h.conn.Read(ctx)
-		if ctx.Err() != nil {
-			errCh <- ctx.Err()
-			return
-		}
 		if err != nil {
-			errCh <- err
+			select {
+			case errCh <- err:
+			case <-ctx.Done():
+			}
 			return
 		}
 		if msgType != websocket.MessageText {

--- a/v2/pkg/engine/resolve/resolve.go
+++ b/v2/pkg/engine/resolve/resolve.go
@@ -6,11 +6,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"golang.org/x/sync/semaphore"
 	"io"
 	"sync"
 	"time"
 
-	"github.com/alitto/pond"
 	"github.com/buger/jsonparser"
 	"github.com/pkg/errors"
 	"go.uber.org/atomic"
@@ -42,10 +42,10 @@ type Resolver struct {
 	bufPool        sync.Pool
 	maxConcurrency chan struct{}
 
-	triggers          map[uint64]*trigger
-	events            chan subscriptionEvent
-	triggerUpdatePool *pond.WorkerPool
-	triggerUpdateBuf  *bytes.Buffer
+	triggers         map[uint64]*trigger
+	events           chan subscriptionEvent
+	triggerUpdateSem *semaphore.Weighted
+	triggerUpdateBuf *bytes.Buffer
 
 	connectionIDs atomic.Int64
 
@@ -170,15 +170,11 @@ func New(ctx context.Context, options ResolverOptions) *Resolver {
 	if options.MaxSubscriptionWorkers == 0 {
 		options.MaxSubscriptionWorkers = 1024
 	}
-	resolver.triggerUpdatePool = pond.New(
-		options.MaxSubscriptionWorkers,
-		0,
-		pond.Context(ctx),
-		pond.IdleTimeout(time.Second*30),
-		pond.Strategy(pond.Lazy()),
-		pond.MinWorkers(16),
-	)
+
+	resolver.triggerUpdateSem = semaphore.NewWeighted(int64(options.MaxSubscriptionWorkers))
+
 	go resolver.handleEvents()
+
 	return resolver
 }
 
@@ -291,13 +287,16 @@ func (r *Resolver) executeSubscriptionUpdate(ctx *Context, sub *sub, sharedInput
 	sub.mux.Lock()
 	sub.pendingUpdates++
 	sub.mux.Unlock()
+
 	if r.options.Debug {
 		fmt.Printf("resolver:trigger:subscription:update:%d\n", sub.id.SubscriptionID)
 	}
 	_, t := r.getTools()
 	defer r.putTools(t)
+
 	input := make([]byte, len(sharedInput))
 	copy(input, sharedInput)
+
 	if err := t.resolvable.InitSubscription(ctx, input, sub.resolve.Trigger.PostProcessing); err != nil {
 		sub.mux.Lock()
 		r.asyncErrorWriter.WriteError(ctx, err, sub.resolve.Response, sub.writer)
@@ -311,6 +310,7 @@ func (r *Resolver) executeSubscriptionUpdate(ctx *Context, sub *sub, sharedInput
 		}
 		return
 	}
+
 	if err := t.loader.LoadGraphQLResponseData(ctx, sub.resolve.Response, t.resolvable); err != nil {
 		sub.mux.Lock()
 		r.asyncErrorWriter.WriteError(ctx, err, sub.resolve.Response, sub.writer)
@@ -324,15 +324,15 @@ func (r *Resolver) executeSubscriptionUpdate(ctx *Context, sub *sub, sharedInput
 		}
 		return
 	}
+
+	sub.mux.Lock()
+	sub.pendingUpdates--
+	sub.mux.Unlock()
+
 	sub.mux.Lock()
 	sub.pendingUpdates--
 	defer sub.mux.Unlock()
-	if sub.writer == nil {
-		if r.options.Debug {
-			fmt.Printf("resolver:trigger:subscription:writer:nil:%d\n", sub.id.SubscriptionID)
-		}
-		return // subscription was already closed by the client
-	}
+
 	if err := t.resolvable.Resolve(ctx.ctx, sub.resolve.Response.Data, sub.resolve.Response.Fetches, sub.writer); err != nil {
 		r.asyncErrorWriter.WriteError(ctx, err, sub.resolve.Response, sub.writer)
 		if r.options.Debug {
@@ -556,10 +556,7 @@ func (r *Resolver) handleRemoveSubscription(id SubscriptionIdentifier) {
 			if s.id == id {
 
 				if ctx.Context().Err() == nil {
-					s.mux.Lock()
 					s.writer.Complete()
-					s.writer = nil
-					s.mux.Unlock()
 				}
 
 				delete(trig.subscriptions, ctx)
@@ -579,6 +576,7 @@ func (r *Resolver) handleRemoveSubscription(id SubscriptionIdentifier) {
 }
 
 func (r *Resolver) handleRemoveClient(id int64) {
+
 	if r.options.Debug {
 		fmt.Printf("resolver:trigger:subscription:remove:client:%d\n", id)
 	}
@@ -588,10 +586,7 @@ func (r *Resolver) handleRemoveClient(id int64) {
 			if s.id.ConnectionID == id && !s.id.internal {
 
 				if c.Context().Err() == nil {
-					s.mux.Lock()
 					s.writer.Complete()
-					s.writer = nil
-					s.mux.Unlock()
 				}
 
 				delete(r.triggers[u].subscriptions, c)
@@ -630,11 +625,17 @@ func (r *Resolver) handleTriggerUpdate(id uint64, data []byte) {
 		if skip {
 			continue
 		}
+
+		if err := r.triggerUpdateSem.Acquire(r.ctx, 1); err != nil {
+			return
+		}
+
 		wg.Add(1)
-		r.triggerUpdatePool.Submit(func() {
+		go func() {
+			defer r.triggerUpdateSem.Release(1)
+			defer wg.Done()
 			r.executeSubscriptionUpdate(c, s, data)
-			wg.Done()
-		})
+		}()
 	}
 }
 
@@ -646,10 +647,7 @@ func (r *Resolver) shutdownTrigger(id uint64) {
 	count := len(trig.subscriptions)
 	for c, s := range trig.subscriptions {
 		if c.Context().Err() == nil {
-			s.mux.Lock()
 			s.writer.Complete()
-			s.writer = nil
-			s.mux.Unlock()
 		}
 		if s.completed != nil {
 			close(s.completed)


### PR DESCRIPTION
This PR fixes

- Remove pond worker and unnecessary mutex locks to avoid deadlock in event loop. A semaphore has been introduced to limit concurrency.
- goroutine leak in the websocket origin handlers. We did not abort `readBlocking` on context cancellation.
