### PR TITLE
[DO NOT MERGE] feat: reduce allocs & improve throughput

### DIFF
--- a/v2/pkg/engine/datasource/httpclient/nethttpclient.go
+++ b/v2/pkg/engine/datasource/httpclient/nethttpclient.go
@@ -199,11 +199,6 @@ func makeHTTPRequest(client *http.Client, ctx context.Context, url, method, head
 	}
 
 	if !enableTrace {
-		if response.ContentLength > 0 {
-			out.Grow(int(response.ContentLength))
-		} else {
-			out.Grow(1024 * 4)
-		}
 		_, err = out.ReadFrom(respReader)
 		return
 	}

--- a/v2/pkg/engine/resolve/loader.go
+++ b/v2/pkg/engine/resolve/loader.go
@@ -387,8 +387,7 @@ func (l *Loader) loadFetch(ctx context.Context, fetch Fetch, fetchItem *FetchIte
 				out: fetch.GetBuffer(),
 			}
 			if l.ctx.TracingOptions.Enable {
-				f.Traces[i] = new(SingleFetch)
-				*f.Traces[i] = *f.Fetch
+				f.Traces[i] = f.Fetch
 				g.Go(func() error {
 					return l.loadFetch(ctx, f.Traces[i], fetchItem, items[i:i+1], results[i])
 				})

--- a/v2/pkg/engine/resolve/loader.go
+++ b/v2/pkg/engine/resolve/loader.go
@@ -207,8 +207,7 @@ func (l *Loader) resolveSingle(item *FetchItem) error {
 				out: f.GetBuffer(),
 			}
 			if l.ctx.TracingOptions.Enable {
-				f.Traces[i] = new(SingleFetch)
-				*f.Traces[i] = *f.Fetch
+				f.Traces[i] = f.Fetch
 				g.Go(func() error {
 					return l.loadFetch(ctx, f.Traces[i], item, items[i:i+1], results[i])
 				})

--- a/v2/pkg/engine/resolve/resolvable.go
+++ b/v2/pkg/engine/resolve/resolvable.go
@@ -159,7 +159,11 @@ func (r *Resolvable) ResolveNode(node Node, data *astjson.Value, out io.Writer) 
 	r.printErr = nil
 	r.authorizationError = nil
 	r.errors = r.astjsonArena.NewArray()
-
+	defer func() {
+		// remove references to buffers when no longer needed
+		r.out = nil
+		r.errors = nil
+	}()
 	hasErrors := r.walkNode(node, data)
 	if hasErrors {
 		return fmt.Errorf("error resolving node")

--- a/v2/pkg/engine/resolve/resolve.go
+++ b/v2/pkg/engine/resolve/resolve.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"runtime"
 	"sync"
 	"time"
 
@@ -177,6 +178,19 @@ func New(ctx context.Context, options ResolverOptions) *Resolver {
 
 	for _, field := range options.AllowedSubgraphErrorFields {
 		allowedErrorFields[field] = struct{}{}
+	}
+
+	if options.BufferPoolOptions.MaxBuffers == 0 {
+		options.BufferPoolOptions.MaxBuffers = runtime.GOMAXPROCS(-1)
+	}
+	if options.BufferPoolOptions.MaxBuffers < 8 {
+		options.BufferPoolOptions.MaxBuffers = 8
+	}
+	if options.BufferPoolOptions.MaxBufferSize == 0 {
+		options.BufferPoolOptions.MaxBufferSize = 1024 * 1024 * 10 // 10MB
+	}
+	if options.BufferPoolOptions.DefaultBufferSize < 1024*8 {
+		options.BufferPoolOptions.DefaultBufferSize = 1024 * 8 // 8KB
 	}
 
 	resolver := &Resolver{

--- a/v2/pkg/pool/limitbufferpool.go
+++ b/v2/pkg/pool/limitbufferpool.go
@@ -43,7 +43,7 @@ func NewLimitBufferPool(ctx context.Context, options LimitBufferPoolOptions) *Li
 		options.DefaultBufferSize = 1024 * 8 // 8KB
 	}
 	if options.MaxBuffers == 0 {
-		options.MaxBuffers = runtime.NumCPU()
+		options.MaxBuffers = runtime.GOMAXPROCS(-1)
 	}
 	if options.MaxBuffers < 8 {
 		options.MaxBuffers = 8

--- a/v2/pkg/pool/limitbufferpool.go
+++ b/v2/pkg/pool/limitbufferpool.go
@@ -1,0 +1,97 @@
+package pool
+
+import (
+	"bytes"
+	"context"
+	"runtime"
+	"time"
+)
+
+// LimitBufferPool is a pool of buffers that is limited in size and is limiting the max size of buffers that should be recycled
+// In addition, it runs a GC runtime that randomly resets a buffer every second to keep the memory usage low when usage is low
+// This is an alternative to sync.Pool, which can grow unbounded rather quickly
+type LimitBufferPool struct {
+	buffers []*ResolvableBuffer
+	index   chan int
+	options LimitBufferPoolOptions
+}
+
+type ResolvableBuffer struct {
+	Buf *bytes.Buffer
+	idx int
+}
+
+type LimitBufferPoolOptions struct {
+	// MaxBuffers limits the total amount of buffers that can be allocated for printing the response
+	// It's recommended to set this to the number of CPU cores available, or a multiple of it
+	// If set to 0, the number of CPU cores is used
+	MaxBuffers int
+	// MaxBufferSize limits the size of the buffer that can be recycled back into the pool
+	// If set to 0, a limit of 10MB is applied
+	// If the buffer cap exceeds this limit, a new buffer with the default size is created
+	MaxBufferSize int
+	// DefaultBufferSize is used to initialize the buffer with a default size
+	// If set to 0, a default size of 8KB is used
+	DefaultBufferSize int
+}
+
+func NewLimitBufferPool(ctx context.Context, options LimitBufferPoolOptions) *LimitBufferPool {
+	if options.MaxBufferSize == 0 {
+		options.MaxBufferSize = 1024 * 1024 * 10 // 10MB
+	}
+	if options.DefaultBufferSize < 1024*8 {
+		options.DefaultBufferSize = 1024 * 8 // 8KB
+	}
+	if options.MaxBuffers == 0 {
+		options.MaxBuffers = runtime.NumCPU()
+	}
+	if options.MaxBuffers < 8 {
+		options.MaxBuffers = 8
+	}
+	pool := &LimitBufferPool{
+		buffers: make([]*ResolvableBuffer, options.MaxBuffers),
+		index:   make(chan int, options.MaxBuffers),
+		options: options,
+	}
+	for i := range pool.buffers {
+		pool.buffers[i] = &ResolvableBuffer{
+			idx: i,
+		}
+		pool.index <- i
+	}
+	go pool.runGC(ctx)
+	return pool
+}
+
+func (p *LimitBufferPool) runGC(ctx context.Context) {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			b := p.Get()
+			b.Buf = nil
+			p.Put(b)
+		}
+	}
+}
+
+func (p *LimitBufferPool) Get() *ResolvableBuffer {
+	i := <-p.index
+	if p.buffers[i].Buf == nil {
+		p.buffers[i].Buf = bytes.NewBuffer(make([]byte, 0, p.options.DefaultBufferSize))
+	}
+	return p.buffers[i]
+}
+
+func (p *LimitBufferPool) Put(buf *ResolvableBuffer) {
+	if buf.Buf != nil {
+		buf.Buf.Reset()
+		if buf.Buf.Cap() > p.options.MaxBufferSize {
+			buf.Buf = bytes.NewBuffer(make([]byte, 0, p.options.DefaultBufferSize))
+		}
+	}
+	p.index <- buf.idx
+}

--- a/v2/pkg/pool/limitbufferpool_test.go
+++ b/v2/pkg/pool/limitbufferpool_test.go
@@ -60,6 +60,7 @@ func TestLimitBufferPool(t *testing.T) {
 		assert.NotNil(t, buf.Buf)
 		assert.Equal(t, 1024, buf.Buf.Cap()) // default size
 		_, err = buf.Buf.Write(bytes.Repeat([]byte("a"), 2048))
+		assert.NoError(t, err)
 		p.Put(buf)
 	}
 

--- a/v2/pkg/pool/limitbufferpool_test.go
+++ b/v2/pkg/pool/limitbufferpool_test.go
@@ -1,0 +1,69 @@
+package pool
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
+)
+
+func TestLimitBufferPool(t *testing.T) {
+	defer goleak.VerifyNone(t,
+		goleak.IgnoreCurrent(), // ignore the test itself
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	p := NewLimitBufferPool(ctx, LimitBufferPoolOptions{
+		MaxBuffers:        4,
+		DefaultBufferSize: 1024,
+		MaxBufferSize:     1024,
+		GCTime:            time.Millisecond * 10,
+	})
+
+	buffers := make([]*ResolvableBuffer, 4)
+
+	for i := 0; i < 4; i++ {
+		buf := p.Get()
+		_, err := buf.Buf.Write(bytes.Repeat([]byte("a"), 64))
+		assert.NoError(t, err)
+		buffers[i] = buf
+	}
+
+	select {
+	case <-p.index:
+		t.Fatal("should not be able to get more buffers")
+	default:
+	}
+
+	for i := 0; i < 4; i++ {
+		p.Put(buffers[i])
+	}
+
+	b := p.Get()
+	assert.NotNil(t, b)
+	assert.Equal(t, 1024, b.Buf.Cap())
+	assert.Equal(t, 0, b.Buf.Len())
+
+	_, err := b.Buf.Write(bytes.Repeat([]byte("a"), 1025))
+	assert.NoError(t, err)
+	assert.Equal(t, 1025, b.Buf.Len()) // write over the limit
+	assert.Equal(t, 2048, b.Buf.Cap()) // should have doubled the initial size
+	p.Put(b)                           // should reset the buffer
+
+	for i := 0; i < 4; i++ {
+		buf := p.Get()
+		assert.NotNil(t, buf.Buf)
+		assert.Equal(t, 1024, buf.Buf.Cap()) // default size
+		p.Put(buf)
+	}
+
+	time.Sleep(time.Millisecond * 100)
+	for i := range p.buffers {
+		assert.Nil(t, p.buffers[i].Buf) // should have been reset by the GC
+	}
+}


### PR DESCRIPTION
...by introducing a limit buffer pool and fetch buffer heuristics

I figures out that we can reduce allocs by almost 50% and increase throughput by 30% by doing 2 changes:

1. add a limit buffer pool to resolvable instead of using sync.Pool or no pool at all
2. add heuristics to loader to estimate the ideal size of fetch buffers

Both changes reduce bytes.growSlice operations to almost zero in hot paths, see below.

before:

<img width="2554" alt="image" src="https://github.com/user-attachments/assets/68272239-3025-42e3-8180-ee2785cd0917">

after:

<img width="2455" alt="image" src="https://github.com/user-attachments/assets/0b7495a8-d3a1-48a3-9ce9-90faa130f62b">

