### PR TITLE
feat(ast): add normalizer option to sort operation fields

### DIFF
--- a/v2/pkg/ast/ast_field.go
+++ b/v2/pkg/ast/ast_field.go
@@ -53,7 +53,7 @@ func (d *Document) FieldNameUnsafeString(ref int) string {
 	return unsafebytes.BytesToString(d.Input.ByteSlice(d.Fields[ref].Name))
 }
 
-// FieldNameString - returns fied name as a string value
+// FieldNameString - returns field name as a string value
 func (d *Document) FieldNameString(ref int) string {
 	return string(d.Input.ByteSlice(d.Fields[ref].Name))
 }

--- a/v2/pkg/ast/ast_selection.go
+++ b/v2/pkg/ast/ast_selection.go
@@ -249,3 +249,7 @@ func (d *Document) SelectionIsFieldSelection(ref int) bool {
 func (d *Document) SelectionIsInlineFragmentSelection(ref int) bool {
 	return d.Selections[ref].Kind == SelectionKindInlineFragment
 }
+
+func (d *Document) SelectionIsFragmentSpreadSelection(ref int) bool {
+	return d.Selections[ref].Kind == SelectionKindFragmentSpread
+}

--- a/v2/pkg/astnormalization/astnormalization_test.go
+++ b/v2/pkg/astnormalization/astnormalization_test.go
@@ -40,6 +40,7 @@ func TestNormalizeOperation(t *testing.T) {
 			WithRemoveFragmentDefinitions(),
 			WithRemoveUnusedVariables(),
 			WithNormalizeDefinition(),
+			WithSortSelectionSetFields(CompareSelectionSetFieldsLexicographically),
 		)
 		normalizer.NormalizeOperation(&operationDocument, &definitionDocument, &report)
 
@@ -94,11 +95,11 @@ func TestNormalizeOperation(t *testing.T) {
 					disallowedSecondRootField
 				}`, `
 				subscription sub {
+					disallowedSecondRootField
 					newMessage {
 						body
 						sender
 					}
-					disallowedSecondRootField
 				}`, "", "")
 	})
 	t.Run("inject default", func(t *testing.T) {
@@ -189,13 +190,12 @@ func TestNormalizeOperation(t *testing.T) {
 				query q {
 					pet {
 						... on Dog {
-							name
 							barkVolume
+							name
 						}
 					}
 				}`, ``, ``)
 	})
-
 	t.Run("fragments", func(t *testing.T) {
 		run(t, variablesExtractionDefinition, `
 			mutation HttpBinPost{
@@ -210,11 +210,11 @@ func TestNormalizeOperation(t *testing.T) {
 			}`, `
 			mutation HttpBinPost($a: HttpBinPostInput){
 			  httpBinPost(input: $a){
-				headers {
-				  userAgent
-				}
 				data {
 				  foo
+				}
+				headers {
+				  userAgent
 				}
 			  }
 			}`, ``, `{"a":{"foo":"bar"}}`)
@@ -240,9 +240,10 @@ func TestNormalizeOperation(t *testing.T) {
 				}
 			}`, `query($a: Location){
 				findUserByLocation(loc: $a) {
-					id
-					name
 					age
+					id
+					metadata
+					name
 					type {
 						... on TrialUser {
 							__typename
@@ -253,7 +254,6 @@ func TestNormalizeOperation(t *testing.T) {
 							subscription
 						}
 					}
-					metadata
 				}
 			}`,
 			`{"a": {"lat": 1.000, "lon": 2.000, "planet": "EARTH"}}`,

--- a/v2/pkg/astnormalization/selection_set_fields_sorting.go
+++ b/v2/pkg/astnormalization/selection_set_fields_sorting.go
@@ -1,0 +1,60 @@
+package astnormalization
+
+import (
+	"bytes"
+	"slices"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astvisitor"
+)
+
+// selectionSetFieldsCompare should return a negative number when doc.Selections[sRefA] < doc.Selections[sRefB],
+// a positive number when doc.Selections[sRefA] > doc.Selections[sRefB]
+// and zero when doc.Selections[sRefA] == doc.Selections[sRefB]
+type selectionSetFieldsCompare func(doc *ast.Document, sRefA, sRefB int) int
+
+func sortSelectionSetFields(walker *astvisitor.Walker, compareFn selectionSetFieldsCompare) {
+	visitor := sortSelectionSetFieldsVisitor{
+		Walker:    walker,
+		compareFn: compareFn,
+	}
+	walker.RegisterEnterDocumentVisitor(&visitor)
+	walker.RegisterEnterSelectionSetVisitor(&visitor)
+}
+
+type sortSelectionSetFieldsVisitor struct {
+	*astvisitor.Walker
+	operation *ast.Document
+	compareFn selectionSetFieldsCompare
+}
+
+func (s *sortSelectionSetFieldsVisitor) EnterDocument(operation, _ *ast.Document) {
+	s.operation = operation
+}
+
+func CompareSelectionSetFieldsLexicographically(doc *ast.Document, sRefA, sRefB int) int {
+	getLexiValue := func(sRef int) []byte {
+		if doc.SelectionIsFieldSelection(sRef) {
+			return doc.FieldAliasOrNameBytes(doc.Selections[sRef].Ref)
+		} else if doc.SelectionIsInlineFragmentSelection(sRef) {
+			return doc.TypeNameBytes(doc.InlineFragments[doc.Selections[sRef].Ref].TypeCondition.Type)
+		} else if doc.SelectionIsFragmentSpreadSelection(sRef) {
+			return doc.FragmentSpreadNameBytes(doc.Selections[sRef].Ref)
+		} else {
+			return nil
+		}
+	}
+
+	return bytes.Compare(getLexiValue(sRefA), getLexiValue(sRefB))
+}
+
+func (s *sortSelectionSetFieldsVisitor) EnterSelectionSet(ssRef int) {
+	if len(s.operation.SelectionSets[ssRef].SelectionRefs) < 2 {
+		// nothing to sort
+		return
+	}
+
+	slices.SortStableFunc(s.operation.SelectionSets[ssRef].SelectionRefs, func(sRefA, sRefB int) int {
+		return s.compareFn(s.operation, sRefA, sRefB)
+	})
+}

--- a/v2/pkg/astnormalization/selection_set_fields_sorting_test.go
+++ b/v2/pkg/astnormalization/selection_set_fields_sorting_test.go
@@ -1,0 +1,176 @@
+package astnormalization
+
+import (
+	"testing"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astvisitor"
+)
+
+func getSortSelectionSetFieldsTestFunc(compareFn selectionSetFieldsCompare) registerNormalizeFunc {
+	return func(walker *astvisitor.Walker) {
+		sortSelectionSetFields(walker, compareFn)
+	}
+}
+
+func TestSortSelectionSetFields(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		run(
+			t,
+			getSortSelectionSetFieldsTestFunc(CompareSelectionSetFieldsLexicographically),
+			testDefinition,
+			`
+					query {
+						simple
+						dog {
+							name
+						}
+						cat {
+							name
+						}
+					}`,
+			`
+					query {
+						cat {
+							name
+						}
+						dog {
+							name
+						}
+						simple
+					}`,
+		)
+	})
+	t.Run("nested", func(t *testing.T) {
+		run(
+			t,
+			getSortSelectionSetFieldsTestFunc(CompareSelectionSetFieldsLexicographically),
+			testDefinition,
+			`
+					query {
+						simple
+						dog {
+							name
+							barkVolume
+						}
+						cat {
+							name
+							meowVolume
+						}
+					}`,
+			`
+					query {
+						cat {
+							meowVolume
+							name
+						}
+						dog {
+							barkVolume
+							name
+						}
+						simple
+					}`,
+		)
+	})
+	t.Run("aliases", func(t *testing.T) {
+		runWithVariables(
+			t,
+			getSortSelectionSetFieldsTestFunc(CompareSelectionSetFieldsLexicographically),
+			testDefinition,
+			`
+					query {
+						simple
+						dogB: findDog(complex: $dogInput) {
+							name
+							barkVolume
+						}
+						dogA: findDog(complex: $dogInput) {
+							name
+							barkVolume
+						}
+						cat {
+							name
+							meowVolume
+						}
+					}`,
+			`
+					query {
+						cat {
+							meowVolume
+							name
+						}
+						dogA: findDog(complex: $dogInput) {
+							barkVolume	
+							name
+						}
+						dogB: findDog(complex: $dogInput) {
+							barkVolume
+							name
+						}
+						simple
+					}`,
+			`{"complex": {"name": "Sparky"}}`,
+		)
+	})
+	t.Run("fragments", func(t *testing.T) {
+		runWithVariables(
+			t,
+			getSortSelectionSetFieldsTestFunc(CompareSelectionSetFieldsLexicographically),
+			testDefinition,
+			`
+					query {
+						...CatFragment
+						... on Query {
+							dog {
+								name
+								barkVolume
+							}
+						}
+						...AnotherCatFragment
+						simple
+						... on Query {
+							anotherDog: dog {
+								name
+								barkVolume
+							}
+						}
+					}
+					fragment CatFragment on Query {	
+						name
+						meowVolume
+					}
+					fragment AnotherCatFragment on Query {	
+						name
+						meowVolume
+					}
+					`,
+			`
+					query {
+						...AnotherCatFragment
+						...CatFragment
+						... on Query {
+							dog {
+								barkVolume
+								name
+							}
+						}
+						... on Query {
+							anotherDog: dog {
+								barkVolume
+								name
+							}
+						}
+						simple
+					}
+					fragment CatFragment on Query {
+						meowVolume
+						name
+					}
+					fragment AnotherCatFragment on Query {
+						meowVolume
+						name
+					}
+					`,
+			`{"complex": {"name": "Sparky"}}`,
+		)
+	})
+}


### PR DESCRIPTION
### What
I've added support for sorting of selection sets fields.
### Why
Normalize them in a deterministic order.
### How
I created a new option for the AST Normalizer that allows passing a compare function and a built-in compare function that sorts  selections lexicographically

- fields by alias or name
- inline fragments by type condition
- fragment spreads by name

Sort is stable.
This normalizer acts after all other normalizers so it can behave correctly in case of merging and inlining of fragments.

### Testing
Updated the general normalization unit test and wrote dedicated unit tests for the new normalizer