### PR TITLE
feat: use new negation regex matching for matching connections

### DIFF
--- a/v2/pkg/engine/datasource/graphql_datasource/configuration.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/configuration.go
@@ -3,13 +3,14 @@ package graphql_datasource
 import (
 	"errors"
 	"fmt"
+	"net/http"
+
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/astparser"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/asttransform"
 	grpcdatasource "github.com/wundergraph/graphql-go-tools/v2/pkg/engine/datasource/grpc_datasource"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/federation"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/operationreport"
-	"net/http"
 )
 
 type ConfigurationInput struct {

--- a/v2/pkg/engine/datasource/graphql_datasource/configuration.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/configuration.go
@@ -3,15 +3,13 @@ package graphql_datasource
 import (
 	"errors"
 	"fmt"
-	"net/http"
-	"regexp"
-
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/astparser"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/asttransform"
 	grpcdatasource "github.com/wundergraph/graphql-go-tools/v2/pkg/engine/datasource/grpc_datasource"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/federation"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/operationreport"
+	"net/http"
 )
 
 type ConfigurationInput struct {
@@ -118,7 +116,7 @@ type SubscriptionConfiguration struct {
 	// name might be forwarded from the client to the upstream server. This is used to determine
 	// which connections can be multiplexed together, but the subscription engine does not forward
 	// these headers by itself.
-	ForwardedClientHeaderRegularExpressions []*regexp.Regexp
+	ForwardedClientHeaderRegularExpressions []RegularExpression
 	WsSubProtocol                           string
 }
 

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
@@ -1905,15 +1905,15 @@ type GraphQLSubscriptionClient interface {
 }
 
 type GraphQLSubscriptionOptions struct {
-	URL                                     string           `json:"url"`
-	InitialPayload                          json.RawMessage  `json:"initial_payload"`
-	Body                                    GraphQLBody      `json:"body"`
-	Header                                  http.Header      `json:"header"`
-	UseSSE                                  bool             `json:"use_sse"`
-	SSEMethodPost                           bool             `json:"sse_method_post"`
-	ForwardedClientHeaderNames              []string         `json:"forwarded_client_header_names"`
-	ForwardedClientHeaderRegularExpressions []*regexp.Regexp `json:"forwarded_client_header_regular_expressions"`
-	WsSubProtocol                           string           `json:"ws_sub_protocol"`
+	URL                                     string              `json:"url"`
+	InitialPayload                          json.RawMessage     `json:"initial_payload"`
+	Body                                    GraphQLBody         `json:"body"`
+	Header                                  http.Header         `json:"header"`
+	UseSSE                                  bool                `json:"use_sse"`
+	SSEMethodPost                           bool                `json:"sse_method_post"`
+	ForwardedClientHeaderNames              []string            `json:"forwarded_client_header_names"`
+	ForwardedClientHeaderRegularExpressions []RegularExpression `json:"forwarded_client_header_regular_expressions"`
+	WsSubProtocol                           string              `json:"ws_sub_protocol"`
 	readTimeout                             time.Duration
 	pingInterval                            time.Duration
 	pingTimeout                             time.Duration
@@ -1924,6 +1924,11 @@ type GraphQLBody struct {
 	OperationName string          `json:"operationName,omitempty"`
 	Variables     json.RawMessage `json:"variables,omitempty"`
 	Extensions    json.RawMessage `json:"extensions,omitempty"`
+}
+
+type RegularExpression struct {
+	Pattern     *regexp.Regexp
+	NegateMatch bool
 }
 
 type SubscriptionSource struct {

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
@@ -427,11 +427,15 @@ func (c *subscriptionClient) requestHash(ctx *resolve.Context, options GraphQLSu
 		}
 	}
 	for _, headerRegexp := range options.ForwardedClientHeaderRegularExpressions {
-		if _, err = xxh.WriteString(headerRegexp.String()); err != nil {
+		if _, err = xxh.WriteString(headerRegexp.Pattern.String()); err != nil {
 			return err
 		}
 		for headerName, values := range ctx.Request.Header {
-			if headerRegexp.MatchString(headerName) {
+			result := headerRegexp.Pattern.MatchString(headerName)
+			if headerRegexp.NegateMatch {
+				result = !result
+			}
+			if result {
 				for _, val := range values {
 					if _, err = xxh.WriteString(val); err != nil {
 						return err

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/buger/jsonparser"
+	"github.com/cespare/xxhash/v2"
 	"github.com/coder/websocket"
 	ll "github.com/jensneuse/abstractlogger"
 	"github.com/stretchr/testify/assert"
@@ -2340,4 +2342,173 @@ func TestClientClosesConnectionOnPingTimeout(t *testing.T) {
 	client.Unsubscribe(subscriptionID)
 	clientCancel() // Cancel client context
 	serverCancel() // Cancel server context (though serverDone should ensure it exited)
+}
+
+func TestRequestHash(t *testing.T) {
+	t.Parallel()
+	client := &subscriptionClient{}
+
+	t.Run("basic request with URL and headers", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := &resolve.Context{
+			Request: resolve.Request{
+				Header: http.Header{},
+			},
+		}
+		options := GraphQLSubscriptionOptions{
+			URL: "http://example.com/graphql",
+			Header: http.Header{
+				"Authorization": []string{"Bearer token"},
+			},
+		}
+		hash := xxhash.New()
+
+		err := client.requestHash(ctx, options, hash)
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(0xacbca06c541c2a79), hash.Sum64())
+	})
+
+	t.Run("request with forwarded client headers", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := &resolve.Context{
+			Request: resolve.Request{
+				Header: http.Header{
+					"X-User-Id": []string{"123"},
+					"X-Role":    []string{"admin"},
+				},
+			},
+		}
+		options := GraphQLSubscriptionOptions{
+			URL:                        "http://example.com/graphql",
+			ForwardedClientHeaderNames: []string{"X-User-Id", "X-Role"},
+		}
+		hash := xxhash.New()
+
+		err := client.requestHash(ctx, options, hash)
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(0xf428bef25952044c), hash.Sum64())
+	})
+
+	t.Run("request with forwarded client header regex patterns", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("with normal", func(t *testing.T) {
+			header := http.Header{
+				"X-Custom-1":  []string{"value1"},
+				"X-There-2":   []string{"value2"},
+				"X-Alright-3": []string{"value3"},
+			}
+			ctx := &resolve.Context{
+				Request: resolve.Request{
+					Header: header,
+				},
+			}
+			options := GraphQLSubscriptionOptions{
+				URL: "http://example.com/graphql",
+				ForwardedClientHeaderRegularExpressions: []RegularExpression{
+					{
+						Pattern:     regexp.MustCompile("^X-Custom-.*$"),
+						NegateMatch: false,
+					},
+				},
+			}
+			hash := xxhash.New()
+
+			err := client.requestHash(ctx, options, hash)
+			assert.NoError(t, err)
+			assert.Equal(t, uint64(0xa06f8622f14e1bf7), hash.Sum64())
+		})
+
+		t.Run("with negative", func(t *testing.T) {
+			t.Parallel()
+
+			ctx := &resolve.Context{
+				Request: resolve.Request{
+					Header: http.Header{
+						"X-Custom-1": []string{"valueThere1"},
+						"X-Custom-2": []string{"valueThere2"},
+					},
+				},
+			}
+			options := GraphQLSubscriptionOptions{
+				URL: "http://example.com/graphql",
+				ForwardedClientHeaderRegularExpressions: []RegularExpression{
+					{
+						Pattern:     regexp.MustCompile("^X-Custom-2"),
+						NegateMatch: true,
+					},
+				},
+			}
+			hash := xxhash.New()
+
+			err := client.requestHash(ctx, options, hash)
+			assert.NoError(t, err)
+			assert.Equal(t, uint64(0x2b166b89e3626dba), hash.Sum64())
+		})
+	})
+
+	t.Run("request with initial payload", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := &resolve.Context{
+			Request: resolve.Request{
+				Header: http.Header{},
+			},
+			InitialPayload: []byte(`{"auth": "token"}`),
+		}
+		options := GraphQLSubscriptionOptions{
+			URL: "http://example.com/graphql",
+		}
+		hash := xxhash.New()
+
+		err := client.requestHash(ctx, options, hash)
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(0x3c5af329478bfcce), hash.Sum64())
+
+	})
+
+	t.Run("request with body components", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := &resolve.Context{
+			Request: resolve.Request{
+				Header: http.Header{},
+			},
+		}
+		options := GraphQLSubscriptionOptions{
+			URL: "http://example.com/graphql",
+			Body: GraphQLBody{
+				Query:         "query { hello }",
+				Variables:     []byte(`{"var": "value"}`),
+				OperationName: "HelloQuery",
+				Extensions:    []byte(`{"ext": "value"}`),
+			},
+		}
+		hash := xxhash.New()
+
+		err := client.requestHash(ctx, options, hash)
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(0xd8d5588c8a466cf2), hash.Sum64())
+	})
+
+	t.Run("empty components", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := &resolve.Context{
+			Request: resolve.Request{
+				Header: http.Header{},
+			},
+		}
+		options := GraphQLSubscriptionOptions{
+			URL: "http://example.com/graphql",
+		}
+		hash := xxhash.New()
+
+		err := client.requestHash(ctx, options, hash)
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(0x767db2231989769), hash.Sum64())
+	})
+
 }


### PR DESCRIPTION
In the router we use negation in regex expression matching via a negation flag, since we also use this logic when creating connections, and we need to assign connections correctly, we apply this logic in the engine.

**Tests**
Add unit tests for checking the hash. There used to be tests that tests if a connection is reused, but it has been removed with certain changes. I would need more time to go through the engine to figure out how to restructure the tests (and why they were removed in the first place) https://github.com/wundergraph/graphql-go-tools/commit/3ec0ebef5a8ab6133b411ab009fe8da289701c5f#diff-2a8da55a93918e23bbe398ea85eb27a43292dd9cc3090eea26264094dc28931bL355-L365