### PR TITLE
fix: query planning for shared entities

### DIFF
--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource_federation_shared_entity_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource_federation_shared_entity_test.go
@@ -1,0 +1,767 @@
+package graphql_datasource
+
+import (
+	"testing"
+
+	. "github.com/wundergraph/graphql-go-tools/v2/pkg/engine/datasourcetesting"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// TestGraphQLDataSourceFederation_SharedEntityWithExternalKeyField reproduces a bug where
+// query planning fails with a 500 error when a query references a shared federation entity
+// where the @key field is @external in one subgraph but non-external in another.
+//
+// Error: "could not select the datasource to resolve CartBundleProduct.code on path
+// query.cartById.$0CartResultSuccess.cart.items.bundleProducts.code"
+//
+// Root cause: When newer composition puts an @external key field only in ExternalFieldNames
+// (not in both FieldNames and ExternalFieldNames), the key_fields_visitor marks the key as
+// external, preventing the cart datasource from being a key source. This breaks the jump
+// graph so no datasource can resolve the field.
+func TestGraphQLDataSourceFederation_SharedEntityWithExternalKeyField(t *testing.T) {
+
+	// Merged supergraph schema (what the router sees after composition)
+	definition := `
+		type Query {
+			cartById(cartId: String!): CartResult
+		}
+
+		union CartResult = CartExceptions | CartResultSuccess
+
+		type CartExceptions {
+			exceptions: [String]!
+		}
+
+		type CartResultSuccess {
+			cart: Cart!
+		}
+
+		type Cart {
+			id: String!
+			items: [CartItem]
+		}
+
+		type CartItem {
+			id: String!
+			product: CommerceProduct
+			bundleProducts: [CartBundleProduct]
+		}
+
+		type CartBundleProduct {
+			code: String
+			name: String
+			category: String
+			entryGroupNumber: Int
+		}
+
+		type CommerceProduct {
+			id: String!
+			title: String
+		}
+	`
+
+	// Cart subgraph SDL — code is @external (not the authority)
+	cartSubgraphSDL := `
+		type Query {
+			cartById(cartId: String!): CartResult
+		}
+
+		union CartResult = CartExceptions | CartResultSuccess
+
+		type CartExceptions {
+			exceptions: [String]!
+		}
+
+		type CartResultSuccess {
+			cart: Cart!
+		}
+
+		type Cart {
+			id: String!
+			items: [CartItem]
+		}
+
+		type CartItem {
+			id: String!
+			product: CommerceProduct
+			bundleProducts: [CartBundleProduct]
+		}
+
+		type CartBundleProduct @key(fields: "code", resolvable: true) @shareable {
+			code: String @external
+			name: String
+			category: String
+			entryGroupNumber: Int
+		}
+
+		type CommerceProduct @key(fields: "id") {
+			id: String!
+		}
+	`
+
+	// Products subgraph SDL — code is non-external (the authority)
+	productsSubgraphSDL := `
+		type Query {
+			_dummy: String
+		}
+
+		type CartBundleProduct @key(fields: "code", resolvable: true) @shareable {
+			code: String
+			name: String
+			entryGroupNumber: Int
+		}
+
+		type CommerceProduct @key(fields: "id") {
+			id: String!
+			title: String
+		}
+	`
+
+	cartDatasourceConfiguration := mustDataSourceConfiguration(t,
+		"cart.service",
+		&plan.DataSourceMetadata{
+			RootNodes: []plan.TypeField{
+				{
+					TypeName:   "Query",
+					FieldNames: []string{"cartById"},
+				},
+				{
+					TypeName: "CartBundleProduct",
+					// Key critical detail: code is ONLY in ExternalFieldNames, NOT in FieldNames.
+					// This models newer composition output where @external key fields
+					// are only in ExternalFieldNames.
+					FieldNames:         []string{"name", "category", "entryGroupNumber"},
+					ExternalFieldNames: []string{"code"},
+				},
+				{
+					TypeName:   "CommerceProduct",
+					FieldNames: []string{"id"},
+				},
+			},
+			ChildNodes: []plan.TypeField{
+				{
+					TypeName:   "CartResultSuccess",
+					FieldNames: []string{"cart"},
+				},
+				{
+					TypeName:   "CartExceptions",
+					FieldNames: []string{"exceptions"},
+				},
+				{
+					TypeName:   "Cart",
+					FieldNames: []string{"id", "items"},
+				},
+				{
+					TypeName:   "CartItem",
+					FieldNames: []string{"id", "product", "bundleProducts"},
+				},
+			},
+			FederationMetaData: plan.FederationMetaData{
+				Keys: plan.FederationFieldConfigurations{
+					{
+						TypeName:     "CartBundleProduct",
+						SelectionSet: "code",
+					},
+					{
+						TypeName:     "CommerceProduct",
+						SelectionSet: "id",
+					},
+				},
+			},
+		},
+		mustCustomConfiguration(t,
+			ConfigurationInput{
+				Fetch: &FetchConfiguration{
+					URL: "http://cart.service",
+				},
+				SchemaConfiguration: mustSchema(t,
+					&FederationConfiguration{
+						Enabled:    true,
+						ServiceSDL: cartSubgraphSDL,
+					},
+					cartSubgraphSDL,
+				),
+			},
+		),
+	)
+
+	productsDatasourceConfiguration := mustDataSourceConfiguration(t,
+		"products.service",
+		&plan.DataSourceMetadata{
+			RootNodes: []plan.TypeField{
+				{
+					TypeName: "CartBundleProduct",
+					// In the products subgraph, code is a regular field (the authority)
+					FieldNames: []string{"code", "name", "entryGroupNumber"},
+				},
+				{
+					TypeName:   "CommerceProduct",
+					FieldNames: []string{"id", "title"},
+				},
+			},
+			FederationMetaData: plan.FederationMetaData{
+				Keys: plan.FederationFieldConfigurations{
+					{
+						TypeName:     "CartBundleProduct",
+						SelectionSet: "code",
+					},
+					{
+						TypeName:     "CommerceProduct",
+						SelectionSet: "id",
+					},
+				},
+			},
+		},
+		mustCustomConfiguration(t,
+			ConfigurationInput{
+				Fetch: &FetchConfiguration{
+					URL: "http://products.service",
+				},
+				SchemaConfiguration: mustSchema(t,
+					&FederationConfiguration{
+						Enabled:    true,
+						ServiceSDL: productsSubgraphSDL,
+					},
+					productsSubgraphSDL,
+				),
+			},
+		),
+	)
+
+	dataSources := []plan.DataSource{
+		cartDatasourceConfiguration,
+		productsDatasourceConfiguration,
+	}
+
+	planConfiguration := plan.Configuration{
+		DataSources:                  dataSources,
+		DisableResolveFieldPositions: true,
+		Fields: plan.FieldConfigurations{
+			{
+				TypeName:  "Query",
+				FieldName: "cartById",
+				Arguments: plan.ArgumentsConfigurations{
+					{
+						Name:       "cartId",
+						SourceType: plan.FieldArgumentSource,
+					},
+				},
+			},
+		},
+	}
+
+	// Test 1: bundleProducts with code field — was FAIL before fix.
+	// The cart subgraph can resolve bundleProducts (it has CartItem.bundleProducts child node)
+	// and should be able to return the code field despite it being @external, because the
+	// planner always includes key fields in subgraph queries and the datasource actively
+	// resolves this entity type (it has non-external fields like name, category).
+	t.Run("bundleProducts with code field", func(t *testing.T) {
+		t.Run("run", RunTest(
+			definition,
+			`
+			query CartQuery($cartId: String!) {
+				cartById(cartId: $cartId) {
+					... on CartResultSuccess {
+						cart {
+							id
+							items {
+								id
+								bundleProducts {
+									code
+									name
+								}
+							}
+						}
+					}
+				}
+			}`,
+			"CartQuery",
+			&plan.SynchronousResponsePlan{
+				Response: &resolve.GraphQLResponse{
+					Fetches: resolve.Sequence(
+						resolve.Single(&resolve.SingleFetch{
+							FetchDependencies: resolve.FetchDependencies{
+								FetchID: 0,
+							},
+							DataSourceIdentifier: []byte("graphql_datasource.Source"),
+							FetchConfiguration: resolve.FetchConfiguration{
+								Input:          `{"method":"POST","url":"http://cart.service","body":{"query":"query($cartId: String!){cartById(cartId: $cartId){__typename ... on CartResultSuccess {cart {id items {id bundleProducts {code name}}}}}}","variables":{"cartId":$$0$$}}}`,
+								DataSource:     &Source{},
+								PostProcessing: DefaultPostProcessingConfiguration,
+								Variables: resolve.NewVariables(
+									&resolve.ContextVariable{
+										Path:     []string{"cartId"},
+										Renderer: resolve.NewJSONVariableRenderer(),
+									},
+								),
+							},
+						}),
+					),
+					Data: &resolve.Object{
+						Fields: []*resolve.Field{
+							{
+								Name: []byte("cartById"),
+								Value: &resolve.Object{
+									Path:     []string{"cartById"},
+									Nullable: true,
+									PossibleTypes: map[string]struct{}{
+										"CartExceptions":    {},
+										"CartResultSuccess": {},
+									},
+									TypeName: "CartResult",
+									Fields: []*resolve.Field{
+										{
+											Name: []byte("cart"),
+											Value: &resolve.Object{
+												Path: []string{"cart"},
+												PossibleTypes: map[string]struct{}{
+													"Cart": {},
+												},
+												TypeName: "Cart",
+												Fields: []*resolve.Field{
+													{
+														Name: []byte("id"),
+														Value: &resolve.String{
+															Path: []string{"id"},
+														},
+													},
+													{
+														Name: []byte("items"),
+														Value: &resolve.Array{
+															Path:     []string{"items"},
+															Nullable: true,
+															Item: &resolve.Object{
+																Nullable: true,
+																PossibleTypes: map[string]struct{}{
+																	"CartItem": {},
+																},
+																TypeName: "CartItem",
+																Fields: []*resolve.Field{
+																	{
+																		Name: []byte("id"),
+																		Value: &resolve.String{
+																			Path: []string{"id"},
+																		},
+																	},
+																	{
+																		Name: []byte("bundleProducts"),
+																		Value: &resolve.Array{
+																			Path:     []string{"bundleProducts"},
+																			Nullable: true,
+																			Item: &resolve.Object{
+																				Nullable: true,
+																				PossibleTypes: map[string]struct{}{
+																					"CartBundleProduct": {},
+																				},
+																				TypeName: "CartBundleProduct",
+																				Fields: []*resolve.Field{
+																					{
+																						Name: []byte("code"),
+																						Value: &resolve.String{
+																							Path:     []string{"code"},
+																							Nullable: true,
+																						},
+																					},
+																					{
+																						Name: []byte("name"),
+																						Value: &resolve.String{
+																							Path:     []string{"name"},
+																							Nullable: true,
+																						},
+																					},
+																				},
+																			},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+											OnTypeNames: [][]byte{[]byte("CartResultSuccess")},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			planConfiguration, WithDefaultPostProcessor(),
+		))
+	})
+
+	// Test 2: Query without bundleProducts — control, should always pass
+	t.Run("cart only fields without bundleProducts", func(t *testing.T) {
+		t.Run("run", RunTest(
+			definition,
+			`
+			query CartQuery($cartId: String!) {
+				cartById(cartId: $cartId) {
+					... on CartResultSuccess {
+						cart {
+							id
+							items {
+								id
+							}
+						}
+					}
+				}
+			}`,
+			"CartQuery",
+			&plan.SynchronousResponsePlan{
+				Response: &resolve.GraphQLResponse{
+					Fetches: resolve.Sequence(
+						resolve.Single(&resolve.SingleFetch{
+							FetchDependencies: resolve.FetchDependencies{
+								FetchID: 0,
+							},
+							DataSourceIdentifier: []byte("graphql_datasource.Source"),
+							FetchConfiguration: resolve.FetchConfiguration{
+								Input:          `{"method":"POST","url":"http://cart.service","body":{"query":"query($cartId: String!){cartById(cartId: $cartId){__typename ... on CartResultSuccess {cart {id items {id}}}}}","variables":{"cartId":$$0$$}}}`,
+								DataSource:     &Source{},
+								PostProcessing: DefaultPostProcessingConfiguration,
+								Variables: resolve.NewVariables(
+									&resolve.ContextVariable{
+										Path:     []string{"cartId"},
+										Renderer: resolve.NewJSONVariableRenderer(),
+									},
+								),
+							},
+						}),
+					),
+					Data: &resolve.Object{
+						Fields: []*resolve.Field{
+							{
+								Name: []byte("cartById"),
+								Value: &resolve.Object{
+									Path:     []string{"cartById"},
+									Nullable: true,
+									PossibleTypes: map[string]struct{}{
+										"CartExceptions":    {},
+										"CartResultSuccess": {},
+									},
+									TypeName: "CartResult",
+									Fields: []*resolve.Field{
+										{
+											Name: []byte("cart"),
+											Value: &resolve.Object{
+												Path: []string{"cart"},
+												PossibleTypes: map[string]struct{}{
+													"Cart": {},
+												},
+												TypeName: "Cart",
+												Fields: []*resolve.Field{
+													{
+														Name: []byte("id"),
+														Value: &resolve.String{
+															Path: []string{"id"},
+														},
+													},
+													{
+														Name: []byte("items"),
+														Value: &resolve.Array{
+															Path:     []string{"items"},
+															Nullable: true,
+															Item: &resolve.Object{
+																Nullable: true,
+																PossibleTypes: map[string]struct{}{
+																	"CartItem": {},
+																},
+																TypeName: "CartItem",
+																Fields: []*resolve.Field{
+																	{
+																		Name: []byte("id"),
+																		Value: &resolve.String{
+																			Path: []string{"id"},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+											OnTypeNames: [][]byte{[]byte("CartResultSuccess")},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			planConfiguration, WithDefaultPostProcessor(),
+		))
+	})
+
+	// Test 3: bundleProducts WITHOUT code field — control, should always pass
+	t.Run("bundleProducts without code field", func(t *testing.T) {
+		t.Run("run", RunTest(
+			definition,
+			`
+			query CartQuery($cartId: String!) {
+				cartById(cartId: $cartId) {
+					... on CartResultSuccess {
+						cart {
+							id
+							items {
+								id
+								bundleProducts {
+									name
+									category
+								}
+							}
+						}
+					}
+				}
+			}`,
+			"CartQuery",
+			&plan.SynchronousResponsePlan{
+				Response: &resolve.GraphQLResponse{
+					Fetches: resolve.Sequence(
+						resolve.Single(&resolve.SingleFetch{
+							FetchDependencies: resolve.FetchDependencies{
+								FetchID: 0,
+							},
+							DataSourceIdentifier: []byte("graphql_datasource.Source"),
+							FetchConfiguration: resolve.FetchConfiguration{
+								Input:          `{"method":"POST","url":"http://cart.service","body":{"query":"query($cartId: String!){cartById(cartId: $cartId){__typename ... on CartResultSuccess {cart {id items {id bundleProducts {name category}}}}}}","variables":{"cartId":$$0$$}}}`,
+								DataSource:     &Source{},
+								PostProcessing: DefaultPostProcessingConfiguration,
+								Variables: resolve.NewVariables(
+									&resolve.ContextVariable{
+										Path:     []string{"cartId"},
+										Renderer: resolve.NewJSONVariableRenderer(),
+									},
+								),
+							},
+						}),
+					),
+					Data: &resolve.Object{
+						Fields: []*resolve.Field{
+							{
+								Name: []byte("cartById"),
+								Value: &resolve.Object{
+									Path:     []string{"cartById"},
+									Nullable: true,
+									PossibleTypes: map[string]struct{}{
+										"CartExceptions":    {},
+										"CartResultSuccess": {},
+									},
+									TypeName: "CartResult",
+									Fields: []*resolve.Field{
+										{
+											Name: []byte("cart"),
+											Value: &resolve.Object{
+												Path: []string{"cart"},
+												PossibleTypes: map[string]struct{}{
+													"Cart": {},
+												},
+												TypeName: "Cart",
+												Fields: []*resolve.Field{
+													{
+														Name: []byte("id"),
+														Value: &resolve.String{
+															Path: []string{"id"},
+														},
+													},
+													{
+														Name: []byte("items"),
+														Value: &resolve.Array{
+															Path:     []string{"items"},
+															Nullable: true,
+															Item: &resolve.Object{
+																Nullable: true,
+																PossibleTypes: map[string]struct{}{
+																	"CartItem": {},
+																},
+																TypeName: "CartItem",
+																Fields: []*resolve.Field{
+																	{
+																		Name: []byte("id"),
+																		Value: &resolve.String{
+																			Path: []string{"id"},
+																		},
+																	},
+																	{
+																		Name: []byte("bundleProducts"),
+																		Value: &resolve.Array{
+																			Path:     []string{"bundleProducts"},
+																			Nullable: true,
+																			Item: &resolve.Object{
+																				Nullable: true,
+																				PossibleTypes: map[string]struct{}{
+																					"CartBundleProduct": {},
+																				},
+																				TypeName: "CartBundleProduct",
+																				Fields: []*resolve.Field{
+																					{
+																						Name: []byte("name"),
+																						Value: &resolve.String{
+																							Path:     []string{"name"},
+																							Nullable: true,
+																						},
+																					},
+																					{
+																						Name: []byte("category"),
+																						Value: &resolve.String{
+																							Path:     []string{"category"},
+																							Nullable: true,
+																						},
+																					},
+																				},
+																			},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+											OnTypeNames: [][]byte{[]byte("CartResultSuccess")},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			planConfiguration, WithDefaultPostProcessor(),
+		))
+	})
+
+	// Test 4: bundleProducts with ONLY code field — was FAIL before fix
+	t.Run("bundleProducts with only code field", func(t *testing.T) {
+		t.Run("run", RunTest(
+			definition,
+			`
+			query CartQuery($cartId: String!) {
+				cartById(cartId: $cartId) {
+					... on CartResultSuccess {
+						cart {
+							id
+							items {
+								id
+								bundleProducts {
+									code
+								}
+							}
+						}
+					}
+				}
+			}`,
+			"CartQuery",
+			&plan.SynchronousResponsePlan{
+				Response: &resolve.GraphQLResponse{
+					Fetches: resolve.Sequence(
+						resolve.Single(&resolve.SingleFetch{
+							FetchDependencies: resolve.FetchDependencies{
+								FetchID: 0,
+							},
+							DataSourceIdentifier: []byte("graphql_datasource.Source"),
+							FetchConfiguration: resolve.FetchConfiguration{
+								Input:          `{"method":"POST","url":"http://cart.service","body":{"query":"query($cartId: String!){cartById(cartId: $cartId){__typename ... on CartResultSuccess {cart {id items {id bundleProducts {code}}}}}}","variables":{"cartId":$$0$$}}}`,
+								DataSource:     &Source{},
+								PostProcessing: DefaultPostProcessingConfiguration,
+								Variables: resolve.NewVariables(
+									&resolve.ContextVariable{
+										Path:     []string{"cartId"},
+										Renderer: resolve.NewJSONVariableRenderer(),
+									},
+								),
+							},
+						}),
+					),
+					Data: &resolve.Object{
+						Fields: []*resolve.Field{
+							{
+								Name: []byte("cartById"),
+								Value: &resolve.Object{
+									Path:     []string{"cartById"},
+									Nullable: true,
+									PossibleTypes: map[string]struct{}{
+										"CartExceptions":    {},
+										"CartResultSuccess": {},
+									},
+									TypeName: "CartResult",
+									Fields: []*resolve.Field{
+										{
+											Name: []byte("cart"),
+											Value: &resolve.Object{
+												Path: []string{"cart"},
+												PossibleTypes: map[string]struct{}{
+													"Cart": {},
+												},
+												TypeName: "Cart",
+												Fields: []*resolve.Field{
+													{
+														Name: []byte("id"),
+														Value: &resolve.String{
+															Path: []string{"id"},
+														},
+													},
+													{
+														Name: []byte("items"),
+														Value: &resolve.Array{
+															Path:     []string{"items"},
+															Nullable: true,
+															Item: &resolve.Object{
+																Nullable: true,
+																PossibleTypes: map[string]struct{}{
+																	"CartItem": {},
+																},
+																TypeName: "CartItem",
+																Fields: []*resolve.Field{
+																	{
+																		Name: []byte("id"),
+																		Value: &resolve.String{
+																			Path: []string{"id"},
+																		},
+																	},
+																	{
+																		Name: []byte("bundleProducts"),
+																		Value: &resolve.Array{
+																			Path:     []string{"bundleProducts"},
+																			Nullable: true,
+																			Item: &resolve.Object{
+																				Nullable: true,
+																				PossibleTypes: map[string]struct{}{
+																					"CartBundleProduct": {},
+																				},
+																				TypeName: "CartBundleProduct",
+																				Fields: []*resolve.Field{
+																					{
+																						Name: []byte("code"),
+																						Value: &resolve.String{
+																							Path:     []string{"code"},
+																							Nullable: true,
+																						},
+																					},
+																				},
+																			},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+											OnTypeNames: [][]byte{[]byte("CartResultSuccess")},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			planConfiguration, WithDefaultPostProcessor(),
+		))
+	})
+}

--- a/v2/pkg/engine/plan/datasource_configuration.go
+++ b/v2/pkg/engine/plan/datasource_configuration.go
@@ -77,6 +77,7 @@ type NodesInfo interface {
 	HasChildNode(typeName, fieldName string) bool
 	HasExternalChildNode(typeName, fieldName string) bool
 	HasChildNodeWithTypename(typeName string) bool
+	HasNonExternalFieldsForType(typeName string) bool
 	RequireFetchReasons() map[FieldCoordinate]struct{}
 }
 
@@ -224,6 +225,24 @@ func (d *DataSourceMetadata) HasChildNodeWithTypename(typeName string) bool {
 	}
 	_, ok := d.childNodesIndex[typeName]
 	return ok
+}
+
+// HasNonExternalFieldsForType returns true if the datasource has at least one
+// non-external field for the given type (in either root or child nodes).
+// This indicates the datasource actively resolves this entity type, not just
+// a stub with only external key fields.
+func (d *DataSourceMetadata) HasNonExternalFieldsForType(typeName string) bool {
+	if d.rootNodesIndex != nil {
+		if index, ok := d.rootNodesIndex[typeName]; ok && len(index.fields) > 0 {
+			return true
+		}
+	}
+	if d.childNodesIndex != nil {
+		if index, ok := d.childNodesIndex[typeName]; ok && len(index.fields) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func (d *DataSourceMetadata) ListRootNodes() TypeFields {

--- a/v2/pkg/engine/plan/datasource_filter_collect_nodes_visitor.go
+++ b/v2/pkg/engine/plan/datasource_filter_collect_nodes_visitor.go
@@ -496,6 +496,15 @@ func (f *collectNodesDSVisitor) EnterField(fieldRef int, itemIds []int, treeNode
 	if isExternal && f.isNotExternalKeyField(info.currentPath) {
 		// external fields which are part of the key should not be marked as external
 		isExternal = false
+		// When an external field becomes non-external due to being a key field,
+		// we still need to create a suggestion for it. Promote the external root/child
+		// node status so the field passes the suggestion condition below.
+		if isExternalRootNode && !hasRootNode {
+			hasRootNode = true
+		}
+		if isExternalChildNode && !hasChildNode {
+			hasChildNode = true
+		}
 	}
 
 	if hasRootNode || hasChildNode || isExternal || isProvided {

--- a/v2/pkg/engine/plan/key_fields_visitor.go
+++ b/v2/pkg/engine/plan/key_fields_visitor.go
@@ -248,6 +248,15 @@ func (v *keyInfoVisitor) EnterField(ref int) {
 			// so we have to bypass this case
 
 			isExternal = false
+		} else if !v.input.keyIsConditional && v.input.dataSource.HasNonExternalFieldsForType(v.input.typeName) {
+			// When the entity type has non-external fields on this datasource,
+			// it means the datasource actively resolves this entity type
+			// (not just a stub with only external key fields).
+			// In this case, the datasource can provide key fields in its response
+			// because the planner always includes key fields in subgraph queries.
+			// This handles newer composition where key fields are only in
+			// ExternalFieldNames (not in both FieldNames and ExternalFieldNames).
+			isExternal = false
 		}
 
 	}


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->
                                                                                             
 ## Summary                                                                                               
                                                                                                        
  Fixes query planning failure (500 error) when a federated query references a shared entity whose @key 
  field is marked @external in one subgraph.                

 **Example:** A CartBundleProduct entity exists in two subgraphs. The cart subgraph owns fields like name
  and category but marks the key field code as @external. The products subgraph owns code. Querying
  bundleProducts { code name } through the cart subgraph would fail with:

  > could not select the datasource to resolve CartBundleProduct.code

  ## Root Cause

  Newer federation composition puts @external key fields only in ExternalFieldNames (not in both
  FieldNames and ExternalFieldNames like older composition did). This broke two assumptions in the
  planner:

  1. Key source detection (key_fields_visitor.go): The existing fallback that un-marks external key
  fields relied on the field being in both FieldNames and ExternalFieldNames. With the field only in
  ExternalFieldNames, the key was incorrectly treated as external, preventing the cart subgraph from
  being a key "source." This broke the jump graph so no datasource could resolve the field.
  2. Field suggestion creation (datasource_filter_collect_nodes_visitor.go): Even after fixing `#1`, the
  cart subgraph still didn't suggest the code field. When the visitor converted an external field to
  non-external (via notExternalKeyPaths), it cleared isExternal but the field had no other qualifying
  flag (hasRootNode, hasChildNode, isProvided were all false). So no suggestion was created and the
  planner routed code to the products subgraph via entity resolution — generating a malformed upstream
  query.

  ## Fix

  Three changes:

  - datasource_configuration.go: Add HasNonExternalFieldsForType() to check whether a datasource
  actively resolves a type (has regular, non-external fields for it) vs. being a stub with only external
   key fields.
  - key_fields_visitor.go: When a key field is external but the datasource has non-external fields for
  that entity type, treat the key as non-external. The datasource actively resolves this entity, so it
  can provide the key field in its response.
  - datasource_filter_collect_nodes_visitor.go: When an external field is reclassified as non-external
  (because it's a key field), promote its external root/child node status to regular root/child status.
  This ensures a field suggestion is actually created, so the planner can route the field to the correct
   datasource.

  Test plan

  - New test TestGraphQLDataSourceFederation_SharedEntityWithExternalKeyField with 4 sub-tests:
    - bundleProducts with code field — the main bug (was failing, now passes)
    - bundleProducts with only code field — variant of the bug (was failing, now passes)
    - cart only fields without bundleProducts — control (always passed)
    - bundleProducts without code field — control (always passed)

  ---      

## CodeRabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for GraphQL federation with shared entities, including scenarios with external key fields and complex entity relationships.

* **Improvements**
  * Enhanced federation support for key fields defined in external field names across subgraphs.
  * Improved query planning and data source resolution in federated GraphQL schemas with shared entities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.

<!--
Please add any additional information or context regarding your changes here.
-->