### PR TITLE
fix: add sorting before creating the hash

### DIFF
--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptrace"
 	"net/textproto"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -431,7 +432,16 @@ func (c *subscriptionClient) requestHash(ctx *resolve.Context, options GraphQLSu
 		if _, err = xxh.WriteString(headerRegexp.Pattern.String()); err != nil {
 			return err
 		}
-		for headerName, values := range ctx.Request.Header {
+
+		// Sort header names for deterministic hashing
+		headerKeys := make([]string, 0, len(ctx.Request.Header))
+		for key := range ctx.Request.Header {
+			headerKeys = append(headerKeys, key)
+		}
+		sort.Strings(headerKeys)
+
+		for _, headerName := range headerKeys {
+			values := ctx.Request.Header[headerName]
 			result := headerRegexp.Pattern.MatchString(headerName)
 			if headerRegexp.NegateMatch {
 				result = !result


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

Right now when there are regex expressions specified, we loop through a map to create a hash which results in non determinsitic hashes. We need to sort before looping

@coderabbitai summary

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.

<!--
Please add any additional information or context regarding your changes here.
-->