### PR TITLE
Support for @defer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/*
+.vscode/*
 *.out
 *.test
 .DS_Store

--- a/v2/pkg/ast/path_test.go
+++ b/v2/pkg/ast/path_test.go
@@ -1,0 +1,106 @@
+package ast_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+)
+
+func TestPath_Overlaps(t *testing.T) {
+	tests := []struct {
+		name   string
+		a, b   ast.Path
+		expect bool
+	}{
+		{
+			name:   "both empty",
+			a:      ast.Path{},
+			b:      ast.Path{},
+			expect: true,
+		},
+		{
+			name:   "same single field",
+			a:      ast.Path{{Kind: ast.FieldName, FieldName: []byte("foo")}},
+			b:      ast.Path{{Kind: ast.FieldName, FieldName: []byte("foo")}},
+			expect: true,
+		},
+		{
+			name:   "one empty",
+			a:      ast.Path{},
+			b:      ast.Path{{Kind: ast.FieldName, FieldName: []byte("foo")}},
+			expect: true,
+		},
+		{
+			name:   "different single field",
+			a:      ast.Path{{Kind: ast.FieldName, FieldName: []byte("foo")}},
+			b:      ast.Path{{Kind: ast.FieldName, FieldName: []byte("bar")}},
+			expect: false,
+		},
+		{
+			name: "prefix matches but one is shorter",
+			a:    ast.Path{{Kind: ast.FieldName, FieldName: []byte("foo")}},
+			b: ast.Path{
+				{Kind: ast.FieldName, FieldName: []byte("foo")},
+				{Kind: ast.FieldName, FieldName: []byte("bar")},
+			},
+			expect: true,
+		},
+		{
+			name:   "same index array overlap",
+			a:      ast.Path{{Kind: ast.ArrayIndex, ArrayIndex: 0}},
+			b:      ast.Path{{Kind: ast.ArrayIndex, ArrayIndex: 0}},
+			expect: true,
+		},
+		{
+			name:   "different index array overlap",
+			a:      ast.Path{{Kind: ast.ArrayIndex, ArrayIndex: 1}},
+			b:      ast.Path{{Kind: ast.ArrayIndex, ArrayIndex: 2}},
+			expect: false,
+		},
+		{
+			name:   "fragment mismatch",
+			a:      ast.Path{{Kind: ast.InlineFragmentName, FragmentRef: 1, FieldName: []byte("FragA")}},
+			b:      ast.Path{{Kind: ast.InlineFragmentName, FragmentRef: 2, FieldName: []byte("FragA")}},
+			expect: false,
+		},
+		{
+			name:   "fragment match",
+			a:      ast.Path{{Kind: ast.InlineFragmentName, FragmentRef: 1, FieldName: []byte("FragA")}},
+			b:      ast.Path{{Kind: ast.InlineFragmentName, FragmentRef: 1, FieldName: []byte("FragA")}},
+			expect: true,
+		},
+		{
+			name: "mixed path partial overlap",
+			a: ast.Path{
+				{Kind: ast.FieldName, FieldName: []byte("foo")},
+				{Kind: ast.ArrayIndex, ArrayIndex: 1},
+			},
+			b: ast.Path{
+				{Kind: ast.FieldName, FieldName: []byte("foo")},
+				{Kind: ast.ArrayIndex, ArrayIndex: 1},
+				{Kind: ast.FieldName, FieldName: []byte("extra")},
+			},
+			expect: true,
+		},
+		{
+			name: "mixed path no overlap at second item",
+			a: ast.Path{
+				{Kind: ast.FieldName, FieldName: []byte("foo")},
+				{Kind: ast.ArrayIndex, ArrayIndex: 2},
+			},
+			b: ast.Path{
+				{Kind: ast.FieldName, FieldName: []byte("foo")},
+				{Kind: ast.ArrayIndex, ArrayIndex: 3},
+			},
+			expect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.a.Overlaps(tt.b), tt.expect)
+			assert.Equal(t, tt.b.Overlaps(tt.a), tt.expect)
+		})
+	}
+}

--- a/v2/pkg/asttransform/baseschema.go
+++ b/v2/pkg/asttransform/baseschema.go
@@ -156,6 +156,22 @@ directive @skip(
     "Skipped when true."
     if: Boolean!
 ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+"Directs the executor to defer this fragment when the if argument is true or undefined."
+directive @defer(
+    "A unique identifier for the results."
+    label: String
+    "Controls whether the fragment will be deferred, usually via a variable."
+    if: Boolean! = true
+) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+"Directs the executor to stream this array field when the if argument is true or undefined."
+directive @stream(
+    "A unique identifier for the results."
+    label: String
+    "Controls streaming, usually via a variable."
+    if: Boolean! = true
+    "The number of results to include in the initial (non-streamed) response."
+    initialCount: Int = 0
+) on FIELD
 "Marks an element of a GraphQL schema as no longer supported."
 directive @deprecated(
     """

--- a/v2/pkg/engine/plan/analyze_plan_kind.go
+++ b/v2/pkg/engine/plan/analyze_plan_kind.go
@@ -41,10 +41,18 @@ func (p *planKindVisitor) EnterDirective(ref int) {
 	switch ancestor.Kind {
 	case ast.NodeKindField:
 		switch directiveName {
-		case "defer":
-			p.hasDeferDirective = true
 		case "stream":
 			p.hasStreamDirective = true
+		}
+	case ast.NodeKindInlineFragment:
+		switch directiveName {
+		case "defer":
+			p.hasDeferDirective = true
+		}
+	case ast.NodeKindFragmentSpread:
+		switch directiveName {
+		case "defer":
+			p.hasDeferDirective = true
 		}
 	}
 }

--- a/v2/pkg/engine/plan/analyze_plan_kind_test.go
+++ b/v2/pkg/engine/plan/analyze_plan_kind_test.go
@@ -100,7 +100,9 @@ func TestAnalyzePlanKind(t *testing.T) {
 					name
 				}
 				primaryFunction
-				favoriteEpisode @defer
+				... @defer {
+					favoriteEpisode
+				}
 			}
 		}`,
 		"MyQuery",
@@ -146,7 +148,9 @@ func TestAnalyzePlanKind(t *testing.T) {
 					name
 				}
 				primaryFunction
-				favoriteEpisode @defer
+				... @defer {
+					favoriteEpisode
+				}
 			}
 		}`,
 		"OperationNameNotExists",
@@ -167,7 +171,9 @@ func TestAnalyzePlanKind(t *testing.T) {
 		subscription NewReviews {
 			newReviews {
 				id
-				stars @defer
+				... @defer {
+					stars
+				}
 			}
 		}`,
 		"NewReviews",

--- a/v2/pkg/engine/plan/defer_visitor.go
+++ b/v2/pkg/engine/plan/defer_visitor.go
@@ -1,0 +1,104 @@
+package plan
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astvisitor"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/lexer/literal"
+)
+
+type deferVisitor struct {
+	walker    *astvisitor.Walker
+	operation *ast.Document
+
+	deferredFragments     []resolve.DeferInfo
+	deferredFragmentStack []resolve.DeferInfo
+	deferredFields        map[int]resolve.DeferInfo
+}
+
+var _ astvisitor.EnterDocumentVisitor = (*deferVisitor)(nil)
+var _ astvisitor.InlineFragmentVisitor = (*deferVisitor)(nil)
+var _ astvisitor.FragmentSpreadVisitor = (*deferVisitor)(nil)
+var _ astvisitor.EnterFieldVisitor = (*deferVisitor)(nil)
+
+var errDuplicateDefer = fmt.Errorf("duplicate defer")
+
+func (v *deferVisitor) EnterDocument(operation, definition *ast.Document) {
+	v.operation = operation
+	v.deferredFragments = nil
+	v.deferredFragmentStack = nil
+	v.deferredFields = make(map[int]resolve.DeferInfo)
+}
+
+func (v *deferVisitor) EnterInlineFragment(ref int) {
+	directives := v.operation.InlineFragments[ref].Directives.Refs
+	if _, ok := v.operation.DirectiveWithNameBytes(directives, literal.DEFER); ok {
+		v.enterDefer(ast.PathItem{
+			Kind:        ast.InlineFragmentName,
+			FieldName:   v.operation.InlineFragmentTypeConditionName(ref),
+			FragmentRef: v.walker.CurrentRef,
+		})
+	}
+}
+
+func (v *deferVisitor) LeaveInlineFragment(ref int) {
+	directives := v.operation.InlineFragments[ref].Directives.Refs
+	if _, ok := v.operation.DirectiveWithNameBytes(directives, literal.DEFER); ok {
+		v.leaveDefer()
+	}
+}
+
+func (v *deferVisitor) EnterFragmentSpread(ref int) {
+	// TODO(cd): Fragment spreads are expanded to inline fragments during normalization. Skipping these.
+}
+
+func (v *deferVisitor) LeaveFragmentSpread(ref int) {
+}
+
+func (v *deferVisitor) EnterField(ref int) {
+	if v.inDefer() {
+		v.deferredFields[ref] = v.currentDefer()
+	}
+}
+
+func (v *deferVisitor) enterDefer(item ast.PathItem) {
+	fullPath := v.fullPathFor(item)
+
+	info := resolve.DeferInfo{Path: fullPath}
+
+	if slices.ContainsFunc(v.deferredFragments, func(el resolve.DeferInfo) bool {
+		return el.Equals(&info)
+	}) {
+		v.walker.StopWithInternalErr(fmt.Errorf("%w for %s %d", errDuplicateDefer, v.walker.CurrentKind.String(), v.walker.CurrentRef))
+		return
+	}
+
+	// v.deferredFragmentStack = append(v.deferredFragmentStack, info)
+	v.deferredFragments = append(v.deferredFragments, info)
+	v.deferredFragmentStack = append(v.deferredFragmentStack, info)
+}
+
+func (v *deferVisitor) leaveDefer() {
+	if !v.inDefer() {
+		return
+	}
+	v.deferredFragmentStack = v.deferredFragmentStack[:len(v.deferredFragmentStack)-1]
+}
+
+func (v *deferVisitor) inDefer() bool {
+	return len(v.deferredFragmentStack) > 0
+}
+
+func (v *deferVisitor) currentDefer() resolve.DeferInfo {
+	return v.deferredFragmentStack[len(v.deferredFragmentStack)-1]
+}
+
+func (v *deferVisitor) fullPathFor(item ast.PathItem) ast.Path {
+	fullPath := append(make([]ast.PathItem, 0, len(v.walker.Path)+1), v.walker.Path...)
+	fullPath = append(fullPath, item)
+
+	return fullPath
+}

--- a/v2/pkg/engine/plan/plan.go
+++ b/v2/pkg/engine/plan/plan.go
@@ -17,8 +17,10 @@ type Plan interface {
 }
 
 type SynchronousResponsePlan struct {
-	Response      *resolve.GraphQLResponse
-	FlushInterval int64
+	Response          *resolve.GraphQLResponse
+	DeferredFragments []resolve.DeferInfo
+	DeferredFields    map[int]resolve.DeferInfo
+	FlushInterval     int64
 }
 
 func (s *SynchronousResponsePlan) SetFlushInterval(interval int64) {

--- a/v2/pkg/engine/plan/planner.go
+++ b/v2/pkg/engine/plan/planner.go
@@ -10,6 +10,7 @@ import (
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/astnormalization"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/astprinter"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/astvisitor"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/operationreport"
 )
 
@@ -17,6 +18,7 @@ type Planner struct {
 	config                Configuration
 	nodeSelectionsWalker  *astvisitor.Walker
 	nodeSelectionsVisitor *nodeSelectionVisitor
+	deferVisitor          *deferVisitor
 	configurationWalker   *astvisitor.Walker
 	configurationVisitor  *configurationVisitor
 	planningWalker        *astvisitor.Walker
@@ -65,6 +67,17 @@ func NewPlanner(config Configuration) (*Planner, error) {
 	nodeSelection.RegisterEnterOperationVisitor(nodeSelectionVisitor)
 	nodeSelection.RegisterSelectionSetVisitor(nodeSelectionVisitor)
 
+	// Defer visitor.
+	deferVisitor := &deferVisitor{
+		walker: &nodeSelection,
+	}
+
+	// Piggy-back on node selection walker.
+	nodeSelection.RegisterEnterDocumentVisitor(deferVisitor)
+	nodeSelection.RegisterInlineFragmentVisitor(deferVisitor)
+	nodeSelection.RegisterFragmentSpreadVisitor(deferVisitor)
+	nodeSelection.RegisterEnterFieldVisitor(deferVisitor)
+
 	// configuration
 	configurationWalker := astvisitor.NewWalker(48)
 	configVisitor := &configurationVisitor{
@@ -76,6 +89,8 @@ func NewPlanner(config Configuration) (*Planner, error) {
 	configurationWalker.RegisterFieldVisitor(configVisitor)
 	configurationWalker.RegisterEnterOperationVisitor(configVisitor)
 	configurationWalker.RegisterSelectionSetVisitor(configVisitor)
+	configurationWalker.RegisterEnterInlineFragmentVisitor(configVisitor)
+	configurationWalker.RegisterEnterFragmentSpreadVisitor(configVisitor)
 
 	// planning
 
@@ -92,6 +107,7 @@ func NewPlanner(config Configuration) (*Planner, error) {
 		configurationVisitor:   configVisitor,
 		nodeSelectionsWalker:   &nodeSelection,
 		nodeSelectionsVisitor:  nodeSelectionVisitor,
+		deferVisitor:           deferVisitor,
 		planningWalker:         &planningWalker,
 		planningVisitor:        planningVisitor,
 		prepareOperationWalker: &prepareOperationWalker,
@@ -158,6 +174,8 @@ func (p *Planner) Plan(operation, definition *ast.Document, operationName string
 	p.planningVisitor.planners = p.configurationVisitor.planners
 	p.planningVisitor.Config = p.config
 	p.planningVisitor.skipFieldsRefs = p.nodeSelectionsVisitor.skipFieldsRefs
+	p.planningVisitor.deferredFragments = p.deferVisitor.deferredFragments
+	p.planningVisitor.deferredFields = p.deferVisitor.deferredFields
 
 	p.planningWalker.ResetVisitors()
 	p.planningWalker.SetVisitorFilter(p.planningVisitor)
@@ -214,7 +232,20 @@ func (p *Planner) findPlanningPaths(operation, definition *ast.Document, report 
 		return
 	}
 
-	p.createPlanningPaths(operation, definition, report)
+	p.createPlanningPaths(operation, definition, nil, report)
+
+	if len(p.deferVisitor.deferredFragments) > 0 {
+		planners := p.configurationVisitor.planners
+
+		for _, targetDefer := range p.deferVisitor.deferredFragments {
+			p.createPlanningPaths(operation, definition, &targetDefer, report)
+			if report.HasErrors() {
+				return
+			}
+			planners = append(planners, p.configurationVisitor.planners...)
+		}
+		p.configurationVisitor.planners = planners
+	}
 }
 
 func (p *Planner) selectNodes(operation, definition *ast.Document, report *operationreport.Report) {
@@ -322,7 +353,7 @@ func (p *Planner) isResolvable(walker astvisitor.Walker, operation, definition *
 	return resolvableReport
 }
 
-func (p *Planner) createPlanningPaths(operation, definition *ast.Document, report *operationreport.Report) {
+func (p *Planner) createPlanningPaths(operation, definition *ast.Document, targetDefer *resolve.DeferInfo, report *operationreport.Report) {
 	if p.config.Debug.PrintPlanningPaths {
 		p.debugMessage("Create planning paths")
 	}
@@ -336,6 +367,9 @@ func (p *Planner) createPlanningPaths(operation, definition *ast.Document, repor
 	// set fields dependencies information
 	p.configurationVisitor.fieldDependsOn, p.configurationVisitor.fieldRequirementsConfigs =
 		p.nodeSelectionsVisitor.fieldDependsOn, p.nodeSelectionsVisitor.fieldRequirementsConfigs
+
+	p.configurationVisitor.targetDefer = targetDefer
+	p.configurationVisitor.planners = nil
 
 	p.configurationVisitor.secondaryRun = false
 	p.configurationWalker.Walk(operation, definition, report)

--- a/v2/pkg/engine/plan/planner_test.go
+++ b/v2/pkg/engine/plan/planner_test.go
@@ -379,7 +379,7 @@ func TestPlanner_Plan(t *testing.T) {
 						name
 					}
 				}
-		
+
 				query MyHero {
 					hero{
 						name
@@ -392,15 +392,15 @@ func TestPlanner_Plan(t *testing.T) {
 	t.Run("unescape response json", func(t *testing.T) {
 		schema := `
 			scalar JSON
-			
+
 			schema {
 				query: Query
 			}
-			
+
 			type Query {
 				hero: Character!
 			}
-			
+
 			type Character {
 				info: JSON!
 				infos: [JSON!]!
@@ -678,11 +678,7 @@ var testDefinitionDSConfiguration = dsb().
 
 const testDefinition = `
 
-directive @defer on FIELD
-
 directive @flushInterval(milliSeconds: Int!) on QUERY | SUBSCRIPTION
-
-directive @stream(initialBatchSize: Int) on FIELD
 
 union SearchResult = Human | Droid | Starship
 

--- a/v2/pkg/engine/plan/planner_test.go
+++ b/v2/pkg/engine/plan/planner_test.go
@@ -304,6 +304,203 @@ func TestPlanner_Plan(t *testing.T) {
 		}))
 	})
 
+	t.Run("defer planning", func(t *testing.T) {
+		t.Run("simple inline fragment", test(testDefinition, `
+			query WithInlineDefer {
+				hero {
+					name
+					... on Droid @defer {
+						primaryFunction
+						favoriteEpisode
+					}
+				}
+			}
+		`, "WithInlineDefer", &SynchronousResponsePlan{
+			Response: &resolve.GraphQLResponse{
+				Data: &resolve.Object{
+					Nullable: false,
+					Fields: []*resolve.Field{
+						{
+							Name: []byte("hero"),
+							Value: &resolve.Object{
+								Path:          []string{"hero"},
+								Nullable:      true,
+								TypeName:      "Character",
+								PossibleTypes: map[string]struct{}{"Droid": {}, "Human": {}},
+								Fields: []*resolve.Field{
+									{
+										Name: []byte("name"),
+										Value: &resolve.String{
+											Path:     []string{"name"},
+											Nullable: false,
+										},
+									},
+									{
+										Name: []byte("primaryFunction"),
+										Value: &resolve.String{
+											Path:     []string{"primaryFunction"},
+											Nullable: false,
+										},
+										OnTypeNames: [][]byte{[]byte("Droid")},
+										DeferPaths: []ast.Path{
+											{
+												ast.PathItem{
+													Kind:      ast.FieldName,
+													FieldName: []byte("query"),
+												},
+												ast.PathItem{
+													Kind:      ast.FieldName,
+													FieldName: []byte("hero"),
+												},
+												ast.PathItem{
+													Kind:      ast.InlineFragmentName,
+													FieldName: []byte("Droid"),
+												},
+											},
+										},
+									},
+									{
+										Name: []byte("favoriteEpisode"),
+										Value: &resolve.Enum{
+											Path:     []string{"favoriteEpisode"},
+											Nullable: true,
+											TypeName: "Episode",
+											Values: []string{
+												"NEWHOPE",
+												"EMPIRE",
+												"JEDI",
+											},
+											InaccessibleValues: []string{},
+										},
+										OnTypeNames: [][]byte{[]byte("Droid")},
+										DeferPaths: []ast.Path{
+											{
+												ast.PathItem{
+													Kind:      ast.FieldName,
+													FieldName: []byte("query"),
+												},
+												ast.PathItem{
+													Kind:      ast.FieldName,
+													FieldName: []byte("hero"),
+												},
+												ast.PathItem{
+													Kind:      ast.InlineFragmentName,
+													FieldName: []byte("Droid"),
+												},
+											},
+										},
+									},
+								},
+							},
+							DeferPaths: []ast.Path{
+								{
+									ast.PathItem{
+										Kind:      ast.FieldName,
+										FieldName: []byte("query"),
+									},
+									ast.PathItem{
+										Kind:      ast.FieldName,
+										FieldName: []byte("hero"),
+									},
+									ast.PathItem{
+										Kind:      ast.InlineFragmentName,
+										FieldName: []byte("Droid"),
+									},
+								},
+							},
+						},
+					},
+					Fetches: []resolve.Fetch{
+						&resolve.SingleFetch{
+							FetchConfiguration: resolve.FetchConfiguration{
+								DataSource: &FakeDataSource{&StatefulSource{}},
+							},
+							DataSourceIdentifier: []byte("plan.FakeDataSource"),
+						},
+						&resolve.SingleFetch{
+							FetchConfiguration: resolve.FetchConfiguration{
+								DataSource: &FakeDataSource{&StatefulSource{}},
+							},
+							DataSourceIdentifier: []byte("plan.FakeDataSource"),
+							DeferInfo: &resolve.DeferInfo{
+								Path: ast.Path{
+									ast.PathItem{
+										Kind:      ast.FieldName,
+										FieldName: []byte("query"),
+									},
+									ast.PathItem{
+										Kind:      ast.FieldName,
+										FieldName: []byte("hero"),
+									},
+									ast.PathItem{
+										Kind:      ast.InlineFragmentName,
+										FieldName: []byte("Droid"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			DeferredFragments: []resolve.DeferInfo{
+				{
+					Path: ast.Path{
+						ast.PathItem{
+							Kind:      ast.FieldName,
+							FieldName: []byte("query"),
+						},
+						ast.PathItem{
+							Kind:      ast.FieldName,
+							FieldName: []byte("hero"),
+						},
+						ast.PathItem{
+							Kind:      ast.InlineFragmentName,
+							FieldName: []byte("Droid"),
+						},
+					},
+				},
+			},
+			DeferredFields: map[int]resolve.DeferInfo{
+				1: {
+					Path: ast.Path{
+						ast.PathItem{
+							Kind:      ast.FieldName,
+							FieldName: []byte("query"),
+						},
+						ast.PathItem{
+							Kind:      ast.FieldName,
+							FieldName: []byte("hero"),
+						},
+						ast.PathItem{
+							Kind:      ast.InlineFragmentName,
+							FieldName: []byte("Droid"),
+						},
+					},
+				},
+				2: {
+					Path: ast.Path{
+						ast.PathItem{
+							Kind:      ast.FieldName,
+							FieldName: []byte("query"),
+						},
+						ast.PathItem{
+							Kind:      ast.FieldName,
+							FieldName: []byte("hero"),
+						},
+						ast.PathItem{
+							Kind:      ast.InlineFragmentName,
+							FieldName: []byte("Droid"),
+						},
+					},
+				},
+			},
+		}, Configuration{
+			DisableResolveFieldPositions: true,
+			DisableIncludeInfo:           true,
+			DataSources:                  []DataSource{testDefinitionDSConfiguration},
+		}))
+	})
+
 	t.Run("operation selection", func(t *testing.T) {
 		cfg := Configuration{
 			DataSources:        []DataSource{testDefinitionDSConfiguration},

--- a/v2/pkg/engine/plan/visitor.go
+++ b/v2/pkg/engine/plan/visitor.go
@@ -254,8 +254,6 @@ func (v *Visitor) EnterDirective(ref int) {
 			v.currentField.Stream = &resolve.StreamField{
 				InitialBatchSize: initialBatchSize,
 			}
-		case "defer":
-			v.currentField.Defer = &resolve.DeferField{}
 		}
 	}
 }

--- a/v2/pkg/engine/plan/visitor.go
+++ b/v2/pkg/engine/plan/visitor.go
@@ -3,6 +3,7 @@ package plan
 import (
 	"bytes"
 	"fmt"
+	"iter"
 	"reflect"
 	"regexp"
 	"slices"
@@ -46,6 +47,8 @@ type Visitor struct {
 	includeQueryPlans            bool
 	indirectInterfaceFields      map[int]indirectInterfaceField
 	pathCache                    map[astvisitor.VisitorKind]map[int]string
+	deferredFragments            []resolve.DeferInfo
+	deferredFields               map[int]resolve.DeferInfo
 }
 
 type indirectInterfaceField struct {
@@ -333,6 +336,20 @@ func (v *Visitor) EnterField(ref int) {
 		Info:        v.resolveFieldInfo(ref, fieldDefinitionTypeRef, onTypeNames),
 	}
 
+	if deferInfo, ok := v.deferredFields[ref]; ok {
+		// This field is part of a deferred fragment.
+		v.currentField.DeferPaths = append(v.currentField.DeferPaths, deferInfo.Path)
+	}
+
+	// Add deferred paths below this field.
+	for path := range v.followingDeferredFragmentPaths(fieldAliasOrName.String()) {
+		if !slices.ContainsFunc(v.currentField.DeferPaths, func(other ast.Path) bool {
+			return path.Equals(other)
+		}) {
+			v.currentField.DeferPaths = append(v.currentField.DeferPaths, path)
+		}
+	}
+
 	if bytes.Equal(fieldName, literal.TYPENAME) {
 		str := &resolve.String{
 			Nullable:   false,
@@ -349,6 +366,19 @@ func (v *Visitor) EnterField(ref int) {
 	*v.currentFields[len(v.currentFields)-1].fields = append(*v.currentFields[len(v.currentFields)-1].fields, v.currentField)
 
 	v.mapFieldConfig(ref)
+}
+
+func (v *Visitor) followingDeferredFragmentPaths(itemName string) iter.Seq[ast.Path] {
+	return func(yield func(ast.Path) bool) {
+		for _, frag := range v.deferredFragments {
+			fullPath := v.Walker.Path.WithoutInlineFragmentNames().DotDelimitedString() + "." + itemName
+			if strings.HasPrefix(frag.Path.WithoutInlineFragmentNames().DotDelimitedString(), fullPath) {
+				if !yield(frag.Path) {
+					return
+				}
+			}
+		}
+	}
 }
 
 func (v *Visitor) mapFieldConfig(ref int) {
@@ -879,7 +909,9 @@ func (v *Visitor) EnterOperationDefinition(ref int) {
 	}
 
 	v.plan = &SynchronousResponsePlan{
-		Response: graphQLResponse,
+		Response:          graphQLResponse,
+		DeferredFragments: v.deferredFragments,
+		DeferredFields:    v.deferredFields,
 	}
 }
 
@@ -1176,6 +1208,7 @@ func (v *Visitor) configureFetch(internal *objectFetchConfiguration, external re
 			DependsOnFetchIDs: internal.dependsOnFetchIDs,
 		},
 		DataSourceIdentifier: []byte(dataSourceType),
+		DeferInfo:            internal.deferInfo,
 	}
 
 	if !v.Config.DisableIncludeInfo {

--- a/v2/pkg/engine/postprocess/extract_deferred_fields.go
+++ b/v2/pkg/engine/postprocess/extract_deferred_fields.go
@@ -1,0 +1,250 @@
+package postprocess
+
+import (
+	"iter"
+	"slices"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+type extractDeferredFields struct{}
+
+func (e *extractDeferredFields) Process(resp *resolve.GraphQLResponse, defers []resolve.DeferInfo) {
+	visitor := newDeferredFieldsVisitor(resp, defers)
+	visitor.walker = &PlanWalker{
+		objectVisitor: visitor,
+		fieldVisitor:  visitor,
+	}
+	visitor.walker.Walk(resp.Data, resp.Info)
+
+	for key, di := range visitor.responseItems {
+		if key == "" {
+			resp.Data.Fields = di.response.Data.Fields
+			resp.Data.Fetches = di.response.Data.Fetches
+			continue
+		}
+		resp.DeferredResponses = append(resp.DeferredResponses, di.response)
+	}
+}
+
+func newDeferredFieldsVisitor(resp *resolve.GraphQLResponse, defers []resolve.DeferInfo) *deferredFieldsVisitor {
+	ret := &deferredFieldsVisitor{
+		deferredFragments: defers,
+		responseItems:     make(map[string]*responseItem, len(defers)),
+	}
+
+	for _, di := range defers {
+		ret.responseItems[di.Path.DotDelimitedString()] = &responseItem{
+			deferInfo: &di,
+			response: &resolve.GraphQLResponse{
+				Info: resp.Info,
+			},
+		}
+	}
+
+	// The immediate response.
+	ret.responseItems[""] = &responseItem{
+		response: &resolve.GraphQLResponse{
+			Info: resp.Info,
+		},
+	}
+	return ret
+}
+
+type deferredFieldsVisitor struct {
+	deferredFragments []resolve.DeferInfo
+	responseItems     map[string]*responseItem
+
+	walker *PlanWalker
+}
+
+func (v *deferredFieldsVisitor) EnterObject(obj *resolve.Object) {
+	var (
+		currentField *resolve.Field
+	)
+
+	if len(v.walker.CurrentFields) > 0 {
+		currentField = v.walker.CurrentFields[len(v.walker.CurrentFields)-1]
+	}
+
+	for resp := range v.matchingResponseItems() {
+		newObject := resp.copyObjectWithoutFields(obj)
+
+		if currentField != nil {
+			if resp.deferInfo == nil || slices.ContainsFunc(currentField.DeferPaths, func(el ast.Path) bool {
+				return resp.deferInfo != nil && el.Equals(resp.deferInfo.Path)
+			}) {
+				resp.updateCurrentFieldObject(currentField, newObject)
+			}
+		}
+		resp.objectStack = append(resp.objectStack, newObject)
+
+		if resp.response.Data == nil {
+			resp.response.Data = newObject
+		}
+	}
+}
+
+func (v *deferredFieldsVisitor) LeaveObject(*resolve.Object) {
+	for resp := range v.matchingResponseItems() {
+		if depth := len(resp.objectStack); depth > 1 {
+			resp.objectStack = resp.objectStack[:depth-1]
+		}
+	}
+}
+
+func (v *deferredFieldsVisitor) EnterField(field *resolve.Field) {
+	// Reasons to append a field:
+	// 1. It's above a defer fragment. matchingResponseItems does this.
+	// 2. It's marked as deferred for some responses, send it there. The field has this information.
+	// 3. It's not marked as deferred, so sent to the immediate response.
+	// 4. It's above a non-deferred field? TODO(cd): post-cleanup.
+	var deferred bool
+	for resp := range v.matchingResponseItems() {
+		if slices.ContainsFunc(field.DeferPaths, func(el ast.Path) bool {
+			return resp.deferInfo != nil && el.Equals(resp.deferInfo.Path)
+		}) {
+			resp.appendField(field)
+			deferred = true
+		}
+	}
+	resp := v.responseItems[""]
+
+	switch field.Value.(type) {
+	case *resolve.Object, *resolve.Array:
+		resp.appendField(field)
+	default:
+		if !deferred {
+			resp.appendField(field)
+		}
+	}
+}
+
+func (v *deferredFieldsVisitor) LeaveField(field *resolve.Field) {}
+
+func (v *deferredFieldsVisitor) matchingResponseItems() iter.Seq[*responseItem] {
+	return func(yield func(*responseItem) bool) {
+		for path, resp := range v.responseItems {
+			if path == "" || resp.deferInfo.HasPrefix(v.walker.path) {
+				if !yield(resp) {
+					return
+				}
+			}
+		}
+	}
+}
+
+type responseItem struct {
+	deferInfo   *resolve.DeferInfo
+	response    *resolve.GraphQLResponse
+	objectStack []*resolve.Object
+	lastArray   *resolve.Array
+}
+
+func (r *responseItem) currentObject() *resolve.Object {
+	if len(r.objectStack) == 0 {
+		return nil
+	}
+	return r.objectStack[len(r.objectStack)-1]
+}
+
+func (r *responseItem) appendField(field *resolve.Field) {
+	newField := r.copyFieldWithoutObjectFields(field)
+	r.currentObject().Fields = append(r.currentObject().Fields, newField)
+
+	if _, ok := field.Value.(*resolve.Array); ok {
+		r.lastArray = newField.Value.(*resolve.Array)
+	} else {
+		r.lastArray = nil
+	}
+}
+
+func (r *responseItem) copyFieldWithoutObjectFields(f *resolve.Field) *resolve.Field {
+	switch fv := f.Value.(type) {
+	case *resolve.Object:
+		ret := &resolve.Field{
+			Name:              f.Name,
+			Position:          f.Position,
+			DeferPaths:        f.DeferPaths,
+			Stream:            f.Stream,
+			OnTypeNames:       f.OnTypeNames,
+			ParentOnTypeNames: f.ParentOnTypeNames,
+			Info:              f.Info,
+		}
+		ret.Value = r.copyObjectWithoutFields(fv)
+		return ret
+	case *resolve.Array:
+		arrObj, ok := fv.Item.(*resolve.Object)
+		if !ok {
+			return f.Copy()
+		}
+		ret := &resolve.Field{
+			Name:              f.Name,
+			Position:          f.Position,
+			DeferPaths:        f.DeferPaths,
+			Stream:            f.Stream,
+			OnTypeNames:       f.OnTypeNames,
+			ParentOnTypeNames: f.ParentOnTypeNames,
+			Info:              f.Info,
+		}
+		newItem := r.copyObjectWithoutFields(arrObj)
+
+		ret.Value = &resolve.Array{
+			Path:     fv.Path,
+			Nullable: fv.Nullable,
+			Item:     newItem,
+		}
+		return ret
+	default:
+		return f.Copy()
+	}
+}
+
+func (r *responseItem) copyObjectWithoutFields(fv *resolve.Object) *resolve.Object {
+	newValue := fv.Copy().(*resolve.Object)
+	newValue.Fields = nil
+
+	if len(fv.PossibleTypes) > 0 {
+		possibleTypes := make(map[string]struct{}, len(fv.PossibleTypes))
+		for k, v := range fv.PossibleTypes {
+			possibleTypes[k] = v
+		}
+		newValue.PossibleTypes = possibleTypes
+	}
+	newValue.SourceName = fv.SourceName
+	newValue.TypeName = fv.TypeName
+	newValue.Fetches = r.fetchesForDeferFrom(fv.Fetches)
+
+	return newValue
+}
+
+func (r *responseItem) updateCurrentFieldObject(field *resolve.Field, obj *resolve.Object) {
+	switch field.Value.(type) {
+	case *resolve.Array:
+		// This object is an item in an array.
+		if r.lastArray != nil {
+			if _, ok := r.lastArray.Item.(*resolve.Object); ok {
+				r.lastArray.Item = obj
+			}
+		}
+	case *resolve.Object:
+		// This object is a field in another object.
+		if r.currentObject() != nil && len(r.currentObject().Fields) > 0 {
+			r.currentObject().Fields[len(r.currentObject().Fields)-1].Value = obj
+		}
+	}
+}
+
+func (r *responseItem) fetchesForDeferFrom(fetches []resolve.Fetch) []resolve.Fetch {
+	var ret []resolve.Fetch
+	for _, fetch := range fetches {
+		if single, ok := fetch.(*resolve.SingleFetch); ok && single != nil {
+			if !single.DeferInfo.Equals(r.deferInfo) {
+				continue
+			}
+		}
+		ret = append(ret, fetch)
+	}
+	return ret
+}

--- a/v2/pkg/engine/postprocess/extract_deferred_fields_test.go
+++ b/v2/pkg/engine/postprocess/extract_deferred_fields_test.go
@@ -1,0 +1,413 @@
+package postprocess
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+func TestExtractDeferredFields_Process(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *resolve.GraphQLResponse
+		defers   []resolve.DeferInfo
+		expected *resolve.GraphQLResponse
+	}{
+		{
+			name: "trivial case",
+			input: &resolve.GraphQLResponse{
+				Info: &resolve.GraphQLResponseInfo{
+					OperationType: ast.OperationTypeQuery,
+				},
+				Data: &resolve.Object{
+					Nullable: false,
+					Fields: []*resolve.Field{
+						{
+							Name: []byte("hero"),
+							Value: &resolve.Object{
+								Path:          []string{"hero"},
+								Nullable:      true,
+								TypeName:      "Character",
+								PossibleTypes: map[string]struct{}{"Droid": {}, "Human": {}},
+								Fields: []*resolve.Field{
+									{
+										Name: []byte("name"),
+										Value: &resolve.String{
+											Path:     []string{"name"},
+											Nullable: false,
+										},
+									},
+								},
+							},
+						},
+					},
+					Fetches: []resolve.Fetch{
+						&resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 1}},
+					},
+				},
+			},
+			expected: &resolve.GraphQLResponse{
+				Info: &resolve.GraphQLResponseInfo{
+					OperationType: ast.OperationTypeQuery,
+				},
+				Data: &resolve.Object{
+					Nullable: false,
+					Fields: []*resolve.Field{
+						{
+							Name: []byte("hero"),
+							Value: &resolve.Object{
+								Path:          []string{"hero"},
+								Nullable:      true,
+								TypeName:      "Character",
+								PossibleTypes: map[string]struct{}{"Droid": {}, "Human": {}},
+								Fields: []*resolve.Field{
+									{
+										Name: []byte("name"),
+										Value: &resolve.String{
+											Path:     []string{"name"},
+											Nullable: false,
+										},
+									},
+								},
+							},
+						},
+					},
+					Fetches: []resolve.Fetch{
+						&resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 1}},
+					},
+				},
+			},
+		},
+		{
+			name: "simple case",
+			input: &resolve.GraphQLResponse{
+				Info: &resolve.GraphQLResponseInfo{
+					OperationType: ast.OperationTypeQuery,
+				},
+				Data: &resolve.Object{
+					Nullable: false,
+					Fields: []*resolve.Field{
+						{
+							Name: []byte("hero"),
+							Value: &resolve.Object{
+								Path:          []string{"hero"},
+								Nullable:      true,
+								TypeName:      "Character",
+								PossibleTypes: map[string]struct{}{"Droid": {}, "Human": {}},
+								Fields: []*resolve.Field{
+									{
+										Name: []byte("name"),
+										Value: &resolve.String{
+											Path:     []string{"name"},
+											Nullable: false,
+										},
+									},
+									{
+										Name: []byte("primaryFunction"),
+										Value: &resolve.String{
+											Path:     []string{"primaryFunction"},
+											Nullable: false,
+										},
+										OnTypeNames: [][]byte{[]byte("Droid")},
+										DeferPaths: []ast.Path{
+											{
+												ast.PathItem{
+													Kind:      ast.FieldName,
+													FieldName: []byte("query"),
+												},
+												ast.PathItem{
+													Kind:      ast.FieldName,
+													FieldName: []byte("hero"),
+												},
+												ast.PathItem{
+													Kind:      ast.InlineFragmentName,
+													FieldName: []byte("Droid"),
+												},
+											},
+										},
+									},
+									{
+										Name: []byte("favoriteEpisode"),
+										Value: &resolve.Enum{
+											Path:     []string{"favoriteEpisode"},
+											Nullable: true,
+											TypeName: "Episode",
+											Values: []string{
+												"NEWHOPE",
+												"EMPIRE",
+												"JEDI",
+											},
+										},
+										OnTypeNames: [][]byte{[]byte("Droid")},
+										DeferPaths: []ast.Path{
+											{
+												ast.PathItem{
+													Kind:      ast.FieldName,
+													FieldName: []byte("query"),
+												},
+												ast.PathItem{
+													Kind:      ast.FieldName,
+													FieldName: []byte("hero"),
+												},
+												ast.PathItem{
+													Kind:      ast.InlineFragmentName,
+													FieldName: []byte("Droid"),
+												},
+											},
+										},
+									},
+								},
+							},
+							DeferPaths: []ast.Path{
+								{
+									ast.PathItem{
+										Kind:      ast.FieldName,
+										FieldName: []byte("query"),
+									},
+									ast.PathItem{
+										Kind:      ast.FieldName,
+										FieldName: []byte("hero"),
+									},
+									ast.PathItem{
+										Kind:      ast.InlineFragmentName,
+										FieldName: []byte("Droid"),
+									},
+								},
+							},
+						},
+					},
+					Fetches: []resolve.Fetch{
+						&resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 1}},
+						&resolve.SingleFetch{
+							FetchDependencies: resolve.FetchDependencies{FetchID: 1},
+							DeferInfo: &resolve.DeferInfo{
+								Path: ast.Path{
+									ast.PathItem{
+										Kind:      ast.FieldName,
+										FieldName: []byte("query"),
+									},
+									ast.PathItem{
+										Kind:      ast.FieldName,
+										FieldName: []byte("hero"),
+									},
+									ast.PathItem{
+										Kind:      ast.InlineFragmentName,
+										FieldName: []byte("Droid"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			defers: []resolve.DeferInfo{
+				{
+					Path: ast.Path{
+						ast.PathItem{
+							Kind:      ast.FieldName,
+							FieldName: []byte("query"),
+						},
+						ast.PathItem{
+							Kind:      ast.FieldName,
+							FieldName: []byte("hero"),
+						},
+						ast.PathItem{
+							Kind:      ast.InlineFragmentName,
+							FieldName: []byte("Droid"),
+						},
+					},
+				},
+			},
+			expected: &resolve.GraphQLResponse{
+				Info: &resolve.GraphQLResponseInfo{
+					OperationType: ast.OperationTypeQuery,
+				},
+				Data: &resolve.Object{
+					Nullable: false,
+					Fields: []*resolve.Field{
+						{
+							Name: []byte("hero"),
+							Value: &resolve.Object{
+								Path:          []string{"hero"},
+								Nullable:      true,
+								TypeName:      "Character",
+								PossibleTypes: map[string]struct{}{"Droid": {}, "Human": {}},
+								Fields: []*resolve.Field{
+									{
+										Name: []byte("name"),
+										Value: &resolve.String{
+											Path:     []string{"name"},
+											Nullable: false,
+										},
+									},
+								},
+							},
+							DeferPaths: []ast.Path{
+								{
+									ast.PathItem{
+										Kind:      ast.FieldName,
+										FieldName: []byte("query"),
+									},
+									ast.PathItem{
+										Kind:      ast.FieldName,
+										FieldName: []byte("hero"),
+									},
+									ast.PathItem{
+										Kind:      ast.InlineFragmentName,
+										FieldName: []byte("Droid"),
+									},
+								},
+							},
+						},
+					},
+					Fetches: []resolve.Fetch{
+						&resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 1}},
+					},
+				},
+				DeferredResponses: []*resolve.GraphQLResponse{
+					{
+						Info: &resolve.GraphQLResponseInfo{
+							OperationType: ast.OperationTypeQuery,
+						},
+						Data: &resolve.Object{
+							Nullable: false,
+							Fields: []*resolve.Field{
+								{
+									Name: []byte("hero"),
+									Value: &resolve.Object{
+										Path:          []string{"hero"},
+										Nullable:      true,
+										TypeName:      "Character",
+										PossibleTypes: map[string]struct{}{"Droid": {}, "Human": {}},
+										Fields: []*resolve.Field{
+											{
+												Name: []byte("primaryFunction"),
+												Value: &resolve.String{
+													Path:     []string{"primaryFunction"},
+													Nullable: false,
+												},
+												OnTypeNames: [][]byte{[]byte("Droid")},
+												DeferPaths: []ast.Path{
+													{
+														ast.PathItem{
+															Kind:      ast.FieldName,
+															FieldName: []byte("query"),
+														},
+														ast.PathItem{
+															Kind:      ast.FieldName,
+															FieldName: []byte("hero"),
+														},
+														ast.PathItem{
+															Kind:      ast.InlineFragmentName,
+															FieldName: []byte("Droid"),
+														},
+													},
+												},
+											},
+											{
+												Name: []byte("favoriteEpisode"),
+												Value: &resolve.Enum{
+													Path:     []string{"favoriteEpisode"},
+													Nullable: true,
+													TypeName: "Episode",
+													Values: []string{
+														"NEWHOPE",
+														"EMPIRE",
+														"JEDI",
+													},
+												},
+												OnTypeNames: [][]byte{[]byte("Droid")},
+												DeferPaths: []ast.Path{
+													{
+														ast.PathItem{
+															Kind:      ast.FieldName,
+															FieldName: []byte("query"),
+														},
+														ast.PathItem{
+															Kind:      ast.FieldName,
+															FieldName: []byte("hero"),
+														},
+														ast.PathItem{
+															Kind:      ast.InlineFragmentName,
+															FieldName: []byte("Droid"),
+														},
+													},
+												},
+											},
+										},
+									},
+									DeferPaths: []ast.Path{
+										{
+											ast.PathItem{
+												Kind:      ast.FieldName,
+												FieldName: []byte("query"),
+											},
+											ast.PathItem{
+												Kind:      ast.FieldName,
+												FieldName: []byte("hero"),
+											},
+											ast.PathItem{
+												Kind:      ast.InlineFragmentName,
+												FieldName: []byte("Droid"),
+											},
+										},
+									},
+								},
+							},
+							Fetches: []resolve.Fetch{
+								&resolve.SingleFetch{
+									FetchDependencies: resolve.FetchDependencies{FetchID: 1},
+									DeferInfo: &resolve.DeferInfo{
+										Path: ast.Path{
+											ast.PathItem{
+												Kind:      ast.FieldName,
+												FieldName: []byte("query"),
+											},
+											ast.PathItem{
+												Kind:      ast.FieldName,
+												FieldName: []byte("hero"),
+											},
+											ast.PathItem{
+												Kind:      ast.InlineFragmentName,
+												FieldName: []byte("Droid"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &extractDeferredFields{}
+			e.Process(tt.input, tt.defers)
+
+			if !assert.Equal(t, tt.expected, tt.input) {
+				formatterConfig := map[reflect.Type]interface{}{
+					reflect.TypeOf([]byte{}): func(b []byte) string { return fmt.Sprintf(`"%s"`, string(b)) },
+				}
+
+				prettyCfg := &pretty.Config{
+					Diffable:          true,
+					IncludeUnexported: false,
+					Formatter:         formatterConfig,
+				}
+
+				if diff := prettyCfg.Compare(tt.expected, tt.input); diff != "" {
+					t.Errorf("Plan does not match(-want +got)\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/v2/pkg/engine/resolve/fetch.go
+++ b/v2/pkg/engine/resolve/fetch.go
@@ -55,6 +55,9 @@ func (f *FetchItem) Equals(other *FetchItem) bool {
 	if !ok {
 		return false
 	}
+	if !l.DeferInfo.Equals(r.DeferInfo) {
+		return false
+	}
 	return l.FetchConfiguration.Equals(&r.FetchConfiguration)
 }
 
@@ -77,6 +80,7 @@ type SingleFetch struct {
 	DataSourceIdentifier []byte
 	Trace                *DataSourceLoadTrace
 	Info                 *FetchInfo
+	DeferInfo            *DeferInfo
 }
 
 func (s *SingleFetch) Dependencies() FetchDependencies {

--- a/v2/pkg/engine/resolve/multipart_json_writer.go
+++ b/v2/pkg/engine/resolve/multipart_json_writer.go
@@ -1,0 +1,130 @@
+package resolve
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// TODO: should this go somewhere else?
+
+// MultipartJSONWriter is a writer that writes multipart incremental responses.
+// Is assumes that all parts share the name contentType.
+// Note that it is not smart enough to stream parts to the writer. Parts are written in bulk.
+// Useful for testing and smaller applications.
+type MultipartJSONWriter struct {
+	Writer        io.Writer
+	BoundaryToken string
+
+	buf          bytes.Buffer
+	wroteInitial bool
+}
+
+var _ IncrementalResponseWriter = (*MultipartJSONWriter)(nil)
+
+const (
+	// DefaultBoundaryToken is the default boundary token used in multipart responses.
+	DefaultBoundaryToken = "graphql-go-tools"
+
+	jsonContentType = "application/json; charset=utf-8"
+)
+
+func (w *MultipartJSONWriter) Write(p []byte) (n int, err error) {
+	n, err = w.buf.Write(p)
+	if err != nil {
+		return n, fmt.Errorf("writing: %w", err)
+	}
+	return n, nil
+}
+
+func (w *MultipartJSONWriter) Flush(path []any) (err error) {
+	if w.buf.Len() == 0 {
+		return nil
+	}
+
+	var part incrementalPart
+
+	if err := json.Unmarshal(w.buf.Bytes(), &part); err != nil {
+		return fmt.Errorf("unmarshaling data: %w", err)
+	}
+	part.HasNext = true
+
+	if _, err := w.Writer.Write(w.partHeader()); err != nil {
+		return fmt.Errorf("writing part header: %w", err)
+	}
+	defer w.buf.Reset()
+
+	if w.wroteInitial {
+		part.Incremental = []incrementalDataPart{
+			{
+				Data: part.Data,
+				Path: path,
+			},
+		}
+		part.Data = nil
+
+		if len(path) > 0 {
+			part.Incremental[0].Path = path
+		}
+	}
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(part); err != nil {
+		return fmt.Errorf("encoding part body: %w", err)
+	}
+	if buf.Len() > 0 {
+		buf.Truncate(buf.Len() - 1) // remove trailing newline
+	}
+	if _, err := buf.WriteTo(w.Writer); err != nil {
+		return fmt.Errorf("writing part body: %w", err)
+	}
+
+	if _, err := w.Writer.Write([]byte("\r\n")); err != nil {
+		return fmt.Errorf("writing part terminator: %w", err)
+	}
+	w.wroteInitial = true
+
+	return nil
+}
+
+func (w *MultipartJSONWriter) Complete() error {
+	if w.wroteInitial {
+		// Kind of a hack, but should work.
+		if _, err := w.Writer.Write([]byte(string(w.partHeader()) + `{"hasNext":false,"incremental":[]}` + "\r\n")); err != nil {
+			return fmt.Errorf("writing final part: %w", err)
+		}
+	}
+	if _, err := w.Writer.Write([]byte(fmt.Sprintf("--%s--\r\n", w.boundaryToken()))); err != nil {
+		return fmt.Errorf("writing final boundary: %w", err)
+	}
+	return nil
+}
+
+func (w *MultipartJSONWriter) partHeader() []byte {
+	return []byte(fmt.Sprintf("--%s\r\nContent-Type: %s\r\n\r\n", w.boundaryToken(), jsonContentType))
+}
+
+func (w *MultipartJSONWriter) boundaryToken() string {
+	if len(w.BoundaryToken) == 0 {
+		return DefaultBoundaryToken
+	}
+	return w.BoundaryToken
+}
+
+// incrementalPart is a part of a multipart response.
+// It can contain a full response (for the first or only part) in `data`, or an incremental part in `incremental`.
+type incrementalPart struct {
+	HasNext bool `json:"hasNext"`
+
+	Data        json.RawMessage       `json:"data,omitempty"`
+	Incremental []incrementalDataPart `json:"incremental,omitempty"`
+
+	Errors     json.RawMessage `json:"errors,omitempty"`
+	Extensions json.RawMessage `json:"extensions,omitempty"`
+}
+
+type incrementalDataPart struct {
+	Data json.RawMessage `json:"data"`
+	Path []any           `json:"path,omitempty"`
+}

--- a/v2/pkg/engine/resolve/multipart_response_writer_test.go
+++ b/v2/pkg/engine/resolve/multipart_response_writer_test.go
@@ -1,0 +1,221 @@
+package resolve_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+func TestMultipartJSONWriter(t *testing.T) {
+	tests := []struct {
+		name          string
+		boundaryToken string
+		path          []any
+		parts         [][]string
+		expected      string
+	}{
+		{
+			name:          "simple case",
+			boundaryToken: "boundary",
+			path:          []any{"path", "to", "part"},
+			parts:         [][]string{[]string{`{"data":"part1"}`}, []string{`{"data":"part2"}`}, []string{`{"data":"part3"}`}},
+			expected: strings.ReplaceAll(`--boundary
+Content-Type: application/json; charset=utf-8
+
+{"hasNext":true,"data":"part1"}
+--boundary
+Content-Type: application/json; charset=utf-8
+
+{"hasNext":true,"incremental":[{"data":"part2","path":["path","to","part"]}]}
+--boundary
+Content-Type: application/json; charset=utf-8
+
+{"hasNext":true,"incremental":[{"data":"part3","path":["path","to","part"]}]}
+--boundary
+Content-Type: application/json; charset=utf-8
+
+{"hasNext":false,"incremental":[]}
+--boundary--
+`, "\n", "\r\n"),
+		},
+		{
+			name:          "multiple writes",
+			boundaryToken: "boundary",
+			path:          []any{"path", 4, "part"},
+			parts:         [][]string{[]string{`{"data":`, `"part1a`, `part1b"}`}, []string{`{"data":"part2"}`}, []string{`{"data":"part3a`, `part3b"}`}},
+			expected: strings.ReplaceAll(`--boundary
+Content-Type: application/json; charset=utf-8
+
+{"hasNext":true,"data":"part1apart1b"}
+--boundary
+Content-Type: application/json; charset=utf-8
+
+{"hasNext":true,"incremental":[{"data":"part2","path":["path",4,"part"]}]}
+--boundary
+Content-Type: application/json; charset=utf-8
+
+{"hasNext":true,"incremental":[{"data":"part3apart3b","path":["path",4,"part"]}]}
+--boundary
+Content-Type: application/json; charset=utf-8
+
+{"hasNext":false,"incremental":[]}
+--boundary--
+`, "\n", "\r\n"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			writer := &resolve.MultipartJSONWriter{
+				Writer:        &buf,
+				BoundaryToken: tt.boundaryToken,
+			}
+
+			for _, part := range tt.parts {
+				for _, p := range part {
+					_, err := writer.Write([]byte(p))
+					require.NoError(t, err)
+				}
+				err := writer.Flush(tt.path)
+				require.NoError(t, err)
+			}
+
+			err := writer.Complete()
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expected, buf.String())
+		})
+	}
+}
+
+func TestMultipartJSONWriter_Write(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         []byte
+		expectedWrite int
+		expectedErr   error
+	}{
+		{
+			name:          "successful write",
+			input:         []byte("test data"),
+			expectedWrite: 9,
+			expectedErr:   nil,
+		},
+		{
+			name:          "empty input",
+			input:         []byte(""),
+			expectedWrite: 0,
+			expectedErr:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			writer := &resolve.MultipartJSONWriter{
+				Writer: &buf,
+			}
+
+			n, err := writer.Write(tt.input)
+			assert.Equal(t, tt.expectedWrite, n)
+			assert.Equal(t, tt.expectedErr, err)
+		})
+	}
+}
+
+func TestMultipartJSONWriter_Flush(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       []byte
+		expectedErr error
+	}{
+		{
+			name:        "successful flush",
+			input:       []byte(`{"data":"test data"}`),
+			expectedErr: nil,
+		},
+		{
+			name:        "flush with empty buffer",
+			input:       []byte(""),
+			expectedErr: nil,
+		},
+		{
+			name:        "flush with error",
+			input:       []byte(`{"error": "data"}`),
+			expectedErr: errors.New("flush error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var w io.Writer
+			if tt.expectedErr != nil {
+				w = &errorWriter{
+					err: tt.expectedErr,
+				}
+			} else {
+				w = &bytes.Buffer{}
+			}
+			writer := &resolve.MultipartJSONWriter{
+				Writer: w,
+			}
+
+			_, err := writer.Write(tt.input)
+			require.NoError(t, err)
+
+			err = writer.Flush(nil)
+			assert.ErrorIs(t, err, tt.expectedErr)
+		})
+	}
+}
+
+func TestMultipartJSONWriter_Complete(t *testing.T) {
+	tests := []struct {
+		name        string
+		expectedErr error
+	}{
+		{
+			name:        "success",
+			expectedErr: nil,
+		},
+		{
+			name:        "error",
+			expectedErr: errors.New("write error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var w io.Writer
+			if tt.expectedErr != nil {
+				w = &errorWriter{
+					err: tt.expectedErr,
+				}
+			} else {
+				w = &bytes.Buffer{}
+			}
+			writer := &resolve.MultipartJSONWriter{
+				Writer: w,
+			}
+
+			err := writer.Complete()
+			assert.ErrorIs(t, err, tt.expectedErr)
+		})
+	}
+}
+
+type errorWriter struct {
+	err error
+}
+
+func (e *errorWriter) Write(p []byte) (n int, err error) {
+	return 0, e.err
+}

--- a/v2/pkg/engine/resolve/node_object_test.go
+++ b/v2/pkg/engine/resolve/node_object_test.go
@@ -1,0 +1,250 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+)
+
+var (
+	pathItem1 = ast.PathItem{Kind: ast.FieldName, FieldName: []byte("query")}
+	pathItem2 = ast.PathItem{Kind: ast.FieldName, FieldName: []byte("object1")}
+	pathItem3 = ast.PathItem{Kind: ast.ArrayIndex, ArrayIndex: 3, FieldName: []byte("field1")}
+
+	fragmentItem = ast.PathItem{Kind: ast.InlineFragmentName, FieldName: []byte("frag2"), FragmentRef: 2}
+	arrayItem    = ast.PathItem{Kind: ast.ArrayIndex, ArrayIndex: 3, FieldName: []byte("arrayField3")}
+
+	emptyPath  = ast.Path{}
+	shortPath1 = ast.Path{pathItem1, pathItem2}
+	shortPath2 = ast.Path{pathItem2, pathItem3}
+	longPath   = ast.Path{pathItem1, pathItem2, pathItem3} // shortPath1 + pathItem3
+)
+
+func TestDeferInfo_Equals(t *testing.T) {
+	tests := []struct {
+		name          string
+		first, second *DeferInfo
+		expected      bool
+	}{
+		{
+			name:     "equal",
+			first:    &DeferInfo{Path: longPath},
+			second:   &DeferInfo{Path: longPath},
+			expected: true,
+		},
+		{
+			name:     "zero-valued equal",
+			first:    &DeferInfo{},
+			second:   &DeferInfo{},
+			expected: true,
+		},
+		{
+			name:     "empty paths equal",
+			first:    &DeferInfo{Path: emptyPath},
+			second:   &DeferInfo{Path: emptyPath},
+			expected: true,
+		},
+		{
+			name:     "both nil equal",
+			first:    nil,
+			second:   nil,
+			expected: true,
+		},
+		{
+			name:     "not equal",
+			first:    &DeferInfo{Path: shortPath1},
+			second:   &DeferInfo{Path: shortPath2},
+			expected: false,
+		},
+		{
+			name:     "one nil not equal empty",
+			first:    nil,
+			second:   &DeferInfo{},
+			expected: false,
+		},
+		{
+			name:     "not equal - one empty path",
+			first:    &DeferInfo{Path: emptyPath},
+			second:   &DeferInfo{Path: shortPath1},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.first.Equals(tt.second))
+			assert.Equal(t, tt.expected, tt.second.Equals(tt.first))
+		})
+	}
+}
+
+func TestDeferInfo_Overlaps(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     *DeferInfo
+		otherPath ast.Path
+		expected  bool
+	}{
+		{
+			name:      "overlaps - equal paths",
+			input:     &DeferInfo{Path: shortPath1},
+			otherPath: shortPath1,
+			expected:  true,
+		},
+		{
+			name:      "overlaps - shorter path",
+			input:     &DeferInfo{Path: longPath},
+			otherPath: shortPath1,
+			expected:  true,
+		},
+		{
+			name:      "overlaps - longer path",
+			input:     &DeferInfo{Path: shortPath1},
+			otherPath: longPath,
+			expected:  true,
+		},
+		{
+			name:      "overlaps - shorter path, mismatched",
+			input:     &DeferInfo{Path: shortPath2},
+			otherPath: longPath,
+			expected:  false,
+		},
+		{
+			name:      "overlaps - longer path, mismatched",
+			input:     &DeferInfo{Path: longPath},
+			otherPath: shortPath2,
+			expected:  false,
+		},
+		{
+			name:      "non-overlapping paths",
+			input:     &DeferInfo{Path: shortPath1},
+			otherPath: shortPath2,
+			expected:  false,
+		},
+		{
+			name:      "empty paths equal",
+			input:     &DeferInfo{Path: emptyPath},
+			otherPath: emptyPath,
+			expected:  true,
+		},
+		{
+			name:      "empty defer path",
+			input:     &DeferInfo{Path: emptyPath},
+			otherPath: shortPath1,
+			expected:  true,
+		},
+		{
+			name:      "nil DeferInfo - empty path",
+			input:     nil,
+			otherPath: emptyPath,
+			expected:  false,
+		},
+		{
+			name:      "nil DeferInfo - non-empty path",
+			input:     nil,
+			otherPath: shortPath1,
+			expected:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.input.Overlaps(tt.otherPath))
+			// TODO: reflexive property test.
+		})
+	}
+}
+func TestDeferInfo_HasPrefix(t *testing.T) {
+	tests := []struct {
+		name      string
+		deferInfo *DeferInfo
+		prefix    []string
+		expected  bool
+	}{
+		{
+			name:      "empty prefix always returns true",
+			deferInfo: &DeferInfo{Path: shortPath1},
+			prefix:    []string{},
+			expected:  true,
+		},
+		{
+			name:      "non-empty prefix with empty DeferInfo path returns false",
+			deferInfo: &DeferInfo{Path: emptyPath},
+			prefix:    []string{"query"},
+			expected:  false,
+		},
+		{
+			name:      "exact match short path",
+			deferInfo: &DeferInfo{Path: shortPath1},
+			prefix:    []string{"query", "object1"},
+			expected:  true,
+		},
+		{
+			name:      "long path with prefix match",
+			deferInfo: &DeferInfo{Path: longPath},
+			prefix:    []string{"query", "object1"},
+			expected:  true,
+		},
+		{
+			name:      "mismatch prefix",
+			deferInfo: &DeferInfo{Path: shortPath1},
+			prefix:    []string{"x", "y"},
+			expected:  false,
+		},
+		{
+			name:      "prefix has no operation type, but matches",
+			deferInfo: &DeferInfo{Path: longPath},
+			prefix:    []string{"object1", "field1"},
+			expected:  true,
+		},
+		{
+			name:      "prefix has no operation type, and mis-matches",
+			deferInfo: &DeferInfo{Path: shortPath1},
+			prefix:    []string{"x"},
+			expected:  false,
+		},
+		{
+			name:      "prefix longer than path",
+			deferInfo: &DeferInfo{Path: shortPath1},
+			prefix:    []string{"query", "object1", "field1"},
+			expected:  false,
+		},
+		{
+			name:      "ignore inline fragment",
+			deferInfo: &DeferInfo{Path: ast.Path{pathItem1, pathItem2, fragmentItem, pathItem3}},
+			prefix:    []string{"query", "object1", "field1"},
+			expected:  true,
+		},
+		{
+			name:      "ignore terminal inline fragment",
+			deferInfo: &DeferInfo{Path: ast.Path{pathItem1, pathItem2, fragmentItem}},
+			prefix:    []string{"query", "object1"},
+			expected:  true,
+		},
+		{
+			name:      "ignore terminal inline fragment, but mis-match",
+			deferInfo: &DeferInfo{Path: ast.Path{pathItem1, pathItem2, fragmentItem}},
+			prefix:    []string{"query", "x"},
+			expected:  false,
+		},
+		{
+			name:      "nil DeferInfo, non-empty prefix",
+			deferInfo: nil,
+			prefix:    []string{"query", "object1"},
+			expected:  false,
+		},
+		{
+			name:      "nil DeferInfo, empty prefix",
+			deferInfo: nil,
+			prefix:    []string{},
+			expected:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.deferInfo.HasPrefix(tt.prefix))
+		})
+	}
+}

--- a/v2/pkg/engine/resolve/resolve.go
+++ b/v2/pkg/engine/resolve/resolve.go
@@ -241,29 +241,80 @@ func (r *Resolver) ResolveGraphQLResponse(ctx *Context, response *GraphQLRespons
 	defer func() {
 		r.maxConcurrency <- struct{}{}
 	}()
-
 	t := newTools(r.options, r.allowedErrorExtensionFields, r.allowedErrorFields)
 
-	err := t.resolvable.Init(ctx, data, response.Info.OperationType)
-	if err != nil {
+	if err := r.doResolve(ctx, t, response, data, writer); err != nil {
 		return nil, err
 	}
 
+	if iw, ok := writer.(IncrementalResponseWriter); ok {
+		if err := iw.Complete(); err != nil {
+			return nil, fmt.Errorf("completing response: %w", err)
+		}
+	}
+	return resp, nil
+}
+
+var errInvalidWriter = errors.New("invalid writer")
+
+func (r *Resolver) doResolve(ctx *Context, t *tools, response *GraphQLResponse, data []byte, writer io.Writer) error {
+	err := t.resolvable.Init(ctx, data, response.Info.OperationType)
+	if err != nil {
+		return err
+	}
 	if !ctx.ExecutionOptions.SkipLoader {
-		err = t.loader.LoadGraphQLResponseData(ctx, response, t.resolvable)
+		err := t.loader.LoadGraphQLResponseData(ctx, response, t.resolvable)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
 	buf := &bytes.Buffer{}
-	err = t.resolvable.Resolve(ctx.ctx, response.Data, response.Fetches, buf)
-	if err != nil {
-		return nil, err
+	if err := t.resolvable.Resolve(ctx.ctx, response.Data, response.Fetches, buf); err != nil {
+		return err
 	}
 
-	_, err = buf.WriteTo(writer)
-	return resp, err
+	if _, err := buf.WriteTo(writer); err != nil {
+		return fmt.Errorf("writing response: %w", err)
+	}
+
+	if iw, ok := writer.(IncrementalResponseWriter); ok {
+		if err := iw.Flush(resolvedPath(response.Data.Path)); err != nil {
+			return fmt.Errorf("flushing immediate response: %w", err)
+		}
+	}
+
+	if len(response.DeferredResponses) > 0 {
+		iw, ok := writer.(IncrementalResponseWriter)
+		if !ok {
+			return fmt.Errorf("%w: writer %T does not support incremental writing", errInvalidWriter, writer)
+		}
+
+		for i, deferredResponse := range response.DeferredResponses {
+			if err := r.doResolve(ctx, t, deferredResponse, nil, iw); err != nil {
+				return fmt.Errorf("resolving deferred response %d: %w", i, err)
+			}
+			if err := iw.Flush(resolvedPath(deferredResponse.Data.Path)); err != nil {
+				return fmt.Errorf("flushing incremental response: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+func resolvedPath(data []string) []any {
+	if len(data) == 0 {
+		return nil
+	}
+	ret := make([]any, len(data))
+	for i, v := range data {
+		if v == "@" {
+			ret[i] = 0 // TODO(cd): need the real values here.
+			continue
+		}
+		ret[i] = v
+	}
+	return ret
 }
 
 type trigger struct {

--- a/v2/pkg/engine/resolve/resolve_test.go
+++ b/v2/pkg/engine/resolve/resolve_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -4765,6 +4766,131 @@ func TestResolver_WithVariableRemapping(t *testing.T) {
 			_, err := resolver.ResolveGraphQLResponse(ctx, res, nil, out)
 			assert.NoError(t, err)
 			assert.Equal(t, `{"data":{"bar":"baz"}}`, out.String())
+		})
+	}
+}
+
+func TestResolver_ResolveGraphQLIncrementalResponse(t *testing.T) {
+	cases := []struct {
+		name     string
+		response *GraphQLResponse
+		expected string
+	}{
+		{
+			name: "sunny day",
+			response: &GraphQLResponse{
+				Info: &GraphQLResponseInfo{
+					OperationType: ast.OperationTypeQuery,
+				},
+				Data: &Object{
+					Nullable: false,
+					Fields: []*Field{
+						{
+							Name: []byte("hero"),
+							Value: &Object{
+								Path:          []string{"hero"},
+								Nullable:      true,
+								TypeName:      "Character",
+								PossibleTypes: map[string]struct{}{"Droid": {}, "Human": {}},
+								Fields: []*Field{
+									{
+										Name: []byte("name"),
+										Value: &String{
+											Path:     []string{"name"},
+											Nullable: false,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Fetches: Single(&SingleFetch{
+					FetchConfiguration: FetchConfiguration{DataSource: FakeDataSource(`{"hero":{"name":"Luke"}}`)},
+				}),
+				DeferredResponses: []*GraphQLResponse{
+					{
+						Info: &GraphQLResponseInfo{
+							OperationType: ast.OperationTypeQuery,
+						},
+						Data: &Object{
+							Path:          []string{"hero"},
+							Nullable:      true,
+							TypeName:      "Character",
+							PossibleTypes: map[string]struct{}{"Droid": {}, "Human": {}},
+							Fields: []*Field{
+								{
+									Name: []byte("__typename"),
+									Value: &String{
+										Path: []string{"__typename"},
+									},
+								},
+								{
+									Name: []byte("primaryFunction"),
+									Value: &String{
+										Path:     []string{"primaryFunction"},
+										Nullable: false,
+									},
+									OnTypeNames: [][]byte{[]byte("Droid")},
+									// Defer: &DeferField{
+									// 	Path: []string{"query", "hero", "$0Droid"},
+									// },
+								},
+								{
+									Name: []byte("favoriteEpisode"),
+									Value: &Enum{
+										Path:     []string{"favoriteEpisode"},
+										Nullable: true,
+										TypeName: "Episode",
+										Values: []string{
+											"NEWHOPE",
+											"EMPIRE",
+											"JEDI",
+										},
+									},
+									OnTypeNames: [][]byte{[]byte("Droid")},
+									// Defer: &DeferField{
+									// 	Path: []string{"query", "hero", "$0Droid"},
+									// },
+								},
+							},
+						},
+						Fetches: Single(&SingleFetch{
+							FetchConfiguration: FetchConfiguration{DataSource: FakeDataSource(`{"hero":{"__typename":"Droid","primaryFunction":"Astromech","favoriteEpisode":"NEWHOPE"}}`)},
+						}),
+					},
+				},
+			},
+			expected: strings.ReplaceAll(`--graphql-go-tools
+Content-Type: application/json; charset=utf-8
+
+{"hasNext":true,"data":{"hero":{"name":"Luke"}}}
+--graphql-go-tools
+Content-Type: application/json; charset=utf-8
+
+{"hasNext":true,"incremental":[{"data":{"__typename":"Droid","primaryFunction":"Astromech","favoriteEpisode":"NEWHOPE"},"path":["hero"]}]}
+--graphql-go-tools
+Content-Type: application/json; charset=utf-8
+
+{"hasNext":false,"incremental":[]}
+--graphql-go-tools--
+`, "\n", "\r\n"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			r := newResolver(ctx)
+			var buf bytes.Buffer
+			w := &MultipartJSONWriter{
+				Writer:        &buf,
+				BoundaryToken: "graphql-go-tools",
+			}
+			info, err := r.ResolveGraphQLResponse(&Context{ctx: ctx}, tc.response, nil, w)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, buf.String())
+			require.NotNil(t, info)
 		})
 	}
 }

--- a/v2/pkg/engine/resolve/response.go
+++ b/v2/pkg/engine/resolve/response.go
@@ -48,6 +48,12 @@ type SubscriptionResponseWriter interface {
 	Complete()
 }
 
+type IncrementalResponseWriter interface {
+	ResponseWriter
+	Flush(path []any) error
+	Complete() error
+}
+
 func writeGraphqlResponse(buf *BufPair, writer io.Writer, ignoreData bool) (err error) {
 	hasErrors := buf.Errors.Len() != 0
 	hasData := buf.Data.Len() != 0 && !ignoreData

--- a/v2/pkg/engine/resolve/response.go
+++ b/v2/pkg/engine/resolve/response.go
@@ -22,11 +22,12 @@ type GraphQLSubscriptionTrigger struct {
 }
 
 type GraphQLResponse struct {
-	Data            *Object
-	RenameTypeNames []RenameTypeName
-	Info            *GraphQLResponseInfo
-	Fetches         *FetchTreeNode
-	DataSources     []DataSourceInfo
+	Data              *Object
+	RenameTypeNames   []RenameTypeName
+	Info              *GraphQLResponseInfo
+	Fetches           *FetchTreeNode
+	DataSources       []DataSourceInfo
+	DeferredResponses []*GraphQLResponse
 }
 
 type GraphQLResponseInfo struct {


### PR DESCRIPTION
Works on simple cases, but takes a naive approach, fetching the whole path rather than reusing previously-fetch data.

Example query:

```graphql
query {
  e: employee(id:1) {
    id
    ... @defer {
      __typename
      ud:updatedAt
      tag
      ... @defer {
        __typename
         details {
          forename
        }
      }
    }
    role {
      title
    }
  }
}
```

Some things still needed:
* Automatic injection of `__typename` in fragment selection sets
* Playground doesn’t recognize multipart
* Related PR for router TBD
* A LOT more testing!