### PR TITLE
fix: support different kinds of close, correct client unsubscribe behaviour

### DIFF
--- a/execution/graphql/result_writer.go
+++ b/execution/graphql/result_writer.go
@@ -9,12 +9,15 @@ import (
 	"strconv"
 
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/datasource/httpclient"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 )
 
 type EngineResultWriter struct {
 	buf           *bytes.Buffer
 	flushCallback func(data []byte)
 }
+
+var _ resolve.SubscriptionResponseWriter = (*EngineResultWriter)(nil)
 
 func NewEngineResultWriter() EngineResultWriter {
 	return EngineResultWriter{
@@ -32,7 +35,7 @@ func (e *EngineResultWriter) Complete() {
 
 }
 
-func (e *EngineResultWriter) Close() {
+func (e *EngineResultWriter) Close(_ resolve.SubscriptionCloseKind) {
 
 }
 

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
@@ -8320,13 +8320,13 @@ func (t *testSubscriptionUpdater) Update(data []byte) {
 	t.updates = append(t.updates, string(data))
 }
 
-func (t *testSubscriptionUpdater) Done() {
+func (t *testSubscriptionUpdater) Complete() {
 	t.mux.Lock()
 	defer t.mux.Unlock()
 	t.done = true
 }
 
-func (t *testSubscriptionUpdater) Close() {
+func (t *testSubscriptionUpdater) Close(kind resolve.SubscriptionCloseKind) {
 	t.mux.Lock()
 	defer t.mux.Unlock()
 	t.closed = true

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_sse_handler.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_sse_handler.go
@@ -48,7 +48,7 @@ func (h *gqlSSEConnectionHandler) StartBlocking() {
 	defer func() {
 		close(dataCh)
 		close(errCh)
-		h.updater.Done()
+		h.updater.Complete()
 	}()
 
 	go h.subscribe(dataCh, errCh)

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_tws_handler.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_tws_handler.go
@@ -36,7 +36,7 @@ func (h *gqlTWSConnectionHandler) ServerClose() {
 	h.shuttingDown.Store(true)
 
 	// Because the server closes the connection, we need to send a close frame to the event loop.
-	h.updater.Close()
+	h.updater.Close(resolve.SubscriptionCloseKindDownstreamServiceError)
 
 	_ = h.conn.SetWriteDeadline(time.Now().Add(writeTimeout))
 	_ = ws.WriteFrame(h.conn, ws.MaskFrame(ws.NewCloseFrame(ws.NewCloseFrameBody(ws.StatusNormalClosure, "Normal Closure"))))
@@ -185,7 +185,7 @@ func (h *gqlTWSConnectionHandler) unsubscribeAllAndCloseConn() {
 }
 
 func (h *gqlTWSConnectionHandler) unsubscribe() {
-	h.updater.Done()
+	h.updater.Complete()
 	req := fmt.Sprintf(completeMessage, "1")
 	_ = h.conn.SetWriteDeadline(time.Now().Add(writeTimeout))
 	err := wsutil.WriteClientText(h.conn, []byte(req))
@@ -223,7 +223,7 @@ func (h *gqlTWSConnectionHandler) handleMessageTypeComplete(data []byte) {
 	if id != "1" {
 		return
 	}
-	h.updater.Done()
+	h.updater.Complete()
 }
 
 func (h *gqlTWSConnectionHandler) handleMessageTypeError(data []byte) {

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_ws_handler.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_ws_handler.go
@@ -31,7 +31,7 @@ type gqlWSConnectionHandler struct {
 
 func (h *gqlWSConnectionHandler) ServerClose() {
 	// Because the server closes the connection, we need to send a close frame to the event loop.
-	h.updater.Close()
+	h.updater.Close(resolve.SubscriptionCloseKindDownstreamServiceError)
 
 	_ = h.conn.SetWriteDeadline(time.Now().Add(writeTimeout))
 	_ = ws.WriteFrame(h.conn, ws.MaskFrame(ws.NewCloseFrame(ws.NewCloseFrameBody(ws.StatusNormalClosure, "Normal Closure"))))
@@ -255,7 +255,7 @@ func (h *gqlWSConnectionHandler) handleMessageTypeComplete(data []byte) {
 	if id != "1" {
 		return
 	}
-	h.updater.Done()
+	h.updater.Complete()
 }
 
 func (h *gqlWSConnectionHandler) handleMessageTypeError(data []byte) {
@@ -294,7 +294,7 @@ func (h *gqlWSConnectionHandler) handleMessageTypeError(data []byte) {
 }
 
 func (h *gqlWSConnectionHandler) unsubscribe() {
-	h.updater.Done()
+	h.updater.Complete()
 	stopRequest := fmt.Sprintf(stopMessage, "1")
 	_ = h.conn.SetWriteDeadline(time.Now().Add(writeTimeout))
 	_ = wsutil.WriteClientText(h.conn, []byte(stopRequest))

--- a/v2/pkg/engine/resolve/event_loop_test.go
+++ b/v2/pkg/engine/resolve/event_loop_test.go
@@ -27,6 +27,8 @@ type FakeSubscriptionWriter struct {
 	messageCountOnComplete int
 }
 
+var _ SubscriptionResponseWriter = (*FakeSubscriptionWriter)(nil)
+
 func (f *FakeSubscriptionWriter) Write(p []byte) (n int, err error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -49,7 +51,7 @@ func (f *FakeSubscriptionWriter) Complete() {
 	f.messageCountOnComplete = len(f.writtenMessages)
 }
 
-func (f *FakeSubscriptionWriter) Close() {
+func (f *FakeSubscriptionWriter) Close(SubscriptionCloseKind) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.closed = true
@@ -74,7 +76,7 @@ func (f *FakeSource) Start(ctx *Context, input []byte, updater SubscriptionUpdat
 				time.Sleep(f.interval)
 			}
 		}
-		updater.Done()
+		updater.Complete()
 	}()
 	return nil
 }

--- a/v2/pkg/engine/resolve/response.go
+++ b/v2/pkg/engine/resolve/response.go
@@ -42,11 +42,19 @@ type ResponseWriter interface {
 	io.Writer
 }
 
+type SubscriptionCloseKind string
+
+const (
+	SubscriptionCloseKindNormal                 SubscriptionCloseKind = "Normal closure"
+	SubscriptionCloseKindDownstreamServiceError SubscriptionCloseKind = "Downstream service error"
+	SubscriptionCloseKindGoingAway              SubscriptionCloseKind = "Going away"
+)
+
 type SubscriptionResponseWriter interface {
 	ResponseWriter
 	Flush() error
 	Complete()
-	Close()
+	Close(kind SubscriptionCloseKind)
 }
 
 func writeGraphqlResponse(buf *BufPair, writer io.Writer, ignoreData bool) (err error) {


### PR DESCRIPTION
In #1158, I added a new path for handling server closure, but as an unintended side effect some scenarios that were previously silently failing such as complete-after-error in subscription init events became obviously broken.

This PR follows up on this by adding options for the _kind_ of closure the caller wants, including 3 to start:

- "normal" = the connection is being closed normally and intentionally, such as in the case of connection failure
- "downstream service error" = the subgraph closes the connection before completing
- "going away" = used during router shutdown to indicate the router itself is shutting down

It also:
- renames many instances of "Shutdown" to "Close" and "Done" to "Complete" for consistent terminology through the router and engine for subscriptions. 
- corrects behaviour where we were not distinguishing between removing clients for different reasons and always sending complete as if it was because the client sent complete, now handles complete separately