### PR TITLE
fix: handle null only for outer list

### DIFF
--- a/execution/engine/execution_engine_grpc_test.go
+++ b/execution/engine/execution_engine_grpc_test.go
@@ -1432,4 +1432,23 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 		require.Contains(t, response, `"teamsByProject":`)
 		require.Contains(t, response, `"favoriteCategories":`)
 	})
+
+	t.Run("should handle empty and nullable list items", func(t *testing.T) {
+		operation := graphql.Request{
+			OperationName: "EmptyAndNullableListItems",
+			Query: `query EmptyAndNullableListItems {
+				author {
+					id
+					authorGroups {
+						id
+						name
+					}
+				}
+			}`,
+		}
+
+		response, err := executeOperation(t, conn, operation, withGRPCMapping(mapping.DefaultGRPCMapping()))
+		require.NoError(t, err)
+		require.Equal(t, `{"data":{"author":{"id":"author-default","authorGroups":[[{"id":"group-auth-1","name":"Team Lead Alpha"},{"id":"group-auth-2","name":"Senior Dev Beta"}],[{"id":"group-auth-3","name":"Junior Dev Gamma"}],[],null]}}}`, response)
+	})
 }

--- a/v2/pkg/engine/datasource/grpc_datasource/grpc_datasource.go
+++ b/v2/pkg/engine/datasource/grpc_datasource/grpc_datasource.go
@@ -329,7 +329,7 @@ func (d *DataSource) traverseList(level int, arena *astjson.Arena, current *astj
 	list := msg.Get(fd).List()
 	if !list.IsValid() {
 		if md.LevelInfo[level].Optional {
-			return arena.NewNull(), nil
+			return arena.NewArray(), nil
 		}
 
 		return arena.NewNull(), fmt.Errorf("cannot add null item to response for non nullable list")

--- a/v2/pkg/engine/datasource/grpc_datasource/grpc_datasource.go
+++ b/v2/pkg/engine/datasource/grpc_datasource/grpc_datasource.go
@@ -299,11 +299,12 @@ func (d *DataSource) traverseList(level int, arena *astjson.Arena, current *astj
 
 	msg := data.Get(fd).Message()
 	if !msg.IsValid() {
+		// If the message is not valid we can either return null if the list is nullable or an error if it is non nullable.
 		if md.LevelInfo[level].Optional {
 			return arena.NewNull(), nil
 		}
 
-		return arena.NewArray(), nil
+		return arena.NewArray(), fmt.Errorf("cannot add null item to response for non nullable list")
 	}
 
 	fd = msg.Descriptor().Fields().ByNumber(1)
@@ -328,6 +329,8 @@ func (d *DataSource) traverseList(level int, arena *astjson.Arena, current *astj
 
 	list := msg.Get(fd).List()
 	if !list.IsValid() {
+		// If the list is not valid, we return an empty array here as the
+		// nullabilty is checked on the outer List wrapper type.
 		return arena.NewArray(), nil
 	}
 

--- a/v2/pkg/engine/datasource/grpc_datasource/grpc_datasource.go
+++ b/v2/pkg/engine/datasource/grpc_datasource/grpc_datasource.go
@@ -328,11 +328,7 @@ func (d *DataSource) traverseList(level int, arena *astjson.Arena, current *astj
 
 	list := msg.Get(fd).List()
 	if !list.IsValid() {
-		if md.LevelInfo[level].Optional {
-			return arena.NewArray(), nil
-		}
-
-		return arena.NewNull(), fmt.Errorf("cannot add null item to response for non nullable list")
+		return arena.NewArray(), nil
 	}
 
 	for i := 0; i < list.Len(); i++ {

--- a/v2/pkg/grpctest/mockservice.go
+++ b/v2/pkg/grpctest/mockservice.go
@@ -1628,6 +1628,10 @@ func (s *MockService) QueryAuthor(ctx context.Context, in *productv1.QueryAuthor
 							{Id: "group-auth-3", Name: "Junior Dev Gamma"},
 						},
 					}},
+					// empty list
+					{List: &productv1.ListOfUser_List{}},
+					// null item
+					nil,
 				},
 			},
 		},


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty and null items in nested lists within gRPC responses, ensuring stricter error reporting and correct output for non-nullable and nullable fields.

* **Tests**
  * Added a test to verify correct handling of empty and nullable list items in GraphQL responses.
  * Enhanced mock data to include cases with empty lists and null entries for more comprehensive testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
