### PR TITLE
chore: switch the engine to normal releases on v2

### DIFF
--- a/.github/workflows/dummy-ci.yaml
+++ b/.github/workflows/dummy-ci.yaml
@@ -7,6 +7,7 @@ on:
       - '.gitignore'
       - 'LICENSE'
       - 'README.md'
+      - 'release-please-config.json'
 jobs:
   build_test:
     timeout-minutes: 5

--- a/.github/workflows/dummy-ci.yaml
+++ b/.github/workflows/dummy-ci.yaml
@@ -9,7 +9,8 @@ on:
       - 'README.md'
       - 'release-please-config.json'
 jobs:
-  build_test:
+  ci:
+    name: CI Success
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,8 +8,6 @@
       "release-type": "go",
       "include-component-in-tag": false,
       "include-v-in-tag": true,
-      "prerelease-type": "rc",
-      "versioning": "prerelease"
     },
     "execution": {
       "package-name": "execution",


### PR DESCRIPTION
Switch release type from pre-releases to normal releases on v2.

