### PR TITLE
fix: don't send heartbeat on some subscription resolver tests

### DIFF
--- a/v2/pkg/engine/resolve/resolve_test.go
+++ b/v2/pkg/engine/resolve/resolve_test.go
@@ -5562,14 +5562,14 @@ func TestResolver_ResolveGraphQLSubscription(t *testing.T) {
 		ctx := &Context{
 			ctx: context.Background(),
 			ExecutionOptions: ExecutionOptions{
-				SendHeartbeat: true,
+				SendHeartbeat: false,
 			},
 		}
 
 		ctx2 := &Context{
 			ctx: context.Background(),
 			ExecutionOptions: ExecutionOptions{
-				SendHeartbeat: true,
+				SendHeartbeat: false,
 			},
 		}
 
@@ -5642,14 +5642,14 @@ func TestResolver_ResolveGraphQLSubscription(t *testing.T) {
 		ctx := &Context{
 			ctx: context.Background(),
 			ExecutionOptions: ExecutionOptions{
-				SendHeartbeat: true,
+				SendHeartbeat: false,
 			},
 		}
 
 		ctx2 := &Context{
 			ctx: context.Background(),
 			ExecutionOptions: ExecutionOptions{
-				SendHeartbeat: true,
+				SendHeartbeat: false,
 			},
 		}
 


### PR DESCRIPTION
@coderabbitai summary

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.

I adjusted two tests which are failing during Githubs CI run:

```
--- FAIL: TestResolver_ResolveGraphQLSubscription (31.69s)
    --- FAIL: TestResolver_ResolveGraphQLSubscription/SubscriptionOnStart_ctx_updater_only_updates_the_right_subscription (0.01s)
        resolve_test.go:5604: 
            	Error Trace:	/home/runner/work/graphql-go-tools/graphql-go-tools/v2/pkg/engine/resolve/resolve_test.go:5604
            	Error:      	Should be true
            	Test:       	TestResolver_ResolveGraphQLSubscription/SubscriptionOnStart_ctx_updater_only_updates_the_right_subscription
    --- FAIL: TestResolver_ResolveGraphQLSubscription/SubscriptionOnStart_ctx_updater_on_multiple_subscriptions_with_same_trigger_works (0.01s)
        resolve_test.go:5674: 
            	Error Trace:	/home/runner/work/graphql-go-tools/graphql-go-tools/v2/pkg/engine/resolve/resolve_test.go:5674
            	Error:      	should not be here
            	Test:       	TestResolver_ResolveGraphQLSubscription/SubscriptionOnStart_ctx_updater_on_multiple_subscriptions_with_same_trigger_works
FAIL
```

These tests work locally, at least on my machine. I assumed it only manifests itself on slower CPU´s like it's the case on Github workers. After testing around with some time.Sleeps() here and there, I found that if messages in tests are not emitted fast enough, then heartbeat messages might find their way into the recorders message list. As these tests have nothing to do with heartbeat testing I disabled them here. I am not 100% sure this is the problem, but I am fairly certain and I think it makes sense anyway.