### PR TITLE
fix: remove semaphore from ResolveGraphQLSubscription

### DIFF
--- a/v2/pkg/engine/resolve/resolve.go
+++ b/v2/pkg/engine/resolve/resolve.go
@@ -50,14 +50,13 @@ type Resolver struct {
 	options        ResolverOptions
 	maxConcurrency chan struct{}
 
-	triggers                map[uint64]*trigger
-	heartbeatSubLock        *sync.Mutex
-	heartbeatSubscriptions  map[*Context]*sub
-	events                  chan subscriptionEvent
-	triggerEventsSem        *semaphore.Weighted
-	triggerEventsSemTimeout time.Duration
-	triggerUpdatesSem       *semaphore.Weighted
-	triggerUpdateBuf        *bytes.Buffer
+	triggers               map[uint64]*trigger
+	heartbeatSubLock       *sync.Mutex
+	heartbeatSubscriptions map[*Context]*sub
+	events                 chan subscriptionEvent
+	triggerEventsSem       *semaphore.Weighted
+	triggerUpdatesSem      *semaphore.Weighted
+	triggerUpdateBuf       *bytes.Buffer
 
 	allowedErrorExtensionFields map[string]struct{}
 	allowedErrorFields          map[string]struct{}
@@ -107,9 +106,6 @@ type ResolverOptions struct {
 	// MaxSubscriptionWorkers limits the concurrency on how many subscription can be added / removed concurrently.
 	// This does not include subscription updates, for that we have a separate semaphore MaxSubscriptionUpdates.
 	MaxSubscriptionWorkers int
-	// MaxSubscriptionWorkersTimeout limits the time a subscription worker can be blocked before giving an error to the
-	// client. This is useful to prevent a client from being blocked indefinitely if the server is under heavy load.
-	MaxSubscriptionWorkersTimeout time.Duration
 
 	// MaxSubscriptionUpdates limits the number of concurrent subscription updates that can be sent to the event loop.
 	MaxSubscriptionUpdates int
@@ -210,15 +206,11 @@ func New(ctx context.Context, options ResolverOptions) *Resolver {
 	if options.MaxSubscriptionWorkers == 0 {
 		options.MaxSubscriptionWorkers = 1024
 	}
-	if options.MaxSubscriptionWorkersTimeout == 0 {
-		options.MaxSubscriptionWorkersTimeout = time.Second
-	}
 	if options.MaxSubscriptionUpdates == 0 {
 		options.MaxSubscriptionUpdates = 1024
 	}
 
 	resolver.triggerEventsSem = semaphore.NewWeighted(int64(options.MaxSubscriptionWorkers))
-	resolver.triggerEventsSemTimeout = options.MaxSubscriptionWorkersTimeout
 	resolver.triggerUpdatesSem = semaphore.NewWeighted(int64(options.MaxSubscriptionUpdates))
 
 	go resolver.handleEvents()
@@ -923,9 +915,7 @@ Loop: // execute fn on the main thread of the incoming request until ctx is done
 }
 
 func (r *Resolver) AsyncResolveGraphQLSubscription(ctx *Context, subscription *GraphQLSubscription, writer SubscriptionResponseWriter, id SubscriptionIdentifier) (err error) {
-	ctxWithTimeout, ctxCancel := context.WithTimeout(r.ctx, r.triggerEventsSemTimeout)
-	defer ctxCancel()
-	if err := r.triggerEventsSem.Acquire(ctxWithTimeout, 1); err != nil {
+	if err := r.triggerEventsSem.Acquire(r.ctx, 1); err != nil {
 		return err
 	}
 	defer r.triggerEventsSem.Release(1)

--- a/v2/pkg/engine/resolve/resolve.go
+++ b/v2/pkg/engine/resolve/resolve.go
@@ -813,13 +813,6 @@ func (r *Resolver) AsyncUnsubscribeClient(connectionID int64) error {
 }
 
 func (r *Resolver) ResolveGraphQLSubscription(ctx *Context, subscription *GraphQLSubscription, writer SubscriptionResponseWriter) error {
-	ctxWithTimeout, ctxCancel := context.WithTimeout(r.ctx, r.triggerEventsSemTimeout)
-	defer ctxCancel()
-	if err := r.triggerEventsSem.Acquire(ctxWithTimeout, 1); err != nil {
-		return err
-	}
-	defer r.triggerEventsSem.Release(1)
-
 	if subscription.Trigger.Source == nil {
 		return errors.New("no data source found")
 	}

--- a/v2/pkg/engine/resolve/resolve_test.go
+++ b/v2/pkg/engine/resolve/resolve_test.go
@@ -88,6 +88,8 @@ func (t *TestErrorWriter) WriteError(ctx *Context, err error, res *GraphQLRespon
 
 var multipartSubHeartbeatInterval = 15 * time.Millisecond
 
+const testMaxSubscriptionWorkers = 1
+
 func newResolver(ctx context.Context) *Resolver {
 	return New(ctx, ResolverOptions{
 		MaxConcurrency:                1024,
@@ -96,6 +98,7 @@ func newResolver(ctx context.Context) *Resolver {
 		PropagateSubgraphStatusCodes:  true,
 		AsyncErrorWriter:              &TestErrorWriter{},
 		MultipartSubHeartbeatInterval: multipartSubHeartbeatInterval,
+		MaxSubscriptionWorkers:        testMaxSubscriptionWorkers,
 	})
 }
 
@@ -4858,6 +4861,8 @@ func createFakeStream(messageFunc messageFunc, delay time.Duration, onStart func
 
 type messageFunc func(counter int) (message string, done bool)
 
+var fakeStreamRequestId atomic.Int32
+
 type _fakeStream struct {
 	messageFunc messageFunc
 	onStart     func(input []byte)
@@ -4880,7 +4885,7 @@ func (f *_fakeStream) AwaitIsDone(t *testing.T, timeout time.Duration) {
 }
 
 func (f *_fakeStream) UniqueRequestID(ctx *Context, input []byte, xxh *xxhash.Digest) (err error) {
-	_, err = xxh.WriteString("fakeStream")
+	_, err = xxh.WriteString(fmt.Sprintf("%d", fakeStreamRequestId.Add(1)))
 	if err != nil {
 		return
 	}
@@ -5390,6 +5395,60 @@ func TestResolver_ResolveGraphQLSubscription(t *testing.T) {
 		assert.ElementsMatch(t, []string{
 			`{"data":null,"extensions":{"queryPlan":{"version":"1","kind":"Sequence","trigger":{"kind":"Trigger","path":"countryUpdated","subgraphName":"country","subgraphId":"0","fetchId":0,"query":"subscription { countryUpdated { name time { local } } }"},"children":[{"kind":"Single","fetch":{"kind":"Single","path":"countryUpdated.time","subgraphName":"time","subgraphId":"1","fetchId":1,"dependsOnFetchIds":[0],"query":"query($representations: [_Any!]!){\n    _entities(representations: $representations){\n        ... on Time {\n            __typename\n            local\n        }\n    }\n}"}}]}}}`,
 		}, recorder.Messages())
+	})
+
+	t.Run("should successfully allow more than one subscription using http multipart", func(t *testing.T) {
+		c, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		fakeStream := createFakeStream(func(counter int) (message string, done bool) {
+			return fmt.Sprintf(`{"data":{"counter":%d}}`, counter), false
+		}, 0, func(input []byte) {
+			assert.Equal(t, `{"method":"POST","url":"http://localhost:4000","body":{"query":"subscription { counter }"}}`, string(input))
+		})
+
+		resolver, plan, _, _ := setup(c, fakeStream)
+
+		ctx := &Context{
+			ctx: context.Background(),
+			ExecutionOptions: ExecutionOptions{
+				SendHeartbeat: true,
+			},
+		}
+
+		const numSubscriptions = testMaxSubscriptionWorkers + 1
+		var resolverCompleted atomic.Uint32
+		var recorderCompleted atomic.Uint32
+		for i := 0; i < numSubscriptions; i++ {
+			recorder := &SubscriptionRecorder{
+				buf:      &bytes.Buffer{},
+				messages: []string{},
+				complete: atomic.Bool{},
+			}
+			recorder.complete.Store(false)
+
+			go func() {
+				defer recorderCompleted.Add(1)
+
+				recorder.AwaitAnyMessageCount(t, defaultTimeout)
+			}()
+
+			go func() {
+				defer resolverCompleted.Add(1)
+
+				err := resolver.ResolveGraphQLSubscription(ctx, plan, recorder)
+				assert.ErrorIs(t, err, context.Canceled)
+			}()
+		}
+		assert.Eventually(t, func() bool {
+			return recorderCompleted.Load() == numSubscriptions
+		}, defaultTimeout, time.Millisecond*100)
+
+		cancel()
+
+		assert.Eventually(t, func() bool {
+			return resolverCompleted.Load() == numSubscriptions
+		}, defaultTimeout, time.Millisecond*100)
 	})
 }
 


### PR DESCRIPTION
The semaphore in the sync method was blocking requests after the 1024th from proceeding.