### PR TITLE
fix: print indent once per level by default

### DIFF
--- a/execution/graphql/normalization_test.go
+++ b/execution/graphql/normalization_test.go
@@ -48,7 +48,7 @@ func TestRequest_Normalize(t *testing.T) {
         name
     }
 }`
-		op, _ := astprinter.PrintStringIndent(&request.document, "  ")
+		op, _ := astprinter.PrintStringIndent(&request.document, "    ")
 		assert.Equal(t, normalizedOperation, op)
 	})
 
@@ -64,7 +64,7 @@ func TestRequest_Normalize(t *testing.T) {
 		assert.True(t, result.Successful)
 		assert.True(t, request.isNormalized)
 
-		op, _ := astprinter.PrintStringIndent(&request.document, "  ")
+		op, _ := astprinter.PrintStringIndent(&request.document, "    ")
 		assert.Equal(t, expectedNormalizedOperation, op)
 	}
 

--- a/execution/graphql/schema.go
+++ b/execution/graphql/schema.go
@@ -105,7 +105,7 @@ func (s *Schema) Normalize() (result NormalizationResult, err error) {
 	}
 
 	normalizedSchemaBuffer := &bytes.Buffer{}
-	err = astprinter.PrintIndent(&s.document, []byte("  "), normalizedSchemaBuffer)
+	err = astprinter.PrintIndent(&s.document, []byte("    "), normalizedSchemaBuffer)
 	if err != nil {
 		return NormalizationResult{
 			Successful: false,
@@ -402,7 +402,7 @@ func createSchema(schemaContent []byte, mergeWithBaseSchema bool) (*Schema, erro
 		}
 
 		rawSchemaBuffer := &bytes.Buffer{}
-		err = astprinter.PrintIndent(&document, []byte("  "), rawSchemaBuffer)
+		err = astprinter.PrintIndent(&document, []byte("    "), rawSchemaBuffer)
 		if err != nil {
 			return nil, err
 		}

--- a/execution/graphql/schema_test.go
+++ b/execution/graphql/schema_test.go
@@ -292,7 +292,7 @@ func TestSchema_Document(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedSchemaBytesBuffer := &bytes.Buffer{}
-	err = astprinter.PrintIndent(&document, []byte("  "), expectedSchemaBytesBuffer)
+	err = astprinter.PrintIndent(&document, []byte("    "), expectedSchemaBytesBuffer)
 	require.NoError(t, err)
 
 	assert.Equal(t, expectedSchemaBytesBuffer.Bytes(), schema.RawSchema())

--- a/pkg/ast/ast_description.go
+++ b/pkg/ast/ast_description.go
@@ -45,7 +45,6 @@ func (d *Document) PrintDescription(description Description, indent []byte, dept
 				skippedWhitespace += 1
 				continue
 			case runes.SPACE:
-				skippedWhitespace += 0.5
 				continue
 			}
 		}

--- a/pkg/ast/ast_test.go
+++ b/pkg/ast/ast_test.go
@@ -182,7 +182,7 @@ func TestCopying(t *testing.T) {
 		}
 	}
 
-	out, err := astprinter.PrintStringIndent(&doc, nil, "  ")
+	out, err := astprinter.PrintStringIndent(&doc, nil, "    ")
 
 	assert.NoError(t, err)
 

--- a/pkg/astprinter/astprinter.go
+++ b/pkg/astprinter/astprinter.go
@@ -18,6 +18,7 @@ func Print(document, definition *ast.Document, out io.Writer) error {
 }
 
 // PrintIndent is the same as Print but accepts an additional indent parameter to set indentation.
+// Indent is written once for every depth level.
 func PrintIndent(document, definition *ast.Document, indent []byte, out io.Writer) error {
 	printer := Printer{
 		indent: indent,
@@ -93,12 +94,12 @@ func (p *printVisitor) indentationDepth() (depth int) {
 	case ast.NodeKindOperationDefinition,
 		ast.NodeKindFragmentDefinition:
 	default:
-		return 2
+		return 1
 	}
 
 	for i := range p.Ancestors {
 		if p.Ancestors[i].Kind == ast.NodeKindSelectionSet {
-			depth += 2
+			depth += 1
 		}
 	}
 

--- a/pkg/astprinter/astprinter_test.go
+++ b/pkg/astprinter/astprinter_test.go
@@ -516,7 +516,7 @@ func TestPrintSchemaDefinition(t *testing.T) {
 	doc := unsafeparser.ParseGraphqlDocumentFile("./testdata/starwars.schema.graphql")
 
 	buff := bytes.Buffer{}
-	err := PrintIndent(&doc, nil, []byte("  "), &buff)
+	err := PrintIndent(&doc, nil, []byte("    "), &buff)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -540,7 +540,7 @@ func TestPrintOperationDefinition(t *testing.T) {
 	operation := unsafeparser.ParseGraphqlDocumentFile("./testdata/introspectionquery.graphql")
 
 	buff := bytes.Buffer{}
-	err := PrintIndent(&operation, &schema, []byte("  "), &buff)
+	err := PrintIndent(&operation, &schema, []byte("    "), &buff)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/asttransform/baseschema_test.go
+++ b/pkg/asttransform/baseschema_test.go
@@ -20,7 +20,7 @@ func runTestMerge(definition, fixtureName string) func(t *testing.T) {
 			panic(err)
 		}
 		buf := bytes.Buffer{}
-		err = astprinter.PrintIndent(&doc, nil, []byte("  "), &buf)
+		err = astprinter.PrintIndent(&doc, nil, []byte("    "), &buf)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/astvalidation/reference/testsgo/harness_test.go
+++ b/pkg/astvalidation/reference/testsgo/harness_test.go
@@ -248,7 +248,7 @@ func ExtendSchema(schema string, sdlStr string) string {
 	report := operationreport.Report{}
 	parser.Parse(&definition, &report)
 
-	res, _ := astprinter.PrintStringIndent(&definition, nil, "  ")
+	res, _ := astprinter.PrintStringIndent(&definition, nil, "    ")
 
 	return res
 }

--- a/pkg/engine/datasourcetesting/datasourcetesting.go
+++ b/pkg/engine/datasourcetesting/datasourcetesting.go
@@ -40,11 +40,11 @@ func RunTest(definition, operation, operationName string, expectedPlan plan.Plan
 		p := plan.NewPlanner(ctx, config)
 		actualPlan := p.Plan(&op, &def, operationName, &report)
 		if report.HasErrors() {
-			_, err := astprinter.PrintStringIndent(&def, nil, "  ")
+			_, err := astprinter.PrintStringIndent(&def, nil, "    ")
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, err = astprinter.PrintStringIndent(&op, &def, "  ")
+			_, err = astprinter.PrintStringIndent(&op, &def, "    ")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/federation/schema.go
+++ b/pkg/federation/schema.go
@@ -63,7 +63,7 @@ func (s *schemaBuilder) extendQueryTypeWithFederationFields(schema string) strin
 		name := doc.ObjectTypeDefinitionNameString(i)
 		if name == queryTypeName {
 			s.extendQueryType(doc, i)
-			out, err := astprinter.PrintStringIndent(doc, nil, "  ")
+			out, err := astprinter.PrintStringIndent(doc, nil, "    ")
 			if err != nil {
 				return schema
 			}

--- a/pkg/graphql/schema.go
+++ b/pkg/graphql/schema.go
@@ -103,7 +103,7 @@ func (s *Schema) Normalize() (result NormalizationResult, err error) {
 	}
 
 	normalizedSchemaBuffer := &bytes.Buffer{}
-	err = astprinter.PrintIndent(&s.document, nil, []byte("  "), normalizedSchemaBuffer)
+	err = astprinter.PrintIndent(&s.document, nil, []byte("    "), normalizedSchemaBuffer)
 	if err != nil {
 		return NormalizationResult{
 			Successful: false,
@@ -416,7 +416,7 @@ func createSchema(schemaContent []byte, mergeWithBaseSchema bool) (*Schema, erro
 		}
 
 		rawSchemaBuffer := &bytes.Buffer{}
-		err = astprinter.PrintIndent(&document, nil, []byte("  "), rawSchemaBuffer)
+		err = astprinter.PrintIndent(&document, nil, []byte("    "), rawSchemaBuffer)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/graphql/schema_test.go
+++ b/pkg/graphql/schema_test.go
@@ -294,7 +294,7 @@ func TestSchema_Document(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedSchemaBytesBuffer := &bytes.Buffer{}
-	err = astprinter.PrintIndent(&document, nil, []byte("  "), expectedSchemaBytesBuffer)
+	err = astprinter.PrintIndent(&document, nil, []byte("    "), expectedSchemaBytesBuffer)
 	require.NoError(t, err)
 
 	assert.Equal(t, expectedSchemaBytesBuffer.Bytes(), schema.Document())

--- a/pkg/internal/unsafeprinter/unsafeprinter.go
+++ b/pkg/internal/unsafeprinter/unsafeprinter.go
@@ -15,7 +15,7 @@ func Print(document, definition *ast.Document) string {
 }
 
 func PrettyPrint(document, definition *ast.Document) string {
-	str, err := astprinter.PrintStringIndent(document, definition, "  ")
+	str, err := astprinter.PrintStringIndent(document, definition, "    ")
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/introspection/converter_test.go
+++ b/pkg/introspection/converter_test.go
@@ -40,7 +40,7 @@ func TestJSONConverter_GraphQLDocument(t *testing.T) {
 	assert.NoError(t, err)
 
 	outWriter := &bytes.Buffer{}
-	err = astprinter.PrintIndent(doc, nil, []byte("  "), outWriter)
+	err = astprinter.PrintIndent(doc, nil, []byte("    "), outWriter)
 	require.NoError(t, err)
 
 	schemaOutputPretty := outWriter.Bytes()

--- a/v2/doc.go
+++ b/v2/doc.go
@@ -139,7 +139,7 @@ func ExamplePrintWithIndentation() {
 		panic(report.Error())
 	}
 
-	out, err := astprinter.PrintStringIndent(document, "  ")
+	out, err := astprinter.PrintStringIndent(document, "    ")
 	if err != nil {
 		panic(err)
 	}
@@ -300,7 +300,7 @@ func ExampleNormalizeDocument() {
 		panic(report.Error())
 	}
 
-	out, err := astprinter.PrintStringIndent(document, "  ")
+	out, err := astprinter.PrintStringIndent(document, "    ")
 	if err != nil {
 		panic(err)
 	}

--- a/v2/pkg/ast/ast_description.go
+++ b/v2/pkg/ast/ast_description.go
@@ -45,7 +45,6 @@ func (d *Document) PrintDescription(description Description, indent []byte, dept
 				skippedWhitespace += 1
 				continue
 			case runes.SPACE:
-				skippedWhitespace += 0.5
 				continue
 			}
 		}

--- a/v2/pkg/ast/ast_test.go
+++ b/v2/pkg/ast/ast_test.go
@@ -182,7 +182,7 @@ func TestCopying(t *testing.T) {
 		}
 	}
 
-	out, err := astprinter.PrintStringIndent(&doc, "  ")
+	out, err := astprinter.PrintStringIndent(&doc, "    ")
 
 	assert.NoError(t, err)
 

--- a/v2/pkg/astminify/minify.go
+++ b/v2/pkg/astminify/minify.go
@@ -117,7 +117,7 @@ func (m *Minifier) Minify(operation []byte, definition *ast.Document, options Mi
 		return
 	}
 	if options.Pretty {
-		p := astprinter.NewPrinter([]byte("  "))
+		p := astprinter.NewPrinter([]byte("    "))
 		return true, p.Print(m.out, out)
 	}
 	return true, k.printer.Print(m.out, out)

--- a/v2/pkg/astnormalization/astnormalization_test.go
+++ b/v2/pkg/astnormalization/astnormalization_test.go
@@ -443,7 +443,7 @@ func TestOperationNormalizer_NormalizeNamedOperation(t *testing.T) {
 		NormalizeNamedOperation(&operation, &definition, []byte("Items"), &report)
 		assert.False(t, report.HasErrors())
 
-		actual, _ := astprinter.PrintStringIndent(&operation, " ")
+		actual, _ := astprinter.PrintStringIndent(&operation, "  ")
 		assert.Equal(t, expectedQuery, actual)
 	})
 
@@ -752,7 +752,7 @@ func TestOperationNormalizer_NormalizeNamedOperation(t *testing.T) {
 		NormalizeNamedOperation(&operation, &definition, []byte("B"), &report)
 		assert.False(t, report.HasErrors())
 
-		actual, _ := astprinter.PrintStringIndent(&operation, " ")
+		actual, _ := astprinter.PrintStringIndent(&operation, "  ")
 		assert.Equal(t, expectedQuery, actual)
 
 		expectedVariables := ``

--- a/v2/pkg/astprinter/astprinter.go
+++ b/v2/pkg/astprinter/astprinter.go
@@ -19,6 +19,7 @@ func Print(document *ast.Document, out io.Writer) error {
 }
 
 // PrintIndent is the same as Print but accepts an additional indent parameter to set indentation.
+// Indent is written once for every depth level.
 func PrintIndent(document *ast.Document, indent []byte, out io.Writer) error {
 	printer := Printer{
 		indent: indent,
@@ -26,6 +27,7 @@ func PrintIndent(document *ast.Document, indent []byte, out io.Writer) error {
 	return printer.Print(document, out)
 }
 
+// PrintIndentDebug is the same as PrintIndent but calls the function for every field.
 func PrintIndentDebug(document *ast.Document, indent []byte, out io.Writer, callback ...func(fieldRef int, out io.Writer)) error {
 	var fieldCallback func(fieldRef int, out io.Writer)
 	if len(callback) > 0 {
@@ -128,12 +130,12 @@ func (p *printVisitor) indentationDepth() (depth int) {
 	case ast.NodeKindOperationDefinition,
 		ast.NodeKindFragmentDefinition:
 	default:
-		return 2
+		return 1
 	}
 
 	for i := range p.Ancestors {
 		if p.Ancestors[i].Kind == ast.NodeKindSelectionSet {
-			depth += 2
+			depth += 1
 		}
 	}
 

--- a/v2/pkg/astprinter/astprinter_test.go
+++ b/v2/pkg/astprinter/astprinter_test.go
@@ -33,7 +33,7 @@ func runWithIndent(t *testing.T, raw string, expected string, indent bool) {
 	printer := Printer{}
 
 	if indent {
-		printer.indent = []byte("  ")
+		printer.indent = []byte("    ")
 	}
 
 	must(t, printer.Print(&doc, buff))
@@ -685,7 +685,7 @@ func TestPrintSchemaDefinition(t *testing.T) {
 	doc := unsafeparser.ParseGraphqlDocumentFile("./testdata/starwars.schema.graphql")
 
 	buff := bytes.Buffer{}
-	err := PrintIndent(&doc, []byte("  "), &buff)
+	err := PrintIndent(&doc, []byte("    "), &buff)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -708,7 +708,7 @@ func TestPrintOperationDefinition(t *testing.T) {
 	operation := unsafeparser.ParseGraphqlDocumentFile("./testdata/introspectionquery.graphql")
 
 	buff := bytes.Buffer{}
-	err := PrintIndent(&operation, []byte("  "), &buff)
+	err := PrintIndent(&operation, []byte("    "), &buff)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/v2/pkg/asttransform/baseschema_test.go
+++ b/v2/pkg/asttransform/baseschema_test.go
@@ -21,7 +21,7 @@ func runTestMerge(definition, fixtureName string) func(t *testing.T) {
 			panic(err)
 		}
 		buf := bytes.Buffer{}
-		err = astprinter.PrintIndent(&doc, []byte("  "), &buf)
+		err = astprinter.PrintIndent(&doc, []byte("    "), &buf)
 		if err != nil {
 			panic(err)
 		}

--- a/v2/pkg/astvalidation/reference/testsgo/harness_test.go
+++ b/v2/pkg/astvalidation/reference/testsgo/harness_test.go
@@ -248,7 +248,7 @@ func ExtendSchema(schema string, sdlStr string) string {
 	report := operationreport.Report{}
 	parser.Parse(&definition, &report)
 
-	res, _ := astprinter.PrintStringIndent(&definition, "  ")
+	res, _ := astprinter.PrintStringIndent(&definition, "    ")
 
 	return res
 }

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
@@ -1316,7 +1316,7 @@ func (p *Planner[T]) debugPrintQueryPlan(operation *ast.Document) {
 		return
 	}
 
-	printedOperation, err := astprinter.PrintStringIndent(operation, "  ")
+	printedOperation, err := astprinter.PrintStringIndent(operation, "    ")
 	if err != nil {
 		p.stopWithError(errors.WithStack(fmt.Errorf("debugPrintQueryPlan: failed to print operation: %w", err)))
 		return
@@ -1343,7 +1343,7 @@ func (p *Planner[T]) debugPrintQueryPlan(operation *ast.Document) {
 			if report.HasErrors() {
 				continue
 			}
-			printedKey, err := astprinter.PrintStringIndent(key, "  ")
+			printedKey, err := astprinter.PrintStringIndent(key, "    ")
 			if err != nil {
 				p.stopWithError(errors.WithStack(fmt.Errorf("debugPrintQueryPlan: failed to print fragment for required fields: %w", err)))
 				return
@@ -1363,7 +1363,7 @@ func (p *Planner[T]) generateQueryPlansForFetchConfiguration(operation *ast.Docu
 	if !p.includeQueryPlanInFetchConfiguration {
 		return
 	}
-	query, err := astprinter.PrintStringIndent(operation, "  ")
+	query, err := astprinter.PrintStringIndent(operation, "    ")
 	if err != nil {
 		p.stopWithError(errors.WithStack(fmt.Errorf("generateQueryPlansForFetchConfiguration: failed to print operation: %w", err)))
 		return
@@ -1379,7 +1379,7 @@ func (p *Planner[T]) generateQueryPlansForFetchConfiguration(operation *ast.Docu
 				p.stopWithError(errors.WithStack(fmt.Errorf("generateQueryPlansForFetchConfiguration: failed to build fragment for required fields: %w", report)))
 				return
 			}
-			printedFragment, err := astprinter.PrintStringIndent(fragmentAst, "  ")
+			printedFragment, err := astprinter.PrintStringIndent(fragmentAst, "    ")
 			if err != nil {
 				p.stopWithError(errors.WithStack(fmt.Errorf("generateQueryPlansForFetchConfiguration: failed to print fragment for required fields: %w", err)))
 				return

--- a/v2/pkg/engine/plan/node_selection_builder.go
+++ b/v2/pkg/engine/plan/node_selection_builder.go
@@ -204,7 +204,7 @@ func (p *NodeSelectionBuilder) printOperation(operation *ast.Document) {
 			}
 		})
 	} else {
-		pp, _ = astprinter.PrintStringIndent(operation, "  ")
+		pp, _ = astprinter.PrintStringIndent(operation, "    ")
 	}
 
 	fmt.Println(pp)

--- a/v2/pkg/federation/schema.go
+++ b/v2/pkg/federation/schema.go
@@ -60,7 +60,7 @@ func (s *schemaBuilder) extendQueryTypeWithFederationFields(schema string, hasEn
 		name := doc.ObjectTypeDefinitionNameString(i)
 		if name == queryTypeName {
 			s.extendQueryType(doc, i, hasEntities)
-			out, err := astprinter.PrintStringIndent(doc, "  ")
+			out, err := astprinter.PrintStringIndent(doc, "    ")
 			if err != nil {
 				return schema
 			}

--- a/v2/pkg/internal/unsafeprinter/unsafeprinter.go
+++ b/v2/pkg/internal/unsafeprinter/unsafeprinter.go
@@ -15,7 +15,7 @@ func Print(document *ast.Document) string {
 }
 
 func PrettyPrint(document *ast.Document) string {
-	str, err := astprinter.PrintStringIndent(document, "  ")
+	str, err := astprinter.PrintStringIndent(document, "    ")
 	if err != nil {
 		panic(err)
 	}

--- a/v2/pkg/introspection/converter_test.go
+++ b/v2/pkg/introspection/converter_test.go
@@ -40,7 +40,7 @@ func TestJSONConverter_GraphQLDocument(t *testing.T) {
 	assert.NoError(t, err)
 
 	outWriter := &bytes.Buffer{}
-	err = astprinter.PrintIndent(doc, []byte("  "), outWriter)
+	err = astprinter.PrintIndent(doc, []byte("    "), outWriter)
 	require.NoError(t, err)
 
 	schemaOutputPretty := outWriter.Bytes()


### PR DESCRIPTION
For v1 and v2 this fixes the default behaviour of the PrintIndent and
PrintStringIndent functions of astprinter. Instead of printing indent
twice for every depth level, it prints it once per level.

The fix does not alter output for other parts, golden tests
are intact. Tests were modified by passing correctly sized indent.

Fixes #405
