### PR TITLE
Fix parser panic on malformed union

### DIFF
--- a/v2/pkg/astparser/parser_test.go
+++ b/v2/pkg/astparser/parser_test.go
@@ -2611,6 +2611,22 @@ func TestParseTodo(t *testing.T) {
 	_ = doc
 }
 
+func TestParseUnionWithUnclosedBlockString(t *testing.T) {
+	t.Run("just block string", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			_, report := ParseGraphqlDocumentString("union\"\"\"")
+			require.True(t, report.HasErrors())
+		})
+	})
+
+	t.Run("block string with content", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			_, report := ParseGraphqlDocumentString("union\"\"\"foo")
+			require.True(t, report.HasErrors())
+		})
+	})
+}
+
 func BenchmarkParseStarwars(b *testing.B) {
 
 	inputFileName := "./testdata/starwars.schema.graphql"

--- a/v2/pkg/lexer/lexer.go
+++ b/v2/pkg/lexer/lexer.go
@@ -352,6 +352,9 @@ func (l *Lexer) readBlockString(tok *token.Token) {
 			quoteCount = 0
 			whitespaceCount++
 		case runes.EOF:
+			tok.SetEnd(l.input.InputPosition, l.input.TextPosition)
+			tok.Literal.Start += uint32(leadingWhitespaceToken)
+			tok.Literal.End -= uint32(whitespaceCount)
 			return
 		case runes.QUOTE:
 			if escaped {


### PR DESCRIPTION
## Summary
- handle EOF while scanning block strings so the lexer records a valid span
- add regression tests covering malformed union inputs containing unterminated block strings

## Testing
- `go test ./...` *(fails: no network access)*