### PR TITLE
test: correctly enable subrequest http errors for the subrequest http error + ok error code test

### DIFF
--- a/execution/engine/execution_engine_test.go
+++ b/execution/engine/execution_engine_test.go
@@ -477,7 +477,7 @@ func TestExecutionEngine_Execute(t *testing.T) {
 			}`,
 		},
 		func(eto *_executionTestOptions) {
-			eto.resolvableOptions.ApolloRouterCompatibilitySubrequestHTTPError = false
+			eto.resolvableOptions.ApolloRouterCompatibilitySubrequestHTTPError = true
 		},
 	))
 


### PR DESCRIPTION
`ApolloRouterCompatibilitySubrequestHTTPError` to `true` when testing ok-ish error codes, still passes.