### PR TITLE
chore: enable the tparallel lint check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - staticcheck
     - bodyclose
     - embeddedstructfieldcheck
+    - tparallel
     # - unused
     # - gosec
 

--- a/v2/pkg/astnormalization/astnormalization_test.go
+++ b/v2/pkg/astnormalization/astnormalization_test.go
@@ -997,6 +997,7 @@ func TestParseMissingBaseSchema(t *testing.T) {
 }
 
 func TestVariablesNormalizer(t *testing.T) {
+	t.Parallel()
 
 	t.Run("httpBinPost", func(t *testing.T) {
 		t.Parallel()

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
@@ -8867,6 +8867,7 @@ func TestLoadFiles(t *testing.T) {
 }
 
 func TestSanitizeKey(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
@@ -583,10 +583,10 @@ func TestWebSocketClientLeaks(t *testing.T) {
 }
 
 func TestAsyncSubscribe(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.SkipNow()
 	}
-	t.Parallel()
 	t.Run("subscribe async", func(t *testing.T) {
 		t.Parallel()
 		serverDone := make(chan struct{})
@@ -1892,10 +1892,10 @@ func TestAsyncSubscribe(t *testing.T) {
 }
 
 func TestClientToSubgraphPingPong(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping test on Windows as it's not reliable")
 	}
-	t.Parallel()
 
 	t.Run("client sends ping message after configured interval", func(t *testing.T) {
 		t.Parallel()
@@ -2433,6 +2433,7 @@ func TestWebSocketUpgradeFailures(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				for key, value := range tc.headers {
 					w.Header().Set(key, value)
@@ -2514,6 +2515,7 @@ func TestInvalidWebSocketAcceptKey(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			var receivedChallengeKey string
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/engine/datasource/grpc_datasource/execution_plan_composite_test.go
+++ b/v2/pkg/engine/datasource/grpc_datasource/execution_plan_composite_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestCompositeTypeExecutionPlan(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		query         string
@@ -627,6 +628,7 @@ func TestCompositeTypeExecutionPlan(t *testing.T) {
 }
 
 func TestMutationUnionExecutionPlan(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		query         string

--- a/v2/pkg/engine/datasource/grpc_datasource/execution_plan_federation_test.go
+++ b/v2/pkg/engine/datasource/grpc_datasource/execution_plan_federation_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestEntityLookup(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name              string
 		query             string
@@ -482,6 +483,7 @@ func TestEntityLookup(t *testing.T) {
 }
 
 func TestEntityKeys(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name              string
 		query             string

--- a/v2/pkg/engine/datasource/grpc_datasource/execution_plan_list_test.go
+++ b/v2/pkg/engine/datasource/grpc_datasource/execution_plan_list_test.go
@@ -3,6 +3,7 @@ package grpcdatasource
 import "testing"
 
 func TestListExecutionPlan(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		query         string
@@ -163,6 +164,7 @@ func TestListExecutionPlan(t *testing.T) {
 }
 
 func TestListParametersExecutionPlan(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		query         string

--- a/v2/pkg/engine/datasource/grpc_datasource/execution_plan_nullable_test.go
+++ b/v2/pkg/engine/datasource/grpc_datasource/execution_plan_nullable_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestNullableFieldsExecutionPlan(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		query         string

--- a/v2/pkg/engine/datasource/grpc_datasource/execution_plan_test.go
+++ b/v2/pkg/engine/datasource/grpc_datasource/execution_plan_test.go
@@ -50,6 +50,7 @@ func runTest(t *testing.T, testCase testCase) {
 }
 
 func TestQueryExecutionPlans(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		query         string
@@ -1113,6 +1114,7 @@ func TestQueryExecutionPlans(t *testing.T) {
 }
 
 func TestProductExecutionPlan(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		query         string
@@ -1367,6 +1369,7 @@ func TestProductExecutionPlan(t *testing.T) {
 }
 
 func TestProductExecutionPlanWithAliases(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		query         string

--- a/v2/pkg/lexer/lexer_test.go
+++ b/v2/pkg/lexer/lexer_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestLexer_Peek_Read(t *testing.T) {
-	t.Parallel()
-
 	type checkFunc func(lex *Lexer, i int)
 
 	run := func(inStr string, checks ...checkFunc) {


### PR DESCRIPTION
It ensures that we use t.Parallel() correctly in tests.

