### PR TITLE
sorting of sets in deterministic order

### DIFF
--- a/v2/pkg/astnormalization/astnormalization.go
+++ b/v2/pkg/astnormalization/astnormalization.go
@@ -149,9 +149,16 @@ type options struct {
 	removeUnusedVariables                 bool
 	removeNotMatchingOperationDefinitions bool
 	normalizeDefinition                   bool
+	sortSelectionSets                     bool
 }
 
 type Option func(options *options)
+
+func WithSortSelectionSets() Option {
+	return func(opts *options) {
+		opts.sortSelectionSets = true
+	}
+}
 
 func WithExtractVariables() Option {
 	return func(options *options) {
@@ -203,6 +210,16 @@ func (o *OperationNormalizer) setupOperationWalkers() {
 		o.operationWalkers = append(o.operationWalkers, walkerStage{
 			name:   "removeNotMatchingOperationDefinitions",
 			walker: &removeNotMatchingOperationDefinitionsWalker,
+		})
+	}
+
+	if o.options.sortSelectionSets {
+		sortSelectionSetsWalker := astvisitor.NewWalker(8)
+		SortSelectionSets(&sortSelectionSetsWalker)
+
+		o.operationWalkers = append(o.operationWalkers, walkerStage{
+			name:   "sortSelectionSets",
+			walker: &sortSelectionSetsWalker,
 		})
 	}
 

--- a/v2/pkg/astnormalization/sort_selection_set.go
+++ b/v2/pkg/astnormalization/sort_selection_set.go
@@ -1,0 +1,86 @@
+package astnormalization
+
+import (
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astvisitor"
+	"sort"
+)
+
+func SortSelectionSets(walker *astvisitor.Walker) {
+	visitor := &sortSelectionSets{
+		Walker: walker,
+	}
+	walker.RegisterEnterDocumentVisitor(visitor)
+	walker.RegisterEnterSelectionSetVisitor(visitor)
+}
+
+type sortSelectionSets struct {
+	*astvisitor.Walker
+	operation *ast.Document
+}
+
+func (s *sortSelectionSets) EnterDocument(operation, _ *ast.Document) {
+	s.operation = operation
+}
+
+func (s *sortSelectionSets) EnterSelectionSet(ref int) {
+	selectionSet := s.operation.SelectionSets[ref]
+	selectionRefs := selectionSet.SelectionRefs
+
+	type sortable struct {
+		ref int
+		key string
+	}
+
+	sortables := make([]sortable, len(selectionRefs))
+	for i, selRef := range selectionRefs {
+		selection := s.operation.Selections[selRef]
+		var key string
+		switch selection.Kind {
+		case ast.SelectionKindField:
+			key = s.fieldKey(selection.Ref)
+		case ast.SelectionKindFragmentSpread:
+			key = s.fragmentSpreadKey(selection.Ref)
+		case ast.SelectionKindInlineFragment:
+			key = s.inlineFragmentKey(selection.Ref)
+		default:
+			key = ""
+		}
+
+		sortables[i] = sortable{selRef, key}
+	}
+
+	sort.SliceStable(sortables, func(i, j int) bool {
+		return sortables[i].key < sortables[j].key
+	})
+
+	sortedSelectionRefs := make([]int, len(sortables))
+	for i, item := range sortables {
+		sortedSelectionRefs[i] = item.ref
+	}
+
+	s.operation.SelectionSets[ref].SelectionRefs = sortedSelectionRefs
+}
+
+func (s *sortSelectionSets) fieldKey(fieldRef int) string {
+	field := s.operation.Fields[fieldRef]
+	if field.Alias.IsDefined {
+		return s.operation.FieldAliasString(fieldRef)
+	}
+
+	return string(s.operation.FieldNameBytes(fieldRef))
+}
+
+func (s *sortSelectionSets) fragmentSpreadKey(spreadRef int) string {
+	return string(s.operation.FragmentSpreadNameBytes(spreadRef))
+}
+
+func (s *sortSelectionSets) inlineFragmentKey(fragmentRef int) string {
+	inlineFragment := s.operation.InlineFragments[fragmentRef]
+	if inlineFragment.TypeCondition.Type == -1 {
+		return ""
+	}
+	typeName := s.operation.TypeNameBytes(inlineFragment.TypeCondition.Type)
+
+	return string(typeName)
+}

--- a/v2/pkg/astnormalization/sort_selection_set_test.go
+++ b/v2/pkg/astnormalization/sort_selection_set_test.go
@@ -1,0 +1,158 @@
+package astnormalization
+
+import (
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/asttransform"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astparser"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astprinter"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/operationreport"
+)
+
+func TestSortSelectionSets(t *testing.T) {
+	schema := `
+		type Query {
+			findEmployees(criteria: Criteria!): [Employee!]!
+			user: User
+		}
+
+		type Employee {
+			id: ID!
+			details: Details!
+		}
+
+		type Details {
+			forename: String!
+			surname: String!
+		}
+
+		type User {
+			id: ID!
+			email: String!
+		}
+
+		input Criteria {
+			nationality: String!
+		}
+	`
+
+	testCases := []struct {
+		name   string
+		input  string
+		output string
+	}{
+		{
+			name: "sorts basic fields alphabetically",
+			input: `
+				query MyQuery {
+					findEmployees(criteria: { nationality: AMERICAN }) {
+						id
+						details {
+							surname
+							forename
+						}
+					}
+				}`,
+			output: `
+				query MyQuery {
+					findEmployees(criteria: {nationality: AMERICAN}) {
+						details {
+							forename
+							surname
+						}
+						id
+					}
+				}`,
+		},
+		{
+			name: "sorts fields with aliases and nested selections",
+			input: `
+				query MyQuery {
+					user {
+						id
+						email
+						... on User {
+							details: id
+							email
+						}
+					}
+				}`,
+			output: `
+				query MyQuery {
+					user {
+						details: id
+						email
+						id
+						... on User {
+							details: id
+							email
+						}
+					}
+				}`,
+		},
+		{
+			name: "sorts fragment spreads and inline fragments",
+			input: `
+				query MyQuery {
+					user {
+						...UserFragment
+						id
+						... on User {
+							email
+						}
+					}
+				}
+
+				fragment UserFragment on User {
+					id
+					email
+				}`,
+
+			output: `
+				query MyQuery {
+					user {
+						email
+						...UserFragment
+						id
+    					}
+				}
+
+				fragment UserFragment on User {
+					email
+					id
+				}`,
+		},
+	}
+
+	schemaDoc, _ := astparser.ParseGraphqlDocumentString(schema)
+	require.NotNil(t, schemaDoc, "schemaDoc should not be nil")
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			operationDoc, _ := astparser.ParseGraphqlDocumentString(tc.input)
+			require.NotNil(t, operationDoc, "operationDoc should not be nil")
+
+			err := asttransform.MergeDefinitionWithBaseSchema(&schemaDoc)
+			assert.NoError(t, err)
+
+			normalizer := NewWithOpts(
+				WithSortSelectionSets(),
+			)
+
+			report := &operationreport.Report{}
+			normalizer.NormalizeOperation(&operationDoc, &schemaDoc, report)
+			require.False(t, report.HasErrors(), report.Error())
+
+			output, err := astprinter.PrintStringIndent(&operationDoc, "  ")
+			require.NoError(t, err)
+
+			expectedOutput, _ := astparser.ParseGraphqlDocumentString(tc.output)
+			expectedPrinted, err := astprinter.PrintStringIndent(&expectedOutput, "  ")
+			require.NoError(t, err)
+
+			assert.Equal(t, expectedPrinted, output)
+		})
+	}
+}


### PR DESCRIPTION
### Description
This PR introduces a new AST normalization transformer that sorts fields in GraphQL selection sets alphabetically. The transformer ensures that fields, fragment spreads, and inline fragments are ordered deterministically, improving consistency and readability in GraphQL queries. 

Sorting Logic:

- Fields are sorted by their name or alias.
- Fragment spreads are sorted by their fragment name.
- Inline fragments are sorted by their type condition.

Furthermore the transformer has followed the options pattern that allows us to enable or disable it instead of coupling it to the logic.

!Note: open to discussion about naming convention