### PR TITLE
feat: add ParseWithDepthLimit to astparser.Parser

### DIFF
--- a/v2/pkg/astparser/errors.go
+++ b/v2/pkg/astparser/errors.go
@@ -51,3 +51,14 @@ func (e ErrUnexpectedIdentKey) Error() string {
 
 	return fmt.Sprintf("unexpected ident - keyword: '%s' literal: '%s' - expected: '%s' position: '%s'%s", e.keyword, e.literal, e.expected, e.position, origins)
 }
+
+// ErrDepthLimitExceeded is returned when the parser encounters nesting depth
+// that exceeds the configured limit during tokenization. This error helps prevent
+// stack overflow and DoS attacks from maliciously deep GraphQL documents.
+type ErrDepthLimitExceeded struct {
+	limit int
+}
+
+func (e ErrDepthLimitExceeded) Error() string {
+	return fmt.Sprintf("allowed parsing depth limit per GraphQL document of '%d' exceeded", e.limit)
+}

--- a/v2/pkg/astparser/errors.go
+++ b/v2/pkg/astparser/errors.go
@@ -60,5 +60,15 @@ type ErrDepthLimitExceeded struct {
 }
 
 func (e ErrDepthLimitExceeded) Error() string {
-	return fmt.Sprintf("allowed parsing depth limit per GraphQL document of '%d' exceeded", e.limit)
+	return fmt.Sprintf("allowed parsing depth per GraphQL document of '%d' exceeded", e.limit)
+}
+
+// ErrFieldsLimitExceeded is returned when the parser encounters a number of fields
+// that exceeds the configured limit during tokenization. This error helps prevent
+type ErrFieldsLimitExceeded struct {
+	limit int
+}
+
+func (e ErrFieldsLimitExceeded) Error() string {
+	return fmt.Sprintf("allowed number of fields per GraphQL document of '%d' exceeded", e.limit)
 }

--- a/v2/pkg/astparser/parser.go
+++ b/v2/pkg/astparser/parser.go
@@ -97,6 +97,21 @@ func (p *Parser) tokenize() {
 	p.tokenizer.Tokenize(&p.document.Input)
 }
 
+// ParseWithDepthLimit parses all input in a Document.Input into the Document with a depth limit
+func (p *Parser) ParseWithDepthLimit(depthLimit int, document *ast.Document, report *operationreport.Report) error {
+	p.document = document
+	p.report = report
+	if err := p.tokenizeWithDepthLimit(depthLimit); err != nil {
+		return err
+	}
+	p.parse()
+	return nil
+}
+
+func (p *Parser) tokenizeWithDepthLimit(depthLimit int) error {
+	return p.tokenizer.TokenizeWithDepthLimit(depthLimit, &p.document.Input)
+}
+
 func (p *Parser) parse() {
 	for {
 		key, literalReference := p.peekLiteral()

--- a/v2/pkg/astparser/parser.go
+++ b/v2/pkg/astparser/parser.go
@@ -97,19 +97,15 @@ func (p *Parser) tokenize() {
 	p.tokenizer.Tokenize(&p.document.Input)
 }
 
-// ParseWithDepthLimit parses all input in a Document.Input into the Document with a depth limit
-func (p *Parser) ParseWithDepthLimit(depthLimit int, document *ast.Document, report *operationreport.Report) error {
+// ParseWithLimits parses all input in a Document.Input into the Document with limits on the number of fields and depth
+func (p *Parser) ParseWithLimits(limits TokenizerLimits, document *ast.Document, report *operationreport.Report) error {
 	p.document = document
 	p.report = report
-	if err := p.tokenizeWithDepthLimit(depthLimit); err != nil {
+	if err := p.tokenizer.TokenizeWithLimits(limits, &p.document.Input); err != nil {
 		return err
 	}
 	p.parse()
 	return nil
-}
-
-func (p *Parser) tokenizeWithDepthLimit(depthLimit int) error {
-	return p.tokenizer.TokenizeWithDepthLimit(depthLimit, &p.document.Input)
 }
 
 func (p *Parser) parse() {

--- a/v2/pkg/astparser/parser.go
+++ b/v2/pkg/astparser/parser.go
@@ -98,14 +98,15 @@ func (p *Parser) tokenize() {
 }
 
 // ParseWithLimits parses all input in a Document.Input into the Document with limits on the number of fields and depth
-func (p *Parser) ParseWithLimits(limits TokenizerLimits, document *ast.Document, report *operationreport.Report) error {
+func (p *Parser) ParseWithLimits(limits TokenizerLimits, document *ast.Document, report *operationreport.Report) (TokenizerStats, error) {
 	p.document = document
 	p.report = report
-	if err := p.tokenizer.TokenizeWithLimits(limits, &p.document.Input); err != nil {
-		return err
+	stats, err := p.tokenizer.TokenizeWithLimits(limits, &p.document.Input)
+	if err != nil {
+		return stats, err
 	}
 	p.parse()
-	return nil
+	return stats, nil
 }
 
 func (p *Parser) parse() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced configurable limits on both nesting depth and number of fields during GraphQL document parsing.
  * Added clear error messages for exceeding depth or field count limits.
  * Enhanced parsing method to return tokenization statistics alongside errors when limits are applied.

* **Tests**
  * Added extensive tests covering parsing behavior with various depth and field limits, including multiple operations and fragments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->