### PR TITLE
feat: add apollo router compat flag for invalid variable rendering

### DIFF
--- a/execution/engine/execution_engine.go
+++ b/execution/engine/execution_engine.go
@@ -68,7 +68,7 @@ type ExecutionEngine struct {
 	resolver                       *resolve.Resolver
 	executionPlanCache             *lru.Cache
 	apolloCompatibilityFlags       apollocompatibility.Flags
-	apolloRouterCompatibilityFlags apollocompatibility.RouterFlags
+	apolloRouterCompatibilityFlags apollocompatibility.ApolloRouterFlags
 }
 
 type WebsocketBeforeStartHook interface {
@@ -145,7 +145,7 @@ func NewExecutionEngine(ctx context.Context, logger abstractlogger.Logger, engin
 		apolloCompatibilityFlags: apollocompatibility.Flags{
 			ReplaceInvalidVarError: resolverOptions.ResolvableOptions.ApolloCompatibilityReplaceInvalidVarError,
 		},
-		apolloRouterCompatibilityFlags: apollocompatibility.RouterFlags{
+		apolloRouterCompatibilityFlags: apollocompatibility.ApolloRouterFlags{
 			ReplaceInvalidVarError: resolverOptions.ResolvableOptions.ApolloRouterCompatibilityReplaceInvalidVarError,
 		},
 	}, nil

--- a/execution/engine/execution_engine.go
+++ b/execution/engine/execution_engine.go
@@ -145,9 +145,6 @@ func NewExecutionEngine(ctx context.Context, logger abstractlogger.Logger, engin
 		apolloCompatibilityFlags: apollocompatibility.Flags{
 			ReplaceInvalidVarError: resolverOptions.ResolvableOptions.ApolloCompatibilityReplaceInvalidVarError,
 		},
-		apolloRouterCompatibilityFlags: apollocompatibility.ApolloRouterFlags{
-			ReplaceInvalidVarError: resolverOptions.ResolvableOptions.ApolloRouterCompatibilityReplaceInvalidVarError,
-		},
 	}, nil
 }
 

--- a/v2/pkg/apollocompatibility/flags.go
+++ b/v2/pkg/apollocompatibility/flags.go
@@ -5,6 +5,6 @@ type Flags struct {
 	ReplaceUndefinedOpFieldError bool
 }
 
-type RouterFlags struct {
+type ApolloRouterFlags struct {
 	ReplaceInvalidVarError bool
 }

--- a/v2/pkg/apollocompatibility/flags.go
+++ b/v2/pkg/apollocompatibility/flags.go
@@ -4,3 +4,7 @@ type Flags struct {
 	ReplaceInvalidVarError       bool
 	ReplaceUndefinedOpFieldError bool
 }
+
+type RouterFlags struct {
+	ReplaceInvalidVarError bool
+}

--- a/v2/pkg/engine/resolve/resolvable.go
+++ b/v2/pkg/engine/resolve/resolvable.go
@@ -64,6 +64,8 @@ type ResolvableOptions struct {
 	ApolloCompatibilitySuppressFetchErrors          bool
 	ApolloCompatibilityReplaceUndefinedOpFieldError bool
 	ApolloCompatibilityReplaceInvalidVarError       bool
+
+	ApolloRouterCompatibilityReplaceInvalidVarError bool
 }
 
 func NewResolvable(options ResolvableOptions) *Resolvable {
@@ -274,9 +276,7 @@ func (r *Resolvable) printExtensions(ctx context.Context, fetchTree *FetchTreeNo
 	r.printBytes(colon)
 	r.printBytes(lBrace)
 
-	var (
-		writeComma bool
-	)
+	var writeComma bool
 
 	if r.ctx.authorizer != nil && r.ctx.authorizer.HasResponseExtensionData(r.ctx) {
 		writeComma = true

--- a/v2/pkg/engine/resolve/resolvable.go
+++ b/v2/pkg/engine/resolve/resolvable.go
@@ -64,8 +64,6 @@ type ResolvableOptions struct {
 	ApolloCompatibilitySuppressFetchErrors          bool
 	ApolloCompatibilityReplaceUndefinedOpFieldError bool
 	ApolloCompatibilityReplaceInvalidVarError       bool
-
-	ApolloRouterCompatibilityReplaceInvalidVarError bool
 }
 
 func NewResolvable(options ResolvableOptions) *Resolvable {

--- a/v2/pkg/errorcodes/const.go
+++ b/v2/pkg/errorcodes/const.go
@@ -1,8 +1,9 @@
 package errorcodes
 
 const (
-	BadUserInput            = "BAD_USER_INPUT"
-	GraphQLValidationFailed = "GRAPHQL_VALIDATION_FAILED"
-	InternalServerError     = "INTERNAL_SERVER_ERROR"
-	InvalidGraphql          = "INVALID_GRAPHQL"
+	BadUserInput                  = "BAD_USER_INPUT"
+	GraphQLValidationFailed       = "GRAPHQL_VALIDATION_FAILED"
+	InternalServerError           = "INTERNAL_SERVER_ERROR"
+	InvalidGraphql                = "INVALID_GRAPHQL"
+	ValidationInvalidTypeVariable = "VALIDATION_INVALID_TYPE_VARIABLE"
 )

--- a/v2/pkg/errorcodes/const.go
+++ b/v2/pkg/errorcodes/const.go
@@ -1,9 +1,12 @@
 package errorcodes
 
 const (
-	BadUserInput                  = "BAD_USER_INPUT"
-	GraphQLValidationFailed       = "GRAPHQL_VALIDATION_FAILED"
-	InternalServerError           = "INTERNAL_SERVER_ERROR"
-	InvalidGraphql                = "INVALID_GRAPHQL"
+	// Apollo Gateway Compatibility
+	BadUserInput            = "BAD_USER_INPUT"
+	GraphQLValidationFailed = "GRAPHQL_VALIDATION_FAILED"
+	InternalServerError     = "INTERNAL_SERVER_ERROR"
+	InvalidGraphql          = "INVALID_GRAPHQL"
+
+	// Apollo Router Compatibility
 	ValidationInvalidTypeVariable = "VALIDATION_INVALID_TYPE_VARIABLE"
 )

--- a/v2/pkg/variablesvalidation/variablesvalidation.go
+++ b/v2/pkg/variablesvalidation/variablesvalidation.go
@@ -50,9 +50,17 @@ func (v *variablesVisitor) invalidValueMessage(variableName, variableContent str
 }
 
 func (v *variablesVisitor) newInvalidVariableError(message string) *InvalidVariableError {
+	if v.opts.ApolloRouterCompatabilityFlags.ReplaceInvalidVarError {
+		return &InvalidVariableError{
+			Message:       fmt.Sprintf("invalid type for variable: '%s'", v.currentVariableName),
+			ExtensionCode: errorcodes.ValidationInvalidTypeVariable,
+		}
+	}
+
 	err := &InvalidVariableError{
 		Message: message,
 	}
+
 	if v.opts.ApolloCompatibilityFlags.ReplaceInvalidVarError {
 		err.ExtensionCode = errorcodes.BadUserInput
 	}
@@ -66,6 +74,7 @@ type VariablesValidator struct {
 
 type VariablesValidatorOptions struct {
 	ApolloCompatibilityFlags        apollocompatibility.Flags
+	ApolloRouterCompatabilityFlags  apollocompatibility.RouterFlags
 	DisableExposingVariablesContent bool
 }
 

--- a/v2/pkg/variablesvalidation/variablesvalidation.go
+++ b/v2/pkg/variablesvalidation/variablesvalidation.go
@@ -74,7 +74,7 @@ type VariablesValidator struct {
 
 type VariablesValidatorOptions struct {
 	ApolloCompatibilityFlags        apollocompatibility.Flags
-	ApolloRouterCompatabilityFlags  apollocompatibility.RouterFlags
+	ApolloRouterCompatabilityFlags  apollocompatibility.ApolloRouterFlags
 	DisableExposingVariablesContent bool
 }
 

--- a/v2/pkg/variablesvalidation/variablesvalidation_test.go
+++ b/v2/pkg/variablesvalidation/variablesvalidation_test.go
@@ -1232,14 +1232,14 @@ func TestVariablesValidation(t *testing.T) {
 		}, err)
 	})
 
-	t.Run("extension code is propagated with apollo compatibility flag", func(t *testing.T) {
+	t.Run("extension code and reduced error is propagated with apollo router compatibility flag", func(t *testing.T) {
 		tc := testCase{
 			schema:    `type Query { hello(filter: String!): String }`,
 			operation: `query Foo($input: String!) { hello(filter: $input) }`,
 			variables: `{"input":null}`,
 		}
 		err := runTestWithOptions(t, tc, VariablesValidatorOptions{
-			ApolloRouterCompatabilityFlags: apollocompatibility.RouterFlags{
+			ApolloRouterCompatabilityFlags: apollocompatibility.ApolloRouterFlags{
 				ReplaceInvalidVarError: true,
 			},
 		})

--- a/v2/pkg/variablesvalidation/variablesvalidation_test.go
+++ b/v2/pkg/variablesvalidation/variablesvalidation_test.go
@@ -1244,7 +1244,7 @@ func TestVariablesValidation(t *testing.T) {
 			},
 		})
 		assert.Equal(t, &InvalidVariableError{
-			ExtensionCode: errorcodes.BadUserInput,
+			ExtensionCode: errorcodes.ValidationInvalidTypeVariable,
 			Message:       `invalid type for variable: 'input'`,
 		}, err)
 	})

--- a/v2/pkg/variablesvalidation/variablesvalidation_test.go
+++ b/v2/pkg/variablesvalidation/variablesvalidation_test.go
@@ -34,6 +34,26 @@ func TestVariablesValidationApolloCompatibility(t *testing.T) {
 		}, err)
 	})
 
+	t.Run("apollo router compatibility overrides apollo gateway compatability", func(t *testing.T) {
+		tc := testCase{
+			schema:    `type Query { hello(filter: String!): String }`,
+			operation: `query Foo($input: String!) { hello(filter: $input) }`,
+			variables: `{"input":null}`,
+		}
+		err := runTestWithOptions(t, tc, VariablesValidatorOptions{
+			ApolloCompatibilityFlags: apollocompatibility.Flags{
+				ReplaceInvalidVarError: true,
+			},
+			ApolloRouterCompatabilityFlags: apollocompatibility.ApolloRouterFlags{
+				ReplaceInvalidVarError: true,
+			},
+		})
+		assert.Equal(t, &InvalidVariableError{
+			ExtensionCode: errorcodes.ValidationInvalidTypeVariable,
+			Message:       `invalid type for variable: 'input'`,
+		}, err)
+	})
+
 	t.Run("extension code and reduced error is propagated with apollo router compatibility flag", func(t *testing.T) {
 		// With the apollo router compatibility flag set, a variety of invalid variable errors should be changed
 		// with a different extension and message

--- a/v2/pkg/variablesvalidation/variablesvalidation_test.go
+++ b/v2/pkg/variablesvalidation/variablesvalidation_test.go
@@ -16,6 +16,143 @@ import (
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/internal/unsafeparser"
 )
 
+func TestVariablesValidationApolloCompatibility(t *testing.T) {
+	t.Run("extension code is propagated with apollo compatibility flag", func(t *testing.T) {
+		tc := testCase{
+			schema:    `type Query { hello(filter: String!): String }`,
+			operation: `query Foo($input: String!) { hello(filter: $input) }`,
+			variables: `{"input":null}`,
+		}
+		err := runTestWithOptions(t, tc, VariablesValidatorOptions{
+			ApolloCompatibilityFlags: apollocompatibility.Flags{
+				ReplaceInvalidVarError: true,
+			},
+		})
+		assert.Equal(t, &InvalidVariableError{
+			ExtensionCode: errorcodes.BadUserInput,
+			Message:       `Variable "$input" got invalid value null; Expected non-nullable type "String!" not to be null.`,
+		}, err)
+	})
+
+	t.Run("extension code and reduced error is propagated with apollo router compatibility flag", func(t *testing.T) {
+		// With the apollo router compatibility flag set, a variety of invalid variable errors should be changed
+		// with a different extension and message
+
+		// Shadow runTest to use the apollo router compatibility flag
+		runTest := func(t *testing.T, tc testCase) error {
+			return runTestWithOptions(t, tc, VariablesValidatorOptions{
+				ApolloRouterCompatabilityFlags: apollocompatibility.ApolloRouterFlags{
+					ReplaceInvalidVarError: true,
+				},
+			})
+		}
+
+		/*
+			affects:
+			- variableRequired
+			- variableRequiredNotProvided
+			- variableInvalidObjectType
+			- variableInvalidNestedType
+			- variableFieldNotDefined
+			- variableEnumValueDoesNotExist
+			- variableInvalidNull
+		*/
+
+		t.Run("variableRequired", func(t *testing.T) {
+			tc := testCase{
+				schema:    `type Query { hello(arg: String!): String }`,
+				operation: `query Foo($bar: String!) { hello }`,
+				variables: `{}`,
+			}
+			err := runTest(t, tc)
+			assert.Equal(t, &InvalidVariableError{
+				ExtensionCode: errorcodes.ValidationInvalidTypeVariable,
+				Message:       `invalid type for variable: 'bar'`,
+			}, err)
+		})
+
+		t.Run("variableRequiredNotProvided", func(t *testing.T) {
+			tc := testCase{
+				schema:    `input Foo { bar: String! } type Query { hello(arg: Foo!): String }`,
+				operation: `query Foo($bar: Foo!) { hello(arg: $bar) }`,
+				variables: `{"bar":{}}`,
+			}
+			err := runTest(t, tc)
+			assert.Equal(t, &InvalidVariableError{
+				ExtensionCode: errorcodes.ValidationInvalidTypeVariable,
+				Message:       `invalid type for variable: 'bar'`,
+			}, err)
+		})
+
+		t.Run("variableInvalidObjectType", func(t *testing.T) {
+			tc := testCase{
+				schema:    `input Foo { bar: String! } type Query { hello(arg: Foo!): String }`,
+				operation: `query Foo($bar: Foo!) { hello(arg: $bar) }`,
+				variables: `{"bar":true}`,
+			}
+			err := runTest(t, tc)
+			assert.Equal(t, &InvalidVariableError{
+				ExtensionCode: errorcodes.ValidationInvalidTypeVariable,
+				Message:       `invalid type for variable: 'bar'`,
+			}, err)
+		})
+
+		t.Run("variableInvalidNestedType", func(t *testing.T) {
+			tc := testCase{
+				schema:    `input Foo { bar: String! } type Query { hello(arg: Foo!): String }`,
+				operation: `query Foo($input: Foo!) { hello(arg: $input) }`,
+				variables: `{"input":{"bar":123}}`,
+			}
+			err := runTest(t, tc)
+			assert.Equal(t, &InvalidVariableError{
+				ExtensionCode: errorcodes.ValidationInvalidTypeVariable,
+				Message:       `invalid type for variable: 'input'`,
+			}, err)
+		})
+
+		t.Run("variableFieldNotDefined", func(t *testing.T) {
+			tc := testCase{
+				schema:    `input Foo { bar: String! } input Bar { foo: Foo! } type Query { hello(arg: Bar!): String }`,
+				operation: `query Foo($input: Bar!) { hello(arg: $input) }`,
+				variables: `{"input":{"foo":{"bar":"hello","baz":"world"}}}`,
+			}
+			err := runTest(t, tc)
+			assert.Equal(t, &InvalidVariableError{
+				ExtensionCode: errorcodes.ValidationInvalidTypeVariable,
+				Message:       `invalid type for variable: 'input'`,
+			}, err)
+		})
+
+		// Apollo Router actually doesn't validate this case, but if they did, they would probably
+		// return this error
+		t.Run("variableEnumValueDoesNotExist", func(t *testing.T) {
+			tc := testCase{
+				schema:    `enum Foo { BAR } type Query { hello(arg: Foo!): String }`,
+				operation: `query Foo($bar: Foo!) { hello(arg: $bar) }`,
+				variables: `{"bar":"BAZ"}`,
+			}
+			err := runTest(t, tc)
+			assert.Equal(t, &InvalidVariableError{
+				ExtensionCode: errorcodes.ValidationInvalidTypeVariable,
+				Message:       `invalid type for variable: 'bar'`,
+			}, err)
+		})
+
+		t.Run("variableInvalidNull", func(t *testing.T) {
+			tc := testCase{
+				schema:    `enum Foo { BAR } type Query { hello(arg: Foo!): String }`,
+				operation: `query Foo($bar: Foo!) { hello(arg: $bar) }`,
+				variables: `{"bar":null}`,
+			}
+			err := runTest(t, tc)
+			assert.Equal(t, &InvalidVariableError{
+				ExtensionCode: errorcodes.ValidationInvalidTypeVariable,
+				Message:       `invalid type for variable: 'bar'`,
+			}, err)
+		})
+	})
+}
+
 func TestVariablesValidation(t *testing.T) {
 	t.Run("required field argument not provided", func(t *testing.T) {
 		tc := testCase{
@@ -1214,39 +1351,6 @@ func TestVariablesValidation(t *testing.T) {
 		}
 		err := runTest(t, tc)
 		require.NoError(t, err)
-	})
-	t.Run("extension code is propagated with apollo compatibility flag", func(t *testing.T) {
-		tc := testCase{
-			schema:    `type Query { hello(filter: String!): String }`,
-			operation: `query Foo($input: String!) { hello(filter: $input) }`,
-			variables: `{"input":null}`,
-		}
-		err := runTestWithOptions(t, tc, VariablesValidatorOptions{
-			ApolloCompatibilityFlags: apollocompatibility.Flags{
-				ReplaceInvalidVarError: true,
-			},
-		})
-		assert.Equal(t, &InvalidVariableError{
-			ExtensionCode: errorcodes.BadUserInput,
-			Message:       `Variable "$input" got invalid value null; Expected non-nullable type "String!" not to be null.`,
-		}, err)
-	})
-
-	t.Run("extension code and reduced error is propagated with apollo router compatibility flag", func(t *testing.T) {
-		tc := testCase{
-			schema:    `type Query { hello(filter: String!): String }`,
-			operation: `query Foo($input: String!) { hello(filter: $input) }`,
-			variables: `{"input":null}`,
-		}
-		err := runTestWithOptions(t, tc, VariablesValidatorOptions{
-			ApolloRouterCompatabilityFlags: apollocompatibility.ApolloRouterFlags{
-				ReplaceInvalidVarError: true,
-			},
-		})
-		assert.Equal(t, &InvalidVariableError{
-			ExtensionCode: errorcodes.ValidationInvalidTypeVariable,
-			Message:       `invalid type for variable: 'input'`,
-		}, err)
 	})
 
 	t.Run("optional Int input object field provided with 1", func(t *testing.T) {

--- a/v2/pkg/variablesvalidation/variablesvalidation_test.go
+++ b/v2/pkg/variablesvalidation/variablesvalidation_test.go
@@ -46,18 +46,6 @@ func TestVariablesValidationApolloCompatibility(t *testing.T) {
 				},
 			})
 		}
-
-		/*
-			affects:
-			- variableRequired
-			- variableRequiredNotProvided
-			- variableInvalidObjectType
-			- variableInvalidNestedType
-			- variableFieldNotDefined
-			- variableEnumValueDoesNotExist
-			- variableInvalidNull
-		*/
-
 		t.Run("variableRequired", func(t *testing.T) {
 			tc := testCase{
 				schema:    `type Query { hello(arg: String!): String }`,


### PR DESCRIPTION
- Adds a new struct to `apollocompatibility` for "router flags" which are compatibility flags for migration from apollo router instead of apollo gateway
- Adds a special path to invalid variable validation to return the router-shaped error
- Plumbs the config through engine/execution code

This has been tested with `cosmo/router-tests` E2E and functions correctly. Critique re: naming welcome, I just picked something and moved on to the fix.