### PR TITLE
feat: make epoll impl lock free and non CPU blocking when idle

### DIFF
--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
@@ -47,12 +47,21 @@ type subscriptionClient struct {
 	epoll       epoller.Poller
 	epollConfig EpollConfiguration
 
-	connections   map[int]*connection
-	connectionsMu sync.RWMutex
+	// connections is a map of fd -> connection to keep track of all active connections
+	connections map[int]*connection
+	// triggers is a map of subscription id -> fd to easily look up the connection for a subscription id
+	triggers map[uint64]int
 
-	triggers          map[uint64]int
+	// clientUnsubscribe is a channel to signal to the epoll run loop that a client needs to be unsubscribed
 	clientUnsubscribe chan uint64
-	serverUnsubscribe chan int
+	// addConn is a channel to signal to the epoll run loop that a new connection needs to be added
+	addConn chan *connection
+	// waitForEventsTicker is the ticker for the epoll run loop
+	// it is used to prevent busy waiting and to limit the CPU usage
+	// instead of polling the epoll instance all the time, we wait until the next tick to throttle the epoll loop
+	waitForEventsTicker *time.Ticker
+	// waitForEventsTick is the channel to receive the tick from the waitForEventsTicker
+	waitForEventsTick <-chan time.Time
 }
 
 func (c *subscriptionClient) SubscribeAsync(ctx *resolve.Context, id uint64, options GraphQLSubscriptionOptions, updater resolve.SubscriptionUpdater) error {
@@ -181,13 +190,19 @@ func NewGraphQLSubscriptionClient(httpClient, streamingClient *http.Client, engi
 			},
 		},
 		onWsConnectionInitCallback: op.onWsConnectionInitCallback,
-		connections:                make(map[int]*connection),
-		triggers:                   make(map[uint64]int),
-		clientUnsubscribe:          make(chan uint64, op.epollConfiguration.BufferSize),
-		serverUnsubscribe:          make(chan int, op.epollConfiguration.BufferSize),
 		epollConfig:                op.epollConfiguration,
 	}
 	if !op.epollConfiguration.Disable {
+		client.connections = make(map[int]*connection)
+		client.triggers = make(map[uint64]int)
+		client.clientUnsubscribe = make(chan uint64, op.epollConfiguration.BufferSize)
+		client.addConn = make(chan *connection, op.epollConfiguration.BufferSize)
+		// this is not needed, but we want to make it explicit that we're starting with nil as the tick channel
+		// reading from nil channels blocks forever, which allows us to prevent the epoll loop from starting
+		// once we add the first connection, we start the ticker and set the tick channel
+		// after the last connection is removed, we set the tick channel to nil again
+		// this way we can start and stop the epoll loop dynamically
+		client.waitForEventsTick = nil
 		// ignore error is ok, it means that epoll is not supported, which is handled gracefully by the client
 		epoll, _ := epoller.NewPoller(op.epollConfiguration.BufferSize, op.epollConfiguration.TickInterval)
 		if epoll != nil {
@@ -199,10 +214,11 @@ func NewGraphQLSubscriptionClient(httpClient, streamingClient *http.Client, engi
 }
 
 type connection struct {
-	id      uint64
-	fd      int
-	conn    net.Conn
-	handler ConnectionHandler
+	id          uint64
+	fd          int
+	conn        net.Conn
+	handler     ConnectionHandler
+	shouldClose bool
 }
 
 // Subscribe initiates a new GraphQL Subscription with the origin
@@ -296,24 +312,16 @@ func (c *subscriptionClient) asyncSubscribeWS(requestContext, engineContext cont
 		}()
 		return nil
 	}
-
+	// init the subscription
 	err = conn.handler.Subscribe()
 	if err != nil {
 		return err
 	}
 
-	if err := c.epoll.Add(conn.conn); err != nil {
-		return err
-	}
-
-	c.connectionsMu.Lock()
 	fd := epoller.SocketFD(conn.conn)
-	conn.id = id
-	conn.fd = fd
-	c.connections[fd] = conn
-	c.triggers[id] = fd
-	c.connectionsMu.Unlock()
-
+	conn.id, conn.fd = id, fd
+	// submit the connection to the epoll run loop
+	c.addConn <- conn
 	return nil
 }
 
@@ -587,35 +595,31 @@ func waitForAck(conn net.Conn) error {
 	}
 }
 
+type connResult struct {
+	fd          int
+	shouldClose bool
+}
+
 func (c *subscriptionClient) runEpoll(ctx context.Context) {
 	defer c.close()
-
 	done := ctx.Done()
+	// both handleConnCh and connResults are buffered channels with a size of WaitForNumEvents
+	// this is important because we submit all events before we start processing them
+	// and we start evaluating the results only after all events have been submitted
+	// this would not be possible with unbuffered channels
+	handleConnCh := make(chan *connection, c.epollConfig.WaitForNumEvents)
+	connResults := make(chan connResult, c.epollConfig.WaitForNumEvents)
 
-	handleConnCh := make(chan *connection)
-
-	// Start workers to handle incoming connections
+	// Start workers to handle connection events
 	// MaxEventWorkers defines the parallelism of how many connections can be handled at the same time
 	// This is the critical number on how much CPU is used
 	for i := 0; i < c.epollConfig.MaxEventWorkers; i++ {
 		go func() {
 			for {
 				select {
-				case id, ok := <-c.clientUnsubscribe:
-					if !ok {
-						return
-					}
-					c.handlePendingClientUnsubscribe(id)
-				case id, ok := <-c.serverUnsubscribe:
-					if !ok {
-						return
-					}
-					c.handlePendingServerUnsubscribe(id)
-				case conn, ok := <-handleConnCh:
-					if !ok {
-						return
-					}
-					c.handleConnection(conn)
+				case conn := <-handleConnCh:
+					shouldClose := c.handleConnectionEvent(conn)
+					connResults <- connResult{fd: conn.fd, shouldClose: shouldClose}
 				case <-done:
 					return
 				}
@@ -623,44 +627,68 @@ func (c *subscriptionClient) runEpoll(ctx context.Context) {
 		}()
 	}
 
-	delay := time.Millisecond * 100
-
+	// This is the main epoll run loop
+	// It's a single threaded event loop that reacts to several events, such as added connections, clients unsubscribing, etc.
 	for {
 		select {
+		// if the engine context is done, we close the epoll loop
 		case <-done:
 			return
-		default:
-			now := time.Now()
-			connections, err := c.epoll.Wait(c.epollConfig.WaitForNumEvents)
-
+		case conn := <-c.addConn:
+			c.handleAddConn(conn)
+		case id := <-c.clientUnsubscribe:
+			c.handleClientUnsubscribe(id)
+			// while len(c.connections) == 0, this channel is nil, so we will never try to wait for epoll events
+			// this is important to prevent busy waiting
+			// once we add the first connection, we start the ticker and set the tick channel
+			// the ticker ensures that we don't poll the epoll instance all the time,
+			// but at most every TickInterval
+		case <-c.waitForEventsTick:
+			events, err := c.epoll.Wait(c.epollConfig.WaitForNumEvents)
 			if err != nil {
 				c.log.Error("epoll.Wait", abstractlogger.Error(err))
 				continue
 			}
 
-			for i := range connections {
+			waitForEvents := len(events)
 
-				id := epoller.SocketFD(connections[i])
-
-				c.connectionsMu.RLock()
-				conn, ok := c.connections[id]
-				c.connectionsMu.RUnlock()
-
+			for i := range events {
+				fd := epoller.SocketFD(events[i])
+				conn, ok := c.connections[fd]
 				if !ok {
 					// Should never happen
-					continue
+					panic(fmt.Sprintf("connection with fd %d not found", fd))
 				}
-
+				// submit the connection to the worker pool
 				handleConnCh <- conn
 			}
 
-			// sleep for the remaining time of the delay
-			// to not spinlock the CPU
+			// we submit all events to the worker pool to handle all events in parallel
+			// instead of just waiting until all handlers are done, we can handle newly added connections or clients unsubscribing simultaneously
+			// we keep doing this until we have results for all events or the engine context is done
+			// this allows us to keep handling events in parallel while being able to manage connections without locks
+			// as a result, we can handle a large number of connections with a single threaded event loop
 
-			sleepTime := delay - time.Since(now)
-
-			if sleepTime > 0 {
-				time.Sleep(sleepTime)
+			for {
+				if waitForEvents == 0 {
+					// once we have results for all events, we can return to the top level loop and wait for the next tick
+					break
+				}
+				select {
+				case result := <-connResults:
+					// if the connection indicates that it should be closed, we close and remove it
+					if result.shouldClose {
+						c.handleServerUnsubscribe(result.fd)
+					}
+					// we decrease the number of events we're waiting for to eventually break the loop
+					waitForEvents--
+				case conn := <-c.addConn:
+					c.handleAddConn(conn)
+				case id := <-c.clientUnsubscribe:
+					c.handleClientUnsubscribe(id)
+				case <-done:
+					return
+				}
 			}
 		}
 	}
@@ -668,8 +696,9 @@ func (c *subscriptionClient) runEpoll(ctx context.Context) {
 
 func (c *subscriptionClient) close() {
 	defer c.log.Debug("subscriptionClient.close", abstractlogger.String("reason", "epoll closed by context"))
-	c.connectionsMu.Lock()
-	defer c.connectionsMu.Unlock()
+	if c.waitForEventsTicker != nil {
+		c.waitForEventsTicker.Stop()
+	}
 	for _, conn := range c.connections {
 		_ = c.epoll.Remove(conn.conn)
 		conn.handler.ServerClose()
@@ -682,10 +711,23 @@ func (c *subscriptionClient) close() {
 	}
 }
 
-func (c *subscriptionClient) handlePendingClientUnsubscribe(id uint64) {
-	c.connectionsMu.Lock()
-	defer c.connectionsMu.Unlock()
+func (c *subscriptionClient) handleAddConn(conn *connection) {
+	if err := c.epoll.Add(conn.conn); err != nil {
+		c.log.Error("subscriptionClient.handleAddConn", abstractlogger.Error(err))
+		conn.handler.ServerClose()
+		return
+	}
+	c.connections[conn.fd] = conn
+	c.triggers[conn.id] = conn.fd
+	// when we previously had 0 connections, we will have 1 connection now
+	// this means we need to start the ticker so that we get epoll events
+	if len(c.connections) == 1 {
+		c.waitForEventsTicker = time.NewTicker(c.epollConfig.TickInterval)
+		c.waitForEventsTick = c.waitForEventsTicker.C
+	}
+}
 
+func (c *subscriptionClient) handleClientUnsubscribe(id uint64) {
 	fd, ok := c.triggers[id]
 	if !ok {
 		return
@@ -696,39 +738,37 @@ func (c *subscriptionClient) handlePendingClientUnsubscribe(id uint64) {
 		return
 	}
 	delete(c.connections, fd)
-
 	_ = c.epoll.Remove(conn.conn)
 	conn.handler.ClientClose()
+	// if we have no connections left, we stop the ticker
+	if len(c.connections) == 0 {
+		c.waitForEventsTicker.Stop()
+		c.waitForEventsTick = nil
+	}
 }
 
-func (c *subscriptionClient) handlePendingServerUnsubscribe(id int) {
-	c.connectionsMu.Lock()
-	defer c.connectionsMu.Unlock()
-
-	conn, ok := c.connections[id]
+func (c *subscriptionClient) handleServerUnsubscribe(fd int) {
+	conn, ok := c.connections[fd]
 	if !ok {
 		return
 	}
-	delete(c.connections, id)
+	delete(c.connections, fd)
 	delete(c.triggers, conn.id)
-
 	_ = c.epoll.Remove(conn.conn)
 	conn.handler.ServerClose()
+	// if we have no connections left, we stop the ticker
+	if len(c.connections) == 0 {
+		c.waitForEventsTicker.Stop()
+		c.waitForEventsTick = nil
+	}
 }
 
-func (c *subscriptionClient) handleConnection(conn *connection) {
+func (c *subscriptionClient) handleConnectionEvent(conn *connection) bool {
 	data, err := readMessage(conn.conn, c.readTimeout)
 	if err != nil {
-		if handleConnectionError(err) {
-			c.serverUnsubscribe <- conn.fd
-			return
-		}
-		return
+		return handleConnectionError(err)
 	}
-	if conn.handler.HandleMessage(data) {
-		c.serverUnsubscribe <- conn.fd
-		return
-	}
+	return conn.handler.HandleMessage(data)
 }
 
 func handleConnectionError(err error) (done bool) {

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
@@ -907,8 +907,6 @@ func TestAsyncSubscribe(t *testing.T) {
 			return true
 		}, time.Second*5, time.Millisecond*10, "server did not close")
 		time.Sleep(time.Second)
-		client.connectionsMu.Lock()
-		defer client.connectionsMu.Unlock()
 		assert.Equal(t, 0, len(client.connections))
 	})
 	t.Run("forever timeout", func(t *testing.T) {
@@ -1105,8 +1103,6 @@ func TestAsyncSubscribe(t *testing.T) {
 				return true
 			}, time.Second, time.Millisecond*10, "server did not close")
 			serverCancel()
-			client.connectionsMu.Lock()
-			defer client.connectionsMu.Unlock()
 			assert.Equal(t, 0, len(client.connections))
 		})
 		t.Run("error object", func(t *testing.T) {
@@ -1390,7 +1386,6 @@ func TestAsyncSubscribe(t *testing.T) {
 			assert.Equal(t, `{"data":{"messageAdded":{"text":"first"}}}`, updater.updates[0])
 			assert.Equal(t, `{"data":{"messageAdded":{"text":"second"}}}`, updater.updates[1])
 			assert.Equal(t, `{"data":{"messageAdded":{"text":"third"}}}`, updater.updates[2])
-			client.Unsubscribe(1)
 			clientCancel()
 			assert.Eventuallyf(t, func() bool {
 				<-serverDone
@@ -1470,7 +1465,6 @@ func TestAsyncSubscribe(t *testing.T) {
 					assert.Equal(t, `{"data":{"messageAdded":{"text":"first"}}}`, updater.updates[0])
 					assert.Equal(t, `{"data":{"messageAdded":{"text":"second"}}}`, updater.updates[1])
 					assert.Equal(t, `{"data":{"messageAdded":{"text":"third"}}}`, updater.updates[2])
-					client.Unsubscribe(uint64(i))
 					clientCancel()
 					wg.Done()
 				}(i)

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
@@ -907,7 +907,7 @@ func TestAsyncSubscribe(t *testing.T) {
 			return true
 		}, time.Second*5, time.Millisecond*10, "server did not close")
 		time.Sleep(time.Second)
-		assert.Equal(t, 0, len(client.connections))
+		assert.Equal(t, false, client.hasConnections.Load())
 	})
 	t.Run("forever timeout", func(t *testing.T) {
 		t.Parallel()
@@ -1103,7 +1103,7 @@ func TestAsyncSubscribe(t *testing.T) {
 				return true
 			}, time.Second, time.Millisecond*10, "server did not close")
 			serverCancel()
-			assert.Equal(t, 0, len(client.connections))
+			assert.Equal(t, false, client.hasConnections.Load())
 		})
 		t.Run("error object", func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
The previous implementation relied on mutexes and locking to achieve concurrency.
This resulted in a lot of complex code.
In addition, I believe that it was possible that events are being handled while we continue with the next loop as we didn't wait for their completion.
Furthermore, one shortcoming of the previous version was that we would always have some CPU spinning when there are 0 connections as we had no means to stop the loop.

This refactor replaces the shared memory + mutex approach with an event loop.
As a result, we have 0% CPU in idle.
Another benefit is that we're able to handle incoming connection events parallel to managing connections.
This is possible as we've moved all connection management to the main loop while handling connection events in the workers. Previously, workers were also managing connections which made a mutex and locking necessary.
As a consequence, the code in most areas is now single threaded and much simpler.