### PR TITLE
feat: add max concurrency for data source collectors

### DIFF
--- a/v2/pkg/engine/plan/configuration.go
+++ b/v2/pkg/engine/plan/configuration.go
@@ -7,12 +7,13 @@ import (
 )
 
 type Configuration struct {
-	Logger                     abstractlogger.Logger
-	DefaultFlushIntervalMillis int64
-	DataSources                []DataSource
-	Fields                     FieldConfigurations
-	Types                      TypeConfigurations
-	EntityInterfaceNames       []string
+	Logger                             abstractlogger.Logger
+	DefaultFlushIntervalMillis         int64
+	DataSources                        []DataSource
+	MaxDataSourceCollectorsConcurrency uint
+	Fields                             FieldConfigurations
+	Types                              TypeConfigurations
+	EntityInterfaceNames               []string
 	// DisableResolveFieldPositions should be set to true for testing purposes
 	// This setting removes position information from all fields
 	// In production, this should be set to false so that error messages are easier to understand

--- a/v2/pkg/engine/plan/datasource_filter_visitor.go
+++ b/v2/pkg/engine/plan/datasource_filter_visitor.go
@@ -23,8 +23,9 @@ type DataSourceFilter struct {
 	enableSelectionReasons bool
 	secondaryRun           bool
 
-	fieldDependsOn map[int][]int
-	dataSources    []DataSource
+	fieldDependsOn                     map[int][]int
+	dataSources                        []DataSource
+	maxDataSourceCollectorsConcurrency uint
 }
 
 func NewDataSourceFilter(operation, definition *ast.Document, report *operationreport.Report) *DataSourceFilter {
@@ -37,6 +38,12 @@ func NewDataSourceFilter(operation, definition *ast.Document, report *operationr
 
 func (f *DataSourceFilter) EnableSelectionReasons() {
 	f.enableSelectionReasons = true
+}
+
+// WithMaxDataSourceCollectorsConcurrency sets the maximum number of concurrent data source collectors
+func (f *DataSourceFilter) WithMaxDataSourceCollectorsConcurrency(maxConcurrency uint) *DataSourceFilter {
+	f.maxDataSourceCollectorsConcurrency = maxConcurrency
+	return f
 }
 
 func (f *DataSourceFilter) FilterDataSources(dataSources []DataSource, existingNodes *NodeSuggestions, landedTo map[int]DSHash, fieldDependsOn map[int][]int) (used []DataSource, suggestions *NodeSuggestions) {
@@ -117,11 +124,12 @@ func (f *DataSourceFilter) collectNodes(dataSources []DataSource, existingNodes 
 	}
 
 	nodesCollector := &nodesCollector{
-		operation:   f.operation,
-		definition:  f.definition,
-		dataSources: dataSources,
-		nodes:       existingNodes,
-		report:      f.report,
+		operation:      f.operation,
+		definition:     f.definition,
+		dataSources:    dataSources,
+		nodes:          existingNodes,
+		report:         f.report,
+		maxConcurrency: f.maxDataSourceCollectorsConcurrency,
 	}
 
 	return nodesCollector.CollectNodes()

--- a/v2/pkg/engine/plan/planner.go
+++ b/v2/pkg/engine/plan/planner.go
@@ -230,6 +230,10 @@ func (p *Planner) selectNodes(operation, definition *ast.Document, report *opera
 		p.printOperation(operation)
 	}
 
+	if p.config.MaxDataSourceCollectorsConcurrency > 0 {
+		dsFilter.WithMaxDataSourceCollectorsConcurrency(p.config.MaxDataSourceCollectorsConcurrency)
+	}
+
 	p.nodeSelectionsVisitor.debug = p.config.Debug
 
 	// set initial suggestions and used data sources


### PR DESCRIPTION
This update introduces a new configuration option, MaxDataSourceCollectorsConcurrency, to control the maximum number of concurrent data source collectors. The nodesCollector and DataSourceFilter have been modified to utilize this new setting, allowing a stricter resource management during data collection.