### PR TITLE
fix(grpc): capture loop variables in goroutine closure

### DIFF
--- a/v2/pkg/engine/datasource/grpc_datasource/grpc_datasource.go
+++ b/v2/pkg/engine/datasource/grpc_datasource/grpc_datasource.go
@@ -113,6 +113,9 @@ func (d *DataSource) Load(ctx context.Context, input []byte, out *bytes.Buffer) 
 
 		// make gRPC calls
 		for index, serviceCall := range serviceCalls {
+			// Capture loop variables to avoid closure issues
+			index := index
+			serviceCall := serviceCall
 			errGrp.Go(func() error {
 				a := astjson.Arena{}
 				// Invoke the gRPC method - this will populate serviceCall.Output


### PR DESCRIPTION
Fix potential race condition by capturing loop variables 'index' and 'serviceCall' by value in the errgroup.Go() closure. Without this fix, all goroutines could reference the same loop variables, leading to concurrent access issues when processing gRPC service calls.

This addresses the race condition reported in cosmo router-tests when processing recursive field resolvers with multiple levels of recursion and aliases.
