### PR TITLE
feat: add depth limit to parser

### DIFF
--- a/v2/pkg/astparser/errors.go
+++ b/v2/pkg/astparser/errors.go
@@ -51,3 +51,14 @@ func (e ErrUnexpectedIdentKey) Error() string {
 
 	return fmt.Sprintf("unexpected ident - keyword: '%s' literal: '%s' - expected: '%s' position: '%s'%s", e.keyword, e.literal, e.expected, e.position, origins)
 }
+
+// ErrDepthLimitExceeded is returned when the parser encounters nesting depth
+// that exceeds the configured limit during tokenization. This error helps prevent
+// stack overflow and DoS attacks from maliciously deep GraphQL documents.
+type ErrDepthLimitExceeded struct {
+	limit int
+}
+
+func (e ErrDepthLimitExceeded) Error() string {
+	return fmt.Sprintf("allowed parsing depth limit per GraphQL document of '%d' exceeded", e.limit)
+}

--- a/v2/pkg/astparser/errors.go
+++ b/v2/pkg/astparser/errors.go
@@ -60,5 +60,15 @@ type ErrDepthLimitExceeded struct {
 }
 
 func (e ErrDepthLimitExceeded) Error() string {
-	return fmt.Sprintf("allowed parsing depth limit per GraphQL document of '%d' exceeded", e.limit)
+	return fmt.Sprintf("allowed parsing depth per GraphQL document of '%d' exceeded", e.limit)
+}
+
+// ErrFieldsLimitExceeded is returned when the parser encounters a number of fields
+// that exceeds the configured limit during tokenization. This error helps prevent
+type ErrFieldsLimitExceeded struct {
+	limit int
+}
+
+func (e ErrFieldsLimitExceeded) Error() string {
+	return fmt.Sprintf("allowed number of fields per GraphQL document of '%d' exceeded", e.limit)
 }

--- a/v2/pkg/astparser/parser.go
+++ b/v2/pkg/astparser/parser.go
@@ -97,6 +97,21 @@ func (p *Parser) tokenize() {
 	p.tokenizer.Tokenize(&p.document.Input)
 }
 
+// ParseWithDepthLimit parses all input in a Document.Input into the Document with a depth limit
+func (p *Parser) ParseWithDepthLimit(depthLimit int, document *ast.Document, report *operationreport.Report) error {
+	p.document = document
+	p.report = report
+	if err := p.tokenizeWithDepthLimit(depthLimit); err != nil {
+		return err
+	}
+	p.parse()
+	return nil
+}
+
+func (p *Parser) tokenizeWithDepthLimit(depthLimit int) error {
+	return p.tokenizer.TokenizeWithDepthLimit(depthLimit, &p.document.Input)
+}
+
 func (p *Parser) parse() {
 	for {
 		key, literalReference := p.peekLiteral()

--- a/v2/pkg/astparser/parser.go
+++ b/v2/pkg/astparser/parser.go
@@ -97,19 +97,15 @@ func (p *Parser) tokenize() {
 	p.tokenizer.Tokenize(&p.document.Input)
 }
 
-// ParseWithDepthLimit parses all input in a Document.Input into the Document with a depth limit
-func (p *Parser) ParseWithDepthLimit(depthLimit int, document *ast.Document, report *operationreport.Report) error {
+// ParseWithLimits parses all input in a Document.Input into the Document with limits on the number of fields and depth
+func (p *Parser) ParseWithLimits(limits TokenizerLimits, document *ast.Document, report *operationreport.Report) error {
 	p.document = document
 	p.report = report
-	if err := p.tokenizeWithDepthLimit(depthLimit); err != nil {
+	if err := p.tokenizer.TokenizeWithLimits(limits, &p.document.Input); err != nil {
 		return err
 	}
 	p.parse()
 	return nil
-}
-
-func (p *Parser) tokenizeWithDepthLimit(depthLimit int) error {
-	return p.tokenizer.TokenizeWithDepthLimit(depthLimit, &p.document.Input)
 }
 
 func (p *Parser) parse() {

--- a/v2/pkg/astparser/parser.go
+++ b/v2/pkg/astparser/parser.go
@@ -98,14 +98,15 @@ func (p *Parser) tokenize() {
 }
 
 // ParseWithLimits parses all input in a Document.Input into the Document with limits on the number of fields and depth
-func (p *Parser) ParseWithLimits(limits TokenizerLimits, document *ast.Document, report *operationreport.Report) error {
+func (p *Parser) ParseWithLimits(limits TokenizerLimits, document *ast.Document, report *operationreport.Report) (TokenizerStats, error) {
 	p.document = document
 	p.report = report
-	if err := p.tokenizer.TokenizeWithLimits(limits, &p.document.Input); err != nil {
-		return err
+	stats, err := p.tokenizer.TokenizeWithLimits(limits, &p.document.Input)
+	if err != nil {
+		return stats, err
 	}
 	p.parse()
-	return nil
+	return stats, nil
 }
 
 func (p *Parser) parse() {


### PR DESCRIPTION
fixes ENG-7607

<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for parsing GraphQL documents with configurable maximum depth and field limits, providing clear error messages when these limits are exceeded.
  * Introduced detailed statistics reporting for total depth and field count during parsing.

* **Bug Fixes**
  * Improved handling of fragment spreads to ensure accurate field counting.

* **Tests**
  * Added comprehensive tests covering depth and field limit enforcement, including scenarios with fragments and multiple operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.

<!--
Please add any additional information or context regarding your changes here.
-->