### PR TITLE
feat: improve error handling

### DIFF
--- a/v2/pkg/engine/datasource/httpclient/nethttpclient.go
+++ b/v2/pkg/engine/datasource/httpclient/nethttpclient.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	"github.com/buger/jsonparser"
-
+	pkgErrors "github.com/pkg/errors"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/lexer/literal"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/pool"
 )
@@ -204,7 +204,7 @@ func makeHTTPRequest(client *http.Client, ctx context.Context, url, method, head
 
 	response, err := client.Do(request)
 	if err != nil {
-		return err
+		return pkgErrors.WithStack(err)
 	}
 	defer response.Body.Close()
 
@@ -262,6 +262,7 @@ func Do(client *http.Client, ctx context.Context, requestInput []byte, out *byte
 	pool.Hash64.Put(h)
 	ctx = context.WithValue(ctx, bodyHashContextKey{}, bodyHash)
 	return makeHTTPRequest(client, ctx, url, method, headers, queryParams, bytes.NewReader(body), enableTrace, out, ContentTypeJSON)
+
 }
 
 func DoMultipartForm(

--- a/v2/pkg/engine/resolve/authorization_test.go
+++ b/v2/pkg/engine/resolve/authorization_test.go
@@ -72,7 +72,7 @@ func TestAuthorization(t *testing.T) {
 				assert.Equal(t, int64(2), authorizer.(*testAuthorizer).preFetchCalls.Load())
 				assert.Equal(t, int64(4), authorizer.(*testAuthorizer).objectFieldCalls.Load())
 
-				require.Nil(t, resolveCtx.subgraphErrors)
+				require.Nil(t, resolveCtx.error)
 			}
 	}))
 	t.Run("validate authorizer args", testFnWithPostEvaluation(func(t *testing.T, ctrl *gomock.Controller) (node *GraphQLResponse, ctx *Context, expectedOutput string, postEvaluation func(t *testing.T)) {
@@ -139,7 +139,7 @@ func TestAuthorization(t *testing.T) {
 				assert.Equal(t, int64(2), authorizer.(*testAuthorizer).preFetchCalls.Load())
 				assert.Equal(t, int64(4), authorizer.(*testAuthorizer).objectFieldCalls.Load())
 
-				require.Nil(t, resolveCtx.subgraphErrors)
+				require.Nil(t, resolveCtx.error)
 			}
 	}))
 	t.Run("disallow field with extension", testFnWithPostEvaluation(func(t *testing.T, ctrl *gomock.Controller) (node *GraphQLResponse, ctx *Context, expectedOutput string, postEvaluation func(t *testing.T)) {
@@ -167,7 +167,7 @@ func TestAuthorization(t *testing.T) {
 				assert.Equal(t, int64(2), authorizer.(*testAuthorizer).preFetchCalls.Load())
 				assert.Equal(t, int64(4), authorizer.(*testAuthorizer).objectFieldCalls.Load())
 
-				require.Nil(t, resolveCtx.subgraphErrors)
+				require.Nil(t, resolveCtx.error)
 			}
 	}))
 	t.Run("no authorization rules/checks", testFnWithPostEvaluation(func(t *testing.T, ctrl *gomock.Controller) (node *GraphQLResponse, ctx *Context, expectedOutput string, postEvaluation func(t *testing.T)) {
@@ -187,7 +187,7 @@ func TestAuthorization(t *testing.T) {
 				assert.Equal(t, int64(0), authorizer.(*testAuthorizer).preFetchCalls.Load())
 				assert.Equal(t, int64(0), authorizer.(*testAuthorizer).objectFieldCalls.Load())
 
-				require.Nil(t, resolveCtx.subgraphErrors)
+				require.Nil(t, resolveCtx.error)
 			}
 	}))
 	t.Run("disallow root fetch", testFnWithPostEvaluation(func(t *testing.T, ctrl *gomock.Controller) (node *GraphQLResponse, ctx *Context, expectedOutput string, postEvaluation func(t *testing.T)) {
@@ -213,7 +213,7 @@ func TestAuthorization(t *testing.T) {
 				assert.Equal(t, int64(0), authorizer.(*testAuthorizer).objectFieldCalls.Load())
 
 				var subgraphError *SubgraphError
-				require.ErrorAs(t, resolveCtx.subgraphErrors, &subgraphError)
+				require.ErrorAs(t, resolveCtx.error, &subgraphError)
 				require.Equal(t, "users", subgraphError.DataSourceInfo.Name)
 				require.Equal(t, "query", subgraphError.Path)
 				require.Equal(t, "Not allowed to fetch from users Subgraph", subgraphError.Reason)
@@ -244,7 +244,7 @@ func TestAuthorization(t *testing.T) {
 				assert.Equal(t, int64(0), authorizer.(*testAuthorizer).objectFieldCalls.Load())
 
 				var subgraphError *SubgraphError
-				require.ErrorAs(t, resolveCtx.subgraphErrors, &subgraphError)
+				require.ErrorAs(t, resolveCtx.error, &subgraphError)
 				require.Equal(t, "users", subgraphError.DataSourceInfo.Name)
 				require.Equal(t, "query", subgraphError.Path)
 				require.Equal(t, "", subgraphError.Reason)
@@ -276,11 +276,11 @@ func TestAuthorization(t *testing.T) {
 				assert.Equal(t, int64(2), authorizer.(*testAuthorizer).preFetchCalls.Load())
 				assert.Equal(t, int64(4), authorizer.(*testAuthorizer).objectFieldCalls.Load())
 
-				require.NotEmpty(t, resolveCtx.subgraphErrors)
-				require.EqualError(t, resolveCtx.subgraphErrors, "Failed to fetch from Subgraph 'products' at Path: 'query.me.reviews.@.product', Reason: Not allowed to fetch from products Subgraph.")
+				require.NotEmpty(t, resolveCtx.error)
+				require.EqualError(t, resolveCtx.error, "Failed to fetch from Subgraph 'products' at Path: 'query.me.reviews.@.product', Reason: Not allowed to fetch from products Subgraph.")
 
 				var subgraphError *SubgraphError
-				require.ErrorAs(t, resolveCtx.subgraphErrors, &subgraphError)
+				require.ErrorAs(t, resolveCtx.error, &subgraphError)
 				require.Equal(t, "products", subgraphError.DataSourceInfo.Name)
 				require.Equal(t, "query.me.reviews.@.product", subgraphError.Path)
 				require.Equal(t, "Not allowed to fetch from products Subgraph", subgraphError.Reason)
@@ -311,7 +311,7 @@ func TestAuthorization(t *testing.T) {
 				assert.Equal(t, int64(4), authorizer.(*testAuthorizer).objectFieldCalls.Load())
 
 				var subgraphError *SubgraphError
-				require.ErrorAs(t, resolveCtx.subgraphErrors, &subgraphError)
+				require.ErrorAs(t, resolveCtx.error, &subgraphError)
 				require.Equal(t, "products", subgraphError.DataSourceInfo.Name)
 				require.Equal(t, "Query.me.reviews.product.data.name", subgraphError.Path)
 				require.Equal(t, "Not allowed to fetch name on Product", subgraphError.Reason)
@@ -344,7 +344,7 @@ func TestAuthorization(t *testing.T) {
 				assert.Equal(t, int64(4), authorizer.(*testAuthorizer).objectFieldCalls.Load())
 
 				var subgraphError *SubgraphError
-				require.ErrorAs(t, resolveCtx.subgraphErrors, &subgraphError)
+				require.ErrorAs(t, resolveCtx.error, &subgraphError)
 				require.Equal(t, "products", subgraphError.DataSourceInfo.Name)
 				require.Equal(t, "query.me.reviews.@.product", subgraphError.Path)
 				require.Equal(t, "Not allowed to fetch from products Subgraph", subgraphError.Reason)
@@ -388,7 +388,7 @@ func TestAuthorization(t *testing.T) {
 				assert.Equal(t, int64(4), authorizer.(*testAuthorizer).objectFieldCalls.Load())
 
 				var subgraphError *SubgraphError
-				require.ErrorAs(t, resolveCtx.subgraphErrors, &subgraphError)
+				require.ErrorAs(t, resolveCtx.error, &subgraphError)
 				require.Equal(t, "reviews", subgraphError.DataSourceInfo.Name)
 				require.Equal(t, "Query.me.reviews.body", subgraphError.Path)
 				require.Equal(t, "Not allowed to fetch body on Review", subgraphError.Reason)
@@ -417,7 +417,7 @@ func TestAuthorization(t *testing.T) {
 				assert.Equal(t, int64(4), authorizer.(*testAuthorizer).objectFieldCalls.Load())
 
 				var subgraphError *SubgraphError
-				require.ErrorAs(t, resolveCtx.subgraphErrors, &subgraphError)
+				require.ErrorAs(t, resolveCtx.error, &subgraphError)
 				require.Equal(t, "reviews", subgraphError.DataSourceInfo.Name)
 				require.Equal(t, "Query.me.reviews.body", subgraphError.Path)
 				require.Equal(t, "", subgraphError.Reason)
@@ -448,7 +448,7 @@ func TestAuthorization(t *testing.T) {
 				assert.Equal(t, int64(4), authorizer.(*testAuthorizer).objectFieldCalls.Load())
 
 				var subgraphError *SubgraphError
-				require.ErrorAs(t, resolveCtx.subgraphErrors, &subgraphError)
+				require.ErrorAs(t, resolveCtx.error, &subgraphError)
 				require.Equal(t, "products", subgraphError.DataSourceInfo.Name)
 				require.Equal(t, "query.me.reviews.@.product", subgraphError.Path)
 				require.Equal(t, "Not allowed to fetch name on Product", subgraphError.Reason)
@@ -479,7 +479,7 @@ func TestAuthorization(t *testing.T) {
 				assert.Equal(t, int64(4), authorizer.(*testAuthorizer).objectFieldCalls.Load())
 
 				var subgraphError *SubgraphError
-				require.ErrorAs(t, resolveCtx.subgraphErrors, &subgraphError)
+				require.ErrorAs(t, resolveCtx.error, &subgraphError)
 				require.Equal(t, "products", subgraphError.DataSourceInfo.Name)
 				require.Equal(t, "Query.me.reviews.product.data.name", subgraphError.Path)
 				require.Equal(t, "Not allowed to fetch name on Product", subgraphError.Reason)

--- a/v2/pkg/engine/resolve/context.go
+++ b/v2/pkg/engine/resolve/context.go
@@ -30,7 +30,7 @@ type Context struct {
 	authorizer  Authorizer
 	rateLimiter RateLimiter
 
-	subgraphErrors error
+	error error
 }
 
 type ExecutionOptions struct {
@@ -103,12 +103,15 @@ func (c *Context) SetRateLimiter(limiter RateLimiter) {
 	c.rateLimiter = limiter
 }
 
-func (c *Context) SubgraphErrors() error {
-	return c.subgraphErrors
+// ExecutionError returns the error that occurred during execution.
+// You can use appendError to append errors to the context e.g. from a subgraph
+func (c *Context) ExecutionError() error {
+	return c.error
 }
 
-func (c *Context) appendSubgraphError(err error) {
-	c.subgraphErrors = errors.Join(c.subgraphErrors, err)
+// appendError appends the error to the context's error field. Should only be used to make the error public
+func (c *Context) appendError(err error) {
+	c.error = errors.Join(c.error, err)
 }
 
 type Request struct {
@@ -168,7 +171,7 @@ func (c *Context) Free() {
 	c.RemapVariables = nil
 	c.TracingOptions.DisableAll()
 	c.Extensions = nil
-	c.subgraphErrors = nil
+	c.error = nil
 	c.authorizer = nil
 	c.LoaderHooks = nil
 }

--- a/v2/pkg/engine/resolve/loader_hooks_test.go
+++ b/v2/pkg/engine/resolve/loader_hooks_test.go
@@ -105,7 +105,7 @@ func TestLoaderHooks_FetchPipeline(t *testing.T) {
 				assert.Equal(t, "errorMessage", subgraphError.DownstreamErrors[0].Message)
 				assert.Nil(t, subgraphError.DownstreamErrors[0].Extensions)
 
-				assert.NotNil(t, resolveCtx.SubgraphErrors())
+				assert.NotNil(t, resolveCtx.ExecutionError())
 			}
 	}))
 
@@ -185,7 +185,7 @@ func TestLoaderHooks_FetchPipeline(t *testing.T) {
 		assert.Equal(t, "errorMessage", subgraphError.DownstreamErrors[0].Message)
 		assert.Nil(t, subgraphError.DownstreamErrors[0].Extensions)
 
-		assert.NotNil(t, resolveCtx.SubgraphErrors())
+		assert.NotNil(t, resolveCtx.ExecutionError())
 	})
 
 	t.Run("parallel fetch with simple subgraph error", testFnWithPostEvaluation(func(t *testing.T, ctrl *gomock.Controller) (node *GraphQLResponse, ctx *Context, expectedOutput string, postEvaluation func(t *testing.T)) {
@@ -249,7 +249,7 @@ func TestLoaderHooks_FetchPipeline(t *testing.T) {
 				assert.Equal(t, "errorMessage", subgraphError.DownstreamErrors[0].Message)
 				assert.Nil(t, subgraphError.DownstreamErrors[0].Extensions)
 
-				assert.NotNil(t, resolveCtx.SubgraphErrors())
+				assert.NotNil(t, resolveCtx.ExecutionError())
 			}
 	}))
 
@@ -314,7 +314,7 @@ func TestLoaderHooks_FetchPipeline(t *testing.T) {
 				assert.Equal(t, "errorMessage", subgraphError.DownstreamErrors[0].Message)
 				assert.Nil(t, subgraphError.DownstreamErrors[0].Extensions)
 
-				assert.NotNil(t, resolveCtx.SubgraphErrors())
+				assert.NotNil(t, resolveCtx.ExecutionError())
 			}
 	}))
 
@@ -380,7 +380,7 @@ func TestLoaderHooks_FetchPipeline(t *testing.T) {
 				assert.Equal(t, "errorMessage2", subgraphError.DownstreamErrors[1].Message)
 				assert.Empty(t, subgraphError.DownstreamErrors[1].Extensions["code"])
 
-				assert.NotNil(t, resolveCtx.SubgraphErrors())
+				assert.NotNil(t, resolveCtx.ExecutionError())
 			}
 	}))
 

--- a/v2/pkg/engine/resolve/resolvable.go
+++ b/v2/pkg/engine/resolve/resolvable.go
@@ -703,7 +703,7 @@ func (r *Resolvable) addRejectFieldError(reason string, ds DataSourceInfo, field
 	} else {
 		errorMessage = fmt.Sprintf("Unauthorized to load field '%s', Reason: %s.", fieldPath, reason)
 	}
-	r.ctx.appendSubgraphError(goerrors.Join(errors.New(errorMessage),
+	r.ctx.appendError(goerrors.Join(errors.New(errorMessage),
 		NewSubgraphError(ds, fieldPath, reason, 0)))
 	fastjsonext.AppendErrorWithExtensionsCodeToArray(r.astjsonArena, r.errors, errorMessage, errorcodes.UnauthorizedFieldOrType, r.path)
 	r.popNodePathElement(nodePath)


### PR DESCRIPTION
This PR cleaned up error handling. Before, we joined errors twice, which resulted in duplicated error messages for subgraph access logs. I renamed `subgraphErrors` to `error` because it never only represented subgraph logs. I also wrapped the http client error with stack information for more verbose logs.