### PR TITLE
feat: improved subscription heartbeats

### DIFF
--- a/execution/graphql/result_writer.go
+++ b/execution/graphql/result_writer.go
@@ -35,6 +35,10 @@ func (e *EngineResultWriter) Complete() {
 
 }
 
+func (e *EngineResultWriter) Heartbeat() error {
+	return nil
+}
+
 func (e *EngineResultWriter) Close(_ resolve.SubscriptionCloseKind) {
 
 }

--- a/v2/pkg/engine/resolve/event_loop_test.go
+++ b/v2/pkg/engine/resolve/event_loop_test.go
@@ -51,7 +51,11 @@ func (f *FakeSubscriptionWriter) Complete() {
 	f.messageCountOnComplete = len(f.writtenMessages)
 }
 
+// Heartbeat writes directly to the writtenMessages slice, as the real implementations implicitly flush
 func (f *FakeSubscriptionWriter) Heartbeat() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.writtenMessages = append(f.writtenMessages, string("heartbeat"))
 	return nil
 }
 

--- a/v2/pkg/engine/resolve/event_loop_test.go
+++ b/v2/pkg/engine/resolve/event_loop_test.go
@@ -123,16 +123,16 @@ func TestEventLoop(t *testing.T) {
 	testReporter := &TestReporter{}
 
 	resolver := New(resolverCtx, ResolverOptions{
-		MaxConcurrency:               1024,
-		Debug:                        false,
-		AsyncErrorWriter:             ew,
-		PropagateSubgraphErrors:      false,
-		PropagateSubgraphStatusCodes: false,
-		SubgraphErrorPropagationMode: SubgraphErrorPropagationModePassThrough,
-		DefaultErrorExtensionCode:    "TEST",
-		MaxRecyclableParserSize:      1024 * 1024,
-		SubHeartbeatInterval:         DefaultHeartbeatInterval,
-		Reporter:                     testReporter,
+		MaxConcurrency:                1024,
+		Debug:                         false,
+		AsyncErrorWriter:              ew,
+		PropagateSubgraphErrors:       false,
+		PropagateSubgraphStatusCodes:  false,
+		SubgraphErrorPropagationMode:  SubgraphErrorPropagationModePassThrough,
+		DefaultErrorExtensionCode:     "TEST",
+		MaxRecyclableParserSize:       1024 * 1024,
+		SubscriptionHeartbeatInterval: DefaultHeartbeatInterval,
+		Reporter:                      testReporter,
 	})
 
 	subscription := &GraphQLSubscription{

--- a/v2/pkg/engine/resolve/event_loop_test.go
+++ b/v2/pkg/engine/resolve/event_loop_test.go
@@ -51,6 +51,10 @@ func (f *FakeSubscriptionWriter) Complete() {
 	f.messageCountOnComplete = len(f.writtenMessages)
 }
 
+func (f *FakeSubscriptionWriter) Heartbeat() error {
+	return nil
+}
+
 func (f *FakeSubscriptionWriter) Close(SubscriptionCloseKind) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/v2/pkg/engine/resolve/event_loop_test.go
+++ b/v2/pkg/engine/resolve/event_loop_test.go
@@ -119,16 +119,16 @@ func TestEventLoop(t *testing.T) {
 	testReporter := &TestReporter{}
 
 	resolver := New(resolverCtx, ResolverOptions{
-		MaxConcurrency:                1024,
-		Debug:                         false,
-		AsyncErrorWriter:              ew,
-		PropagateSubgraphErrors:       false,
-		PropagateSubgraphStatusCodes:  false,
-		SubgraphErrorPropagationMode:  SubgraphErrorPropagationModePassThrough,
-		DefaultErrorExtensionCode:     "TEST",
-		MaxRecyclableParserSize:       1024 * 1024,
-		MultipartSubHeartbeatInterval: DefaultHeartbeatInterval,
-		Reporter:                      testReporter,
+		MaxConcurrency:               1024,
+		Debug:                        false,
+		AsyncErrorWriter:             ew,
+		PropagateSubgraphErrors:      false,
+		PropagateSubgraphStatusCodes: false,
+		SubgraphErrorPropagationMode: SubgraphErrorPropagationModePassThrough,
+		DefaultErrorExtensionCode:    "TEST",
+		MaxRecyclableParserSize:      1024 * 1024,
+		SubHeartbeatInterval:         DefaultHeartbeatInterval,
+		Reporter:                     testReporter,
 	})
 
 	subscription := &GraphQLSubscription{

--- a/v2/pkg/engine/resolve/resolve.go
+++ b/v2/pkg/engine/resolve/resolve.go
@@ -139,8 +139,8 @@ type ResolverOptions struct {
 	ResolvableOptions ResolvableOptions
 	// AllowedCustomSubgraphErrorFields defines which fields are allowed in the subgraph error when in passthrough mode
 	AllowedSubgraphErrorFields []string
-	// SubHeartbeatInterval defines the interval in which a heartbeat is sent to all subscriptions (whether or not this does anything is determined by the subscription response writer)
-	SubHeartbeatInterval time.Duration
+	// SubscriptionHeartbeatInterval defines the interval in which a heartbeat is sent to all subscriptions (whether or not this does anything is determined by the subscription response writer)
+	SubscriptionHeartbeatInterval time.Duration
 	// MaxSubscriptionFetchTimeout defines the maximum time a subscription fetch can take before it is considered timed out
 	MaxSubscriptionFetchTimeout time.Duration
 	// ApolloRouterCompatibilitySubrequestHTTPError is a compatibility flag for Apollo Router, it is used to handle HTTP errors in subrequests differently
@@ -154,8 +154,8 @@ func New(ctx context.Context, options ResolverOptions) *Resolver {
 		options.MaxConcurrency = 32
 	}
 
-	if options.SubHeartbeatInterval <= 0 {
-		options.SubHeartbeatInterval = DefaultHeartbeatInterval
+	if options.SubscriptionHeartbeatInterval <= 0 {
+		options.SubscriptionHeartbeatInterval = DefaultHeartbeatInterval
 	}
 
 	// We transform the allowed fields into a map for faster lookups
@@ -198,7 +198,7 @@ func New(ctx context.Context, options ResolverOptions) *Resolver {
 		triggerUpdateBuf:             bytes.NewBuffer(make([]byte, 0, 1024)),
 		allowedErrorExtensionFields:  allowedExtensionFields,
 		allowedErrorFields:           allowedErrorFields,
-		heartbeatInterval:            options.SubHeartbeatInterval,
+		heartbeatInterval:            options.SubscriptionHeartbeatInterval,
 		maxSubscriptionFetchTimeout:  options.MaxSubscriptionFetchTimeout,
 	}
 	resolver.maxConcurrency = make(chan struct{}, options.MaxConcurrency)

--- a/v2/pkg/engine/resolve/resolve.go
+++ b/v2/pkg/engine/resolve/resolve.go
@@ -139,8 +139,8 @@ type ResolverOptions struct {
 	ResolvableOptions ResolvableOptions
 	// AllowedCustomSubgraphErrorFields defines which fields are allowed in the subgraph error when in passthrough mode
 	AllowedSubgraphErrorFields []string
-	// MultipartSubHeartbeatInterval defines the interval in which a heartbeat is sent to all multipart subscriptions
-	MultipartSubHeartbeatInterval time.Duration
+	// SubHeartbeatInterval defines the interval in which a heartbeat is sent to all subscriptions (whether or not this does anything is determined by the subscription response writer)
+	SubHeartbeatInterval time.Duration
 	// MaxSubscriptionFetchTimeout defines the maximum time a subscription fetch can take before it is considered timed out
 	MaxSubscriptionFetchTimeout time.Duration
 	// ApolloRouterCompatibilitySubrequestHTTPError is a compatibility flag for Apollo Router, it is used to handle HTTP errors in subrequests differently
@@ -154,8 +154,8 @@ func New(ctx context.Context, options ResolverOptions) *Resolver {
 		options.MaxConcurrency = 32
 	}
 
-	if options.MultipartSubHeartbeatInterval <= 0 {
-		options.MultipartSubHeartbeatInterval = DefaultHeartbeatInterval
+	if options.SubHeartbeatInterval <= 0 {
+		options.SubHeartbeatInterval = DefaultHeartbeatInterval
 	}
 
 	// We transform the allowed fields into a map for faster lookups
@@ -198,7 +198,7 @@ func New(ctx context.Context, options ResolverOptions) *Resolver {
 		triggerUpdateBuf:             bytes.NewBuffer(make([]byte, 0, 1024)),
 		allowedErrorExtensionFields:  allowedExtensionFields,
 		allowedErrorFields:           allowedErrorFields,
-		heartbeatInterval:            options.MultipartSubHeartbeatInterval,
+		heartbeatInterval:            options.SubHeartbeatInterval,
 		maxSubscriptionFetchTimeout:  options.MaxSubscriptionFetchTimeout,
 	}
 	resolver.maxConcurrency = make(chan struct{}, options.MaxConcurrency)

--- a/v2/pkg/engine/resolve/resolve_test.go
+++ b/v2/pkg/engine/resolve/resolve_test.go
@@ -86,16 +86,16 @@ func (t *TestErrorWriter) WriteError(ctx *Context, err error, res *GraphQLRespon
 	}
 }
 
-var multipartSubHeartbeatInterval = 100 * time.Millisecond
+var subscriptionHeartbeatInterval = 100 * time.Millisecond
 
 func newResolver(ctx context.Context) *Resolver {
 	return New(ctx, ResolverOptions{
-		MaxConcurrency:               1024,
-		Debug:                        false,
-		PropagateSubgraphErrors:      true,
-		PropagateSubgraphStatusCodes: true,
-		AsyncErrorWriter:             &TestErrorWriter{},
-		SubHeartbeatInterval:         multipartSubHeartbeatInterval,
+		MaxConcurrency:                1024,
+		Debug:                         false,
+		PropagateSubgraphErrors:       true,
+		PropagateSubgraphStatusCodes:  true,
+		AsyncErrorWriter:              &TestErrorWriter{},
+		SubscriptionHeartbeatInterval: subscriptionHeartbeatInterval,
 	})
 }
 

--- a/v2/pkg/engine/resolve/resolve_test.go
+++ b/v2/pkg/engine/resolve/resolve_test.go
@@ -4777,6 +4777,10 @@ func (s *SubscriptionRecorder) Complete() {
 	s.complete.Store(true)
 }
 
+func (s *SubscriptionRecorder) Heartbeat() error {
+	return nil
+}
+
 func (s *SubscriptionRecorder) Close(_ SubscriptionCloseKind) {
 	s.closed.Store(true)
 }

--- a/v2/pkg/engine/resolve/resolve_test.go
+++ b/v2/pkg/engine/resolve/resolve_test.go
@@ -90,12 +90,12 @@ var multipartSubHeartbeatInterval = 100 * time.Millisecond
 
 func newResolver(ctx context.Context) *Resolver {
 	return New(ctx, ResolverOptions{
-		MaxConcurrency:                1024,
-		Debug:                         false,
-		PropagateSubgraphErrors:       true,
-		PropagateSubgraphStatusCodes:  true,
-		AsyncErrorWriter:              &TestErrorWriter{},
-		MultipartSubHeartbeatInterval: multipartSubHeartbeatInterval,
+		MaxConcurrency:               1024,
+		Debug:                        false,
+		PropagateSubgraphErrors:      true,
+		PropagateSubgraphStatusCodes: true,
+		AsyncErrorWriter:             &TestErrorWriter{},
+		SubHeartbeatInterval:         multipartSubHeartbeatInterval,
 	})
 }
 

--- a/v2/pkg/engine/resolve/resolve_test.go
+++ b/v2/pkg/engine/resolve/resolve_test.go
@@ -4778,6 +4778,9 @@ func (s *SubscriptionRecorder) Complete() {
 }
 
 func (s *SubscriptionRecorder) Heartbeat() error {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	s.messages = append(s.messages, "heartbeat")
 	return nil
 }
 

--- a/v2/pkg/engine/resolve/response.go
+++ b/v2/pkg/engine/resolve/response.go
@@ -67,6 +67,7 @@ type SubscriptionResponseWriter interface {
 	ResponseWriter
 	Flush() error
 	Complete()
+	Heartbeat() error
 	Close(kind SubscriptionCloseKind)
 }
 


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit subscription heartbeat signaling support to response writers.

* **Bug Fixes**
  * Heartbeats now stop promptly on client disconnect or resolver shutdown, preventing stray heartbeat errors.

* **Performance**
  * Heartbeat emission streamlined to a single writer call, reducing overhead and improving idle stability.

* **Refactor**
  * Consolidated and renamed subscription heartbeat configuration for clearer setup and consistent behavior.

* **Tests**
  * Subscription tests updated to record and verify heartbeat events; test writers now support heartbeat signaling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.

<!--
Please add any additional information or context regarding your changes here.
-->