### PR TITLE
fix: use int in netpoll's BenchmarkSocketFdReflect

### DIFF
--- a/v2/pkg/netpoll/fd_test.go
+++ b/v2/pkg/netpoll/fd_test.go
@@ -8,12 +8,12 @@ import (
 	"testing"
 )
 
-func reflectSocketFDAsUint(conn net.Conn) uint64 {
+func reflectSocketFDAsInt(conn net.Conn) int64 {
 	tcpConn := reflect.Indirect(reflect.ValueOf(conn)).FieldByName("conn")
 	fdVal := tcpConn.FieldByName("fd")
 	pfdVal := reflect.Indirect(fdVal).FieldByName("pfd")
 
-	return pfdVal.FieldByName("Sysfd").Uint()
+	return pfdVal.FieldByName("Sysfd").Int()
 }
 
 func rawSocketFD(conn net.Conn) uint64 {
@@ -33,12 +33,12 @@ func rawSocketFD(conn net.Conn) uint64 {
 
 func BenchmarkSocketFdReflect(b *testing.B) {
 	var con, _ = net.Dial(`udp`, "8.8.8.8:53")
-	fd := uint64(0)
+	fd := int64(0)
 	b.ResetTimer()
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		fd = reflectSocketFDAsUint(con)
+		fd = reflectSocketFDAsInt(con)
 	}
 	runtime.KeepAlive(fd)
 }


### PR DESCRIPTION
This fixes the failing Benchmark in the netpoll lib.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated internal handling of socket file descriptors to use signed integer types instead of unsigned. No visible impact to end-user functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
