### PR TITLE
fix: don't panic when calling QueryPlan on FetchTreeNode if `includeQueryPlans` is false

### DIFF
--- a/v2/pkg/engine/resolve/fetchtree.go
+++ b/v2/pkg/engine/resolve/fetchtree.go
@@ -209,9 +209,12 @@ func (n *FetchTreeNode) queryPlan() *FetchTreeQueryPlanNode {
 				DependsOnFetchIDs: f.FetchDependencies.DependsOnFetchIDs,
 				SubgraphName:      f.Info.DataSourceName,
 				SubgraphID:        f.Info.DataSourceID,
-				Query:             f.Info.QueryPlan.Query,
-				Representations:   f.Info.QueryPlan.DependsOnFields,
 				Path:              n.Item.ResponsePath,
+			}
+
+			if f.Info.QueryPlan != nil {
+				queryPlan.Fetch.Query = f.Info.QueryPlan.Query
+				queryPlan.Fetch.Representations = f.Info.QueryPlan.DependsOnFields
 			}
 		case *EntityFetch:
 			queryPlan.Fetch = &FetchTreeQueryPlan{
@@ -220,9 +223,12 @@ func (n *FetchTreeNode) queryPlan() *FetchTreeQueryPlanNode {
 				DependsOnFetchIDs: f.FetchDependencies.DependsOnFetchIDs,
 				SubgraphName:      f.Info.DataSourceName,
 				SubgraphID:        f.Info.DataSourceID,
-				Query:             f.Info.QueryPlan.Query,
-				Representations:   f.Info.QueryPlan.DependsOnFields,
 				Path:              n.Item.ResponsePath,
+			}
+
+			if f.Info.QueryPlan != nil {
+				queryPlan.Fetch.Query = f.Info.QueryPlan.Query
+				queryPlan.Fetch.Representations = f.Info.QueryPlan.DependsOnFields
 			}
 		case *BatchEntityFetch:
 			queryPlan.Fetch = &FetchTreeQueryPlan{
@@ -231,9 +237,12 @@ func (n *FetchTreeNode) queryPlan() *FetchTreeQueryPlanNode {
 				DependsOnFetchIDs: f.FetchDependencies.DependsOnFetchIDs,
 				SubgraphName:      f.Info.DataSourceName,
 				SubgraphID:        f.Info.DataSourceID,
-				Query:             f.Info.QueryPlan.Query,
-				Representations:   f.Info.QueryPlan.DependsOnFields,
 				Path:              n.Item.ResponsePath,
+			}
+
+			if f.Info.QueryPlan != nil {
+				queryPlan.Fetch.Query = f.Info.QueryPlan.Query
+				queryPlan.Fetch.Representations = f.Info.QueryPlan.DependsOnFields
 			}
 		case *ParallelListItemFetch:
 			queryPlan.Fetch = &FetchTreeQueryPlan{
@@ -242,9 +251,12 @@ func (n *FetchTreeNode) queryPlan() *FetchTreeQueryPlanNode {
 				DependsOnFetchIDs: f.Fetch.FetchDependencies.DependsOnFetchIDs,
 				SubgraphName:      f.Fetch.Info.DataSourceName,
 				SubgraphID:        f.Fetch.Info.DataSourceID,
-				Query:             f.Fetch.Info.QueryPlan.Query,
-				Representations:   f.Fetch.Info.QueryPlan.DependsOnFields,
 				Path:              n.Item.ResponsePath,
+			}
+
+			if f.Fetch.Info.QueryPlan != nil {
+				queryPlan.Fetch.Query = f.Fetch.Info.QueryPlan.Query
+				queryPlan.Fetch.Representations = f.Fetch.Info.QueryPlan.DependsOnFields
 			}
 		default:
 		}


### PR DESCRIPTION
This currently panics because https://github.com/wundergraph/graphql-go-tools/blob/e75a1dd24d5255b6cc990269c5c7922f851f4fc1/v2/pkg/engine/resolve/fetchtree.go#L212-L213 is a nil pointer dereference when 

This change makes it just fail empty instead of panic, which is fine for what it's needed for in the router.

I originally made this not nil at the source in https://github.com/wundergraph/graphql-go-tools/blob/dd0d9cc2a9192799c4b3c5ecaa89134c03e01801/v2/pkg/engine/plan/visitor.go#L1259-L1261
but it causes like 1000+ inline snapshot tests to fail which are hardcoded and don't have `-update`, so I catch the nilness at usage site instead