### PR TITLE
fix: missing field refs in union types

### DIFF
--- a/v2/pkg/engine/datasource/graphql_datasource/configuration.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/configuration.go
@@ -175,6 +175,14 @@ func NewSchemaConfiguration(upstreamSchema string, federationCfg *FederationConf
 		if report.HasErrors() {
 			return nil, fmt.Errorf("unable to parse federation schema: %v", report)
 		}
+
+		// As BuildFederationSchema is already merged with base definitions, we actually don't want to do it again,
+		// but as we have to parse the schema again, we also need to make sure to add the typename fields to union types again
+		// TODO: find a better way to do this
+		typeNamesVisitor := asttransform.NewTypeNameVisitor()
+		if err := typeNamesVisitor.ExtendSchema(definition); err != nil {
+			return nil, fmt.Errorf("unable to extend federation schema with type names: %v", err)
+		}
 	} else {
 		definition.Input.ResetInputString(cfg.upstreamSchema)
 		definitionParser.Parse(definition, report)


### PR DESCRIPTION
fixes ENG-7595

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that union types in GraphQL federation schemas correctly include the `__typename` field after parsing, improving compatibility and schema introspection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.

<!--
Please add any additional information or context regarding your changes here.
-->