### PR TITLE
feat: remove intermediate buffer from ResolveGraphQLResponse

### DIFF
--- a/v2/pkg/engine/resolve/resolve.go
+++ b/v2/pkg/engine/resolve/resolve.go
@@ -259,13 +259,11 @@ func (r *Resolver) ResolveGraphQLResponse(ctx *Context, response *GraphQLRespons
 		}
 	}
 
-	buf := &bytes.Buffer{}
-	err = t.resolvable.Resolve(ctx.ctx, response.Data, response.Fetches, buf)
+	err = t.resolvable.Resolve(ctx.ctx, response.Data, response.Fetches, writer)
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = buf.WriteTo(writer)
 	return resp, err
 }
 


### PR DESCRIPTION
Improves performance once https://github.com/wundergraph/cosmo/pull/1795 is merged, as that PR moves the intermediate buffer from engine into the router.

This is technically a behaviourally breaking change, as `writer` could be written to in `err` case, before it would not have been. Our tests all still pass, which means we weren't asserting the previous behaviour, but some consumer could theoretically depend on it as the router did.