### PR TITLE
fix(graphiql): update graphiql playground to latest version

### DIFF
--- a/v2/pkg/playground/files/playground.html
+++ b/v2/pkg/playground/files/playground.html
@@ -65,6 +65,8 @@
       import createGraphQLWorker from 'https://esm.sh/monaco-graphql/esm/graphql.worker.js?worker';
       import createEditorWorker from 'https://esm.sh/monaco-editor/esm/vs/editor/editor.worker.js?worker';
 
+      const endpointURL = "{{ .EndpointURL }}";
+
       globalThis.MonacoEnvironment = {
         getWorker(_workerId, label) {
           console.info('MonacoEnvironment.getWorker', { label });
@@ -79,7 +81,7 @@
       };
 
       const fetcher = createGraphiQLFetcher({
-        url: 'https://countries.trevorblades.com',
+        url: endpointURL,
       });
       const plugins = [HISTORY_PLUGIN, explorerPlugin()];
 

--- a/v2/pkg/playground/files/playground.html
+++ b/v2/pkg/playground/files/playground.html
@@ -1,5 +1,5 @@
 <!--
- *  Copyright (c) 2021 GraphQL Contributors
+ *  Copyright (c) 2025 GraphQL Contributors
  *  All rights reserved.
  *
  *  This source code is licensed under the license found in the
@@ -7,87 +7,98 @@
 -->
 <!doctype html>
 <html lang="en">
-<head>
-    <title>GraphiQL</title>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GraphiQL 5 with React 19 and GraphiQL Explorer</title>
     <style>
-        body {
-            height: 100%;
-            margin: 0;
-            width: 100%;
-            overflow: hidden;
-        }
+      body {
+        margin: 0;
+      }
 
-        #graphiql {
-            height: 100vh;
-        }
+      #graphiql {
+        height: 100dvh;
+      }
+
+      .loading {
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 4rem;
+      }
     </style>
-    <!--
-      This GraphiQL example depends on Promise and fetch, which are available in
-      modern browsers, but can be "polyfilled" for older browsers.
-      GraphiQL itself depends on React DOM.
-      If you do not want to rely on a CDN, you can host these files locally or
-      include them directly in your favored resource bundler.
-    -->
-    <script
-            crossorigin
-            src="https://unpkg.com/react@18/umd/react.development.js"
-    ></script>
-    <script
-            crossorigin
-            src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"
-    ></script>
-    <!--
-      These two files can be found in the npm module, however you may wish to
-      copy them directly into your environment, or perhaps include them in your
-      favored resource bundler.
-     -->
-    <script
-            src="https://unpkg.com/graphiql/graphiql.min.js"
-            type="application/javascript"
-    ></script>
-    <script
-            src="https://unpkg.com/subscriptions-transport-ws@0.11.0/browser/client.js"
-            type="application/javascript"
-    ></script>
-    <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
-    <!--
-      These are imports for the GraphIQL Explorer plugin.
-     -->
-    <script
-            src="https://unpkg.com/@graphiql/plugin-explorer/dist/index.umd.js"
-            crossorigin
-    ></script>
-
+    <link rel="stylesheet" href="https://esm.sh/graphiql/dist/style.css" />
     <link
-            rel="stylesheet"
-            href="https://unpkg.com/@graphiql/plugin-explorer/dist/style.css"
+      rel="stylesheet"
+      href="https://esm.sh/@graphiql/plugin-explorer/dist/style.css"
     />
-</head>
+    <!-- Note: the ?standalone flag bundles the module along with all of its `dependencies`, excluding `peerDependencies`, into a single JavaScript file. -->
+    <script type="importmap">
+      {
+        "imports": {
+          "react": "https://esm.sh/react@19.1.0",
+          "react/jsx-runtime": "https://esm.sh/react@19.1.0/jsx-runtime",
 
-<body>
-<div id="graphiql">Loading...</div>
-<script>
-    const endpointURL = "{{ .EndpointURL }}";
-    const subscriptionEndpointURL = "ws://"+ window.location.host + "{{ .SubscriptionEndpointURL }}";
-    const root = ReactDOM.createRoot(document.getElementById('graphiql'));
-    console.log("endpointURL: ", endpointURL)
-    console.log("subscriptionEndpointURL: ", subscriptionEndpointURL)
+          "react-dom": "https://esm.sh/react-dom@19.1.0",
+          "react-dom/client": "https://esm.sh/react-dom@19.1.0/client",
 
-    let subscriptionsClient = new window.SubscriptionsTransportWs.SubscriptionClient(subscriptionEndpointURL, {
-        reconnect: true
-    });
-    const fetcher = GraphiQL.createFetcher({
-        url: endpointURL,
-        legacyClient: subscriptionsClient,
-    });
-    const explorerPlugin = GraphiQLPluginExplorer.explorerPlugin();
-    root.render(
-        React.createElement(GraphiQL, {
-            fetcher,
-            defaultEditorToolsVisibility: true,
-            plugins: [explorerPlugin],
-        }),
-    );
-</script>
-</body>
+          "graphiql": "https://esm.sh/graphiql?standalone&external=react,react-dom,@graphiql/react,graphql",
+          "@graphiql/plugin-explorer": "https://esm.sh/@graphiql/plugin-explorer?standalone&external=react,@graphiql/react,graphql",
+          "@graphiql/react": "https://esm.sh/@graphiql/react?standalone&external=react,react-dom,graphql",
+
+          "@graphiql/toolkit": "https://esm.sh/@graphiql/toolkit?standalone&external=graphql",
+          "graphql": "https://esm.sh/graphql@16.11.0"
+        }
+      }
+    </script>
+    <script type="module">
+      // Import React and ReactDOM
+      import React from 'react';
+      import ReactDOM from 'react-dom/client';
+      // Import GraphiQL and the Explorer plugin
+      import { GraphiQL, HISTORY_PLUGIN } from 'graphiql';
+      import { createGraphiQLFetcher } from '@graphiql/toolkit';
+      import { explorerPlugin } from '@graphiql/plugin-explorer';
+
+      import createJSONWorker from 'https://esm.sh/monaco-editor/esm/vs/language/json/json.worker.js?worker';
+      import createGraphQLWorker from 'https://esm.sh/monaco-graphql/esm/graphql.worker.js?worker';
+      import createEditorWorker from 'https://esm.sh/monaco-editor/esm/vs/editor/editor.worker.js?worker';
+
+      globalThis.MonacoEnvironment = {
+        getWorker(_workerId, label) {
+          console.info('MonacoEnvironment.getWorker', { label });
+          switch (label) {
+            case 'json':
+              return createJSONWorker();
+            case 'graphql':
+              return createGraphQLWorker();
+          }
+          return createEditorWorker();
+        },
+      };
+
+      const fetcher = createGraphiQLFetcher({
+        url: 'https://countries.trevorblades.com',
+      });
+      const plugins = [HISTORY_PLUGIN, explorerPlugin()];
+
+      function App() {
+        return React.createElement(GraphiQL, {
+          fetcher,
+          plugins,
+          defaultEditorToolsVisibility: true,
+        });
+      }
+
+      const container = document.getElementById('graphiql');
+      const root = ReactDOM.createRoot(container);
+      root.render(React.createElement(App));
+    </script>
+  </head>
+  <body>
+    <div id="graphiql">
+      <div class="loading">Loading…</div>
+    </div>
+  </body>
 </html>


### PR DESCRIPTION
This PR migrates GraphiQL to v5 following the official migration guide:  
https://github.com/graphql/graphiql/blob/main/docs/migration/graphiql-5.0.0.md

relates https://github.com/graphql/graphiql/issues/4034