### PR TITLE
Fix: README.md code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,26 +118,26 @@ ExampleParsePrintDocument shows you the most basic usage of the library.
 It parses a GraphQL document and prints it back to a writer.
 */
 func ExampleParsePrintDocument() {
-	input := []byte(`query Hello { world }`)
+  input := []byte(`query Hello { world }`)
 
-	report := &operationreport.Report{}
-	document := ast.NewSmallDocument()
-	parser := astparser.NewParser()
-	printer := &astprinter.Printer{}
+  report := &operationreport.Report{}
+  document := ast.NewSmallDocument()
+  parser := astparser.NewParser()
+  printer := &astprinter.Printer{}
 
-	document.Input.ResetInputBytes(input)
-	parser.Parse(document, report)
+  document.Input.ResetInputBytes(input)
+  parser.Parse(document, report)
 
-	if report.HasErrors() {
-		panic(report.Error())
-	}
+  if report.HasErrors() {
+    panic(report.Error())
+  }
 
-	out := &bytes.Buffer{}
-	err := printer.Print(document, out)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Println(out.String()) // Output: query Hello {world}
+  out := &bytes.Buffer{}
+  err := printer.Print(document, out)
+  if err != nil {
+    panic(err)
+  }
+  fmt.Println(out.String()) // Output: query Hello {world}
 }
 
 /*
@@ -147,33 +147,33 @@ Let's try to parse a more complex document and print it back to a writer.
 
 // ExampleParseComplexDocument shows a special feature of the printer
 func ExampleParseComplexDocument() {
-	input := []byte(`
-		{
-			hello
-			foo {
-				bar
-			}
-		}
-	`)
+  input := []byte(`
+    query {
+      hello
+      foo {
+        bar
+      }
+    }
+  `)
 
-	report := &operationreport.Report{}
-	document := ast.NewSmallDocument()
-	parser := astparser.NewParser()
-	printer := &astprinter.Printer{}
+  report := &operationreport.Report{}
+  document := ast.NewSmallDocument()
+  parser := astparser.NewParser()
+  printer := &astprinter.Printer{}
 
-	document.Input.ResetInputBytes(input)
-	parser.Parse(document, report)
+  document.Input.ResetInputBytes(input)
+  parser.Parse(document, report)
 
-	if report.HasErrors() {
-		panic(report.Error())
-	}
+  if report.HasErrors() {
+    panic(report.Error())
+  }
 
-	out := &bytes.Buffer{}
-	err := printer.Print(document, out)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Println(out.String()) // Output: { hello foo { bar } }
+  out := &bytes.Buffer{}
+  err := printer.Print(document, out)
+  if err != nil {
+    panic(err)
+  }
+  fmt.Println(out.String()) // Output: { hello foo { bar } }
 }
 
 /*
@@ -182,37 +182,37 @@ But what if we wanted to print the document with indentation?
 */
 
 func ExamplePrintWithIndentation() {
-	input := []byte(`
-		{
-			hello
-			foo {
-				bar
-			}
-		}
-	`)
+  input := []byte(`
+    {
+      hello
+      foo {
+        bar
+      }
+    }
+  `)
 
-	report := &operationreport.Report{}
-	document := ast.NewSmallDocument()
-	parser := astparser.NewParser()
+  report := &operationreport.Report{}
+  document := ast.NewSmallDocument()
+  parser := astparser.NewParser()
 
-	document.Input.ResetInputBytes(input)
-	parser.Parse(document, report)
+  document.Input.ResetInputBytes(input)
+  parser.Parse(document, report)
 
-	if report.HasErrors() {
-		panic(report.Error())
-	}
+  if report.HasErrors() {
+    panic(report.Error())
+  }
 
-	out, err := astprinter.PrintStringIndent(document, "  ")
-	if err != nil {
-		panic(err)
-	}
-	fmt.Println(out)
-	// Output: {
-	//   hello
-	//   foo {
-	//     bar
-	//   }
-	// }
+  out, err := astprinter.PrintStringIndent(document, "  ")
+  if err != nil {
+    panic(err)
+  }
+  fmt.Println(out)
+  // Output: {
+  //   hello
+  //   foo {
+  //     bar
+  //   }
+  // }
 }
 
 /*
@@ -223,45 +223,45 @@ And what if we wanted to know about the Operation type?
 */
 
 func ExampleParseOperationNameAndType() {
-	input := []byte(`
-		query MyQuery {
-			hello
-			foo {
-				bar
-			}
-		}
-	`)
+  input := []byte(`
+    query MyQuery {
+      hello
+      foo {
+        bar
+      }
+    }
+  `)
 
-	report := &operationreport.Report{}
-	document := ast.NewSmallDocument()
-	parser := astparser.NewParser()
+  report := &operationreport.Report{}
+  document := ast.NewSmallDocument()
+  parser := astparser.NewParser()
 
-	document.Input.ResetInputBytes(input)
-	parser.Parse(document, report)
+  document.Input.ResetInputBytes(input)
+  parser.Parse(document, report)
 
-	if report.HasErrors() {
-		panic(report.Error())
-	}
+  if report.HasErrors() {
+    panic(report.Error())
+  }
 
-	operationCount := 0
-	var (
-		operationNames []string
-		operationTypes []ast.OperationType
-	)
+  operationCount := 0
+  var (
+    operationNames []string
+    operationTypes []ast.OperationType
+  )
 
-	for _, node := range document.RootNodes {
-		if node.Kind != ast.NodeKindOperationDefinition {
-			continue
-		}
-		operationCount++
-		name := document.OperationDefinitionNameString(node.Ref)
-		operationNames = append(operationNames, name)
-		operationType := document.OperationDefinitions[node.Ref].OperationType
-		operationTypes = append(operationTypes, operationType)
-	}
+  for _, node := range document.RootNodes {
+    if node.Kind != ast.NodeKindOperationDefinition {
+      continue
+    }
+    operationCount++
+    name := document.OperationDefinitionNameString(node.Ref)
+    operationNames = append(operationNames, name)
+    operationType := document.OperationDefinitions[node.Ref].OperationType
+    operationTypes = append(operationTypes, operationType)
+  }
 
-	fmt.Println(operationCount) // Output: 1
-	fmt.Println(operationNames) // Output: [MyQuery]
+  fmt.Println(operationCount) // Output: 1
+  fmt.Println(operationNames) // Output: [MyQuery]
 }
 
 /*
@@ -285,93 +285,93 @@ So, let's normalize the document!
 */
 
 func ExampleNormalizeDocument() {
-	input := []byte(`
-		query MyQuery {
-			hello
-			hello
-			foo {
-				bar
-				bar
-			}
-			...MyFragment
-		}
+  input := []byte(`
+    query MyQuery {
+      hello
+      hello
+      foo {
+        bar
+        bar
+      }
+      ...MyFragment
+    }
 
-		fragment MyFragment on Query {
-			hello
-			foo {
-				bar
-			}
-		}
-	`)
+    fragment MyFragment on Query {
+      hello
+      foo {
+        bar
+      }
+    }
+  `)
 
-	schema := []byte(`
-		type Query {
-			hello: String
-			foo: Foo
-		}
-	
-		type Foo {
-			bar: String
-		}
-	`)
+  schema := []byte(`
+    type Query {
+      hello: String
+      foo: Foo
+    }
+  
+    type Foo {
+      bar: String
+    }
+  `)
 
-	report := &operationreport.Report{}
-	document := ast.NewSmallDocument()
-	parser := astparser.NewParser()
+  report := &operationreport.Report{}
+  document := ast.NewSmallDocument()
+  parser := astparser.NewParser()
 
-	document.Input.ResetInputBytes(input)
-	parser.Parse(document, report)
+  document.Input.ResetInputBytes(input)
+  parser.Parse(document, report)
 
-	if report.HasErrors() {
-		panic(report.Error())
-	}
+  if report.HasErrors() {
+    panic(report.Error())
+  }
 
-	schemaDocument := ast.NewSmallDocument()
-	schemaParser := astparser.NewParser()
-	schemaDocument.Input.ResetInputBytes(schema)
-	schemaParser.Parse(schemaDocument, report)
+  schemaDocument := ast.NewSmallDocument()
+  schemaParser := astparser.NewParser()
+  schemaDocument.Input.ResetInputBytes(schema)
+  schemaParser.Parse(schemaDocument, report)
 
-	if report.HasErrors() {
-		panic(report.Error())
-	}
+  if report.HasErrors() {
+    panic(report.Error())
+  }
 
-	// graphql-go-tools is very strict about the schema
-	// the above GraphQL Schema is not fully valid, e.g. the `schema { query: Query }` part is missing
-	// we can fix this automatically by merging the schema with a base schema
-	err := asttransform.MergeDefinitionWithBaseSchema(schemaDocument)
-	if err != nil {
-		panic(err)
-	}
+  // graphql-go-tools is very strict about the schema
+  // the above GraphQL Schema is not fully valid, e.g. the `schema { query: Query }` part is missing
+  // we can fix this automatically by merging the schema with a base schema
+  err := asttransform.MergeDefinitionWithBaseSchema(schemaDocument)
+  if err != nil {
+    panic(err)
+  }
 
-	// you can customize what rules the normalizer should apply
-	normalizer := astnormalization.NewWithOpts(
-		astnormalization.WithExtractVariables(),
-		astnormalization.WithInlineFragmentSpreads(),
-		astnormalization.WithRemoveFragmentDefinitions(),
-		astnormalization.WithRemoveNotMatchingOperationDefinitions(),
-	)
+  // you can customize what rules the normalizer should apply
+  normalizer := astnormalization.NewWithOpts(
+    astnormalization.WithExtractVariables(),
+    astnormalization.WithInlineFragmentSpreads(),
+    astnormalization.WithRemoveFragmentDefinitions(),
+    astnormalization.WithRemoveNotMatchingOperationDefinitions(),
+  )
 
-	// It's generally recommended to always give your operation a name
-	// If it doesn't have a name, just add one to the AST before normalizing it
-	// This is not strictly necessary, but ensures that all normalization rules work as expected
-	normalizer.NormalizeNamedOperation(document, schemaDocument, []byte("MyQuery"), report)
+  // It's generally recommended to always give your operation a name
+  // If it doesn't have a name, just add one to the AST before normalizing it
+  // This is not strictly necessary, but ensures that all normalization rules work as expected
+  normalizer.NormalizeNamedOperation(document, schemaDocument, []byte("MyQuery"), report)
 
-	if report.HasErrors() {
-		panic(report.Error())
-	}
+  if report.HasErrors() {
+    panic(report.Error())
+  }
 
-	out, err := astprinter.PrintStringIndent(document, "  ")
-	if err != nil {
-		panic(err)
-	}
+  out, err := astprinter.PrintStringIndent(document, "  ")
+  if err != nil {
+    panic(err)
+  }
 
-	fmt.Println(out)
-	// Output: query MyQuery {
-	//   hello
-	//   foo {
-	//     bar
-	//   }
-	// }
+  fmt.Println(out)
+  // Output: query MyQuery {
+  //   hello
+  //   foo {
+  //     bar
+  //   }
+  // }
 }
 
 /*
@@ -385,45 +385,45 @@ Alright. Let's do it!
 */
 
 func ExampleValidateDocument() {
-	input := []byte(`
-		query MyQuery {
-			helo
-		}
-	`)
-	schema := []byte(`
-		type Query {
-			hello: String
-		}
-	`)
+  input := []byte(`
+    query MyQuery {
+      helo
+    }
+  `)
+  schema := []byte(`
+    type Query {
+      hello: String
+    }
+  `)
 
-	report := &operationreport.Report{}
+  report := &operationreport.Report{}
 
-	operationDocumentParser := astparser.NewParser()
-	operationDocument := ast.NewSmallDocument()
-	operationDocument.Input.ResetInputBytes(input)
-	operationDocumentParser.Parse(operationDocument, report)
-	if report.HasErrors() {
-		panic(report.Error())
-	}
+  operationDocumentParser := astparser.NewParser()
+  operationDocument := ast.NewSmallDocument()
+  operationDocument.Input.ResetInputBytes(input)
+  operationDocumentParser.Parse(operationDocument, report)
+  if report.HasErrors() {
+    panic(report.Error())
+  }
 
-	schemaParser := astparser.NewParser()
-	schemaDocument := ast.NewSmallDocument()
-	schemaDocument.Input.ResetInputBytes(schema)
-	schemaParser.Parse(schemaDocument, report)
-	if report.HasErrors() {
-		panic(report.Error())
-	}
+  schemaParser := astparser.NewParser()
+  schemaDocument := ast.NewSmallDocument()
+  schemaDocument.Input.ResetInputBytes(schema)
+  schemaParser.Parse(schemaDocument, report)
+  if report.HasErrors() {
+    panic(report.Error())
+  }
 
-	err := asttransform.MergeDefinitionWithBaseSchema(schemaDocument)
-	if err != nil {
-		panic(err)
-	}
+  err := asttransform.MergeDefinitionWithBaseSchema(schemaDocument)
+  if err != nil {
+    panic(err)
+  }
 
-	validator := astvalidation.DefaultOperationValidator()
-	validator.Validate(operationDocument, schemaDocument, report)
-	if report.HasErrors() {
-		println(report.Error())
-	}
+  validator := astvalidation.DefaultOperationValidator()
+  validator.Validate(operationDocument, schemaDocument, report)
+  if report.HasErrors() {
+    println(report.Error())
+  }
 }
 
 /*
@@ -436,36 +436,36 @@ Let's take a look!
 */
 
 func ExampleGenerateCacheKey() {
-	operationDocument := ast.NewSmallDocument()
-	schemaDocument := ast.NewSmallDocument()
-	report := &operationreport.Report{}
+  operationDocument := ast.NewSmallDocument()
+  schemaDocument := ast.NewSmallDocument()
+  report := &operationreport.Report{}
 
-	normalizer := astnormalization.NewWithOpts(
-		astnormalization.WithExtractVariables(),
-		astnormalization.WithInlineFragmentSpreads(),
-		astnormalization.WithRemoveFragmentDefinitions(),
-		astnormalization.WithRemoveNotMatchingOperationDefinitions(),
-	)
+  normalizer := astnormalization.NewWithOpts(
+    astnormalization.WithExtractVariables(),
+    astnormalization.WithInlineFragmentSpreads(),
+    astnormalization.WithRemoveFragmentDefinitions(),
+    astnormalization.WithRemoveNotMatchingOperationDefinitions(),
+  )
 
-	normalizer.NormalizeNamedOperation(
-		operationDocument, schemaDocument, []byte("MyQuery"), report)
-	printer := &astprinter.Printer{}
-	keyGen := xxhash.New()
-	err := printer.Print(operationDocument, keyGen)
-	if err != nil {
-		panic(err)
-	}
+  normalizer.NormalizeNamedOperation(
+    operationDocument, schemaDocument, []byte("MyQuery"), report)
+  printer := &astprinter.Printer{}
+  keyGen := xxhash.New()
+  err := printer.Print(operationDocument, keyGen)
+  if err != nil {
+    panic(err)
+  }
 
-	// you might be thinking that we're done now, but we're not
-	// we've extracted the variables, so we need to add them to the cache key
+  // you might be thinking that we're done now, but we're not
+  // we've extracted the variables, so we need to add them to the cache key
 
-	_, err = keyGen.Write(operationDocument.Input.Variables)
-	if err != nil {
-		panic(err)
-	}
+  _, err = keyGen.Write(operationDocument.Input.Variables)
+  if err != nil {
+    panic(err)
+  }
 
-	key := keyGen.Sum64()
-	fmt.Printf("%x\n", key) // Output: {cache key}
+  key := keyGen.Sum64()
+  fmt.Printf("%x\n", key) // Output: {cache key}
 }
 
 /*
@@ -480,55 +480,55 @@ Let's change out code to account for this.
 */
 
 func ExampleGenerateCacheKeyWithStaticOperationName() {
-	staticOperationName := []byte("O")
+  staticOperationName := []byte("O")
 
-	operationDocument := ast.NewSmallDocument()
-	schemaDocument := ast.NewSmallDocument()
-	report := &operationreport.Report{}
+  operationDocument := ast.NewSmallDocument()
+  schemaDocument := ast.NewSmallDocument()
+  report := &operationreport.Report{}
 
-	normalizer := astnormalization.NewWithOpts(
-		astnormalization.WithExtractVariables(),
-		astnormalization.WithInlineFragmentSpreads(),
-		astnormalization.WithRemoveFragmentDefinitions(),
-		astnormalization.WithRemoveNotMatchingOperationDefinitions(),
-	)
+  normalizer := astnormalization.NewWithOpts(
+    astnormalization.WithExtractVariables(),
+    astnormalization.WithInlineFragmentSpreads(),
+    astnormalization.WithRemoveFragmentDefinitions(),
+    astnormalization.WithRemoveNotMatchingOperationDefinitions(),
+  )
 
-	// First, we add the static operation name to the document and get an "address" to the byte slice (string) in the document
-	// We cannot just add a string to an AST because the AST only stores references to byte slices
-	// Storing strings in AST nodes would be very inefficient and would require a lot of allocations
-	nameRef := operationDocument.Input.AppendInputBytes(staticOperationName)
+  // First, we add the static operation name to the document and get an "address" to the byte slice (string) in the document
+  // We cannot just add a string to an AST because the AST only stores references to byte slices
+  // Storing strings in AST nodes would be very inefficient and would require a lot of allocations
+  nameRef := operationDocument.Input.AppendInputBytes(staticOperationName)
 
-	for _, node := range operationDocument.RootNodes {
-		if node.Kind != ast.NodeKindOperationDefinition {
-			continue
-		}
-		name := operationDocument.OperationDefinitionNameString(node.Ref)
-		if name != "MyQuery" {
-			continue
-		}
-		// Then we set the name of the operation to the address of the static operation name
-		// Now we have renamed MyQuery to O
-		operationDocument.OperationDefinitions[node.Ref].Name = nameRef
-	}
+  for _, node := range operationDocument.RootNodes {
+    if node.Kind != ast.NodeKindOperationDefinition {
+      continue
+    }
+    name := operationDocument.OperationDefinitionNameString(node.Ref)
+    if name != "MyQuery" {
+      continue
+    }
+    // Then we set the name of the operation to the address of the static operation name
+    // Now we have renamed MyQuery to O
+    operationDocument.OperationDefinitions[node.Ref].Name = nameRef
+  }
 
-	// Now we can normalize the modified document
-	// All Operations that don't have the name O will be removed
-	normalizer.NormalizeNamedOperation(operationDocument, schemaDocument, staticOperationName, report)
+  // Now we can normalize the modified document
+  // All Operations that don't have the name O will be removed
+  normalizer.NormalizeNamedOperation(operationDocument, schemaDocument, staticOperationName, report)
 
-	printer := &astprinter.Printer{}
-	keyGen := xxhash.New()
-	err := printer.Print(operationDocument, keyGen)
-	if err != nil {
-		panic(err)
-	}
+  printer := &astprinter.Printer{}
+  keyGen := xxhash.New()
+  err := printer.Print(operationDocument, keyGen)
+  if err != nil {
+    panic(err)
+  }
 
-	_, err = keyGen.Write(operationDocument.Input.Variables)
-	if err != nil {
-		panic(err)
-	}
+  _, err = keyGen.Write(operationDocument.Input.Variables)
+  if err != nil {
+    panic(err)
+  }
 
-	key := keyGen.Sum64()
-	fmt.Printf("%x\n", key) // Output: {cache key}
+  key := keyGen.Sum64()
+  fmt.Printf("%x\n", key) // Output: {cache key}
 }
 
 /*
@@ -558,75 +558,75 @@ so that the planner knows how to create an execution plan for the DataSource and
 */
 
 func ExamplePlanOperation() {
-	staticDataSource, err := plan.NewDataSourceConfiguration[staticdatasource.Configuration](
-		"StaticDataSource",
-		&staticdatasource.Factory[staticdatasource.Configuration]{},
-		&plan.DataSourceMetadata{
-			RootNodes: []plan.TypeField{
-				{
-					TypeName:   "Query",
-					FieldNames: []string{"hello"},
-				},
-			},
-		},
-		staticdatasource.Configuration{
-			Data: `{"hello":"world"}`,
-		},
-	)
-	if err != nil {
-		panic(err)
-	}
+  staticDataSource, err := plan.NewDataSourceConfiguration[staticdatasource.Configuration](
+    "StaticDataSource",
+    &staticdatasource.Factory[staticdatasource.Configuration]{},
+    &plan.DataSourceMetadata{
+      RootNodes: []plan.TypeField{
+        {
+          TypeName:   "Query",
+          FieldNames: []string{"hello"},
+        },
+      },
+    },
+    staticdatasource.Configuration{
+      Data: `{"hello":"world"}`,
+    },
+  )
+  if err != nil {
+    panic(err)
+  }
 
-	config := plan.Configuration{
-		DataSources: []plan.DataSource{
-			staticDataSource,
-		},
-		Fields: []plan.FieldConfiguration{
-			{
-				TypeName:              "Query", // attach this config to the Query type and the field hello
-				FieldName:             "hello",
-				DisableDefaultMapping: true,              // disable the default mapping for this field which only applies to GraphQL APIs
-				Path:                  []string{"hello"}, // returns the value of the field "hello" from the JSON data
-			},
-		},
-	}
+  config := plan.Configuration{
+    DataSources: []plan.DataSource{
+      staticDataSource,
+    },
+    Fields: []plan.FieldConfiguration{
+      {
+        TypeName:              "Query", // attach this config to the Query type and the field hello
+        FieldName:             "hello",
+        DisableDefaultMapping: true,              // disable the default mapping for this field which only applies to GraphQL APIs
+        Path:                  []string{"hello"}, // returns the value of the field "hello" from the JSON data
+      },
+    },
+  }
 
-	input := []byte(`query O { hello }`)
-	schema := []byte(`type Query { hello: String }`)
+  input := []byte(`query O { hello }`)
+  schema := []byte(`type Query { hello: String }`)
 
-	report := &operationreport.Report{}
-	operationDocument := ast.NewSmallDocument()
-	operationDocumentParser := astparser.NewParser()
-	operationDocument.Input.ResetInputBytes(input)
-	operationDocumentParser.Parse(operationDocument, report)
-	if report.HasErrors() {
-		panic(report.Error())
-	}
+  report := &operationreport.Report{}
+  operationDocument := ast.NewSmallDocument()
+  operationDocumentParser := astparser.NewParser()
+  operationDocument.Input.ResetInputBytes(input)
+  operationDocumentParser.Parse(operationDocument, report)
+  if report.HasErrors() {
+    panic(report.Error())
+  }
 
-	schemaDocument := ast.NewSmallDocument()
-	schemaParser := astparser.NewParser()
-	schemaDocument.Input.ResetInputBytes(schema)
-	schemaParser.Parse(schemaDocument, report)
-	if report.HasErrors() {
-		panic(report.Error())
-	}
+  schemaDocument := ast.NewSmallDocument()
+  schemaParser := astparser.NewParser()
+  schemaDocument.Input.ResetInputBytes(schema)
+  schemaParser.Parse(schemaDocument, report)
+  if report.HasErrors() {
+    panic(report.Error())
+  }
 
-	operationName := "O"
+  operationName := "O"
 
-	err = asttransform.MergeDefinitionWithBaseSchema(schemaDocument)
-	if err != nil {
-		panic(err)
-	}
+  err = asttransform.MergeDefinitionWithBaseSchema(schemaDocument)
+  if err != nil {
+    panic(err)
+  }
 
-	planner, err := plan.NewPlanner(config)
-	if err != nil {
-		panic(err)
-	}
-	executionPlan := planner.Plan(operationDocument, schemaDocument, operationName, report)
-	if report.HasErrors() {
-		panic(report.Error())
-	}
-	fmt.Printf("%+v\n", executionPlan) // Output: Plan...
+  planner, err := plan.NewPlanner(config)
+  if err != nil {
+    panic(err)
+  }
+  executionPlan := planner.Plan(operationDocument, schemaDocument, operationName, report)
+  if report.HasErrors() {
+    panic(report.Error())
+  }
+  fmt.Printf("%+v\n", executionPlan) // Output: Plan...
 }
 
 /*
@@ -635,22 +635,22 @@ This plan can now be executed by using the Resolver.
 */
 
 func ExampleExecuteOperation() {
-	var preparedPlan plan.Plan
-	resolver := resolve.New(context.Background(), resolve.ResolverOptions{})
+  var preparedPlan plan.Plan
+  resolver := resolve.New(context.Background(), resolve.ResolverOptions{})
 
-	ctx := resolve.NewContext(context.Background())
+  ctx := resolve.NewContext(context.Background())
 
-	switch p := preparedPlan.(type) {
-	case *plan.SynchronousResponsePlan:
-		out := &bytes.Buffer{}
-		err, _ := resolver.ResolveGraphQLResponse(ctx, p.Response, nil, out)
-		if err != nil {
-			panic(err)
-		}
-		fmt.Println(out.String()) // Output: {"data":{"hello":"world"}}
-	case *plan.SubscriptionResponsePlan:
-		// this is a Query, so we ignore Subscriptions for now, but they are supported
-	}
+  switch p := preparedPlan.(type) {
+  case *plan.SynchronousResponsePlan:
+    out := &bytes.Buffer{}
+    err, _ := resolver.ResolveGraphQLResponse(ctx, p.Response, nil, out)
+    if err != nil {
+      panic(err)
+    }
+    fmt.Println(out.String()) // Output: {"data":{"hello":"world"}}
+  case *plan.SubscriptionResponsePlan:
+    // this is a Query, so we ignore Subscriptions for now, but they are supported
+  }
 }
 
 /*
@@ -673,66 +673,66 @@ This is useful, e.g. when you want to extract information about the fields that 
 */
 
 type visitor struct {
-	walker                *astvisitor.Walker
-	operation, definition *ast.Document
-	typeFields            [][]string
+  walker                *astvisitor.Walker
+  operation, definition *ast.Document
+  typeFields            [][]string
 }
 
 func (v *visitor) EnterField(ref int) {
-	// get the name of the enclosing type (Query)
-	enclosingTypeName := v.walker.EnclosingTypeDefinition.NameString(v.definition)
-	// get the name of the field (hello)
-	fieldName := v.operation.FieldNameString(ref)
-	// get the type definition of the field (String)
-	definitionRef, exists := v.walker.FieldDefinition(ref)
-	if !exists {
-		return
-	}
-	// get the name of the field type (String)
-	fieldTypeName := v.definition.FieldDefinitionTypeNameString(definitionRef)
-	v.typeFields = append(v.typeFields, []string{enclosingTypeName, fieldName, fieldTypeName})
+  // get the name of the enclosing type (Query)
+  enclosingTypeName := v.walker.EnclosingTypeDefinition.NameString(v.definition)
+  // get the name of the field (hello)
+  fieldName := v.operation.FieldNameString(ref)
+  // get the type definition of the field (String)
+  definitionRef, exists := v.walker.FieldDefinition(ref)
+  if !exists {
+    return
+  }
+  // get the name of the field type (String)
+  fieldTypeName := v.definition.FieldDefinitionTypeNameString(definitionRef)
+  v.typeFields = append(v.typeFields, []string{enclosingTypeName, fieldName, fieldTypeName})
 }
 
 func ExampleWalkAST() {
-	report := &operationreport.Report{}
+  report := &operationreport.Report{}
 
-	operationInput := []byte(`query O { hello }`)
-	operationParser := astparser.NewParser()
-	operationDocument := ast.NewSmallDocument()
-	operationDocument.Input.ResetInputBytes(operationInput)
-	operationParser.Parse(operationDocument, report)
-	if report.HasErrors() {
-		panic(report.Error())
-	}
+  operationInput := []byte(`query O { hello }`)
+  operationParser := astparser.NewParser()
+  operationDocument := ast.NewSmallDocument()
+  operationDocument.Input.ResetInputBytes(operationInput)
+  operationParser.Parse(operationDocument, report)
+  if report.HasErrors() {
+    panic(report.Error())
+  }
 
-	schemaInput := []byte(`type Query { hello: String }`)
-	schemaParser := astparser.NewParser()
-	schemaDocument := ast.NewSmallDocument()
-	schemaDocument.Input.ResetInputBytes(schemaInput)
-	schemaParser.Parse(schemaDocument, report)
-	if report.HasErrors() {
-		panic(report.Error())
-	}
+  schemaInput := []byte(`type Query { hello: String }`)
+  schemaParser := astparser.NewParser()
+  schemaDocument := ast.NewSmallDocument()
+  schemaDocument.Input.ResetInputBytes(schemaInput)
+  schemaParser.Parse(schemaDocument, report)
+  if report.HasErrors() {
+    panic(report.Error())
+  }
 
-	err := asttransform.MergeDefinitionWithBaseSchema(schemaDocument)
-	if err != nil {
-		panic(err)
-	}
+  err := asttransform.MergeDefinitionWithBaseSchema(schemaDocument)
+  if err != nil {
+    panic(err)
+  }
 
-	walker := astvisitor.NewWalker(24)
+  walker := astvisitor.NewWalker(24)
 
-	vis := &visitor{
-		walker:     &walker,
-		operation:  operationDocument,
-		definition: schemaDocument,
-	}
+  vis := &visitor{
+    walker:     &walker,
+    operation:  operationDocument,
+    definition: schemaDocument,
+  }
 
-	walker.RegisterEnterFieldVisitor(vis)
-	walker.Walk(operationDocument, schemaDocument, report)
-	if report.HasErrors() {
-		panic(report.Error())
-	}
-	fmt.Printf("%+v\n", vis.typeFields) // Output: [[Query hello String]]
+  walker.RegisterEnterFieldVisitor(vis)
+  walker.Walk(operationDocument, schemaDocument, report)
+  if report.HasErrors() {
+    panic(report.Error())
+  }
+  fmt.Printf("%+v\n", vis.typeFields) // Output: [[Query hello String]]
 }
 
 /*


### PR DESCRIPTION
I've noticed some examples from the README do not work properly. Updated the code so that it compiles and outputs expected values.

Only https://github.com/wundergraph/graphql-go-tools/commit/9512399c56620f5a5c6136eab54b4a0d8c373900 should be properly reviewed. The second commit makes the indentation uniform for entire code snippet.