### PR TITLE
chore: remove obsolete packr generate directive

### DIFF
--- a/pkg/execution/handler.go
+++ b/pkg/execution/handler.go
@@ -1,4 +1,3 @@
-//go:generate packr
 //go:generate graphql-go-tools gen directiveUnmarshalCode -f ./graphql_definitions/**/*.graphql -p execution -o ./datasource_config.go -s Config
 package execution
 


### PR DESCRIPTION
This pull request will remove the obsolete packr generate directive so that folks will have an easier time contributing to this repository since they won't need to have packr installed locally.

This is a follow-up to #360 where it got missed.



Signed-off-by: Steve Coffman <steve@khanacademy.org>
