### PR TITLE
feat(engine): mutex free subscription handling

### DIFF
--- a/v2/pkg/engine/resolve/event_loop_test.go
+++ b/v2/pkg/engine/resolve/event_loop_test.go
@@ -1,0 +1,180 @@
+package resolve
+
+import (
+	"context"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cespare/xxhash/v2"
+	"github.com/stretchr/testify/require"
+)
+
+type FakeErrorWriter struct{}
+
+func (f *FakeErrorWriter) WriteError(ctx *Context, err error, res *GraphQLResponse, w io.Writer) {
+
+}
+
+type FakeSubscriptionWriter struct {
+	mu              sync.Mutex
+	buf             []byte
+	writtenMessages []string
+	completed       bool
+}
+
+func (f *FakeSubscriptionWriter) Write(p []byte) (n int, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.buf = append(f.buf, p...)
+	return len(p), nil
+}
+
+func (f *FakeSubscriptionWriter) Flush() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.writtenMessages = append(f.writtenMessages, string(f.buf))
+	f.buf = nil
+	return nil
+}
+
+func (f *FakeSubscriptionWriter) Complete() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.completed = true
+}
+
+type FakeSource struct {
+	updates  []string
+	interval time.Duration
+}
+
+func (f *FakeSource) UniqueRequestID(ctx *Context, input []byte, xxh *xxhash.Digest) (err error) {
+	_, err = xxh.Write(input)
+	return err
+}
+
+func (f *FakeSource) Start(ctx *Context, input []byte, updater SubscriptionUpdater) error {
+	go func() {
+		for i, u := range f.updates {
+			updater.Update([]byte(u))
+			if i < len(f.updates)-1 {
+				time.Sleep(f.interval)
+			}
+		}
+		updater.Done()
+	}()
+	return nil
+}
+
+type TestReporter struct {
+	eventLoopStopped chan struct{}
+	triggers         atomic.Int64
+	subscriptions    atomic.Int64
+}
+
+func (t *TestReporter) EventLoopStopped() {
+	close(t.eventLoopStopped)
+}
+
+func (t *TestReporter) SubscriptionUpdateSent() {
+
+}
+
+func (t *TestReporter) SubscriptionCountInc(count int) {
+	t.subscriptions.Add(int64(count))
+}
+
+func (t *TestReporter) SubscriptionCountDec(count int) {
+	t.subscriptions.Add(-int64(count))
+}
+
+func (t *TestReporter) TriggerCountInc(count int) {
+	t.triggers.Add(int64(count))
+}
+
+func (t *TestReporter) TriggerCountDec(count int) {
+	t.triggers.Add(-int64(count))
+}
+
+func TestEventLoop(t *testing.T) {
+
+	resolverCtx, stopEventLoop := context.WithCancel(context.Background())
+	t.Cleanup(stopEventLoop)
+
+	ew := &FakeErrorWriter{}
+	testReporter := &TestReporter{
+		eventLoopStopped: make(chan struct{}),
+	}
+
+	resolver := New(resolverCtx, ResolverOptions{
+		MaxConcurrency:                1024,
+		Debug:                         false,
+		AsyncErrorWriter:              ew,
+		PropagateSubgraphErrors:       false,
+		PropagateSubgraphStatusCodes:  false,
+		SubgraphErrorPropagationMode:  SubgraphErrorPropagationModePassThrough,
+		DefaultErrorExtensionCode:     "TEST",
+		MaxRecyclableParserSize:       1024 * 1024,
+		MultipartSubHeartbeatInterval: DefaultHeartbeatInterval,
+		Reporter:                      testReporter,
+	})
+
+	subscription := &GraphQLSubscription{
+		Trigger: GraphQLSubscriptionTrigger{
+			InputTemplate: InputTemplate{},
+			Source: &FakeSource{
+				interval: time.Millisecond * 100,
+				updates: []string{
+					`{"data":{"counter":1}}`,
+					`{"data":{"counter":2}}`,
+					`{"data":{"counter":3}}`,
+				},
+			},
+			PostProcessing: PostProcessingConfiguration{
+				SelectResponseDataPath:   []string{"data"},
+				SelectResponseErrorsPath: []string{"errors"},
+			},
+		},
+		Response: &GraphQLResponse{
+			Data: &Object{
+				Fields: []*Field{
+					{
+						Name: []byte("counter"),
+						Value: &Integer{
+							Path:     []string{"counter"},
+							Nullable: false,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	writer := &FakeSubscriptionWriter{}
+
+	subscriptionCtx := &Context{}
+	subscriptionCtx = subscriptionCtx.WithContext(context.Background())
+
+	err := resolver.ResolveGraphQLSubscription(subscriptionCtx, subscription, writer)
+	require.NoError(t, err)
+
+	writer.mu.Lock()
+	defer writer.mu.Unlock()
+	require.Equal(t, true, writer.completed)
+	require.Equal(t, 3, len(writer.writtenMessages))
+
+	stopEventLoop()
+
+	select {
+	case <-testReporter.eventLoopStopped:
+	case <-time.After(time.Second * 5):
+		t.Fatal("event loop did not stop")
+	}
+	triggerCount := testReporter.triggers.Load()
+	subscriptionCount := testReporter.subscriptions.Load()
+	require.Equal(t, int64(0), triggerCount)
+	require.Equal(t, int64(0), subscriptionCount)
+}

--- a/v2/pkg/engine/resolve/resolve.go
+++ b/v2/pkg/engine/resolve/resolve.go
@@ -757,7 +757,7 @@ func (r *Resolver) shutdownTriggerSubscriptions(id uint64, shutdownMatcher func(
 			continue
 		}
 
-		if c.Context().Err() == nil {
+		if s.executor == nil && c.Context().Err() == nil {
 			s.writer.Complete()
 		}
 
@@ -934,6 +934,7 @@ Loop: // execute fn on the main thread of the incoming request until ctx is done
 					fn()
 				}
 			}
+			writer.Complete()
 			return nil
 		case fn := <-executor:
 			fn()

--- a/v2/pkg/engine/resolve/resolve.go
+++ b/v2/pkg/engine/resolve/resolve.go
@@ -36,6 +36,7 @@ type Reporter interface {
 	TriggerCountInc(count int)
 	// TriggerCountDec decreased when a trigger is removed e.g. when a trigger is shutdown
 	TriggerCountDec(count int)
+	EventLoopStopped()
 }
 
 type AsyncErrorWriter interface {
@@ -283,7 +284,8 @@ type sub struct {
 	// this ensures that ctx cancellation works properly when a client disconnects
 	executor chan func()
 	// workChan is used to send work to the writer goroutine. All work is processed sequentially.
-	workChan chan func()
+	workChan     chan func()
+	inflightChan chan struct{}
 }
 
 // startWorker runs in its own goroutine to process fetches and write data to the client synchronously
@@ -505,14 +507,15 @@ func (r *Resolver) handleAddSubscription(triggerID uint64, add *addSubscription)
 		fmt.Printf("resolver:trigger:subscription:add:%d:%d\n", triggerID, add.id.SubscriptionID)
 	}
 	s := &sub{
-		ctx:       add.ctx,
-		resolve:   add.resolve,
-		writer:    add.writer,
-		id:        add.id,
-		completed: add.completed,
-		executor:  add.executor,
-		workChan:  make(chan func(), 32),
-		resolver:  r,
+		ctx:          add.ctx,
+		resolve:      add.resolve,
+		writer:       add.writer,
+		id:           add.id,
+		completed:    add.completed,
+		executor:     add.executor,
+		workChan:     make(chan func(), 32),
+		inflightChan: add.inflight,
+		resolver:     r,
 	}
 
 	if add.ctx.ExecutionOptions.SendHeartbeat {
@@ -689,8 +692,11 @@ func (r *Resolver) handleTriggerUpdate(id uint64, data []byte) {
 			continue
 		}
 
+		<-s.inflightChan
+
 		fn := func() {
 			r.executeSubscriptionUpdate(c, s, data)
+			s.inflightChan <- struct{}{}
 		}
 
 		// Send the update to the executor channel to be executed on the main thread
@@ -781,6 +787,9 @@ func (r *Resolver) handleShutdown() {
 		fmt.Printf("resolver:trigger:shutdown:done\n")
 	}
 	r.triggers = make(map[uint64]*trigger)
+	if r.reporter != nil {
+		r.reporter.EventLoopStopped()
+	}
 }
 
 type SubscriptionIdentifier struct {
@@ -870,6 +879,7 @@ func (r *Resolver) ResolveGraphQLSubscription(ctx *Context, subscription *GraphQ
 	}
 	completed := make(chan struct{})
 	executor := make(chan func())
+	inflight := r.createInflightChan()
 	select {
 	case <-r.ctx.Done():
 		return r.ctx.Err()
@@ -884,6 +894,7 @@ func (r *Resolver) ResolveGraphQLSubscription(ctx *Context, subscription *GraphQ
 			id:        id,
 			completed: completed,
 			executor:  executor,
+			inflight:  inflight,
 		},
 	}:
 	}
@@ -906,6 +917,24 @@ Loop: // execute fn on the main thread of the incoming request until ctx is done
 			}
 		case <-ctx.Context().Done():
 			break Loop
+		case <-completed:
+			// if the origin Subgraph completed the subscription
+			// we have to make sure that there are no more inflight requests
+			// As such, we keep draining the inflight channel until it's empty
+			// we keep executing fn's from the executor channel until all inglight requests are done
+			// or until the client or resolver cancels the context
+			for i := 0; i < 32; i++ {
+				select {
+				case <-inflight:
+				case <-ctx.Context().Done():
+					return ctx.Context().Err()
+				case <-r.ctx.Done():
+					return r.ctx.Err()
+				case fn := <-executor:
+					fn()
+				}
+			}
+			return nil
 		case fn := <-executor:
 			fn()
 		}
@@ -971,22 +1000,33 @@ func (r *Resolver) AsyncResolveGraphQLSubscription(ctx *Context, subscription *G
 	}
 	uniqueID := xxh.Sum64()
 
-	select {
-	case <-r.ctx.Done():
-		return r.ctx.Err()
-	case r.events <- subscriptionEvent{
+	event := subscriptionEvent{
 		triggerID: uniqueID,
 		kind:      subscriptionEventKindAddSubscription,
 		addSubscription: &addSubscription{
-			ctx:     ctx,
-			input:   input,
-			resolve: subscription,
-			writer:  writer,
-			id:      id,
+			ctx:      ctx,
+			input:    input,
+			resolve:  subscription,
+			writer:   writer,
+			id:       id,
+			inflight: r.createInflightChan(),
 		},
-	}:
+	}
+
+	select {
+	case <-r.ctx.Done():
+		return r.ctx.Err()
+	case r.events <- event:
 	}
 	return nil
+}
+
+func (r *Resolver) createInflightChan() chan struct{} {
+	inflight := make(chan struct{}, 32)
+	for i := 0; i < 32; i++ {
+		inflight <- struct{}{}
+	}
+	return inflight
 }
 
 func (r *Resolver) subscriptionInput(ctx *Context, subscription *GraphQLSubscription) (input []byte, err error) {
@@ -1065,6 +1105,7 @@ type addSubscription struct {
 	id        SubscriptionIdentifier
 	completed chan struct{}
 	executor  chan func()
+	inflight  chan struct{}
 }
 
 type subscriptionEventKind int


### PR DESCRIPTION
When a origin completes a subscription, we drain inflight events before closing the connection to the client. In addition, we're only sending the complete event when all events were handled.