### PR TITLE
fix: avoid duplicate joins on errors

### DIFF
--- a/v2/pkg/engine/resolve/loader.go
+++ b/v2/pkg/engine/resolve/loader.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
-	goerrors "errors"
 	"fmt"
 	"net/http"
 	"net/http/httptrace"
@@ -67,7 +66,7 @@ func (ri *ResponseInfo) GetResponseBody() string {
 func newResponseInfo(res *result, subgraphError error) *ResponseInfo {
 	responseInfo := &ResponseInfo{
 		StatusCode:   res.statusCode,
-		Err:          goerrors.Join(res.err, subgraphError),
+		Err:          subgraphError,
 		responseBody: res.out,
 	}
 	if res.httpResponseContext != nil {


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

In case of non http errors the errors are duplicated resulting in duplicates in the error message such as

```
Post \"http://localhost:4001/graphql\": dial tcp [::1]:4001: connect: connection refused
Post \"http://localhost:4001/graphql\": dial tcp [::1]:4001: connect: connection refused
Failed to fetch from Subgraph 'employees'.
```

This is as we join the same error multiple times. Since we already join `res.err` and set it to `l.ctx.subgraphErrors` in `l.mergeResult` we can simply remove the join inside `newResponseInfo`


@coderabbitai summary

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.

<!--
Please add any additional information or context regarding your changes here.
-->