### PR TITLE
fix: make propagated operation names unique

### DIFF
--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource_federation_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource_federation_test.go
@@ -2111,7 +2111,8 @@ func TestGraphQLDataSourceFederation(t *testing.T) {
 										},
 										DataSourceIdentifier: []byte("graphql_datasource.Source"),
 										FetchConfiguration: resolve.FetchConfiguration{
-											Input:          `{"method":"POST","url":"http://service-a","body":{"query":"query CompositeKey__service_a {user {__typename account {id} id} otherUser {__typename account {id} id}}"}}`,
+											Input:          `{"method":"POST","url":"http://service-a","body":{"query":"query CompositeKey__service_a__0 {user {__typename account {id} id} otherUser {__typename account {id} id}}"}}`,
+											OperationName:  "CompositeKey__service_a",
 											DataSource:     &Source{},
 											PostProcessing: DefaultPostProcessingConfiguration,
 										},
@@ -2123,7 +2124,8 @@ func TestGraphQLDataSourceFederation(t *testing.T) {
 										},
 										DataSourceIdentifier: []byte("graphql_datasource.Source"),
 										FetchConfiguration: resolve.FetchConfiguration{
-											Input: `{"method":"POST","url":"http://service-b","body":{"query":"query CompositeKey__service_b($representations: [_Any!]!){_entities(representations: $representations){... on User {__typename foo}}}","variables":{"representations":[$$0$$]}}}`,
+											Input:         `{"method":"POST","url":"http://service-b","body":{"query":"query CompositeKey__service_b__1($representations: [_Any!]!){_entities(representations: $representations){... on User {__typename foo}}}","variables":{"representations":[$$0$$]}}}`,
+											OperationName: "CompositeKey__service_b",
 											Variables: resolve.NewVariables(
 												&resolve.ResolvableObjectVariable{
 													Renderer: resolve.NewGraphQLVariableResolveRenderer(&resolve.Object{
@@ -2175,7 +2177,8 @@ func TestGraphQLDataSourceFederation(t *testing.T) {
 										},
 										DataSourceIdentifier: []byte("graphql_datasource.Source"),
 										FetchConfiguration: resolve.FetchConfiguration{
-											Input: `{"method":"POST","url":"http://service-b","body":{"query":"query CompositeKey__service_b($representations: [_Any!]!){_entities(representations: $representations){... on User {__typename foo}}}","variables":{"representations":[$$0$$]}}}`,
+											Input:         `{"method":"POST","url":"http://service-b","body":{"query":"query CompositeKey__service_b__2($representations: [_Any!]!){_entities(representations: $representations){... on User {__typename foo}}}","variables":{"representations":[$$0$$]}}}`,
+											OperationName: "CompositeKey__service_b",
 											Variables: resolve.NewVariables(
 												&resolve.ResolvableObjectVariable{
 													Renderer: resolve.NewGraphQLVariableResolveRenderer(&resolve.Object{
@@ -2891,7 +2894,8 @@ func TestGraphQLDataSourceFederation(t *testing.T) {
 									},
 									DataSourceIdentifier: []byte("graphql_datasource.Source"),
 									FetchConfiguration: resolve.FetchConfiguration{
-										Input:          `{"method":"POST","url":"http://service-a","body":{"query":"query CompositeKey__s_rvic_e_a {user {__typename account {id} id} otherUser {__typename account {id} id}}"}}`,
+										Input:          `{"method":"POST","url":"http://service-a","body":{"query":"query CompositeKey__s_rvic_e_a__0 {user {__typename account {id} id} otherUser {__typename account {id} id}}"}}`,
+										OperationName:  "CompositeKey__s_rvic_e_a",
 										DataSource:     &Source{},
 										PostProcessing: DefaultPostProcessingConfiguration,
 									},
@@ -2903,7 +2907,8 @@ func TestGraphQLDataSourceFederation(t *testing.T) {
 									},
 									DataSourceIdentifier: []byte("graphql_datasource.Source"),
 									FetchConfiguration: resolve.FetchConfiguration{
-										Input: `{"method":"POST","url":"http://service-b","body":{"query":"query CompositeKey__service_b($representations: [_Any!]!){_entities(representations: $representations){... on User {__typename foo}}}","variables":{"representations":[$$0$$]}}}`,
+										Input:         `{"method":"POST","url":"http://service-b","body":{"query":"query CompositeKey__service_b__1($representations: [_Any!]!){_entities(representations: $representations){... on User {__typename foo}}}","variables":{"representations":[$$0$$]}}}`,
+										OperationName: "CompositeKey__service_b",
 										Variables: resolve.NewVariables(
 											&resolve.ResolvableObjectVariable{
 												Renderer: resolve.NewGraphQLVariableResolveRenderer(&resolve.Object{
@@ -2955,7 +2960,8 @@ func TestGraphQLDataSourceFederation(t *testing.T) {
 									},
 									DataSourceIdentifier: []byte("graphql_datasource.Source"),
 									FetchConfiguration: resolve.FetchConfiguration{
-										Input: `{"method":"POST","url":"http://service-b","body":{"query":"query CompositeKey__service_b($representations: [_Any!]!){_entities(representations: $representations){... on User {__typename foo}}}","variables":{"representations":[$$0$$]}}}`,
+										Input:         `{"method":"POST","url":"http://service-b","body":{"query":"query CompositeKey__service_b__2($representations: [_Any!]!){_entities(representations: $representations){... on User {__typename foo}}}","variables":{"representations":[$$0$$]}}}`,
+										OperationName: "CompositeKey__service_b",
 										Variables: resolve.NewVariables(
 											&resolve.ResolvableObjectVariable{
 												Renderer: resolve.NewGraphQLVariableResolveRenderer(&resolve.Object{
@@ -12099,7 +12105,8 @@ func TestGraphQLDataSourceFederation(t *testing.T) {
 							Fetches: resolve.Sequence(
 								resolve.Single(&resolve.SingleFetch{
 									FetchConfiguration: resolve.FetchConfiguration{
-										Input:          `{"method":"POST","url":"http://first.service","body":{"query":"query Accounts__first_service {accounts {__typename ... on User {__typename id} ... on Admin {__typename adminID} ... on Moderator {__typename moderatorID}}}"}}`,
+										Input:          `{"method":"POST","url":"http://first.service","body":{"query":"query Accounts__first_service__0 {accounts {__typename ... on User {__typename id} ... on Admin {__typename adminID} ... on Moderator {__typename moderatorID}}}"}}`,
+										OperationName:  "Accounts__first_service",
 										PostProcessing: DefaultPostProcessingConfiguration,
 										DataSource:     &Source{},
 									},
@@ -12110,7 +12117,8 @@ func TestGraphQLDataSourceFederation(t *testing.T) {
 										FetchID:           1,
 										DependsOnFetchIDs: []int{0},
 									}, FetchConfiguration: resolve.FetchConfiguration{
-										Input:                                 `{"method":"POST","url":"http://second.service","body":{"query":"query Accounts__second_service($representations: [_Any!]!){_entities(representations: $representations){... on User {__typename name} ... on Admin {__typename adminName}}}","variables":{"representations":[$$0$$]}}}`,
+										Input:                                 `{"method":"POST","url":"http://second.service","body":{"query":"query Accounts__second_service__1($representations: [_Any!]!){_entities(representations: $representations){... on User {__typename name} ... on Admin {__typename adminName}}}","variables":{"representations":[$$0$$]}}}`,
+										OperationName:                         "Accounts__second_service",
 										DataSource:                            &Source{},
 										SetTemplateOutputToNullOnVariableNull: true,
 										RequiresEntityBatchFetch:              true,
@@ -12161,7 +12169,8 @@ func TestGraphQLDataSourceFederation(t *testing.T) {
 										DependsOnFetchIDs: []int{0},
 									},
 									FetchConfiguration: resolve.FetchConfiguration{
-										Input:                                 `{"method":"POST","url":"http://third.service","body":{"query":"query Accounts__third_service($representations: [_Any!]!){_entities(representations: $representations){... on Moderator {__typename subject address {__typename id}}}}","variables":{"representations":[$$0$$]}}}`,
+										Input:                                 `{"method":"POST","url":"http://third.service","body":{"query":"query Accounts__third_service__2($representations: [_Any!]!){_entities(representations: $representations){... on Moderator {__typename subject address {__typename id}}}}","variables":{"representations":[$$0$$]}}}`,
+										OperationName:                         "Accounts__third_service",
 										DataSource:                            &Source{},
 										SetTemplateOutputToNullOnVariableNull: true,
 										RequiresEntityBatchFetch:              true,
@@ -12198,7 +12207,8 @@ func TestGraphQLDataSourceFederation(t *testing.T) {
 										DependsOnFetchIDs: []int{2},
 									},
 									FetchConfiguration: resolve.FetchConfiguration{
-										Input:                                 `{"method":"POST","url":"http://first.service","body":{"query":"query Accounts__first_service($representations: [_Any!]!){_entities(representations: $representations){... on Address {__typename zip}}}","variables":{"representations":[$$0$$]}}}`,
+										Input:                                 `{"method":"POST","url":"http://first.service","body":{"query":"query Accounts__first_service__3($representations: [_Any!]!){_entities(representations: $representations){... on Address {__typename zip}}}","variables":{"representations":[$$0$$]}}}`,
+										OperationName:                         "Accounts__first_service",
 										DataSource:                            &Source{},
 										SetTemplateOutputToNullOnVariableNull: true,
 										RequiresEntityBatchFetch:              true,

--- a/v2/pkg/engine/plan/planner.go
+++ b/v2/pkg/engine/plan/planner.go
@@ -24,14 +24,16 @@ type Planner struct {
 	prepareOperationWalker *astvisitor.Walker
 }
 
-// NewPlanner creates a new Planner from the Configuration
+// NewPlanner creates a new Planner from the Configuration.
+//
 // NOTE: All stateful DataSources should be initiated with the same context.Context object provided to the PlannerFactory.
-// The context.Context object is used to determine the lifecycle of stateful DataSources
-// It's important to note that stateful DataSources must be closed when they are no longer being used
+// The context.Context object is used to determine the lifecycle of stateful DataSources.
+// It's important to note that stateful DataSources must be closed when they are no longer being used.
+//
 // Stateful DataSources could be those that initiate a WebSocket connection to an origin, a database client, a streaming client, etc...
-// To ensure that there are no memory leaks, it's therefore important to add a cancel func or timeout to the context.Context
-// At the time when the resolver and all operations should be garbage collected, ensure to first cancel or timeout the ctx object
-// If you don't cancel the context.Context, the goroutines will run indefinitely and there's no reference left to stop them
+// To ensure that there are no memory leaks, it's therefore important to add a cancel func or timeout to the context.Context.
+// At the time when the resolver and all operations should be garbage collected, ensure to first cancel or timeout the ctx object.
+// If you don't cancel the context.Context, the goroutines will run indefinitely and there's no reference left to stop them.
 func NewPlanner(config Configuration) (*Planner, error) {
 	if config.Logger == nil {
 		config.Logger = abstractlogger.Noop{}

--- a/v2/pkg/engine/plan/visitor.go
+++ b/v2/pkg/engine/plan/visitor.go
@@ -28,6 +28,7 @@ type QueryPlanProvider interface {
 	IncludeQueryPlanInFetchConfiguration()
 }
 
+// Visitor creates the shape of resolve.GraphQLResponse.
 type Visitor struct {
 	Operation, Definition        *ast.Document
 	Walker                       *astvisitor.Walker
@@ -1286,7 +1287,7 @@ func (v *Visitor) configureSubscription(config *objectFetchConfiguration) {
 
 func (v *Visitor) configureObjectFetch(config *objectFetchConfiguration) {
 	fetchConfig := config.planner.ConfigureFetch()
-	// If the datasource is missing, we can anticipate that configure fetch failed
+	// If the datasource is missing, we can expect that configure fetch failed
 	if fetchConfig.DataSource == nil {
 		return
 	}

--- a/v2/pkg/engine/postprocess/fetch_id_appender.go
+++ b/v2/pkg/engine/postprocess/fetch_id_appender.go
@@ -24,7 +24,9 @@ func (f *fetchIDAppender) traverseNode(node *resolve.FetchTreeNode) {
 	}
 	switch node.Kind {
 	case resolve.FetchTreeNodeKindSingle:
-		f.traverseSingleFetch(node.Item.Fetch.(*resolve.SingleFetch))
+		if singleFetch, ok := node.Item.Fetch.(*resolve.SingleFetch); ok {
+			f.traverseSingleFetch(singleFetch)
+		}
 	case resolve.FetchTreeNodeKindParallel, resolve.FetchTreeNodeKindSequence:
 		for i := range node.ChildNodes {
 			f.traverseNode(node.ChildNodes[i])

--- a/v2/pkg/engine/postprocess/fetch_id_appender.go
+++ b/v2/pkg/engine/postprocess/fetch_id_appender.go
@@ -2,8 +2,9 @@ package postprocess
 
 import (
 	"fmt"
-	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 	"strings"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 )
 
 // fetchIDAppender is a processor to append fetchIDs to the operation names propagated downstream.

--- a/v2/pkg/engine/postprocess/fetch_id_appender.go
+++ b/v2/pkg/engine/postprocess/fetch_id_appender.go
@@ -39,5 +39,9 @@ func (f *fetchIDAppender) traverseSingleFetch(fetch *resolve.SingleFetch) {
 	if fetch.OperationName != "" {
 		expandedName := fmt.Sprintf("%s__%d", fetch.OperationName, fetch.FetchID)
 		fetch.Input = strings.Replace(fetch.Input, fetch.OperationName, expandedName, 1)
+		if fetch.QueryPlan != nil {
+			// Needed for debugging of query plans
+			fetch.QueryPlan.Query = strings.Replace(fetch.QueryPlan.Query, fetch.OperationName, expandedName, 1)
+		}
 	}
 }

--- a/v2/pkg/engine/postprocess/postprocess.go
+++ b/v2/pkg/engine/postprocess/postprocess.go
@@ -157,6 +157,7 @@ func (p *Processor) Process(pre plan.Plan) plan.Plan {
 		p.createFetchTree(t.Response.Response)
 		p.appendTriggerToFetchTree(t.Response)
 		p.dedupe.ProcessFetchTree(t.Response.Response.Fetches)
+		p.appendFetchID.ProcessFetchTree(t.Response.Response.Fetches)
 		p.resolveInputTemplates.ProcessFetchTree(t.Response.Response.Fetches)
 		p.resolveInputTemplates.ProcessTrigger(&t.Response.Trigger)
 		for i := range p.processFetchTree {

--- a/v2/pkg/engine/resolve/fetch.go
+++ b/v2/pkg/engine/resolve/fetch.go
@@ -291,23 +291,40 @@ type FetchConfiguration struct {
 	Input      string
 	Variables  Variables
 	DataSource DataSource
-	// RequiresParallelListItemFetch is used to indicate that the single fetches should be executed without batching
-	// When we have multiple fetches attached to the object - after post-processing of a plan we will get ParallelListItemFetch instead of ParallelFetch
+
+	// RequiresParallelListItemFetch indicates that the single fetches should be executed without batching.
+	// If we have multiple fetches attached to the object, then after post-processing of a plan
+	// we will get ParallelListItemFetch instead of ParallelFetch.
+	// Happens only for objects under the array path and used only for the introspection.
 	RequiresParallelListItemFetch bool
-	// RequiresEntityFetch will be set to true if the fetch is an entity fetch on an object. After post-processing, we will get EntityFetch
+
+	// RequiresEntityFetch will be set to true if the fetch is an entity fetch on an object.
+	// After post-processing, we will get EntityFetch.
 	RequiresEntityFetch bool
-	// RequiresEntityBatchFetch indicates that entity fetches on array items could be batched. After post-processing, we will get EntityBatchFetch
+
+	// RequiresEntityBatchFetch indicates that entity fetches on array items should be batched.
+	// After post-processing, we will get EntityBatchFetch.
 	RequiresEntityBatchFetch bool
-	PostProcessing           PostProcessingConfiguration
+
+	// PostProcessing specifies the data and error extraction path in the response along with
+	// the merge path where will insert the response.
+	PostProcessing PostProcessingConfiguration
+
 	// SetTemplateOutputToNullOnVariableNull will safely return "null" if one of the template variables renders to null
 	// This is the case, e.g. when using batching and one sibling is null, resulting in a null value for one batch item
 	// Returning null in this case tells the batch implementation to skip this item
 	SetTemplateOutputToNullOnVariableNull bool
-	QueryPlan                             *QueryPlan
-	// CoordinateDependencies contain a list of GraphCoordinates (typeName+fieldName) and which fields from other fetches they depend on
+
+	QueryPlan *QueryPlan
+
+	// CoordinateDependencies contain a list of GraphCoordinates (typeName+fieldName)
+	// and which fields from other fetches they depend on.
 	// This information is useful to understand why a fetch depends on other fetches,
 	// and how multiple dependencies lead to a chain of fetches
 	CoordinateDependencies []FetchDependency
+
+	// OperationName is non-empty when the operation name is propagated the downstream subgraph fetch.
+	OperationName string
 }
 
 func (fc *FetchConfiguration) Equals(other *FetchConfiguration) bool {


### PR DESCRIPTION
When operation names are sent to downstream subgraphs, send them in the following format:

    $operationName__$subgraphName__$sequenceID

Also some comments were updated.

<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operation names are now propagated to downstream subgraph fetches, improving traceability in federated GraphQL queries.
  * Fetch IDs are automatically appended to operation names in fetch trees, ensuring uniqueness across parallel and nested fetches.

* **Bug Fixes**
  * None.

* **Documentation**
  * Improved and clarified comments for several configuration fields and functions to enhance readability and understanding.

* **Tests**
  * Updated federation test cases to reflect operation name propagation and fetch ID appending in fetch configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.

<!--
Please add any additional information or context regarding your changes here.
-->