### PR TITLE
fix(websocket): handle ping/pong correctly

### DIFF
--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
@@ -1837,6 +1837,7 @@ type GraphQLSubscriptionOptions struct {
 	ForwardedClientHeaderRegularExpressions []*regexp.Regexp `json:"forwarded_client_header_regular_expressions"`
 	WsSubProtocol                           string           `json:"ws_sub_protocol"`
 	readTimeout                             time.Duration    `json:"-"`
+	pingInterval                            time.Duration    `json:"-"`
 }
 
 type GraphQLBody struct {

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
@@ -1838,6 +1838,7 @@ type GraphQLSubscriptionOptions struct {
 	WsSubProtocol                           string           `json:"ws_sub_protocol"`
 	readTimeout                             time.Duration    `json:"-"`
 	pingInterval                            time.Duration    `json:"-"`
+	pingTimeout                             time.Duration    `json:"-"`
 }
 
 type GraphQLBody struct {

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
@@ -626,7 +626,7 @@ type ConnectionHandler interface {
 	// HandleMessage handles the incoming message from the connection
 	HandleMessage(data []byte) (done bool)
 	// Ping used to send a ping message to the upstream server to remain the connection alive
-	// It also keeps track of when the last ping was sent and pong was received to early detect connection drops
+	// It also keeps track of when the last ping was sent and pong was received to initiate a close
 	Ping()
 	// ServerClose closes the connection from the server side
 	ServerClose()

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
@@ -197,6 +197,8 @@ func IsDefaultGraphQLSubscriptionClient(client GraphQLSubscriptionClient) bool {
 }
 
 func NewGraphQLSubscriptionClient(httpClient, streamingClient *http.Client, engineCtx context.Context, options ...Options) GraphQLSubscriptionClient {
+
+	// Defaults
 	op := &opts{
 		readTimeout:  time.Millisecond * 100,
 		pingInterval: 10 * time.Second,

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
@@ -639,9 +639,8 @@ type ConnectionHandler interface {
 	StartBlocking() error
 	// HandleMessage handles the incoming message from the connection
 	HandleMessage(data []byte) (done bool)
-	// Ping used to send a ping message to the upstream server to remain the connection alive
-	// It also keeps track of when the last ping was sent and pong was received to initiate a close
-	// if the connection is not alive anymore
+	// Ping used to send a ping message to the upstream server to remain the connection alive.
+	// It also keeps track of when the last ping to initiate a shutdown of the dead connection
 	Ping()
 	// ServerClose closes the connection from the server side
 	ServerClose()

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
@@ -739,6 +739,7 @@ func (c *subscriptionClient) runNetPoll(ctx context.Context) {
 			// Send a ping to all connections
 			// We distribute the ping to all workers to prevent single threaded bottlenecks
 			// However, this required state synchronization with the last ping time on the handler
+			// because PING and PONG can be handled on different go routines
 			for _, conn := range c.netPollState.connections {
 				pingCh <- conn
 			}

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
@@ -29,10 +29,14 @@ import (
 )
 
 const (
-	writeTimeout       = 10 * time.Second
+	// The time to write a message to the server connection before timing out
+	writeTimeout = 10 * time.Second
+	// The time to read a message from the server connection before timing out
 	readMessageTimeout = 1 * time.Second
-	ackWaitTimeout     = 30 * time.Second
-	pongWaitTimeout    = 5 * time.Second
+	// The time to wait for a connection ack message from the server before timing out
+	ackWaitTimeout = 30 * time.Second
+	// The time to wait for a pong message from the server before timing out
+	pongWaitTimeout = 5 * time.Second
 )
 
 type netPollState struct {

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
@@ -35,7 +35,7 @@ const (
 	readMessageTimeout = 1 * time.Second
 	// The time to wait for a connection ack message from the server before timing out
 	ackWaitTimeout = 30 * time.Second
-	// The time to wait for a pong message from the server before timing out
+	// The time to wait for a pong message from the server after sending a ping message
 	pongWaitTimeout = 5 * time.Second
 )
 

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
@@ -737,6 +737,8 @@ func (c *subscriptionClient) runNetPoll(ctx context.Context) {
 			return
 		case <-pingTicker.C:
 			// Send a ping to all connections
+			// We distribute the ping to all workers to prevent single threaded bottlenecks
+			// However, this required state synchronization with the last ping time on the handler
 			for _, conn := range c.netPollState.connections {
 				pingCh <- conn
 			}

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
@@ -31,7 +31,7 @@ import (
 const (
 	// The time to write a message to the server connection before timing out
 	writeTimeout = 10 * time.Second
-	// The time to read a message from the server connection before timing out
+	// The time to read the message payload from the server before timing out
 	readMessageTimeout = 1 * time.Second
 	// The time to wait for a connection ack message from the server before timing out
 	ackWaitTimeout = 30 * time.Second

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
@@ -2281,6 +2281,7 @@ func TestClientClosesConnectionOnPingTimeout(t *testing.T) {
 	client := NewGraphQLSubscriptionClient(http.DefaultClient, http.DefaultClient, serverCtx,
 		WithLogger(logger()),
 		WithPingInterval(500*time.Millisecond),
+		WithPingTimeout(100*time.Millisecond),
 		// Need netpoll enabled for ping/pong handling
 		WithNetPollConfiguration(NetPollConfiguration{
 			Enable:           true,

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
@@ -1945,7 +1945,7 @@ func TestClientToSubgraphPingPong(t *testing.T) {
 					break
 				}
 
-				msgType, data, err = conn.Read(readCtx)
+				_, data, err = conn.Read(readCtx)
 				if err != nil {
 					// Connection closed or timeout
 					t.Logf("Connection read ended: %v", err)
@@ -2227,7 +2227,7 @@ func TestClientClosesConnectionOnPingTimeout(t *testing.T) {
 
 		hasReceivedPing := false
 		for !hasReceivedPing {
-			msgType, data, err = conn.Read(readCtx)
+			_, data, err = conn.Read(readCtx)
 			if err != nil {
 				t.Logf("Server read error (expected after client closes): %v", err)
 				// Expecting an error here eventually as the client should close the connection
@@ -2258,7 +2258,7 @@ func TestClientClosesConnectionOnPingTimeout(t *testing.T) {
 		for {
 			// Use a timeout context to make sure we don't hang indefinitely
 			readCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
-			msgType, data, err = conn.Read(readCtx)
+			_, data, err = conn.Read(readCtx)
 			cancel()
 
 			if err != nil {

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
@@ -2257,15 +2257,13 @@ func TestClientClosesConnectionOnPingTimeout(t *testing.T) {
 		// Keep reading until the connection is closed by the client
 		for {
 			// Use a timeout context to make sure we don't hang indefinitely
-			readCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+			readCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 			_, data, err = conn.Read(readCtx)
 			cancel()
 
 			if err != nil {
 				t.Logf("Server read error after ping (expected): %v", err)
 				assert.Error(t, err, "Server should encounter read error after client closes connection")
-				// Signal that the server is done (connection closed)
-				close(serverDone)
 				return // Exit handler goroutine
 			}
 

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_tws_handler.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_tws_handler.go
@@ -294,8 +294,7 @@ func (h *gqlTWSConnectionHandler) Ping() {
 
 	lastPingTimestamp := h.lastPingSentUnix.Load()
 
-	// This can only happen when the PONG took longer than a full ping interval.
-	// This also implies that we will detect not immediately but on the next ping interval.
+	// We will detect a dead connection not immediately but on the next ping interval.
 	if lastPingTimestamp > 0 {
 		pingTime := time.Unix(0, lastPingTimestamp)
 		duration := time.Since(pingTime)

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_tws_handler.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_tws_handler.go
@@ -305,8 +305,10 @@ func (h *gqlTWSConnectionHandler) Ping() {
 			// and we assume the connection is dead. ServerClose will send a done event to the client
 			// event loop to close all triggers and subscriptions
 			h.ServerClose()
-			return
 		}
+
+		// We don't want to send another ping if one is already in flight
+		return
 	}
 
 	// Start measuring the time since to write the message to the connection, including the IO time

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_tws_handler.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_tws_handler.go
@@ -296,6 +296,9 @@ func (h *gqlTWSConnectionHandler) Ping() {
 			h.log.Error("ping timeout exceeded. Closing connection")
 			// Reset timestamp to avoid duplicate closes if Ping gets called again
 			h.lastPingSentUnix.Store(0)
+			// We close the connection because the ping timeout has been exceeded,
+			// and we assume the connection is dead. ServerClose will send a done event to the client
+			// event loop to close all triggers and subscriptions
 			h.ServerClose()
 			return
 		}

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_tws_handler.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_tws_handler.go
@@ -101,9 +101,6 @@ func newGQLTWSConnectionHandler(requestContext, engineContext context.Context, c
 		pingTimeout:    options.pingTimeout,
 	}
 
-	// Initialize atomic field to 0 (no ping in flight)
-	handler.lastPingSentUnix.Store(0)
-
 	return &connection{
 		handler: handler,
 		netConn: conn,

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_tws_handler.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_tws_handler.go
@@ -294,7 +294,8 @@ func (h *gqlTWSConnectionHandler) Ping() {
 
 	lastPingTimestamp := h.lastPingSentUnix.Load()
 
-	// Only check the ping timeout if the last ping took longer than a ping interval.
+	// This can only happen when the PONG took longer than a full ping interval.
+	// This also implies that we will detect not immediately but on the next ping interval.
 	if lastPingTimestamp > 0 {
 		pingTime := time.Unix(0, lastPingTimestamp)
 		duration := time.Since(pingTime)

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_tws_handler.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_tws_handler.go
@@ -291,12 +291,13 @@ func (h *gqlTWSConnectionHandler) Ping() {
 
 	_ = h.conn.SetWriteDeadline(time.Now().Add(writeTimeout))
 	err := wsutil.WriteClientText(h.conn, []byte(pingMessage))
+
+	h.lastPingSentAt = time.Now()
+
 	if err != nil {
 		h.log.Error("failed to write ping message", abstractlogger.Error(err))
 		return
 	}
-
-	h.lastPingSentAt = time.Now()
 }
 
 func (h *gqlTWSConnectionHandler) handleMessageTypeNext(data []byte) {

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_tws_handler.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_tws_handler.go
@@ -294,7 +294,7 @@ func (h *gqlTWSConnectionHandler) Ping() {
 
 	lastPingTimestamp := h.lastPingSentUnix.Load()
 
-	// Only check the ping timeout if we have sent a ping before
+	// Only check the ping timeout if the last ping took longer than a ping interval.
 	if lastPingTimestamp > 0 {
 		pingTime := time.Unix(0, lastPingTimestamp)
 		duration := time.Since(pingTime)
@@ -307,8 +307,6 @@ func (h *gqlTWSConnectionHandler) Ping() {
 			h.ServerClose()
 			return
 		}
-
-		h.log.Debug("last ping succeeded", abstractlogger.String("duration", pingTime.String()))
 	}
 
 	// Start measuring the time since to write the message to the connection, including the IO time

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_tws_handler.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_tws_handler.go
@@ -280,11 +280,13 @@ func (h *gqlTWSConnectionHandler) handleMessageTypePing() {
 
 func (h *gqlTWSConnectionHandler) handleMessageTypePong() {
 	// Reset timestamp to indicate no ping in flight
+	// Can be called from different workers and must be protected
 	h.lastPingSentUnix.Store(0)
 }
 
 func (h *gqlTWSConnectionHandler) Ping() {
 	// Get current timestamp of last ping
+	// Can be called from different workers and must be protected
 	lastPingTimestamp := h.lastPingSentUnix.Load()
 
 	// If a ping is in flight, check if it has timed out

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_ws_handler.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_ws_handler.go
@@ -196,6 +196,12 @@ func (h *gqlWSConnectionHandler) unsubscribeAllAndCloseConn() {
 	_ = h.conn.Close()
 }
 
+func (h *gqlWSConnectionHandler) Ping() {
+	// This protocol has no client side ping/pong mechanism. The server send a ka message to understand
+	// if the connection is still alive. The client only acknowledges the retrieval of the ka message
+	// by consuming it in the readBlocking loop.
+}
+
 // subscribe adds a new Subscription to the gqlWSConnectionHandler and sends the startMessage to the origin
 func (h *gqlWSConnectionHandler) subscribe() error {
 	graphQLBody, err := json.Marshal(h.options.Body)

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_ws_handler.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_ws_handler.go
@@ -200,6 +200,10 @@ func (h *gqlWSConnectionHandler) Ping() {
 	// This protocol has no client side ping/pong mechanism. The server send a ka message to understand
 	// if the connection is still alive. The client only acknowledges the retrieval of the ka message
 	// by consuming it in the readBlocking loop.
+
+	// TODO We could check if we receive a ka message in a certain time frame and if not, we could close the connection
+	// However, because we don't send something to the server, we can't verify if the connection is still healthy and
+	// responsive from both sides.
 }
 
 // subscribe adds a new Subscription to the gqlWSConnectionHandler and sends the startMessage to the origin

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_ws_proto_types.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_ws_proto_types.go
@@ -31,9 +31,11 @@ const (
 
 	subscribeMessage = `{"id":"%s","type":"subscribe","payload":%s}`
 	pongMessage      = `{"type":"pong"}`
+	pingMessage      = `{"type":"ping"}`
 	completeMessage  = `{"id":"%s","type":"complete"}`
 
 	messageTypePing = "ping"
+	messageTypePong = "pong"
 	messageTypeNext = "next"
 )
 


### PR DESCRIPTION
This PR adds proper Ping/Pong support for upstream subgraphs. It ensures that the subgraph doesn't mark the connection as dead. For instance, the `graphql-ws` library supports lazy close timeouts. If the router doesn't signal that it is alive, the connection will be aborted, along with all subscriptions.