### PR TITLE
feat: improve apollo gateway compatible field selection validation

### DIFF
--- a/execution/subscription/legacy_handler_test.go
+++ b/execution/subscription/legacy_handler_test.go
@@ -225,7 +225,7 @@ func TestHandler_Handle(t *testing.T) {
 				expectedErrorMessage := Message{
 					Id:      "1",
 					Type:    MessageTypeError,
-					Payload: []byte(`[{"message":"field: serverName not defined on type: Query","path":["query"]}]`),
+					Payload: []byte(`[{"message":"Cannot query field "age" on type "Query".","path":["query"]}]`),
 				}
 
 				messagesFromServer := client.readFromServer()

--- a/execution/subscription/legacy_handler_test.go
+++ b/execution/subscription/legacy_handler_test.go
@@ -225,7 +225,7 @@ func TestHandler_Handle(t *testing.T) {
 				expectedErrorMessage := Message{
 					Id:      "1",
 					Type:    MessageTypeError,
-					Payload: []byte(`[{"message":"Cannot query field "age" on type "Query".","path":["query"]}]`),
+					Payload: []byte(`[{"message":"Cannot query field \"serverName\" on type \"Query\".","path":["query"]}]`),
 				}
 
 				messagesFromServer := client.readFromServer()

--- a/v2/pkg/apollocompatibility/flags.go
+++ b/v2/pkg/apollocompatibility/flags.go
@@ -1,8 +1,8 @@
 package apollocompatibility
 
 type Flags struct {
-	ReplaceInvalidVarError       bool
-	ReplaceUndefinedOpFieldError bool
+	ReplaceInvalidVarError     bool
+	UseGraphQLValidationErrors bool
 }
 
 type ApolloRouterFlags struct {

--- a/v2/pkg/apollocompatibility/flags.go
+++ b/v2/pkg/apollocompatibility/flags.go
@@ -1,8 +1,8 @@
 package apollocompatibility
 
 type Flags struct {
-	ReplaceInvalidVarError     bool
-	UseGraphQLValidationErrors bool
+	ReplaceInvalidVarError       bool
+	UseValidationFailedExtension bool
 }
 
 type ApolloRouterFlags struct {

--- a/v2/pkg/apollocompatibility/flags.go
+++ b/v2/pkg/apollocompatibility/flags.go
@@ -1,8 +1,8 @@
 package apollocompatibility
 
 type Flags struct {
-	ReplaceInvalidVarError       bool
-	UseValidationFailedExtension bool
+	ReplaceInvalidVarError           bool
+	UseGraphQLValidationFailedStatus bool
 }
 
 type ApolloRouterFlags struct {

--- a/v2/pkg/astvalidation/operation_rule_fragments.go
+++ b/v2/pkg/astvalidation/operation_rule_fragments.go
@@ -92,11 +92,14 @@ func (f *fragmentsVisitor) EnterInlineFragment(ref int) {
 
 	if !f.definition.NodeFragmentIsAllowedOnNode(node, f.EnclosingTypeDefinition) {
 		enclosingTypeName := f.definition.NodeNameBytes(f.EnclosingTypeDefinition)
+
+		err := operationreport.ErrInlineFragmentOnTypeMismatchEnclosingType(typeName, enclosingTypeName)
 		if f.apolloCompatibilityFlags.UseGraphQLValidationErrors {
-			f.StopWithExternalErr(operationreport.ErrApolloCompatibleInlineFragmentOnTypeMismatchEnclosingType(typeName, enclosingTypeName))
-		} else {
-			f.StopWithExternalErr(operationreport.ErrInlineFragmentOnTypeMismatchEnclosingType(typeName, enclosingTypeName))
+			err = operationreport.ApolloGraphQLValidationError(err)
 		}
+
+		f.StopWithExternalErr(err)
+
 		return
 	}
 }

--- a/v2/pkg/astvalidation/operation_rule_validate_field_selections.go
+++ b/v2/pkg/astvalidation/operation_rule_validate_field_selections.go
@@ -58,7 +58,7 @@ func (f *fieldDefined) ValidateInterfaceOrObjectTypeField(ref int, enclosingType
 		definitionTypeRef := f.definition.FieldDefinitionType(i)
 
 		buf := bytes.Buffer{}
-		f.definition.PrintType(definitionTypeRef, &buf)
+		_ = f.definition.PrintType(definitionTypeRef, &buf)
 
 		definitionTypeName := buf.String()
 

--- a/v2/pkg/astvalidation/operation_rule_validate_field_selections.go
+++ b/v2/pkg/astvalidation/operation_rule_validate_field_selections.go
@@ -63,11 +63,16 @@ func (f *fieldDefined) ValidateInterfaceOrObjectTypeField(ref int, enclosingType
 			fieldDefinitionTypeKind := f.definition.FieldDefinitionTypeNode(i).Kind
 
 			if hasSelections && (fieldDefinitionTypeKind == ast.NodeKindEnumTypeDefinition || fieldDefinitionTypeKind == ast.NodeKindScalarTypeDefinition) {
-				f.StopWithExternalErr(operationreport.ErrFieldSelectionOnLeaf(definitionName, definitionTypeName))
+				// For field selection errors, use the position of the selection set's opening brace
+				position := f.operation.SelectionSets[f.operation.Fields[ref].SelectionSet].LBrace
+				f.StopWithExternalErr(operationreport.ErrFieldSelectionOnLeaf(definitionName, definitionTypeName, position))
 			}
 
 			if !hasSelections && (fieldDefinitionTypeKind != ast.NodeKindScalarTypeDefinition && fieldDefinitionTypeKind != ast.NodeKindEnumTypeDefinition) {
-				f.StopWithExternalErr(operationreport.ErrMissingFieldSelectionOnNonScalar(fieldName, definitionTypeName))
+				// Get the position of the field in the operation
+				position := f.operation.Fields[ref].Position
+
+				f.StopWithExternalErr(operationreport.ErrMissingFieldSelectionOnNonScalar(fieldName, definitionTypeName, position))
 			}
 
 			return

--- a/v2/pkg/astvalidation/operation_rule_validate_field_selections.go
+++ b/v2/pkg/astvalidation/operation_rule_validate_field_selections.go
@@ -53,26 +53,22 @@ func (f *fieldDefined) ValidateInterfaceOrObjectTypeField(ref int, enclosingType
 		definitionName := f.definition.FieldDefinitionNameBytes(i)
 		definitionTypeRef := f.definition.FieldDefinitionType(i)
 
-		buf := bytes.Buffer{}
-		_ = f.definition.PrintType(definitionTypeRef, &buf)
-
-		definitionTypeName := buf.String()
-
 		if bytes.Equal(fieldName, definitionName) {
 			// field is defined
 			fieldDefinitionTypeKind := f.definition.FieldDefinitionTypeNode(i).Kind
+			definitionTypeName, _ := f.definition.PrintTypeBytes(definitionTypeRef, nil)
 
 			if hasSelections && (fieldDefinitionTypeKind == ast.NodeKindEnumTypeDefinition || fieldDefinitionTypeKind == ast.NodeKindScalarTypeDefinition) {
 				// For field selection errors, use the position of the selection set's opening brace
 				position := f.operation.SelectionSets[f.operation.Fields[ref].SelectionSet].LBrace
-				f.StopWithExternalErr(operationreport.ErrFieldSelectionOnLeaf(definitionName, definitionTypeName, position))
+				f.StopWithExternalErr(operationreport.ErrFieldSelectionOnLeaf(definitionName, string(definitionTypeName), position))
 			}
 
 			if !hasSelections && (fieldDefinitionTypeKind != ast.NodeKindScalarTypeDefinition && fieldDefinitionTypeKind != ast.NodeKindEnumTypeDefinition) {
 				// Get the position of the field in the operation
 				position := f.operation.Fields[ref].Position
 
-				f.StopWithExternalErr(operationreport.ErrMissingFieldSelectionOnNonScalar(fieldName, definitionTypeName, position))
+				f.StopWithExternalErr(operationreport.ErrMissingFieldSelectionOnNonScalar(fieldName, string(definitionTypeName), position))
 			}
 
 			return

--- a/v2/pkg/astvalidation/operation_validation.go
+++ b/v2/pkg/astvalidation/operation_validation.go
@@ -33,12 +33,10 @@ func DefaultOperationValidator(options ...Option) *OperationValidator {
 		walker: astvisitor.NewWalker(48),
 	}
 
-	if opts.ApolloCompatibilityFlags.UseGraphQLValidationErrors {
+	if opts.ApolloCompatibilityFlags.UseValidationFailedExtension {
 		validator.walker.OnExternalError = func(err *operationreport.ExternalError) {
-			if opts.ApolloCompatibilityFlags.UseGraphQLValidationErrors {
-				err.ExtensionCode = errorcodes.GraphQLValidationFailed
-				err.StatusCode = http.StatusBadRequest
-			}
+			err.ExtensionCode = errorcodes.GraphQLValidationFailed
+			err.StatusCode = http.StatusBadRequest
 		}
 	}
 

--- a/v2/pkg/astvalidation/operation_validation.go
+++ b/v2/pkg/astvalidation/operation_validation.go
@@ -33,7 +33,7 @@ func DefaultOperationValidator(options ...Option) *OperationValidator {
 		walker: astvisitor.NewWalker(48),
 	}
 
-	if opts.ApolloCompatibilityFlags.UseValidationFailedExtension {
+	if opts.ApolloCompatibilityFlags.UseGraphQLValidationFailedStatus {
 		validator.walker.OnExternalError = func(err *operationreport.ExternalError) {
 			err.ExtensionCode = errorcodes.GraphQLValidationFailed
 			err.StatusCode = http.StatusBadRequest

--- a/v2/pkg/astvalidation/operation_validation.go
+++ b/v2/pkg/astvalidation/operation_validation.go
@@ -42,7 +42,7 @@ func DefaultOperationValidator(options ...Option) *OperationValidator {
 	validator.RegisterRule(Values())
 	validator.RegisterRule(ArgumentUniqueness())
 	validator.RegisterRule(RequiredArguments())
-	validator.RegisterRule(Fragments())
+	validator.RegisterRule(Fragments(opts))
 	validator.RegisterRule(DirectivesAreDefined())
 	validator.RegisterRule(DirectivesAreInValidLocations())
 	validator.RegisterRule(VariableUniqueness())

--- a/v2/pkg/astvalidation/operation_validation_test.go
+++ b/v2/pkg/astvalidation/operation_validation_test.go
@@ -2426,7 +2426,7 @@ func TestExecutionValidation(t *testing.T) {
     									name
   									}
 								}`,
-						Fragments(), Valid)
+						Fragments(OperationValidatorOptions{}), Valid)
 				})
 				t.Run("127", func(t *testing.T) {
 					run(t, `	
@@ -2443,7 +2443,7 @@ func TestExecutionValidation(t *testing.T) {
     									name
   									}
 								}`,
-						Fragments(), Invalid)
+						Fragments(OperationValidatorOptions{}), Invalid)
 				})
 			})
 			t.Run("5.5.1.2 Fragment Spread Existence", func(t *testing.T) {
@@ -2468,13 +2468,13 @@ func TestExecutionValidation(t *testing.T) {
   								... @include(if: true) {
     								name
   								}
-							}`, Fragments(), Valid)
+							}`, Fragments(OperationValidatorOptions{}), Valid)
 				})
 				t.Run("129", func(t *testing.T) {
 					run(t, `	
 								fragment notOnExistingType on NotInSchema {
   									name
-								}`, Fragments(), Invalid, withExpectNormalizationError())
+								}`, Fragments(OperationValidatorOptions{}), Invalid, withExpectNormalizationError())
 				})
 				t.Run("129", func(t *testing.T) {
 					run(t, `	
@@ -2482,7 +2482,7 @@ func TestExecutionValidation(t *testing.T) {
   									... on NotInSchema {
     									name
   									}
-								}`, Fragments(), Invalid, withExpectNormalizationError())
+								}`, Fragments(OperationValidatorOptions{}), Invalid, withExpectNormalizationError())
 				})
 			})
 			t.Run("5.5.1.3 Fragments on Composite Types", func(t *testing.T) {
@@ -2506,14 +2506,14 @@ func TestExecutionValidation(t *testing.T) {
 										name
 									}
 								}`,
-						Fragments(), Valid)
+						Fragments(OperationValidatorOptions{}), Valid)
 				})
 				t.Run("131", func(t *testing.T) {
 					run(t, `
 								fragment fragOnScalar on Int {
 									something
 								}`,
-						Fragments(), Invalid, withExpectNormalizationError())
+						Fragments(OperationValidatorOptions{}), Invalid, withExpectNormalizationError())
 				})
 				t.Run("131", func(t *testing.T) {
 					run(t, `
@@ -2522,7 +2522,7 @@ func TestExecutionValidation(t *testing.T) {
 										somethingElse
 									}
 								}`,
-						Fragments(), Invalid, withExpectNormalizationError())
+						Fragments(OperationValidatorOptions{}), Invalid, withExpectNormalizationError())
 				})
 			})
 			t.Run("5.5.1.4 Fragments must be used", func(t *testing.T) {
@@ -2545,7 +2545,7 @@ func TestExecutionValidation(t *testing.T) {
 										...nameFragment2
 									}
 								}`,
-						Fragments(), Invalid)
+						Fragments(OperationValidatorOptions{}), Invalid)
 				})
 				t.Run("132 variant", func(t *testing.T) {
 					run(t, `
@@ -2555,7 +2555,7 @@ func TestExecutionValidation(t *testing.T) {
 								{
 									...dogNames
 								}`,
-						Fragments(), Valid)
+						Fragments(OperationValidatorOptions{}), Valid)
 				})
 				t.Run("132 variant", func(t *testing.T) {
 					run(t, `
@@ -2565,7 +2565,7 @@ func TestExecutionValidation(t *testing.T) {
 								{
 									...dogNames
 								}`,
-						Fragments(), Invalid, withExpectNormalizationError())
+						Fragments(OperationValidatorOptions{}), Invalid, withExpectNormalizationError())
 				})
 				t.Run("132 variant", func(t *testing.T) {
 					run(t, `	fragment dogNames on Query {
@@ -2574,7 +2574,7 @@ func TestExecutionValidation(t *testing.T) {
 								{
 									... { ...dogNames }
 								}`,
-						Fragments(), Valid)
+						Fragments(OperationValidatorOptions{}), Valid)
 				})
 			})
 		})
@@ -2587,7 +2587,7 @@ func TestExecutionValidation(t *testing.T) {
 										...undefinedFragment
 									}
 								}`,
-						Fragments(), Invalid, withExpectNormalizationError(), withValidationErrors("undefinedFragment undefined"))
+						Fragments(OperationValidatorOptions{}), Invalid, withExpectNormalizationError(), withValidationErrors("undefinedFragment undefined"))
 				})
 				t.Run("Undefined fragment after valid fragment returns ErrFragmentUndefined", func(t *testing.T) {
 					run(t, `
@@ -2603,7 +2603,7 @@ func TestExecutionValidation(t *testing.T) {
 									name
 									meowVolume
 								}`,
-						Fragments(), Invalid, withExpectNormalizationError(), withValidationErrors("undefinedFragment undefined"))
+						Fragments(OperationValidatorOptions{}), Invalid, withExpectNormalizationError(), withValidationErrors("undefinedFragment undefined"))
 				})
 			})
 			t.Run("5.5.2.2 Fragment spreads must not form cycles", func(t *testing.T) {
@@ -2622,7 +2622,7 @@ func TestExecutionValidation(t *testing.T) {
 						barkVolume
 						...nameFragment
 					}`,
-						Fragments(), Invalid, withValidationErrors("external: fragment spread: nameFragment forms fragment cycle"), withDisableNormalization())
+						Fragments(OperationValidatorOptions{}), Invalid, withValidationErrors("external: fragment spread: nameFragment forms fragment cycle"), withDisableNormalization())
 				})
 				t.Run("136", func(t *testing.T) {
 					run(t, `
@@ -2643,7 +2643,7 @@ func TestExecutionValidation(t *testing.T) {
 										...dogFragment
 									}
 								}`,
-						Fragments(), Invalid, withExpectNormalizationError())
+						Fragments(OperationValidatorOptions{}), Invalid, withExpectNormalizationError())
 				})
 				t.Run("136 variant", func(t *testing.T) {
 					run(t, `
@@ -2664,7 +2664,7 @@ func TestExecutionValidation(t *testing.T) {
 										... { ...dogFragment }
 									}
 								}`,
-						Fragments(), Invalid, withExpectNormalizationError())
+						Fragments(OperationValidatorOptions{}), Invalid, withExpectNormalizationError())
 				})
 			})
 			t.Run("5.5.2.3 Fragment spread is possible", func(t *testing.T) {
@@ -2681,7 +2681,7 @@ func TestExecutionValidation(t *testing.T) {
 											barkVolume
 										}
 									}`,
-							Fragments(), Valid)
+							Fragments(OperationValidatorOptions{}), Valid)
 					})
 					t.Run("137 variant", func(t *testing.T) {
 						run(t, `
@@ -2695,7 +2695,7 @@ func TestExecutionValidation(t *testing.T) {
 											barkVolume
 										}
 									}`,
-							Fragments(), Invalid, withExpectNormalizationError())
+							Fragments(OperationValidatorOptions{}), Invalid, withExpectNormalizationError())
 					})
 					t.Run("138", func(t *testing.T) {
 						run(t, `
@@ -2709,7 +2709,7 @@ func TestExecutionValidation(t *testing.T) {
 											meowVolume
 										}
 									}`,
-							Fragments(), Invalid)
+							Fragments(OperationValidatorOptions{}), Invalid)
 					})
 					t.Run("138 variant", func(t *testing.T) {
 						run(t, `
@@ -2723,7 +2723,7 @@ func TestExecutionValidation(t *testing.T) {
 											meowVolume
 										}
 									}`,
-							Fragments(), Valid)
+							Fragments(OperationValidatorOptions{}), Valid)
 					})
 					t.Run("Spreading a fragment on an invalid type returns ErrInvalidFragmentSpread", func(t *testing.T) {
 						run(t, `
@@ -2735,7 +2735,7 @@ func TestExecutionValidation(t *testing.T) {
 									fragment invalidCatFragment on Cat {
 										meowVolume
 									}`,
-							Fragments(), Invalid, withValidationErrors("external: fragment spread: fragment invalidCatFragment must be spread on type Cat and not type Dog"))
+							Fragments(OperationValidatorOptions{}), Invalid, withValidationErrors("external: fragment spread: fragment invalidCatFragment must be spread on type Cat and not type Dog"))
 					})
 				})
 				t.Run("5.5.2.3.2 Abstract Spreads in Object Scope", func(t *testing.T) {
@@ -2749,7 +2749,7 @@ func TestExecutionValidation(t *testing.T) {
 											}
 										}
 									}`,
-							Fragments(), Valid)
+							Fragments(OperationValidatorOptions{}), Valid)
 					})
 					t.Run("140", func(t *testing.T) {
 						run(t, `
@@ -2758,7 +2758,7 @@ func TestExecutionValidation(t *testing.T) {
 											...on Dog { ...on CatOrDog { ...on Cat { meowVolume } } }
 										}
 									}`,
-							Fragments(), Valid)
+							Fragments(OperationValidatorOptions{}), Valid)
 					})
 				})
 				t.Run("5.5.2.3.3 Object Spreads In Abstract Scope", func(t *testing.T) {
@@ -2780,7 +2780,7 @@ func TestExecutionValidation(t *testing.T) {
 											meowVolume
 										}
 									}`,
-							Fragments(), Valid)
+							Fragments(OperationValidatorOptions{}), Valid)
 					})
 					t.Run("142", func(t *testing.T) {
 						run(t, ` fragment sentientFragment on Sentient {
@@ -2788,7 +2788,7 @@ func TestExecutionValidation(t *testing.T) {
 											barkVolume
 										}
 									}`,
-							Fragments(), Invalid)
+							Fragments(OperationValidatorOptions{}), Invalid)
 					})
 					t.Run("142 variant", func(t *testing.T) {
 						run(t, ` fragment humanOrAlienFragment on HumanOrAlien {
@@ -2796,7 +2796,7 @@ func TestExecutionValidation(t *testing.T) {
 											meowVolume
 										}
 									}`,
-							Fragments(), Invalid)
+							Fragments(OperationValidatorOptions{}), Invalid)
 					})
 				})
 				t.Run("5.5.2.3.4 Abstract Spreads in Abstract Scope", func(t *testing.T) {
@@ -2807,7 +2807,7 @@ func TestExecutionValidation(t *testing.T) {
 											...on Pet { ...on DogOrHuman { ...on Dog { barkVolume } } }
 										}
 									}`,
-							Fragments(), Valid)
+							Fragments(OperationValidatorOptions{}), Valid)
 					})
 					t.Run("143 variant", func(t *testing.T) {
 						run(t, `
@@ -2816,7 +2816,7 @@ func TestExecutionValidation(t *testing.T) {
 											...on DogOrHuman { ...on Pet { ...on Dog { barkVolume } } }
 										}
 									}`,
-							Fragments(), Valid)
+							Fragments(OperationValidatorOptions{}), Valid)
 					})
 					t.Run("144", func(t *testing.T) {
 						run(t, `
@@ -2831,7 +2831,7 @@ func TestExecutionValidation(t *testing.T) {
 									fragment sentientFragment on Sentient {
 										name
 									}`,
-							Fragments(), Invalid)
+							Fragments(OperationValidatorOptions{}), Invalid)
 					})
 					t.Run("interface into interface", func(t *testing.T) {
 						runWithDefinition(t,
@@ -2872,7 +2872,7 @@ func TestExecutionValidation(t *testing.T) {
 											}
 										}
 									}`,
-							Fragments(), Valid)
+							Fragments(OperationValidatorOptions{}), Valid)
 					})
 					t.Run("union into union", func(t *testing.T) {
 						runWithDefinition(t,
@@ -2912,7 +2912,7 @@ func TestExecutionValidation(t *testing.T) {
 											}
 										}
 									}`,
-							Fragments(), Valid)
+							Fragments(OperationValidatorOptions{}), Valid)
 					})
 				})
 			})
@@ -4700,37 +4700,33 @@ func TestValidateFieldSelection(t *testing.T) {
 		})
 
 		t.Run("with flag disabled, should return normal error ", func(t *testing.T) {
-			options := []Option{
-				WithApolloCompatibilityFlags(
-					apollocompatibility.Flags{
-						ReplaceUndefinedOpFieldError: false,
-					},
-				),
-			}
+			option := WithApolloCompatibilityFlags(
+				apollocompatibility.Flags{
+					UseGraphQLValidationErrors: false,
+				},
+			)
 
 			expectedError := operationreport.ExternalError{
 				Message: `field: age not defined on type: Query`,
 			}
 
-			assertOperationValidationErrorIs(t, op, doc, expectedError, options...)
+			assertOperationValidationErrorIs(t, op, doc, expectedError, option)
 		})
 
-		t.Run("with flag enabled, should return GRAPHQL_VALIDATION_FAILED", func(t *testing.T) {
-			options := []Option{
-				WithApolloCompatibilityFlags(
-					apollocompatibility.Flags{
-						ReplaceUndefinedOpFieldError: true,
-					},
-				),
-			}
+		t.Run("with flag enabled, should return apollo compatible error", func(t *testing.T) {
+			option := WithApolloCompatibilityFlags(
+				apollocompatibility.Flags{
+					UseGraphQLValidationErrors: true,
+				},
+			)
 
 			expectedError := operationreport.ExternalError{
 				ExtensionCode: errorcodes.GraphQLValidationFailed,
 				StatusCode:    http.StatusBadRequest,
-				Message:       `Cannot query "age" on type "Query".`,
+				Message:       `Cannot query field "age" on type "Query".`,
 			}
 
-			assertOperationValidationErrorIs(t, op, doc, expectedError, options...)
+			assertOperationValidationErrorIs(t, op, doc, expectedError, option)
 		})
 	})
 
@@ -4745,6 +4741,22 @@ func TestValidateFieldSelection(t *testing.T) {
 
 			assertOperationValidationErrorIs(t, op, doc, expectedError)
 		})
+
+		t.Run("with flag enabled, should return apollo compatible error", func(t *testing.T) {
+			option := WithApolloCompatibilityFlags(
+				apollocompatibility.Flags{
+					UseGraphQLValidationErrors: true,
+				},
+			)
+
+			expectedError := operationreport.ExternalError{
+				ExtensionCode: errorcodes.GraphQLValidationFailed,
+				StatusCode:    http.StatusBadRequest,
+				Message:       `Field "status" must not have a selection since type "Status!" has no subfields.`,
+			}
+
+			assertOperationValidationErrorIs(t, op, doc, expectedError, option)
+		})
 	})
 
 	t.Run("selecting on a scalar", func(t *testing.T) {
@@ -4758,6 +4770,80 @@ func TestValidateFieldSelection(t *testing.T) {
 
 			assertOperationValidationErrorIs(t, op, doc, expectedError)
 		})
+
+		t.Run("with flag enabled, should return apollo compatible error", func(t *testing.T) {
+			option := WithApolloCompatibilityFlags(
+				apollocompatibility.Flags{
+					UseGraphQLValidationErrors: true,
+				},
+			)
+
+			expectedError := operationreport.ExternalError{
+				ExtensionCode: errorcodes.GraphQLValidationFailed,
+				StatusCode:    http.StatusBadRequest,
+				Message:       `Field "name" must not have a selection since type "String!" has no subfields.`,
+			}
+
+			assertOperationValidationErrorIs(t, op, doc, expectedError, option)
+		})
+	})
+
+	t.Run("no subfield selection", func(t *testing.T) {
+		doc := unsafeparser.ParseGraphqlDocumentStringWithBaseSchema(`type Query { someType(id: ID!): SomeType! } type SomeType { id: ID! }`)
+		op := unsafeparser.ParseGraphqlDocumentString(`query { someType(id: "hi") }`)
+
+		t.Run("by default, should return normal error", func(t *testing.T) {
+			expectedError := operationreport.ExternalError{
+				Message: `non scalar field: someType on type: Query must have selections`,
+			}
+
+			assertOperationValidationErrorIs(t, op, doc, expectedError)
+		})
+
+		t.Run("with flag enabled, should return apollo compatible error", func(t *testing.T) {
+			option := WithApolloCompatibilityFlags(
+				apollocompatibility.Flags{
+					UseGraphQLValidationErrors: true,
+				},
+			)
+
+			expectedError := operationreport.ExternalError{
+				ExtensionCode: errorcodes.GraphQLValidationFailed,
+				StatusCode:    http.StatusBadRequest,
+				Message:       `Field "someType" of type "SomeType!" must have a selection of subfields. Did you mean "someType { ... }"?`,
+			}
+
+			assertOperationValidationErrorIs(t, op, doc, expectedError, option)
+		})
+	})
+
+	t.Run("non-existent field selection", func(t *testing.T) {
+		doc := unsafeparser.ParseGraphqlDocumentStringWithBaseSchema(`type Query { someType(id: ID!): SomeType! } type SomeType { id: ID! }`)
+		op := unsafeparser.ParseGraphqlDocumentString(`query { someType(id: "hi") { foo } }`)
+
+		t.Run("by default, should return normal error", func(t *testing.T) {
+			expectedError := operationreport.ExternalError{
+				Message: `field: foo not defined on type: SomeType`,
+			}
+
+			assertOperationValidationErrorIs(t, op, doc, expectedError)
+		})
+
+		t.Run("with flag enabled, should return apollo compatible error", func(t *testing.T) {
+			option := WithApolloCompatibilityFlags(
+				apollocompatibility.Flags{
+					UseGraphQLValidationErrors: true,
+				},
+			)
+
+			expectedError := operationreport.ExternalError{
+				ExtensionCode: errorcodes.GraphQLValidationFailed,
+				StatusCode:    http.StatusBadRequest,
+				Message:       `Cannot query field "foo" on type "SomeType".`,
+			}
+
+			assertOperationValidationErrorIs(t, op, doc, expectedError, option)
+		})
 	})
 
 	t.Run("invalid fragment spread", func(t *testing.T) {
@@ -4770,6 +4856,22 @@ func TestValidateFieldSelection(t *testing.T) {
 			}
 
 			assertOperationValidationErrorIs(t, op, doc, expectedError)
+		})
+
+		t.Run("with flag enabled, should return apollo compatible error", func(t *testing.T) {
+			option := WithApolloCompatibilityFlags(
+				apollocompatibility.Flags{
+					UseGraphQLValidationErrors: true,
+				},
+			)
+
+			expectedError := operationreport.ExternalError{
+				ExtensionCode: errorcodes.GraphQLValidationFailed,
+				StatusCode:    http.StatusBadRequest,
+				Message:       `Fragment cannot be spread here as objects of type "Query" can never be of type "SomeType".`,
+			}
+
+			assertOperationValidationErrorIs(t, op, doc, expectedError, option)
 		})
 	})
 }

--- a/v2/pkg/astvalidation/operation_validation_test.go
+++ b/v2/pkg/astvalidation/operation_validation_test.go
@@ -4713,7 +4713,7 @@ func TestValidateFieldSelection(t *testing.T) {
 			assertOperationValidationErrorIs(t, op, doc, expectedError, option)
 		})
 
-		t.Run("with flag enabled, should return apollo compatible error", func(t *testing.T) {
+		t.Run("with flag enabled, should have apollo extension and status", func(t *testing.T) {
 			option := WithApolloCompatibilityFlags(
 				apollocompatibility.Flags{
 					UseGraphQLValidationErrors: true,
@@ -4736,13 +4736,13 @@ func TestValidateFieldSelection(t *testing.T) {
 
 		t.Run("by default, should return normal error", func(t *testing.T) {
 			expectedError := operationreport.ExternalError{
-				Message: `cannot select field on enum status`,
+				Message: `Field "status" must not have a selection since type "Status!" has no subfields.`,
 			}
 
 			assertOperationValidationErrorIs(t, op, doc, expectedError)
 		})
 
-		t.Run("with flag enabled, should return apollo compatible error", func(t *testing.T) {
+		t.Run("with flag enabled, should have apollo extension and status", func(t *testing.T) {
 			option := WithApolloCompatibilityFlags(
 				apollocompatibility.Flags{
 					UseGraphQLValidationErrors: true,
@@ -4765,13 +4765,13 @@ func TestValidateFieldSelection(t *testing.T) {
 
 		t.Run("by default, should return normal error", func(t *testing.T) {
 			expectedError := operationreport.ExternalError{
-				Message: `cannot select field on scalar name`,
+				Message: `Field "name" must not have a selection since type "String!" has no subfields.`,
 			}
 
 			assertOperationValidationErrorIs(t, op, doc, expectedError)
 		})
 
-		t.Run("with flag enabled, should return apollo compatible error", func(t *testing.T) {
+		t.Run("with flag enabled, should have apollo extension and status", func(t *testing.T) {
 			option := WithApolloCompatibilityFlags(
 				apollocompatibility.Flags{
 					UseGraphQLValidationErrors: true,
@@ -4794,13 +4794,13 @@ func TestValidateFieldSelection(t *testing.T) {
 
 		t.Run("by default, should return normal error", func(t *testing.T) {
 			expectedError := operationreport.ExternalError{
-				Message: `non scalar field: someType on type: Query must have selections`,
+				Message: `Field "someType" of type "SomeType!" must have a selection of subfields. Did you mean "someType { ... }"?`,
 			}
 
 			assertOperationValidationErrorIs(t, op, doc, expectedError)
 		})
 
-		t.Run("with flag enabled, should return apollo compatible error", func(t *testing.T) {
+		t.Run("with flag enabled, should have apollo extension and status", func(t *testing.T) {
 			option := WithApolloCompatibilityFlags(
 				apollocompatibility.Flags{
 					UseGraphQLValidationErrors: true,
@@ -4829,7 +4829,7 @@ func TestValidateFieldSelection(t *testing.T) {
 			assertOperationValidationErrorIs(t, op, doc, expectedError)
 		})
 
-		t.Run("with flag enabled, should return apollo compatible error", func(t *testing.T) {
+		t.Run("with flag enabled, should have apollo extension and status", func(t *testing.T) {
 			option := WithApolloCompatibilityFlags(
 				apollocompatibility.Flags{
 					UseGraphQLValidationErrors: true,
@@ -4852,13 +4852,13 @@ func TestValidateFieldSelection(t *testing.T) {
 
 		t.Run("by default, should return normal error", func(t *testing.T) {
 			expectedError := operationreport.ExternalError{
-				Message: `inline fragment on type: SomeType mismatches enclosing type: Query`,
+				Message: `Fragment cannot be spread here as objects of type "Query" can never be of type "SomeType".`,
 			}
 
 			assertOperationValidationErrorIs(t, op, doc, expectedError)
 		})
 
-		t.Run("with flag enabled, should return apollo compatible error", func(t *testing.T) {
+		t.Run("with flag enabled, should have apollo extension and status", func(t *testing.T) {
 			option := WithApolloCompatibilityFlags(
 				apollocompatibility.Flags{
 					UseGraphQLValidationErrors: true,

--- a/v2/pkg/astvalidation/operation_validation_test.go
+++ b/v2/pkg/astvalidation/operation_validation_test.go
@@ -322,7 +322,7 @@ func TestExecutionValidation(t *testing.T) {
 							fragment aliasedLyingFieldTargetNotDefined on Dog {
 								barkVolume: kawVolume
 							}`,
-					FieldSelections(OperationValidatorOptions{}), Invalid, withExpectNormalizationError())
+					FieldSelections(), Invalid, withExpectNormalizationError())
 			})
 			t.Run("104 variant", func(t *testing.T) {
 				run(t, `
@@ -331,7 +331,7 @@ func TestExecutionValidation(t *testing.T) {
 									barkVolume: kawVolume
 								}
 							}`,
-					FieldSelections(OperationValidatorOptions{}), Invalid, withExpectNormalizationError())
+					FieldSelections(), Invalid, withExpectNormalizationError())
 			})
 			t.Run("103", func(t *testing.T) {
 				run(t, `	{
@@ -342,7 +342,7 @@ func TestExecutionValidation(t *testing.T) {
 							fragment interfaceFieldSelection on Pet {
 								name
 							}`,
-					FieldSelections(OperationValidatorOptions{}), Valid)
+					FieldSelections(), Valid)
 			})
 			t.Run("104", func(t *testing.T) {
 				run(t, `
@@ -354,7 +354,7 @@ func TestExecutionValidation(t *testing.T) {
 							fragment definedOnImplementorsButNotInterface on Pet {
 								nickname
 							}`,
-					FieldSelections(OperationValidatorOptions{}), Invalid, withExpectNormalizationError())
+					FieldSelections(), Invalid, withExpectNormalizationError())
 			})
 			t.Run("105", func(t *testing.T) {
 				run(t, `	fragment inDirectFieldSelectionOnUnion on CatOrDog {
@@ -366,7 +366,7 @@ func TestExecutionValidation(t *testing.T) {
 	    							name
 	  							}
 							}`,
-					FieldSelections(OperationValidatorOptions{}), Valid)
+					FieldSelections(), Valid)
 			})
 			t.Run("105 variant", func(t *testing.T) {
 				run(t, `
@@ -379,7 +379,7 @@ func TestExecutionValidation(t *testing.T) {
 	    							name
 	  							}
 							}`,
-					FieldSelections(OperationValidatorOptions{}), Valid)
+					FieldSelections(), Valid)
 			})
 			t.Run("105 variant", func(t *testing.T) {
 				run(t, `
@@ -392,7 +392,7 @@ func TestExecutionValidation(t *testing.T) {
 	    							x
 	  							}
 							}`,
-					FieldSelections(OperationValidatorOptions{}), Invalid, withExpectNormalizationError())
+					FieldSelections(), Invalid, withExpectNormalizationError())
 			})
 			t.Run("106", func(t *testing.T) {
 				run(t, `
@@ -400,7 +400,7 @@ func TestExecutionValidation(t *testing.T) {
 								name
 								barkVolume
 							}`,
-					FieldSelections(OperationValidatorOptions{}), Invalid, withExpectNormalizationError())
+					FieldSelections(), Invalid, withExpectNormalizationError())
 			})
 			t.Run("106 variant", func(t *testing.T) {
 				run(t, `
@@ -409,7 +409,7 @@ func TestExecutionValidation(t *testing.T) {
 									name
 								}
 							}`,
-					FieldSelections(OperationValidatorOptions{}), Invalid, withExpectNormalizationError())
+					FieldSelections(), Invalid, withExpectNormalizationError())
 			})
 		})
 		t.Run("5.3.2 Field Selection Merging", func(t *testing.T) {
@@ -2025,7 +2025,7 @@ func TestExecutionValidation(t *testing.T) {
 				run(t, `	fragment scalarSelection on Dog {
 								barkVolume
 							}`,
-					FieldSelections(OperationValidatorOptions{}), Valid)
+					FieldSelections(), Valid)
 			})
 			t.Run("114", func(t *testing.T) {
 				run(t, `
@@ -2034,32 +2034,32 @@ func TestExecutionValidation(t *testing.T) {
 									sinceWhen
 								}
 							}`,
-					FieldSelections(OperationValidatorOptions{}), Invalid, withExpectNormalizationError())
+					FieldSelections(), Invalid, withExpectNormalizationError())
 			})
 			t.Run("116", func(t *testing.T) {
 				run(t, `	
 							query directQueryOnObjectWithoutSubFields {
 								human
 							}`,
-					FieldSelections(OperationValidatorOptions{}), Invalid)
+					FieldSelections(), Invalid)
 				run(t, `	query directQueryOnInterfaceWithoutSubFields {
 								pet
 							}`,
-					FieldSelections(OperationValidatorOptions{}), Invalid)
+					FieldSelections(), Invalid)
 				run(t, `	query directQueryOnUnionWithoutSubFields {
 								catOrDog
 							}`,
-					FieldSelections(OperationValidatorOptions{}), Invalid)
+					FieldSelections(), Invalid)
 				run(t, `
 							mutation directQueryOnUnionWithoutSubFields {
 								catOrDog
 							}`,
-					FieldSelections(OperationValidatorOptions{}), Invalid, withExpectNormalizationError())
+					FieldSelections(), Invalid, withExpectNormalizationError())
 				run(t, `
 							subscription directQueryOnUnionWithoutSubFields {
 								catOrDog
 							}`,
-					FieldSelections(OperationValidatorOptions{}), Invalid, withExpectNormalizationError())
+					FieldSelections(), Invalid, withExpectNormalizationError())
 			})
 		})
 	})
@@ -2426,7 +2426,7 @@ func TestExecutionValidation(t *testing.T) {
     									name
   									}
 								}`,
-						Fragments(OperationValidatorOptions{}), Valid)
+						Fragments(), Valid)
 				})
 				t.Run("127", func(t *testing.T) {
 					run(t, `	
@@ -2443,7 +2443,7 @@ func TestExecutionValidation(t *testing.T) {
     									name
   									}
 								}`,
-						Fragments(OperationValidatorOptions{}), Invalid)
+						Fragments(), Invalid)
 				})
 			})
 			t.Run("5.5.1.2 Fragment Spread Existence", func(t *testing.T) {
@@ -2468,13 +2468,13 @@ func TestExecutionValidation(t *testing.T) {
   								... @include(if: true) {
     								name
   								}
-							}`, Fragments(OperationValidatorOptions{}), Valid)
+							}`, Fragments(), Valid)
 				})
 				t.Run("129", func(t *testing.T) {
 					run(t, `	
 								fragment notOnExistingType on NotInSchema {
   									name
-								}`, Fragments(OperationValidatorOptions{}), Invalid, withExpectNormalizationError())
+								}`, Fragments(), Invalid, withExpectNormalizationError())
 				})
 				t.Run("129", func(t *testing.T) {
 					run(t, `	
@@ -2482,7 +2482,7 @@ func TestExecutionValidation(t *testing.T) {
   									... on NotInSchema {
     									name
   									}
-								}`, Fragments(OperationValidatorOptions{}), Invalid, withExpectNormalizationError())
+								}`, Fragments(), Invalid, withExpectNormalizationError())
 				})
 			})
 			t.Run("5.5.1.3 Fragments on Composite Types", func(t *testing.T) {
@@ -2506,14 +2506,14 @@ func TestExecutionValidation(t *testing.T) {
 										name
 									}
 								}`,
-						Fragments(OperationValidatorOptions{}), Valid)
+						Fragments(), Valid)
 				})
 				t.Run("131", func(t *testing.T) {
 					run(t, `
 								fragment fragOnScalar on Int {
 									something
 								}`,
-						Fragments(OperationValidatorOptions{}), Invalid, withExpectNormalizationError())
+						Fragments(), Invalid, withExpectNormalizationError())
 				})
 				t.Run("131", func(t *testing.T) {
 					run(t, `
@@ -2522,7 +2522,7 @@ func TestExecutionValidation(t *testing.T) {
 										somethingElse
 									}
 								}`,
-						Fragments(OperationValidatorOptions{}), Invalid, withExpectNormalizationError())
+						Fragments(), Invalid, withExpectNormalizationError())
 				})
 			})
 			t.Run("5.5.1.4 Fragments must be used", func(t *testing.T) {
@@ -2545,7 +2545,7 @@ func TestExecutionValidation(t *testing.T) {
 										...nameFragment2
 									}
 								}`,
-						Fragments(OperationValidatorOptions{}), Invalid)
+						Fragments(), Invalid)
 				})
 				t.Run("132 variant", func(t *testing.T) {
 					run(t, `
@@ -2555,7 +2555,7 @@ func TestExecutionValidation(t *testing.T) {
 								{
 									...dogNames
 								}`,
-						Fragments(OperationValidatorOptions{}), Valid)
+						Fragments(), Valid)
 				})
 				t.Run("132 variant", func(t *testing.T) {
 					run(t, `
@@ -2565,7 +2565,7 @@ func TestExecutionValidation(t *testing.T) {
 								{
 									...dogNames
 								}`,
-						Fragments(OperationValidatorOptions{}), Invalid, withExpectNormalizationError())
+						Fragments(), Invalid, withExpectNormalizationError())
 				})
 				t.Run("132 variant", func(t *testing.T) {
 					run(t, `	fragment dogNames on Query {
@@ -2574,7 +2574,7 @@ func TestExecutionValidation(t *testing.T) {
 								{
 									... { ...dogNames }
 								}`,
-						Fragments(OperationValidatorOptions{}), Valid)
+						Fragments(), Valid)
 				})
 			})
 		})
@@ -2587,7 +2587,7 @@ func TestExecutionValidation(t *testing.T) {
 										...undefinedFragment
 									}
 								}`,
-						Fragments(OperationValidatorOptions{}), Invalid, withExpectNormalizationError(), withValidationErrors("undefinedFragment undefined"))
+						Fragments(), Invalid, withExpectNormalizationError(), withValidationErrors("undefinedFragment undefined"))
 				})
 				t.Run("Undefined fragment after valid fragment returns ErrFragmentUndefined", func(t *testing.T) {
 					run(t, `
@@ -2603,7 +2603,7 @@ func TestExecutionValidation(t *testing.T) {
 									name
 									meowVolume
 								}`,
-						Fragments(OperationValidatorOptions{}), Invalid, withExpectNormalizationError(), withValidationErrors("undefinedFragment undefined"))
+						Fragments(), Invalid, withExpectNormalizationError(), withValidationErrors("undefinedFragment undefined"))
 				})
 			})
 			t.Run("5.5.2.2 Fragment spreads must not form cycles", func(t *testing.T) {
@@ -2622,7 +2622,7 @@ func TestExecutionValidation(t *testing.T) {
 						barkVolume
 						...nameFragment
 					}`,
-						Fragments(OperationValidatorOptions{}), Invalid, withValidationErrors("external: fragment spread: nameFragment forms fragment cycle"), withDisableNormalization())
+						Fragments(), Invalid, withValidationErrors("external: fragment spread: nameFragment forms fragment cycle"), withDisableNormalization())
 				})
 				t.Run("136", func(t *testing.T) {
 					run(t, `
@@ -2643,7 +2643,7 @@ func TestExecutionValidation(t *testing.T) {
 										...dogFragment
 									}
 								}`,
-						Fragments(OperationValidatorOptions{}), Invalid, withExpectNormalizationError())
+						Fragments(), Invalid, withExpectNormalizationError())
 				})
 				t.Run("136 variant", func(t *testing.T) {
 					run(t, `
@@ -2664,7 +2664,7 @@ func TestExecutionValidation(t *testing.T) {
 										... { ...dogFragment }
 									}
 								}`,
-						Fragments(OperationValidatorOptions{}), Invalid, withExpectNormalizationError())
+						Fragments(), Invalid, withExpectNormalizationError())
 				})
 			})
 			t.Run("5.5.2.3 Fragment spread is possible", func(t *testing.T) {
@@ -2681,7 +2681,7 @@ func TestExecutionValidation(t *testing.T) {
 											barkVolume
 										}
 									}`,
-							Fragments(OperationValidatorOptions{}), Valid)
+							Fragments(), Valid)
 					})
 					t.Run("137 variant", func(t *testing.T) {
 						run(t, `
@@ -2695,7 +2695,7 @@ func TestExecutionValidation(t *testing.T) {
 											barkVolume
 										}
 									}`,
-							Fragments(OperationValidatorOptions{}), Invalid, withExpectNormalizationError())
+							Fragments(), Invalid, withExpectNormalizationError())
 					})
 					t.Run("138", func(t *testing.T) {
 						run(t, `
@@ -2709,7 +2709,7 @@ func TestExecutionValidation(t *testing.T) {
 											meowVolume
 										}
 									}`,
-							Fragments(OperationValidatorOptions{}), Invalid)
+							Fragments(), Invalid)
 					})
 					t.Run("138 variant", func(t *testing.T) {
 						run(t, `
@@ -2723,7 +2723,7 @@ func TestExecutionValidation(t *testing.T) {
 											meowVolume
 										}
 									}`,
-							Fragments(OperationValidatorOptions{}), Valid)
+							Fragments(), Valid)
 					})
 					t.Run("Spreading a fragment on an invalid type returns ErrInvalidFragmentSpread", func(t *testing.T) {
 						run(t, `
@@ -2735,7 +2735,7 @@ func TestExecutionValidation(t *testing.T) {
 									fragment invalidCatFragment on Cat {
 										meowVolume
 									}`,
-							Fragments(OperationValidatorOptions{}), Invalid, withValidationErrors("external: fragment spread: fragment invalidCatFragment must be spread on type Cat and not type Dog"))
+							Fragments(), Invalid, withValidationErrors("external: fragment spread: fragment invalidCatFragment must be spread on type Cat and not type Dog"))
 					})
 				})
 				t.Run("5.5.2.3.2 Abstract Spreads in Object Scope", func(t *testing.T) {
@@ -2749,7 +2749,7 @@ func TestExecutionValidation(t *testing.T) {
 											}
 										}
 									}`,
-							Fragments(OperationValidatorOptions{}), Valid)
+							Fragments(), Valid)
 					})
 					t.Run("140", func(t *testing.T) {
 						run(t, `
@@ -2758,7 +2758,7 @@ func TestExecutionValidation(t *testing.T) {
 											...on Dog { ...on CatOrDog { ...on Cat { meowVolume } } }
 										}
 									}`,
-							Fragments(OperationValidatorOptions{}), Valid)
+							Fragments(), Valid)
 					})
 				})
 				t.Run("5.5.2.3.3 Object Spreads In Abstract Scope", func(t *testing.T) {
@@ -2780,7 +2780,7 @@ func TestExecutionValidation(t *testing.T) {
 											meowVolume
 										}
 									}`,
-							Fragments(OperationValidatorOptions{}), Valid)
+							Fragments(), Valid)
 					})
 					t.Run("142", func(t *testing.T) {
 						run(t, ` fragment sentientFragment on Sentient {
@@ -2788,7 +2788,7 @@ func TestExecutionValidation(t *testing.T) {
 											barkVolume
 										}
 									}`,
-							Fragments(OperationValidatorOptions{}), Invalid)
+							Fragments(), Invalid)
 					})
 					t.Run("142 variant", func(t *testing.T) {
 						run(t, ` fragment humanOrAlienFragment on HumanOrAlien {
@@ -2796,7 +2796,7 @@ func TestExecutionValidation(t *testing.T) {
 											meowVolume
 										}
 									}`,
-							Fragments(OperationValidatorOptions{}), Invalid)
+							Fragments(), Invalid)
 					})
 				})
 				t.Run("5.5.2.3.4 Abstract Spreads in Abstract Scope", func(t *testing.T) {
@@ -2807,7 +2807,7 @@ func TestExecutionValidation(t *testing.T) {
 											...on Pet { ...on DogOrHuman { ...on Dog { barkVolume } } }
 										}
 									}`,
-							Fragments(OperationValidatorOptions{}), Valid)
+							Fragments(), Valid)
 					})
 					t.Run("143 variant", func(t *testing.T) {
 						run(t, `
@@ -2816,7 +2816,7 @@ func TestExecutionValidation(t *testing.T) {
 											...on DogOrHuman { ...on Pet { ...on Dog { barkVolume } } }
 										}
 									}`,
-							Fragments(OperationValidatorOptions{}), Valid)
+							Fragments(), Valid)
 					})
 					t.Run("144", func(t *testing.T) {
 						run(t, `
@@ -2831,7 +2831,7 @@ func TestExecutionValidation(t *testing.T) {
 									fragment sentientFragment on Sentient {
 										name
 									}`,
-							Fragments(OperationValidatorOptions{}), Invalid)
+							Fragments(), Invalid)
 					})
 					t.Run("interface into interface", func(t *testing.T) {
 						runWithDefinition(t,
@@ -2872,7 +2872,7 @@ func TestExecutionValidation(t *testing.T) {
 											}
 										}
 									}`,
-							Fragments(OperationValidatorOptions{}), Valid)
+							Fragments(), Valid)
 					})
 					t.Run("union into union", func(t *testing.T) {
 						runWithDefinition(t,
@@ -2912,7 +2912,7 @@ func TestExecutionValidation(t *testing.T) {
 											}
 										}
 									}`,
-							Fragments(OperationValidatorOptions{}), Valid)
+							Fragments(), Valid)
 					})
 				})
 			})
@@ -4695,7 +4695,7 @@ func TestValidateFieldSelection(t *testing.T) {
 
 		t.Run("by default, should return normal error", func(t *testing.T) {
 			assertOperationValidationErrorIs(t, op, doc, operationreport.ExternalError{
-				Message: `field: age not defined on type: Query`,
+				Message: `Cannot query field "age" on type "Query".`,
 			})
 		})
 
@@ -4707,7 +4707,7 @@ func TestValidateFieldSelection(t *testing.T) {
 			)
 
 			expectedError := operationreport.ExternalError{
-				Message: `field: age not defined on type: Query`,
+				Message: `Cannot query field "age" on type "Query".`,
 			}
 
 			assertOperationValidationErrorIs(t, op, doc, expectedError, option)
@@ -4823,7 +4823,7 @@ func TestValidateFieldSelection(t *testing.T) {
 
 		t.Run("by default, should return normal error", func(t *testing.T) {
 			expectedError := operationreport.ExternalError{
-				Message: `field: foo not defined on type: SomeType`,
+				Message: `Cannot query field "foo" on type "SomeType".`,
 			}
 
 			assertOperationValidationErrorIs(t, op, doc, expectedError)

--- a/v2/pkg/astvalidation/operation_validation_test.go
+++ b/v2/pkg/astvalidation/operation_validation_test.go
@@ -4702,7 +4702,7 @@ func TestValidateFieldSelection(t *testing.T) {
 		t.Run("with flag disabled, should return normal error ", func(t *testing.T) {
 			option := WithApolloCompatibilityFlags(
 				apollocompatibility.Flags{
-					UseValidationFailedExtension: false,
+					UseGraphQLValidationFailedStatus: false,
 				},
 			)
 
@@ -4716,7 +4716,7 @@ func TestValidateFieldSelection(t *testing.T) {
 		t.Run("with flag enabled, should have apollo extension and status", func(t *testing.T) {
 			option := WithApolloCompatibilityFlags(
 				apollocompatibility.Flags{
-					UseValidationFailedExtension: true,
+					UseGraphQLValidationFailedStatus: true,
 				},
 			)
 
@@ -4745,7 +4745,7 @@ func TestValidateFieldSelection(t *testing.T) {
 		t.Run("with flag enabled, should have apollo extension and status", func(t *testing.T) {
 			option := WithApolloCompatibilityFlags(
 				apollocompatibility.Flags{
-					UseValidationFailedExtension: true,
+					UseGraphQLValidationFailedStatus: true,
 				},
 			)
 
@@ -4774,7 +4774,7 @@ func TestValidateFieldSelection(t *testing.T) {
 		t.Run("with flag enabled, should have apollo extension and status", func(t *testing.T) {
 			option := WithApolloCompatibilityFlags(
 				apollocompatibility.Flags{
-					UseValidationFailedExtension: true,
+					UseGraphQLValidationFailedStatus: true,
 				},
 			)
 
@@ -4803,7 +4803,7 @@ func TestValidateFieldSelection(t *testing.T) {
 		t.Run("with flag enabled, should have apollo extension and status", func(t *testing.T) {
 			option := WithApolloCompatibilityFlags(
 				apollocompatibility.Flags{
-					UseValidationFailedExtension: true,
+					UseGraphQLValidationFailedStatus: true,
 				},
 			)
 
@@ -4832,7 +4832,7 @@ func TestValidateFieldSelection(t *testing.T) {
 		t.Run("with flag enabled, should have apollo extension and status", func(t *testing.T) {
 			option := WithApolloCompatibilityFlags(
 				apollocompatibility.Flags{
-					UseValidationFailedExtension: true,
+					UseGraphQLValidationFailedStatus: true,
 				},
 			)
 
@@ -4861,7 +4861,7 @@ func TestValidateFieldSelection(t *testing.T) {
 		t.Run("with flag enabled, should have apollo extension and status", func(t *testing.T) {
 			option := WithApolloCompatibilityFlags(
 				apollocompatibility.Flags{
-					UseValidationFailedExtension: true,
+					UseGraphQLValidationFailedStatus: true,
 				},
 			)
 

--- a/v2/pkg/astvalidation/operation_validation_test.go
+++ b/v2/pkg/astvalidation/operation_validation_test.go
@@ -4702,7 +4702,7 @@ func TestValidateFieldSelection(t *testing.T) {
 		t.Run("with flag disabled, should return normal error ", func(t *testing.T) {
 			option := WithApolloCompatibilityFlags(
 				apollocompatibility.Flags{
-					UseGraphQLValidationErrors: false,
+					UseValidationFailedExtension: false,
 				},
 			)
 
@@ -4716,7 +4716,7 @@ func TestValidateFieldSelection(t *testing.T) {
 		t.Run("with flag enabled, should have apollo extension and status", func(t *testing.T) {
 			option := WithApolloCompatibilityFlags(
 				apollocompatibility.Flags{
-					UseGraphQLValidationErrors: true,
+					UseValidationFailedExtension: true,
 				},
 			)
 
@@ -4745,7 +4745,7 @@ func TestValidateFieldSelection(t *testing.T) {
 		t.Run("with flag enabled, should have apollo extension and status", func(t *testing.T) {
 			option := WithApolloCompatibilityFlags(
 				apollocompatibility.Flags{
-					UseGraphQLValidationErrors: true,
+					UseValidationFailedExtension: true,
 				},
 			)
 
@@ -4774,7 +4774,7 @@ func TestValidateFieldSelection(t *testing.T) {
 		t.Run("with flag enabled, should have apollo extension and status", func(t *testing.T) {
 			option := WithApolloCompatibilityFlags(
 				apollocompatibility.Flags{
-					UseGraphQLValidationErrors: true,
+					UseValidationFailedExtension: true,
 				},
 			)
 
@@ -4803,7 +4803,7 @@ func TestValidateFieldSelection(t *testing.T) {
 		t.Run("with flag enabled, should have apollo extension and status", func(t *testing.T) {
 			option := WithApolloCompatibilityFlags(
 				apollocompatibility.Flags{
-					UseGraphQLValidationErrors: true,
+					UseValidationFailedExtension: true,
 				},
 			)
 
@@ -4832,7 +4832,7 @@ func TestValidateFieldSelection(t *testing.T) {
 		t.Run("with flag enabled, should have apollo extension and status", func(t *testing.T) {
 			option := WithApolloCompatibilityFlags(
 				apollocompatibility.Flags{
-					UseGraphQLValidationErrors: true,
+					UseValidationFailedExtension: true,
 				},
 			)
 
@@ -4861,7 +4861,7 @@ func TestValidateFieldSelection(t *testing.T) {
 		t.Run("with flag enabled, should have apollo extension and status", func(t *testing.T) {
 			option := WithApolloCompatibilityFlags(
 				apollocompatibility.Flags{
-					UseGraphQLValidationErrors: true,
+					UseValidationFailedExtension: true,
 				},
 			)
 

--- a/v2/pkg/astvalidation/reference/testsgo/ScalarLeafsRule_test.go
+++ b/v2/pkg/astvalidation/reference/testsgo/ScalarLeafsRule_test.go
@@ -5,8 +5,6 @@ import (
 )
 
 func TestScalarLeafsRule(t *testing.T) {
-	t.Skip()
-
 	ExpectErrors := func(t *testing.T, queryStr string) ResultCompare {
 		return ExpectValidationErrors(t, ScalarLeafsRule, queryStr)
 	}

--- a/v2/pkg/astvalidation/reference/testsgo/harness_test.go
+++ b/v2/pkg/astvalidation/reference/testsgo/harness_test.go
@@ -85,16 +85,16 @@ var rulesMap = map[string][]astvalidation.Rule{
 	UniqueVariableNamesRule:                   {astvalidation.VariableUniqueness()},
 	ValuesOfCorrectTypeRule:                   {astvalidation.Values()},
 	VariablesAreInputTypesRule:                {astvalidation.VariablesAreInputTypes()},
-	KnownTypeNamesOperationRule:               {astvalidation.VariablesAreInputTypes(), astvalidation.Fragments()},
+	KnownTypeNamesOperationRule:               {astvalidation.VariablesAreInputTypes(), astvalidation.Fragments(astvalidation.OperationValidatorOptions{})},
 	VariablesInAllowedPositionRule:            {astvalidation.Values()},
 
 	// fragments rules
-	FragmentsOnCompositeTypesRule: {astvalidation.Fragments()},
-	KnownFragmentNamesRule:        {astvalidation.Fragments()},
-	NoFragmentCyclesRule:          {astvalidation.Fragments()},
-	NoUnusedFragmentsRule:         {astvalidation.Fragments()},
-	PossibleFragmentSpreadsRule:   {astvalidation.Fragments()},
-	UniqueFragmentNamesRule:       {astvalidation.Fragments()},
+	FragmentsOnCompositeTypesRule: {astvalidation.Fragments(astvalidation.OperationValidatorOptions{})},
+	KnownFragmentNamesRule:        {astvalidation.Fragments(astvalidation.OperationValidatorOptions{})},
+	NoFragmentCyclesRule:          {astvalidation.Fragments(astvalidation.OperationValidatorOptions{})},
+	NoUnusedFragmentsRule:         {astvalidation.Fragments(astvalidation.OperationValidatorOptions{})},
+	PossibleFragmentSpreadsRule:   {astvalidation.Fragments(astvalidation.OperationValidatorOptions{})},
+	UniqueFragmentNamesRule:       {astvalidation.Fragments(astvalidation.OperationValidatorOptions{})},
 
 	// not mapped rules
 

--- a/v2/pkg/astvalidation/reference/testsgo/harness_test.go
+++ b/v2/pkg/astvalidation/reference/testsgo/harness_test.go
@@ -101,7 +101,7 @@ var rulesMap = map[string][]astvalidation.Rule{
 	UniqueInputFieldNamesRule:  {astvalidation.Values()},
 	UniqueDirectiveNamesRule:   {},
 	LoneSchemaDefinitionRule:   {},
-	ScalarLeafsRule:            {},
+	ScalarLeafsRule:            {astvalidation.FieldSelections()},
 	PossibleTypeExtensionsRule: {},
 }
 

--- a/v2/pkg/astvalidation/reference/testsgo/harness_test.go
+++ b/v2/pkg/astvalidation/reference/testsgo/harness_test.go
@@ -63,7 +63,7 @@ const (
 
 var rulesMap = map[string][]astvalidation.Rule{
 	ExecutableDefinitionsRule:                 {astvalidation.DocumentContainsExecutableOperation()},
-	FieldsOnCorrectTypeRule:                   {astvalidation.FieldSelections(astvalidation.OperationValidatorOptions{})},
+	FieldsOnCorrectTypeRule:                   {astvalidation.FieldSelections()},
 	KnownArgumentNamesRule:                    {astvalidation.KnownArguments()},
 	KnownArgumentNamesOnDirectivesRule:        {},
 	KnownDirectivesRule:                       {astvalidation.DirectivesAreDefined()},
@@ -85,16 +85,16 @@ var rulesMap = map[string][]astvalidation.Rule{
 	UniqueVariableNamesRule:                   {astvalidation.VariableUniqueness()},
 	ValuesOfCorrectTypeRule:                   {astvalidation.Values()},
 	VariablesAreInputTypesRule:                {astvalidation.VariablesAreInputTypes()},
-	KnownTypeNamesOperationRule:               {astvalidation.VariablesAreInputTypes(), astvalidation.Fragments(astvalidation.OperationValidatorOptions{})},
+	KnownTypeNamesOperationRule:               {astvalidation.VariablesAreInputTypes(), astvalidation.Fragments()},
 	VariablesInAllowedPositionRule:            {astvalidation.Values()},
 
 	// fragments rules
-	FragmentsOnCompositeTypesRule: {astvalidation.Fragments(astvalidation.OperationValidatorOptions{})},
-	KnownFragmentNamesRule:        {astvalidation.Fragments(astvalidation.OperationValidatorOptions{})},
-	NoFragmentCyclesRule:          {astvalidation.Fragments(astvalidation.OperationValidatorOptions{})},
-	NoUnusedFragmentsRule:         {astvalidation.Fragments(astvalidation.OperationValidatorOptions{})},
-	PossibleFragmentSpreadsRule:   {astvalidation.Fragments(astvalidation.OperationValidatorOptions{})},
-	UniqueFragmentNamesRule:       {astvalidation.Fragments(astvalidation.OperationValidatorOptions{})},
+	FragmentsOnCompositeTypesRule: {astvalidation.Fragments()},
+	KnownFragmentNamesRule:        {astvalidation.Fragments()},
+	NoFragmentCyclesRule:          {astvalidation.Fragments()},
+	NoUnusedFragmentsRule:         {astvalidation.Fragments()},
+	PossibleFragmentSpreadsRule:   {astvalidation.Fragments()},
+	UniqueFragmentNamesRule:       {astvalidation.Fragments()},
 
 	// not mapped rules
 

--- a/v2/pkg/astvisitor/visitor.go
+++ b/v2/pkg/astvisitor/visitor.go
@@ -92,6 +92,8 @@ type Walker struct {
 	revisit         bool
 	filter          VisitorFilter
 	deferred        []func()
+
+	OnExternalError func(err *operationreport.ExternalError)
 }
 
 // NewWalker returns a fully initialized Walker
@@ -3921,6 +3923,11 @@ func (w *Walker) HandleInternalErr(err error) bool {
 func (w *Walker) StopWithExternalErr(err operationreport.ExternalError) {
 	w.stop = true
 	err.Path = w.Path
+
+	if w.OnExternalError != nil {
+		w.OnExternalError(&err)
+	}
+
 	w.Report.AddExternalError(err)
 }
 

--- a/v2/pkg/engine/resolve/resolvable.go
+++ b/v2/pkg/engine/resolve/resolvable.go
@@ -61,11 +61,10 @@ type Resolvable struct {
 }
 
 type ResolvableOptions struct {
-	ApolloCompatibilityValueCompletionInExtensions  bool
-	ApolloCompatibilityTruncateFloatValues          bool
-	ApolloCompatibilitySuppressFetchErrors          bool
-	ApolloCompatibilityReplaceUndefinedOpFieldError bool
-	ApolloCompatibilityReplaceInvalidVarError       bool
+	ApolloCompatibilityValueCompletionInExtensions bool
+	ApolloCompatibilityTruncateFloatValues         bool
+	ApolloCompatibilitySuppressFetchErrors         bool
+	ApolloCompatibilityReplaceInvalidVarError      bool
 
 	ApolloRouterCompatibilitySubrequestHTTPError bool
 }

--- a/v2/pkg/operationreport/externalerror.go
+++ b/v2/pkg/operationreport/externalerror.go
@@ -60,7 +60,7 @@ func ErrFieldUndefinedOnType(fieldName, typeName ast.ByteSlice) (err ExternalErr
 }
 
 func ErrApolloCompatibleFieldUndefinedOnType(fieldName, typeName ast.ByteSlice) (err ExternalError) {
-	err.Message = fmt.Sprintf(`Cannot query "%s" on type "%s".`, fieldName, typeName)
+	err.Message = fmt.Sprintf(`Cannot query field "%s" on type "%s".`, fieldName, typeName)
 	err.ExtensionCode = errorcodes.GraphQLValidationFailed
 	err.StatusCode = http.StatusBadRequest
 	return err
@@ -172,13 +172,34 @@ func ErrFieldSelectionOnScalar(scalarTypeName ast.ByteSlice) (err ExternalError)
 	return err
 }
 
+func ErrApolloCompatibleFieldSelectionOnScalar(scalarTypeName, typeName ast.ByteSlice) (err ExternalError) {
+	err.Message = fmt.Sprintf(`Field "%s" must not have a selection since type "%s" has no subfields.`, scalarTypeName, typeName)
+	err.ExtensionCode = errorcodes.GraphQLValidationFailed
+	err.StatusCode = http.StatusBadRequest
+	return err
+}
+
 func ErrFieldSelectionOnEnum(enumTypeName ast.ByteSlice) (err ExternalError) {
 	err.Message = fmt.Sprintf("cannot select field on enum %s", enumTypeName)
 	return err
 }
 
+func ErrApolloCompatibleFieldSelectionOnEnum(enumTypeName, typeName ast.ByteSlice) (err ExternalError) {
+	err.Message = fmt.Sprintf(`Field "%s" must not have a selection since type "%s" has no subfields.`, enumTypeName, typeName)
+	err.ExtensionCode = errorcodes.GraphQLValidationFailed
+	err.StatusCode = http.StatusBadRequest
+	return err
+}
+
 func ErrMissingFieldSelectionOnNonScalar(fieldName, enclosingTypeName ast.ByteSlice) (err ExternalError) {
 	err.Message = fmt.Sprintf("non scalar field: %s on type: %s must have selections", fieldName, enclosingTypeName)
+	return err
+}
+
+func ErrApolloCompatibleMissingFieldSelectionOnNonScalar(fieldName, enclosingTypeName ast.ByteSlice) (err ExternalError) {
+	err.Message = fmt.Sprintf(`Field "%s" of type "%s" must have a selection of subfields. Did you mean "%[1]s { ... }"?`, fieldName, enclosingTypeName)
+	err.ExtensionCode = errorcodes.GraphQLValidationFailed
+	err.StatusCode = http.StatusBadRequest
 	return err
 }
 
@@ -389,6 +410,13 @@ func ErrInlineFragmentOnTypeDisallowed(onTypeName ast.ByteSlice) (err ExternalEr
 
 func ErrInlineFragmentOnTypeMismatchEnclosingType(fragmentTypeName, enclosingTypeName ast.ByteSlice) (err ExternalError) {
 	err.Message = fmt.Sprintf("inline fragment on type: %s mismatches enclosing type: %s", fragmentTypeName, enclosingTypeName)
+	return err
+}
+
+func ErrApolloCompatibleInlineFragmentOnTypeMismatchEnclosingType(fragmentTypeName, enclosingTypeName ast.ByteSlice) (err ExternalError) {
+	err.Message = fmt.Sprintf(`Fragment cannot be spread here as objects of type "%s" can never be of type "%s".`, enclosingTypeName, fragmentTypeName)
+	err.ExtensionCode = errorcodes.GraphQLValidationFailed
+	err.StatusCode = http.StatusBadRequest
 	return err
 }
 

--- a/v2/pkg/operationreport/externalerror.go
+++ b/v2/pkg/operationreport/externalerror.go
@@ -160,13 +160,15 @@ func ErrDifferingFieldsOnPotentiallySameType(objectName ast.ByteSlice) (err Exte
 	return err
 }
 
-func ErrFieldSelectionOnLeaf(enumTypeName ast.ByteSlice, typeName string) (err ExternalError) {
+func ErrFieldSelectionOnLeaf(enumTypeName ast.ByteSlice, typeName string, position position.Position) (err ExternalError) {
 	err.Message = fmt.Sprintf(`Field "%s" must not have a selection since type "%s" has no subfields.`, enumTypeName, typeName)
+	err.Locations = LocationsFromPosition(position)
 	return err
 }
 
-func ErrMissingFieldSelectionOnNonScalar(fieldName ast.ByteSlice, enclosingTypeName string) (err ExternalError) {
+func ErrMissingFieldSelectionOnNonScalar(fieldName ast.ByteSlice, enclosingTypeName string, position position.Position) (err ExternalError) {
 	err.Message = fmt.Sprintf(`Field "%s" of type "%s" must have a selection of subfields. Did you mean "%[1]s { ... }"?`, fieldName, enclosingTypeName)
+	err.Locations = LocationsFromPosition(position)
 	return err
 }
 

--- a/v2/pkg/operationreport/externalerror.go
+++ b/v2/pkg/operationreport/externalerror.go
@@ -55,14 +55,7 @@ func ErrDocumentDoesntContainExecutableOperation() (err ExternalError) {
 }
 
 func ErrFieldUndefinedOnType(fieldName, typeName ast.ByteSlice) (err ExternalError) {
-	err.Message = fmt.Sprintf("field: %s not defined on type: %s", fieldName, typeName)
-	return err
-}
-
-func ErrApolloCompatibleFieldUndefinedOnType(fieldName, typeName ast.ByteSlice) (err ExternalError) {
 	err.Message = fmt.Sprintf(`Cannot query field "%s" on type "%s".`, fieldName, typeName)
-	err.ExtensionCode = errorcodes.GraphQLValidationFailed
-	err.StatusCode = http.StatusBadRequest
 	return err
 }
 

--- a/v2/pkg/operationreport/externalerror.go
+++ b/v2/pkg/operationreport/externalerror.go
@@ -2,10 +2,8 @@ package operationreport
 
 import (
 	"fmt"
-	"net/http"
 
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
-	"github.com/wundergraph/graphql-go-tools/v2/pkg/errorcodes"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/lexer/position"
 )
 
@@ -497,14 +495,5 @@ func ErrDuplicateFieldsMustBeIdentical(fieldName, parentName, typeOne, typeTwo s
 	err.Message = fmt.Sprintf("field '%s' on type '%s' is defined in multiple subgraphs "+
 		"but the fields cannot be merged because the types of the fields are non-identical:\n"+
 		"first subgraph: type '%s'\n second subgraph: type '%s'", fieldName, parentName, typeOne, typeTwo)
-	return err
-}
-
-// Apollo compatibility wrappers
-
-func ApolloGraphQLValidationError(err ExternalError) ExternalError {
-	err.ExtensionCode = errorcodes.GraphQLValidationFailed
-	err.StatusCode = http.StatusBadRequest
-
 	return err
 }

--- a/v2/pkg/operationreport/externalerror.go
+++ b/v2/pkg/operationreport/externalerror.go
@@ -2,10 +2,11 @@ package operationreport
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/errorcodes"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/lexer/position"
-	"net/http"
 )
 
 const (
@@ -166,8 +167,13 @@ func ErrDifferingFieldsOnPotentiallySameType(objectName ast.ByteSlice) (err Exte
 	return err
 }
 
-func ErrFieldSelectionOnScalar(fieldName, scalarTypeName ast.ByteSlice) (err ExternalError) {
-	err.Message = fmt.Sprintf("cannot select field: %s on scalar %s", fieldName, scalarTypeName)
+func ErrFieldSelectionOnScalar(scalarTypeName ast.ByteSlice) (err ExternalError) {
+	err.Message = fmt.Sprintf("cannot select field on scalar %s", scalarTypeName)
+	return err
+}
+
+func ErrFieldSelectionOnEnum(enumTypeName ast.ByteSlice) (err ExternalError) {
+	err.Message = fmt.Sprintf("cannot select field on enum %s", enumTypeName)
 	return err
 }
 

--- a/v2/pkg/operationreport/externalerror.go
+++ b/v2/pkg/operationreport/externalerror.go
@@ -167,39 +167,13 @@ func ErrDifferingFieldsOnPotentiallySameType(objectName ast.ByteSlice) (err Exte
 	return err
 }
 
-func ErrFieldSelectionOnScalar(scalarTypeName ast.ByteSlice) (err ExternalError) {
-	err.Message = fmt.Sprintf("cannot select field on scalar %s", scalarTypeName)
-	return err
-}
-
-func ErrApolloCompatibleFieldSelectionOnScalar(scalarTypeName, typeName ast.ByteSlice) (err ExternalError) {
-	err.Message = fmt.Sprintf(`Field "%s" must not have a selection since type "%s" has no subfields.`, scalarTypeName, typeName)
-	err.ExtensionCode = errorcodes.GraphQLValidationFailed
-	err.StatusCode = http.StatusBadRequest
-	return err
-}
-
-func ErrFieldSelectionOnEnum(enumTypeName ast.ByteSlice) (err ExternalError) {
-	err.Message = fmt.Sprintf("cannot select field on enum %s", enumTypeName)
-	return err
-}
-
-func ErrApolloCompatibleFieldSelectionOnEnum(enumTypeName, typeName ast.ByteSlice) (err ExternalError) {
+func ErrFieldSelectionOnLeaf(enumTypeName ast.ByteSlice, typeName string) (err ExternalError) {
 	err.Message = fmt.Sprintf(`Field "%s" must not have a selection since type "%s" has no subfields.`, enumTypeName, typeName)
-	err.ExtensionCode = errorcodes.GraphQLValidationFailed
-	err.StatusCode = http.StatusBadRequest
 	return err
 }
 
-func ErrMissingFieldSelectionOnNonScalar(fieldName, enclosingTypeName ast.ByteSlice) (err ExternalError) {
-	err.Message = fmt.Sprintf("non scalar field: %s on type: %s must have selections", fieldName, enclosingTypeName)
-	return err
-}
-
-func ErrApolloCompatibleMissingFieldSelectionOnNonScalar(fieldName, enclosingTypeName ast.ByteSlice) (err ExternalError) {
+func ErrMissingFieldSelectionOnNonScalar(fieldName ast.ByteSlice, enclosingTypeName string) (err ExternalError) {
 	err.Message = fmt.Sprintf(`Field "%s" of type "%s" must have a selection of subfields. Did you mean "%[1]s { ... }"?`, fieldName, enclosingTypeName)
-	err.ExtensionCode = errorcodes.GraphQLValidationFailed
-	err.StatusCode = http.StatusBadRequest
 	return err
 }
 
@@ -409,14 +383,7 @@ func ErrInlineFragmentOnTypeDisallowed(onTypeName ast.ByteSlice) (err ExternalEr
 }
 
 func ErrInlineFragmentOnTypeMismatchEnclosingType(fragmentTypeName, enclosingTypeName ast.ByteSlice) (err ExternalError) {
-	err.Message = fmt.Sprintf("inline fragment on type: %s mismatches enclosing type: %s", fragmentTypeName, enclosingTypeName)
-	return err
-}
-
-func ErrApolloCompatibleInlineFragmentOnTypeMismatchEnclosingType(fragmentTypeName, enclosingTypeName ast.ByteSlice) (err ExternalError) {
 	err.Message = fmt.Sprintf(`Fragment cannot be spread here as objects of type "%s" can never be of type "%s".`, enclosingTypeName, fragmentTypeName)
-	err.ExtensionCode = errorcodes.GraphQLValidationFailed
-	err.StatusCode = http.StatusBadRequest
 	return err
 }
 
@@ -535,5 +502,14 @@ func ErrDuplicateFieldsMustBeIdentical(fieldName, parentName, typeOne, typeTwo s
 	err.Message = fmt.Sprintf("field '%s' on type '%s' is defined in multiple subgraphs "+
 		"but the fields cannot be merged because the types of the fields are non-identical:\n"+
 		"first subgraph: type '%s'\n second subgraph: type '%s'", fieldName, parentName, typeOne, typeTwo)
+	return err
+}
+
+// Apollo compatibility wrappers
+
+func ApolloGraphQLValidationError(err ExternalError) ExternalError {
+	err.ExtensionCode = errorcodes.GraphQLValidationFailed
+	err.StatusCode = http.StatusBadRequest
+
 	return err
 }


### PR DESCRIPTION
Currently, we only have Apollo Gateway compatibility for a few basic types of field selection validation, this PR expands it to include and test:

- selecting an undefined operation
- selecting on an enum
- selecting on a scalar
- no select on object
- select non-existent field
- invalid fragment spread

The Apollo extension and 400 status compatibility should also extend to all operation validation errors now, and as such is governed by a new, less specific flag.

It also changes the format for a few existing errors:

| Old Format                                                  | New Format                                                                                  |
| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| `field: %s not defined on type: %s`                         | `Cannot query field "%s" on type "%s".`                                                     |
| `cannot select field: %s on scalar %s`                      | `Field "%s" must not have a selection since type "%s" has no subfields.`                    |
| `non scalar field: %s on type: %s must have selections`     | `Field "%s" of type "%s" must have a selection of subfields. Did you mean "%[1]s { ... }"?` |
| `inline fragment on type: %s mismatches enclosing type: %s` | `Fragment cannot be spread here as objects of type "%s" can never be of type "%s".`         |


We also now pass ScalarLeafsRule ported tests from `graphql-js`, so I've enabled them to prevent regressions