### PR TITLE
fix: test v2 benchmarks on ci

### DIFF
--- a/.github/workflows/execution.yml
+++ b/.github/workflows/execution.yml
@@ -36,7 +36,7 @@ jobs:
         id: go
       - name: CI
         working-directory: execution
-        run: make ci
+        run: make test-quick
       - name: Run tests under race detector
         working-directory: execution
         if: runner.os != 'Windows' # These are very slow on Windows, skip them

--- a/.github/workflows/v2.yml
+++ b/.github/workflows/v2.yml
@@ -40,7 +40,7 @@ jobs:
         id: go
       - name: CI
         working-directory: v2
-        run: make ci
+        run: make test-quick
       - name: Run tests under race detector
         working-directory: v2
         if: runner.os != 'Windows' # These are very slow on Windows, skip them

--- a/execution/Makefile
+++ b/execution/Makefile
@@ -7,10 +7,6 @@ test:
 test-quick:
 	go test -count=1 ./...
 
-.PHONY: test-no-race
-test-no-race:
-	go test -count=1 ./...
-
 # updateTestFixtures will update all! golden fixtures
 .PHONY: updateTestFixtures
 updateTestFixtures:
@@ -22,12 +18,6 @@ format:
 
 .PHONY: prepare-merge
 prepare-merge: format test
-
-.PHONY: ci
-ci: test
-
-.PHONY: ci-quick
-ci-full: test-quick
 
 .PHONY: update-deps
 update-deps:

--- a/v2/Makefile
+++ b/v2/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test
 test:
-	go test -race ./...
+	go test -race -count=1 ./...
 
 test-fresh: clean-testcache test
 
@@ -9,11 +9,7 @@ test-stability:
 
 .PHONY: test-quick
 test-quick:
-	go test -count=1 ./...
-
-.PHONY: test
-test-no-race:
-	go test -race ./...
+	go test -count=1 -run=. -bench=. -benchtime=1x ./...
 
 clean-testcache:
 	go clean -testcache
@@ -29,12 +25,6 @@ format:
 
 .PHONY: prepare-merge
 prepare-merge: format test
-
-.PHONY: ci
-ci: test
-
-.PHONY: ci-quick
-ci-full: test-quick
 
 .PHONY: generate
 generate: $(GOPATH)/bin/go-enum $(GOPATH)/bin/mockgen $(GOPATH)/bin/stringer

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource_federation_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource_federation_test.go
@@ -14684,7 +14684,7 @@ func TestGraphQLDataSourceFederation(t *testing.T) {
 				},
 				DisableResolveFieldPositions: true,
 				Debug: plan.DebugConfiguration{
-					PrintQueryPlans: true,
+					PrintQueryPlans: false,
 				},
 			}
 


### PR DESCRIPTION
Include benchmarks into quick tests of v2.

In addition, I have attempted to simplify Makefile rules for testing. Instead of aliasing let's use "test" and "test-quick" rules directly from github workflows.

@coderabbitai summary

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.

<!--
Please add any additional information or context regarding your changes here.
-->