### PR TITLE
fix: set request in hook context before send request, in case of error

### DIFF
--- a/v2/pkg/engine/datasource/httpclient/nethttpclient.go
+++ b/v2/pkg/engine/datasource/httpclient/nethttpclient.go
@@ -198,12 +198,14 @@ func makeHTTPRequest(client *http.Client, ctx context.Context, url, method, head
 	setRequest(ctx, request)
 
 	response, err := client.Do(request)
+
+	// Set response, even before error check, to ensure that it's in the context
+	setResponseStatus(ctx, request, response)
+
 	if err != nil {
 		return err
 	}
 	defer response.Body.Close()
-
-	setResponseStatus(ctx, request, response)
 
 	respReader, err := respBodyReader(response)
 	if err != nil {

--- a/v2/pkg/engine/datasource/httpclient/nethttpclient.go
+++ b/v2/pkg/engine/datasource/httpclient/nethttpclient.go
@@ -79,6 +79,12 @@ func InjectResponseContext(ctx context.Context) (context.Context, *ResponseConte
 	return context.WithValue(ctx, responseContextKey{}, value), value
 }
 
+func setRequest(ctx context.Context, request *http.Request) {
+	if value, ok := ctx.Value(responseContextKey{}).(*ResponseContext); ok {
+		value.Request = request
+	}
+}
+
 func setResponseStatus(ctx context.Context, request *http.Request, response *http.Response) {
 	if value, ok := ctx.Value(responseContextKey{}).(*ResponseContext); ok {
 		value.StatusCode = response.StatusCode
@@ -188,6 +194,8 @@ func makeHTTPRequest(client *http.Client, ctx context.Context, url, method, head
 	request.Header.Add(ContentTypeHeader, contentType)
 	request.Header.Set(AcceptEncodingHeader, EncodingGzip)
 	request.Header.Add(AcceptEncodingHeader, EncodingDeflate)
+
+	setRequest(ctx, request)
 
 	response, err := client.Do(request)
 	if err != nil {

--- a/v2/pkg/engine/datasource/httpclient/nethttpclient.go
+++ b/v2/pkg/engine/datasource/httpclient/nethttpclient.go
@@ -87,7 +87,11 @@ func setRequest(ctx context.Context, request *http.Request) {
 
 func setResponseStatus(ctx context.Context, request *http.Request, response *http.Response) {
 	if value, ok := ctx.Value(responseContextKey{}).(*ResponseContext); ok {
-		value.StatusCode = response.StatusCode
+		if response != nil {
+			value.StatusCode = response.StatusCode
+		} else {
+			value.StatusCode = 0
+		}
 		value.Request = request
 		value.Response = response
 	}

--- a/v2/pkg/engine/datasource/httpclient/nethttpclient.go
+++ b/v2/pkg/engine/datasource/httpclient/nethttpclient.go
@@ -203,15 +203,15 @@ func makeHTTPRequest(client *http.Client, ctx context.Context, url, method, head
 
 	response, err := client.Do(request)
 
-	// Set response, even before error check, to ensure that it's in the context
-	setResponseStatus(ctx, request, response)
-
 	if err != nil {
 		return err
 	}
 	defer response.Body.Close()
 
+	setResponseStatus(ctx, request, response)
+
 	respReader, err := respBodyReader(response)
+
 	if err != nil {
 		return err
 	}

--- a/v2/pkg/engine/datasource/httpclient/nethttpclient.go
+++ b/v2/pkg/engine/datasource/httpclient/nethttpclient.go
@@ -202,7 +202,6 @@ func makeHTTPRequest(client *http.Client, ctx context.Context, url, method, head
 	setRequest(ctx, request)
 
 	response, err := client.Do(request)
-
 	if err != nil {
 		return err
 	}
@@ -211,7 +210,6 @@ func makeHTTPRequest(client *http.Client, ctx context.Context, url, method, head
 	setResponseStatus(ctx, request, response)
 
 	respReader, err := respBodyReader(response)
-
 	if err != nil {
 		return err
 	}

--- a/v2/pkg/engine/resolve/loader.go
+++ b/v2/pkg/engine/resolve/loader.go
@@ -62,9 +62,16 @@ func newResponseInfo(res *result, subgraphError error) *ResponseInfo {
 		// We're using the response.Request here, because the body will be nil (since the response was read) and won't
 		// cause a memory leak.
 		if res.httpResponseContext.Response != nil {
-			responseInfo.Request = res.httpResponseContext.Response.Request
-			responseInfo.ResponseHeaders = res.httpResponseContext.Response.Header.Clone()
-		} else {
+			if res.httpResponseContext.Response.Request != nil {
+				responseInfo.Request = res.httpResponseContext.Response.Request
+			}
+
+			if res.httpResponseContext.Response.Header != nil {
+				responseInfo.ResponseHeaders = res.httpResponseContext.Response.Header.Clone()
+			}
+		}
+
+		if responseInfo.Request == nil {
 			// In cases where the request errors, the response will be nil, and so we need to get the original request
 			responseInfo.Request = res.httpResponseContext.Request
 		}


### PR DESCRIPTION
This will be added to https://github.com/wundergraph/cosmo/pull/1445, to ensure that it's more resilient

Previously, we weren't setting the request (even when we really should have had access), because in error cases we were exiting before setting the request/response context. This ensures that we can pass the correct information to the access logs