### PR TITLE
feat: add bytecode compilation and execution for GraphQL responses

### DIFF
--- a/v2/pkg/engine/planbytecode/bench_test.go
+++ b/v2/pkg/engine/planbytecode/bench_test.go
@@ -1,0 +1,56 @@
+package planbytecode
+
+import (
+	"testing"
+
+	"github.com/wundergraph/astjson"
+	arena "github.com/wundergraph/go-arena"
+)
+
+var benchmarkSink int
+
+func BenchmarkJSONMergeASTJSON(b *testing.B) {
+	src := []byte(`{"id":"1","name":"Ada","reviews":[{"body":"ok","meta":{"score":10}},{"body":"fine","meta":{"score":8}}],"extra":true}`)
+	targetBytes := []byte(`{"id":"1"}`)
+	a := arena.NewMonotonicArena(arena.WithMinBufferSize(64 * 1024))
+	defer a.Release()
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(src)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		a.Reset()
+		target, err := astjson.ParseBytesWithArena(a, targetBytes)
+		if err != nil {
+			b.Fatal(err)
+		}
+		response, err := astjson.ParseBytesWithArena(a, src)
+		if err != nil {
+			b.Fatal(err)
+		}
+		merged, _, err := astjson.MergeValuesWithPath(a, target, response)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchmarkSink += int(merged.Type())
+	}
+}
+
+func BenchmarkJSONPasteByteRanges(b *testing.B) {
+	src := []byte(`{"id":"1","name":"Ada","reviews":[{"body":"ok","meta":{"score":10}},{"body":"fine","meta":{"score":8}}],"extra":true}`)
+	fields := []string{"id", "name", "reviews"}
+	rangesScratch := make([]ByteRange, 0, len(fields))
+	out := make([]byte, 0, len(src))
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(src)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ranges, ok := ScanObjectFieldRanges(src, fields, rangesScratch[:0])
+		if !ok {
+			b.Fatal("scan failed")
+		}
+		out = AppendObjectFromRanges(out[:0], src, ranges)
+		benchmarkSink += len(out)
+	}
+}

--- a/v2/pkg/engine/planbytecode/bytecode.go
+++ b/v2/pkg/engine/planbytecode/bytecode.go
@@ -1,0 +1,177 @@
+package planbytecode
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type Opcode uint32
+
+const (
+	OpNop Opcode = iota
+	OpEnterSequence
+	OpLeaveSequence
+	OpEnterParallel
+	OpLeaveParallel
+	OpFetchSubgraph
+	OpPasteAtPointer
+	OpEnterObject
+	OpLeaveObject
+	OpEnterArray
+	OpLeaveArray
+	OpProjectField
+	OpEmitLiteral
+	OpEmitResponse
+)
+
+func (o Opcode) String() string {
+	switch o {
+	case OpNop:
+		return "nop"
+	case OpEnterSequence:
+		return "enter_sequence"
+	case OpLeaveSequence:
+		return "leave_sequence"
+	case OpEnterParallel:
+		return "enter_parallel"
+	case OpLeaveParallel:
+		return "leave_parallel"
+	case OpFetchSubgraph:
+		return "fetch_subgraph"
+	case OpPasteAtPointer:
+		return "paste_at_pointer"
+	case OpEnterObject:
+		return "enter_object"
+	case OpLeaveObject:
+		return "leave_object"
+	case OpEnterArray:
+		return "enter_array"
+	case OpLeaveArray:
+		return "leave_array"
+	case OpProjectField:
+		return "project_field"
+	case OpEmitLiteral:
+		return "emit_literal"
+	case OpEmitResponse:
+		return "emit_response"
+	default:
+		return fmt.Sprintf("opcode_%d", o)
+	}
+}
+
+// Op is intentionally fixed-width. The operands index into side tables on Program.
+type Op struct {
+	Code Opcode
+	A    uint32
+	B    uint32
+	C    uint32
+}
+
+type Program struct {
+	Ops           []Op
+	Strings       []string
+	QuotedStrings []string
+	Paths         [][]string
+	Fetches       []Fetch
+
+	DirectResponse *DirectResponse
+
+	Stats       Stats
+	Unsupported []UnsupportedFeature
+}
+
+func (p *Program) FastPathReady() bool {
+	return p != nil && len(p.Unsupported) == 0
+}
+
+func (p *Program) DirectResponseReady() bool {
+	return p != nil && p.DirectResponse != nil && len(
+		p.DirectResponse.Fields,
+	) != 0 && len(p.Unsupported) == 0
+}
+
+func (p *Program) QuotedString(ref uint32) (string, bool) {
+	if p == nil || int(ref) >= len(p.Strings) {
+		return "", false
+	}
+
+	if int(ref) < len(p.QuotedStrings) && p.QuotedStrings[ref] != "" {
+		return p.QuotedStrings[ref], true
+	}
+
+	return strconv.Quote(p.Strings[ref]), true
+}
+
+type Stats struct {
+	Fetches        int
+	DCEFetches     int
+	Objects        int
+	Arrays         int
+	Fields         int
+	Literals       int
+	ResponseNodes  int
+	UnsupportedOps int
+}
+
+type UnsupportedFeature struct {
+	Feature string
+	Reason  string
+}
+
+type Fetch struct {
+	Kind                        uint32
+	DataSourceIDRef             uint32
+	DataSourceNameRef           uint32
+	ResponsePathRef             uint32
+	SelectResponseDataPathRef   uint32
+	SelectResponseErrorsPathRef uint32
+	MergePathRef                uint32
+	DependsOnFetchIDs           []int
+
+	// Item is intentionally opaque to keep this IR package independent from
+	// resolve. The engine compiler stores *resolve.FetchItem here, and the
+	// resolve-owned interpreter type-asserts it back inside the resolve package.
+	Item any `json:"-"`
+}
+
+type DirectResponse struct {
+	Fields []DirectField
+}
+
+type DirectField struct {
+	NameRef    uint32
+	PathRef    uint32
+	LiteralRef uint32
+	Flags      uint32
+	ItemFlags  uint32
+	Children   []DirectField
+}
+
+const (
+	DirectFieldFlagLiteral uint32 = 1 << 31
+	DirectFieldKindMask    uint32 = 0x0000ffff
+	DirectFieldNullable    uint32 = 1 << 16
+)
+
+func EncodeDirectFieldFlags(kind uint32, nullable bool, literal bool) uint32 {
+	flags := kind & DirectFieldKindMask
+	if nullable {
+		flags |= DirectFieldNullable
+	}
+	if literal {
+		flags |= DirectFieldFlagLiteral
+	}
+	return flags
+}
+
+func DirectFieldKind(flags uint32) uint32 {
+	return flags & DirectFieldKindMask
+}
+
+func DirectFieldIsNullable(flags uint32) bool {
+	return flags&DirectFieldNullable != 0
+}
+
+func DirectFieldIsLiteral(flags uint32) bool {
+	return flags&DirectFieldFlagLiteral != 0
+}

--- a/v2/pkg/engine/planbytecode/bytecode_test.go
+++ b/v2/pkg/engine/planbytecode/bytecode_test.go
@@ -1,0 +1,12 @@
+package planbytecode
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpIsFixedWidth(t *testing.T) {
+	require.Equal(t, uintptr(16), unsafe.Sizeof(Op{}))
+}

--- a/v2/pkg/engine/planbytecode/compiler/bench_test.go
+++ b/v2/pkg/engine/planbytecode/compiler/bench_test.go
@@ -1,0 +1,122 @@
+package compiler
+
+import (
+	"testing"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/planbytecode"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+var benchmarkSink int
+
+func BenchmarkResponseTreeWalk(b *testing.B) {
+	p := benchmarkPlan()
+	response := p.Response
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		benchmarkSink += walkFetchTree(response.Fetches)
+		benchmarkSink += walkNodeTree(response.Data)
+	}
+}
+
+func BenchmarkBytecodeOpWalk(b *testing.B) {
+	program, err := Compile(benchmarkPlan())
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		count := 0
+
+		for _, op := range program.Ops {
+			switch op.Code {
+			case planbytecode.OpFetchSubgraph, planbytecode.OpPasteAtPointer, planbytecode.OpProjectField, planbytecode.OpEmitLiteral:
+				count++
+			}
+		}
+
+		benchmarkSink += count
+	}
+}
+
+func BenchmarkCompileStaticPlan(b *testing.B) {
+	p := benchmarkPlan()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		program, err := Compile(p)
+
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		benchmarkSink += len(program.Ops)
+	}
+}
+
+func benchmarkPlan() *plan.SynchronousResponsePlan {
+	return syncResponsePlan(
+		resolve.Sequence(
+			resolve.SingleWithPath(singleFetch("users", "query Users { user { id name reviews { body score } } }", []string{"data"}, nil), "query.user"),
+			resolve.Parallel(
+				resolve.SingleWithPath(singleFetch("reviews", "query Reviews { reviews { body score } }", []string{"data"}, []string{"reviews"}), "query.user.reviews"),
+				resolve.SingleWithPath(singleFetch("products", "query Products { products { upc name } }", []string{"data"}, []string{"products"}), "query.user.products"),
+				resolve.SingleWithPath(singleFetch("inventory", "query Inventory { inventory { inStock } }", []string{"data"}, []string{"inventory"}), "query.user.inventory"),
+			),
+		),
+		rootObject(
+			field("user", objectValue("user",
+				field("id", stringValue("id")),
+				field("name", stringValue("name", true)),
+				field("reviews", arrayValue("reviews",
+					rootObject(
+						field("body", stringValue("body", true)),
+						field("score", integerValue("score", true)),
+					),
+				)),
+				field("kind", staticStringAt("kind", "User")),
+			)),
+		),
+	)
+}
+
+func walkFetchTree(node *resolve.FetchTreeNode) int {
+	if node == nil {
+		return 0
+	}
+
+	count := 1
+
+	for _, child := range node.ChildNodes {
+		count += walkFetchTree(child)
+	}
+
+	return count
+}
+
+func walkNodeTree(node resolve.Node) int {
+	switch n := node.(type) {
+	case nil:
+		return 0
+	case *resolve.Object:
+		count := 1
+
+		for _, field := range n.Fields {
+			count++
+			count += walkNodeTree(field.Value)
+		}
+
+		return count
+	case *resolve.Array:
+		return 1 + walkNodeTree(n.Item)
+	default:
+		return 1
+	}
+}

--- a/v2/pkg/engine/planbytecode/compiler/compile.go
+++ b/v2/pkg/engine/planbytecode/compiler/compile.go
@@ -1,0 +1,757 @@
+package compiler
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astparser"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
+	engineplan "github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/planbytecode"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+type Compiler struct {
+	program    planbytecode.Program
+	stringRefs map[string]uint32
+	pathRefs   map[string]uint32
+}
+
+func Compile(plan plan.Plan) (*planbytecode.Program, error) {
+	compiler := Compiler{
+		stringRefs: make(map[string]uint32),
+		pathRefs:   make(map[string]uint32),
+	}
+
+	return compiler.Compile(plan)
+}
+
+func (compiler *Compiler) Compile(
+	plan plan.Plan,
+) (*planbytecode.Program, error) {
+	if plan == nil {
+		return nil, errors.New(
+			"compile bytecode plan: nil plan",
+		)
+	}
+
+	switch typed := plan.(type) {
+	case *engineplan.SynchronousResponsePlan:
+		if typed.Response == nil {
+			return nil, errors.New(
+				"compile bytecode plan: nil response",
+			)
+		}
+
+		compiler.compileGraphQLResponse(typed.Response)
+	case *engineplan.SubscriptionResponsePlan:
+		compiler.unsupported(
+			"subscription",
+			"subscriptions remain on the interpreted resolver path",
+		)
+	default:
+		compiler.unsupported(
+			"plan_kind",
+			fmt.Sprintf("unsupported plan type %T",
+				plan,
+			),
+		)
+	}
+
+	return &compiler.program, nil
+}
+
+func (compiler *Compiler) compileGraphQLResponse(
+	response *resolve.GraphQLResponse,
+) {
+	compiler.compileFetchTree(response.Fetches)
+	compiler.compileDirectResponse(response)
+	compiler.compileNode(response.Data)
+	compiler.emit(planbytecode.OpEmitResponse, 0, 0, 0)
+}
+
+func (compiler *Compiler) compileDirectResponse(
+	response *resolve.GraphQLResponse,
+) {
+	if response == nil || response.Data == nil {
+		return
+	}
+
+	if !directFetchTreeEligible(response.Fetches) {
+		return
+	}
+
+	if len(response.Data.Path) != 0 ||
+		len(response.Data.PossibleTypes) != 0 ||
+		response.Data.Nullable {
+		return
+	}
+
+	fields := make([]planbytecode.DirectField, 0, len(response.Data.Fields))
+
+	for _, field := range response.Data.Fields {
+		direct, ok := compiler.compileDirectField(field)
+		if !ok {
+			return
+		}
+		fields = append(fields, direct)
+	}
+
+	if len(fields) == 0 {
+		return
+	}
+
+	compiler.program.DirectResponse = &planbytecode.DirectResponse{
+		Fields: fields,
+	}
+}
+
+func (compiler *Compiler) compileDirectField(
+	field *resolve.Field,
+) (planbytecode.DirectField, bool) {
+	if field == nil ||
+		field.Value == nil ||
+		field.Defer != nil ||
+		field.Stream != nil ||
+		len(field.OnTypeNames) != 0 ||
+		len(field.ParentOnTypeNames) != 0 ||
+		(field.Info != nil && field.Info.HasAuthorizationRule) {
+		return planbytecode.DirectField{}, false
+	}
+
+	name := string(field.Name)
+	switch typed := field.Value.(type) {
+	case *resolve.StaticString:
+		return planbytecode.DirectField{
+			NameRef:    compiler.stringRef(name),
+			LiteralRef: compiler.stringRef(typed.Value),
+			Flags: planbytecode.EncodeDirectFieldFlags(
+				uint32(resolve.NodeKindStaticString), false, true,
+			),
+		}, true
+	case *resolve.Null:
+		return planbytecode.DirectField{
+			NameRef: compiler.stringRef(name),
+			Flags: planbytecode.EncodeDirectFieldFlags(
+				uint32(resolve.NodeKindNull), true, true,
+			),
+		}, true
+	case *resolve.Object:
+		if !directFieldPathMatches(name, typed.Path) ||
+			len(typed.PossibleTypes) != 0 {
+			return planbytecode.DirectField{}, false
+		}
+		children, ok := compiler.compileDirectFields(typed.Fields)
+		if !ok {
+			return planbytecode.DirectField{}, false
+		}
+		return planbytecode.DirectField{
+			NameRef: compiler.stringRef(name),
+			PathRef: compiler.pathRef(typed.Path),
+			Flags: planbytecode.EncodeDirectFieldFlags(
+				uint32(resolve.NodeKindObject), typed.Nullable, false,
+			),
+			Children: children,
+		}, true
+	case *resolve.Array:
+		if typed.SkipItem != nil || !directFieldPathMatches(name, typed.Path) {
+			return planbytecode.DirectField{}, false
+		}
+		itemFlags, children, ok := compiler.compileDirectArrayItem(typed.Item)
+		if !ok {
+			return planbytecode.DirectField{}, false
+		}
+		return planbytecode.DirectField{
+			NameRef: compiler.stringRef(name),
+			PathRef: compiler.pathRef(typed.Path),
+			Flags: planbytecode.EncodeDirectFieldFlags(
+				uint32(resolve.NodeKindArray), typed.Nullable, false,
+			),
+			ItemFlags: itemFlags,
+			Children:  children,
+		}, true
+	case *resolve.String:
+		if typed.Export != nil || typed.UnescapeResponseJson || typed.IsTypeName || !directFieldPathMatches(name, typed.Path) {
+			return planbytecode.DirectField{}, false
+		}
+	case *resolve.Boolean:
+		if typed.Export != nil || !directFieldPathMatches(name, typed.Path) {
+			return planbytecode.DirectField{}, false
+		}
+	case *resolve.Integer:
+		if typed.Export != nil || !directFieldPathMatches(name, typed.Path) {
+			return planbytecode.DirectField{}, false
+		}
+	case *resolve.Float:
+		if typed.Export != nil || !directFieldPathMatches(name, typed.Path) {
+			return planbytecode.DirectField{}, false
+		}
+	case *resolve.BigInt:
+		if typed.Export != nil || !directFieldPathMatches(name, typed.Path) {
+			return planbytecode.DirectField{}, false
+		}
+	case *resolve.Scalar:
+		if typed.Export != nil || !directFieldPathMatches(name, typed.Path) {
+			return planbytecode.DirectField{}, false
+		}
+	default:
+		return planbytecode.DirectField{}, false
+	}
+
+	return planbytecode.DirectField{
+		NameRef: compiler.stringRef(name),
+		PathRef: compiler.pathRef(field.Value.NodePath()),
+		Flags: planbytecode.EncodeDirectFieldFlags(
+			uint32(field.Value.NodeKind()), field.Value.NodeNullable(), false,
+		),
+	}, true
+}
+
+func (compiler *Compiler) compileDirectFields(
+	fields []*resolve.Field,
+) ([]planbytecode.DirectField, bool) {
+	out := make([]planbytecode.DirectField, 0, len(fields))
+	for _, field := range fields {
+		direct, ok := compiler.compileDirectField(field)
+		if !ok {
+			return nil, false
+		}
+		out = append(out, direct)
+	}
+	return out, true
+}
+
+func (compiler *Compiler) compileDirectArrayItem(
+	item resolve.Node,
+) (uint32, []planbytecode.DirectField, bool) {
+	switch typed := item.(type) {
+	case *resolve.Object:
+		if len(typed.Path) != 0 ||
+			len(typed.PossibleTypes) != 0 {
+			return 0, nil, false
+		}
+
+		children, ok := compiler.compileDirectFields(typed.Fields)
+
+		if !ok {
+			return 0, nil, false
+		}
+
+		return planbytecode.EncodeDirectFieldFlags(
+			uint32(resolve.NodeKindObject), typed.Nullable, false,
+		), children, true
+	case *resolve.String:
+		if typed.Export != nil || typed.UnescapeResponseJson || typed.IsTypeName || len(typed.Path) != 0 {
+			return 0, nil, false
+		}
+	case *resolve.Boolean:
+		if typed.Export != nil || len(typed.Path) != 0 {
+			return 0, nil, false
+		}
+	case *resolve.Integer:
+		if typed.Export != nil || len(typed.Path) != 0 {
+			return 0, nil, false
+		}
+	case *resolve.Float:
+		if typed.Export != nil || len(typed.Path) != 0 {
+			return 0, nil, false
+		}
+	case *resolve.BigInt:
+		if typed.Export != nil || len(typed.Path) != 0 {
+			return 0, nil, false
+		}
+	case *resolve.Scalar:
+		if typed.Export != nil || len(typed.Path) != 0 {
+			return 0, nil, false
+		}
+	default:
+		return 0, nil, false
+	}
+
+	return planbytecode.EncodeDirectFieldFlags(
+		uint32(item.NodeKind()), item.NodeNullable(), false,
+	), nil, true
+}
+
+func directFieldPathMatches(name string, path []string) bool {
+	return len(path) == 1 && path[0] == name
+}
+
+func directFetchTreeEligible(node *resolve.FetchTreeNode) bool {
+	var dataAvailable bool
+	return directFetchTreeEligibleWithState(node, &dataAvailable)
+}
+
+func directFetchTreeEligibleWithState(node *resolve.FetchTreeNode, dataAvailable *bool) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case resolve.FetchTreeNodeKindSingle:
+		if node.Item == nil || node.Item.Fetch == nil {
+			return false
+		}
+		if directFetchItemRequiresParentData(node.Item) && !*dataAvailable {
+			return false
+		}
+		if !directFetchItemEligible(node.Item) {
+			return false
+		}
+		*dataAvailable = true
+		return true
+	case resolve.FetchTreeNodeKindSequence, resolve.FetchTreeNodeKindParallel:
+		if len(node.ChildNodes) == 0 {
+			return false
+		}
+		if node.Kind == resolve.FetchTreeNodeKindParallel {
+			availableBeforeParallel := *dataAvailable
+			anyChildProducesData := false
+			for _, child := range node.ChildNodes {
+				childDataAvailable := availableBeforeParallel
+				if !directFetchTreeEligibleWithState(child, &childDataAvailable) {
+					return false
+				}
+				anyChildProducesData = anyChildProducesData || childDataAvailable
+			}
+			*dataAvailable = *dataAvailable || anyChildProducesData
+			return true
+		}
+		for _, child := range node.ChildNodes {
+			if !directFetchTreeEligibleWithState(child, dataAvailable) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+func directFetchItemRequiresParentData(item *resolve.FetchItem) bool {
+	return item != nil && len(item.FetchPath) != 0
+}
+
+func directFetchItemEligible(item *resolve.FetchItem) bool {
+	switch item.Fetch.(type) {
+	case *resolve.SingleFetch:
+		return len(item.FetchPath) == 0
+	case *resolve.EntityFetch:
+		return directObjectFetchPathEligible(item.FetchPath)
+	case *resolve.BatchEntityFetch:
+		return directArrayFetchPathEligible(item.FetchPath)
+	default:
+		return false
+	}
+}
+
+func directObjectFetchPathEligible(path []resolve.FetchItemPathElement) bool {
+	if !directFetchPathEligible(path) ||
+		path[len(path)-1].Kind != resolve.FetchItemPathElementKindObject {
+		return false
+	}
+	return true
+}
+
+func directArrayFetchPathEligible(path []resolve.FetchItemPathElement) bool {
+	if !directFetchPathEligible(path) {
+		return false
+	}
+	for i := range path {
+		if path[i].Kind == resolve.FetchItemPathElementKindArray {
+			return true
+		}
+	}
+	return false
+}
+
+func directFetchPathEligible(path []resolve.FetchItemPathElement) bool {
+	if len(path) == 0 {
+		return false
+	}
+	for i := range path {
+		if len(path[i].Path) != 1 || len(path[i].TypeNames) != 0 {
+			return false
+		}
+		switch path[i].Kind {
+		case resolve.FetchItemPathElementKindObject, resolve.FetchItemPathElementKindArray:
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func (compiler *Compiler) compileFetchTree(node *resolve.FetchTreeNode) {
+	if node == nil {
+		return
+	}
+
+	switch node.Kind {
+	case resolve.FetchTreeNodeKindSingle:
+		if node.Item == nil || node.Item.Fetch == nil {
+			return
+		}
+
+		if compiler.fetchSelectionSetIsEmpty(node.Item.Fetch) {
+			compiler.program.Stats.DCEFetches++
+			return
+		}
+
+		fetchRef := compiler.addFetch(node.Item)
+		compiler.emit(planbytecode.OpFetchSubgraph, fetchRef, uint32(node.Item.Fetch.FetchKind()), 0)
+		compiler.emit(planbytecode.OpPasteAtPointer, fetchRef, compiler.pathRef(postProcessing(node.Item.Fetch).SelectResponseDataPath), compiler.pathRef(postProcessing(node.Item.Fetch).MergePath))
+	case resolve.FetchTreeNodeKindSequence:
+		opRef := compiler.emit(planbytecode.OpEnterSequence, 0, 0, 0)
+		var emittedChildren uint32
+
+		for _, child := range node.ChildNodes {
+			before := len(compiler.program.Ops)
+			compiler.compileFetchTree(child)
+
+			if len(compiler.program.Ops) != before {
+				emittedChildren++
+			}
+		}
+
+		compiler.program.Ops[opRef].A = emittedChildren
+		leaveRef := compiler.emit(planbytecode.OpLeaveSequence, 0, 0, 0)
+		compiler.program.Ops[opRef].B = uint32(leaveRef)
+	case resolve.FetchTreeNodeKindParallel:
+		opRef := compiler.emit(planbytecode.OpEnterParallel, 0, 0, 0)
+		var emittedChildren uint32
+
+		for _, child := range node.ChildNodes {
+			if child == nil || child.Kind != resolve.FetchTreeNodeKindSingle {
+				compiler.unsupported("nested_parallel", "bytecode interpreter only supports direct fetch children in parallel groups")
+			}
+
+			before := len(compiler.program.Ops)
+			compiler.compileFetchTree(child)
+
+			if len(compiler.program.Ops) != before {
+				emittedChildren++
+			}
+		}
+
+		compiler.program.Ops[opRef].A = emittedChildren
+		leaveRef := compiler.emit(planbytecode.OpLeaveParallel, 0, 0, 0)
+		compiler.program.Ops[opRef].B = uint32(leaveRef)
+	case resolve.FetchTreeNodeKindTrigger:
+		compiler.unsupported("trigger_fetch", "trigger fetches are subscription-only")
+	default:
+		compiler.unsupported("fetch_tree", fmt.Sprintf("unsupported fetch tree node kind %q", node.Kind))
+	}
+}
+
+func (compiler *Compiler) compileNode(node resolve.Node) {
+	if node == nil {
+		return
+	}
+
+	compiler.program.Stats.ResponseNodes++
+
+	switch typed := node.(type) {
+	case *resolve.Object:
+		compiler.program.Stats.Objects++
+		compiler.emit(planbytecode.OpEnterObject, compiler.pathRef(typed.Path), uint32(len(typed.Fields)), boolOperand(typed.Nullable))
+
+		for _, field := range typed.Fields {
+			compiler.compileField(field)
+		}
+
+		compiler.emit(planbytecode.OpLeaveObject, 0, 0, 0)
+	case *resolve.EmptyObject:
+		compiler.program.Stats.Objects++
+		compiler.emit(planbytecode.OpEnterObject, compiler.pathRef(nil), 0, 0)
+		compiler.emit(planbytecode.OpLeaveObject, 0, 0, 0)
+	case *resolve.Array:
+		compiler.program.Stats.Arrays++
+		compiler.emit(planbytecode.OpEnterArray, compiler.pathRef(typed.Path), 0, boolOperand(typed.Nullable))
+
+		if typed.SkipItem != nil {
+			compiler.unsupported("array_skip_item", "array item predicate requires interpreted resolver")
+		}
+
+		compiler.compileNode(typed.Item)
+		compiler.emit(planbytecode.OpLeaveArray, 0, 0, 0)
+	case *resolve.EmptyArray:
+		compiler.program.Stats.Arrays++
+		compiler.emit(planbytecode.OpEnterArray, compiler.pathRef(nil), 0, 0)
+		compiler.emit(planbytecode.OpLeaveArray, 0, 0, 0)
+	case *resolve.StaticString:
+		compiler.program.Stats.Literals++
+		compiler.emit(planbytecode.OpEmitLiteral, compiler.stringRef(typed.Value), compiler.pathRef(typed.Path), uint32(node.NodeKind()))
+	case *resolve.CustomNode:
+		compiler.unsupported("custom_node", "custom field resolver requires interpreted resolver")
+		compiler.emit(planbytecode.OpProjectField, 0, compiler.pathRef(typed.Path), encodeNodeFlags(node.NodeKind(), typed.Nullable))
+	default:
+		compiler.emit(planbytecode.OpProjectField, 0, compiler.pathRef(node.NodePath()), encodeNodeFlags(node.NodeKind(), node.NodeNullable()))
+	}
+}
+
+func (compiler *Compiler) compileField(field *resolve.Field) {
+	if field == nil {
+		return
+	}
+	if field.Value == nil {
+		compiler.unsupported("nil_field_value", "field has no response value node")
+		return
+	}
+	compiler.program.Stats.Fields++
+	if field.Defer != nil {
+		compiler.unsupported("defer", "@defer fields remain on the interpreted resolver path")
+	}
+	if field.Stream != nil {
+		compiler.unsupported("stream", "@stream fields remain on the interpreted resolver path")
+	}
+	if len(field.OnTypeNames) != 0 || len(field.ParentOnTypeNames) != 0 {
+		compiler.unsupported("abstract_type_guard", "runtime typename guards require interpreted resolver")
+	}
+	if field.Info != nil && field.Info.HasAuthorizationRule {
+		compiler.unsupported("authorization", "field authorization can skip fields at runtime")
+	}
+
+	compiler.emit(planbytecode.OpProjectField, compiler.stringRef(string(field.Name)), compiler.pathRef(field.Value.NodePath()), encodeNodeFlags(field.Value.NodeKind(), field.Value.NodeNullable()))
+	compiler.compileNestedNode(field.Value)
+}
+
+func (compiler *Compiler) compileNestedNode(node resolve.Node) {
+	switch node.(type) {
+	case *resolve.Object, *resolve.EmptyObject, *resolve.Array, *resolve.EmptyArray, *resolve.StaticString, *resolve.CustomNode:
+		compiler.compileNode(node)
+	}
+}
+
+func (compiler *Compiler) addFetch(item *resolve.FetchItem) uint32 {
+	post := postProcessing(item.Fetch)
+	info := item.Fetch.FetchInfo()
+	fetch := planbytecode.Fetch{
+		Kind:                        uint32(item.Fetch.FetchKind()),
+		ResponsePathRef:             compiler.stringRef(item.ResponsePath),
+		SelectResponseDataPathRef:   compiler.pathRef(post.SelectResponseDataPath),
+		SelectResponseErrorsPathRef: compiler.pathRef(post.SelectResponseErrorsPath),
+		MergePathRef:                compiler.pathRef(post.MergePath),
+		Item:                        item,
+	}
+
+	if deps := item.Fetch.Dependencies(); deps != nil {
+		fetch.DependsOnFetchIDs = deps.DependsOnFetchIDs
+	}
+
+	if info != nil {
+		fetch.DataSourceIDRef = compiler.stringRef(info.DataSourceID)
+		fetch.DataSourceNameRef = compiler.stringRef(info.DataSourceName)
+	}
+
+	compiler.program.Fetches = append(compiler.program.Fetches, fetch)
+	compiler.program.Stats.Fetches++
+
+	return uint32(len(compiler.program.Fetches) - 1)
+}
+
+func (compiler *Compiler) fetchSelectionSetIsEmpty(fetch resolve.Fetch) bool {
+	query := fetchQuery(fetch)
+	return query != "" && graphQLSelectionSetIsEmpty(query)
+}
+
+func (compiler *Compiler) emit(code planbytecode.Opcode, a, b, d uint32) int {
+	compiler.program.Ops = append(compiler.program.Ops, planbytecode.Op{Code: code, A: a, B: b, C: d})
+	return len(compiler.program.Ops) - 1
+}
+
+func (compiler *Compiler) unsupported(feature, reason string) {
+	compiler.program.Unsupported = append(
+		compiler.program.Unsupported, planbytecode.UnsupportedFeature{
+			Feature: feature,
+			Reason:  reason,
+		},
+	)
+
+	compiler.program.Stats.UnsupportedOps++
+}
+
+func (compiler *Compiler) stringRef(value string) uint32 {
+	if ref, ok := compiler.stringRefs[value]; ok {
+		return ref
+	}
+
+	ref := uint32(len(compiler.program.Strings))
+	compiler.stringRefs[value] = ref
+	compiler.program.Strings = append(compiler.program.Strings, value)
+
+	compiler.program.QuotedStrings = append(
+		compiler.program.QuotedStrings, strconv.Quote(value),
+	)
+
+	return ref
+}
+
+func (compiler *Compiler) pathRef(path []string) uint32 {
+	keyBytes, _ := json.Marshal(path)
+	key := string(keyBytes)
+
+	if ref, ok := compiler.pathRefs[key]; ok {
+		return ref
+	}
+
+	ref := uint32(len(compiler.program.Paths))
+	compiler.pathRefs[key] = ref
+	copied := append([]string(nil), path...)
+	compiler.program.Paths = append(compiler.program.Paths, copied)
+
+	return ref
+}
+
+func boolOperand(v bool) uint32 {
+	if v {
+		return 1
+	}
+
+	return 0
+}
+
+func encodeNodeFlags(kind resolve.NodeKind, nullable bool) uint32 {
+	out := uint32(kind)
+
+	if nullable {
+		out |= 1 << 16
+	}
+
+	return out
+}
+
+func postProcessing(fetch resolve.Fetch) resolve.PostProcessingConfiguration {
+	switch typed := fetch.(type) {
+	case *resolve.SingleFetch:
+		return typed.PostProcessing
+	case *resolve.EntityFetch:
+		return typed.PostProcessing
+	case *resolve.BatchEntityFetch:
+		return typed.PostProcessing
+	default:
+		return resolve.PostProcessingConfiguration{}
+	}
+}
+
+func fetchQuery(fetch resolve.Fetch) string {
+	if info := fetch.FetchInfo(); info != nil && info.QueryPlan != nil && info.QueryPlan.Query != "" {
+		return info.QueryPlan.Query
+	}
+
+	switch typed := fetch.(type) {
+	case *resolve.SingleFetch:
+		if typed.QueryPlan != nil && typed.QueryPlan.Query != "" {
+			return typed.QueryPlan.Query
+		}
+
+		return queryFromJSONInput(typed.Input)
+	case *resolve.EntityFetch:
+		return queryFromTemplates(typed.Input.Header, typed.Input.Item, typed.Input.Footer)
+	case *resolve.BatchEntityFetch:
+		templates := []resolve.InputTemplate{typed.Input.Header}
+		templates = append(templates, typed.Input.Items...)
+		templates = append(templates, typed.Input.Footer)
+
+		return queryFromTemplates(templates...)
+	default:
+		return ""
+	}
+}
+
+func queryFromTemplates(templates ...resolve.InputTemplate) string {
+	for _, tmpl := range templates {
+		for _, segment := range tmpl.Segments {
+			if segment.SegmentType == resolve.StaticSegmentType {
+				if query := queryFromJSONInput(string(segment.Data)); query != "" {
+					return query
+				}
+			}
+		}
+	}
+
+	return ""
+}
+
+func queryFromJSONInput(input string) string {
+	if input == "" {
+		return ""
+	}
+
+	var value any
+
+	if err := json.Unmarshal([]byte(input), &value); err != nil {
+		return ""
+	}
+
+	return findQueryString(value)
+}
+
+func findQueryString(value any) string {
+	switch typed := value.(type) {
+	case map[string]any:
+		if query, ok := typed["query"].(string); ok {
+			return query
+		}
+
+		for _, child := range typed {
+			if query := findQueryString(child); query != "" {
+				return query
+			}
+		}
+	case []any:
+		for _, child := range typed {
+			if query := findQueryString(child); query != "" {
+				return query
+			}
+		}
+	}
+	return ""
+}
+
+func graphQLSelectionSetIsEmpty(query string) bool {
+	doc, report := astparser.ParseGraphqlDocumentString(query)
+	if report.HasErrors() {
+		return false
+	}
+
+	for i := range doc.OperationDefinitions {
+		op := doc.OperationDefinitions[i]
+
+		if op.HasSelections && !selectionSetIsEmpty(&doc, op.SelectionSet) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func selectionSetIsEmpty(doc *ast.Document, selectionSetRef int) bool {
+	for _, selectionRef := range doc.SelectionSets[selectionSetRef].SelectionRefs {
+		selection := doc.Selections[selectionRef]
+
+		switch selection.Kind {
+		case ast.SelectionKindField:
+			fieldName := doc.FieldNameString(selection.Ref)
+			alias := doc.FieldAliasOrNameString(selection.Ref)
+
+			if fieldName == "__typename" && alias == "__internal__typename_placeholder" {
+				continue
+			}
+
+			return false
+		case ast.SelectionKindInlineFragment:
+			fragment := doc.InlineFragments[selection.Ref]
+
+			if fragment.HasSelections && !selectionSetIsEmpty(doc, fragment.SelectionSet) {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+
+	return true
+}

--- a/v2/pkg/engine/planbytecode/compiler/compile_test.go
+++ b/v2/pkg/engine/planbytecode/compiler/compile_test.go
@@ -1,0 +1,326 @@
+package compiler
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wundergraph/astjson"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astnormalization"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astparser"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/asttransform"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/planbytecode"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/operationreport"
+)
+
+func TestCompileFlattensFetchTreeAndResponseShape(t *testing.T) {
+	p := syncResponsePlan(
+		resolve.Sequence(
+			resolve.SingleWithPath(singleFetch("users", "query Users { user { id name } }", []string{"data"}, nil), "query.user"),
+			resolve.Parallel(
+				resolve.SingleWithPath(singleFetch("reviews", "query Reviews { reviews { body } }", []string{"data"}, []string{"reviews"}), "query.user.reviews"),
+				resolve.SingleWithPath(singleFetch("products", "query Products { products { upc } }", []string{"data"}, []string{"products"}), "query.user.products"),
+			),
+		),
+		rootObject(
+			field("user", objectValue("user",
+				field("id", stringValue("id")),
+				field("kind", staticStringAt("kind", "User")),
+			)),
+		),
+	)
+
+	program, err := Compile(p)
+	require.NoError(t, err)
+	require.True(t, program.FastPathReady())
+	require.Empty(t, program.Unsupported)
+	require.Equal(t, 3, program.Stats.Fetches)
+	require.Equal(t, 3, len(program.Fetches))
+	require.Equal(t, 2, program.Stats.Objects)
+	require.Equal(t, 3, program.Stats.Fields)
+	require.Equal(t, 1, program.Stats.Literals)
+
+	require.Equal(t, []planbytecode.Opcode{
+		planbytecode.OpEnterSequence,
+		planbytecode.OpFetchSubgraph,
+		planbytecode.OpPasteAtPointer,
+		planbytecode.OpEnterParallel,
+		planbytecode.OpFetchSubgraph,
+		planbytecode.OpPasteAtPointer,
+		planbytecode.OpFetchSubgraph,
+		planbytecode.OpPasteAtPointer,
+		planbytecode.OpLeaveParallel,
+		planbytecode.OpLeaveSequence,
+		planbytecode.OpEnterObject,
+		planbytecode.OpProjectField,
+		planbytecode.OpEnterObject,
+		planbytecode.OpProjectField,
+		planbytecode.OpProjectField,
+		planbytecode.OpEmitLiteral,
+		planbytecode.OpLeaveObject,
+		planbytecode.OpLeaveObject,
+		planbytecode.OpEmitResponse,
+	}, opcodes(program.Ops))
+	require.Equal(t, uint32(2), program.Ops[0].A)
+	require.Equal(t, uint32(9), program.Ops[0].B)
+	require.Equal(t, uint32(2), program.Ops[3].A)
+	require.Equal(t, uint32(8), program.Ops[3].B)
+
+	require.Contains(t, program.Strings, "users")
+	require.Contains(t, program.Strings, "reviews")
+	require.Contains(t, program.Strings, "products")
+	require.Equal(t, len(program.Strings), len(program.QuotedStrings))
+	for i := range program.Strings {
+		require.Equal(t, strconv.Quote(program.Strings[i]), program.QuotedStrings[i])
+	}
+	require.Contains(t, program.Paths, []string{"data"})
+	require.Contains(t, program.Paths, []string{"reviews"})
+}
+
+func TestCompileDCEsPlaceholderOnlyFetch(t *testing.T) {
+	p := syncResponsePlan(
+		resolve.Sequence(
+			resolve.SingleWithPath(singleFetch("empty", "query Empty { __internal__typename_placeholder: __typename }", []string{"data"}, nil), "query.empty"),
+			resolve.SingleWithPath(singleFetch("users", "query Users { user { id } }", []string{"data"}, nil), "query.user"),
+		),
+		rootObject(),
+	)
+
+	program, err := Compile(p)
+	require.NoError(t, err)
+	require.True(t, program.FastPathReady())
+	require.Equal(t, 1, program.Stats.DCEFetches)
+	require.Equal(t, 1, program.Stats.Fetches)
+	require.Equal(t, []planbytecode.Opcode{
+		planbytecode.OpEnterSequence,
+		planbytecode.OpFetchSubgraph,
+		planbytecode.OpPasteAtPointer,
+		planbytecode.OpLeaveSequence,
+		planbytecode.OpEnterObject,
+		planbytecode.OpLeaveObject,
+		planbytecode.OpEmitResponse,
+	}, opcodes(program.Ops))
+	require.Equal(t, uint32(1), program.Ops[0].A)
+	require.Equal(t, uint32(3), program.Ops[0].B)
+	require.Equal(t, "users", program.Strings[program.Fetches[0].DataSourceNameRef])
+}
+
+func TestCompileDirectResponseForFlatRootScalars(t *testing.T) {
+	p := syncResponsePlan(
+		resolve.Sequence(
+			resolve.SingleWithPath(singleFetch("users", "query Users { a b }", []string{"data"}, nil), "query"),
+			resolve.SingleWithPath(singleFetch("inventory", "query Inventory { c }", []string{"data"}, nil), "query"),
+		),
+		rootObject(
+			field("a", integerValue("a")),
+			field("b", stringValue("b", true)),
+			field("c", booleanValue("c")),
+			field("kind", staticStringValue("User")),
+		),
+	)
+
+	program, err := Compile(p)
+	require.NoError(t, err)
+	require.True(t, program.DirectResponseReady())
+	require.Len(t, program.DirectResponse.Fields, 4)
+	require.Equal(t, uint32(resolve.NodeKindInteger), planbytecode.DirectFieldKind(program.DirectResponse.Fields[0].Flags))
+	require.Equal(t, uint32(resolve.NodeKindString), planbytecode.DirectFieldKind(program.DirectResponse.Fields[1].Flags))
+	require.True(t, planbytecode.DirectFieldIsNullable(program.DirectResponse.Fields[1].Flags))
+	require.True(t, planbytecode.DirectFieldIsLiteral(program.DirectResponse.Fields[3].Flags))
+}
+
+func TestCompileDirectResponseForNestedShape(t *testing.T) {
+	p := syncResponsePlan(
+		resolve.SingleWithPath(singleFetch("users", "query Users { user { id posts { title } } }", []string{"data"}, nil), "query"),
+		rootObject(
+			field("user", objectValue("user",
+				field("id", stringValue("id")),
+				field("posts", arrayValue("posts",
+					rootObject(field("title", stringValue("title"))),
+				)),
+			)),
+		),
+	)
+
+	program, err := Compile(p)
+	require.NoError(t, err)
+	require.True(t, program.DirectResponseReady())
+	require.Len(t, program.DirectResponse.Fields, 1)
+	require.Equal(t, uint32(resolve.NodeKindObject), planbytecode.DirectFieldKind(program.DirectResponse.Fields[0].Flags))
+	require.Len(t, program.DirectResponse.Fields[0].Children, 2)
+	require.Equal(t, uint32(resolve.NodeKindArray), planbytecode.DirectFieldKind(program.DirectResponse.Fields[0].Children[1].Flags))
+	require.Equal(t, uint32(resolve.NodeKindObject), planbytecode.DirectFieldKind(program.DirectResponse.Fields[0].Children[1].ItemFlags))
+}
+
+func TestCompileDirectResponseForRootArrayBatchEntityFetch(t *testing.T) {
+	p := syncResponsePlan(
+		resolve.Sequence(
+			resolve.SingleWithPath(singleFetch("products", "query Products { products { name upc } }", []string{"data"}, nil), "query"),
+			resolve.SingleWithPath(batchEntityFetch("stock", "data", "_entities"), "query.products", resolve.ArrayPath("products")),
+		),
+		rootObject(
+			field("products", arrayValue("products",
+				rootObject(
+					field("name", stringValue("name")),
+					field("stock", integerValue("stock")),
+				),
+			)),
+		),
+	)
+
+	program, err := Compile(p)
+	require.NoError(t, err)
+	require.True(t, program.DirectResponseReady())
+	require.Len(t, program.DirectResponse.Fields, 1)
+	require.Equal(t, uint32(resolve.NodeKindArray), planbytecode.DirectFieldKind(program.DirectResponse.Fields[0].Flags))
+	require.Len(t, program.DirectResponse.Fields[0].Children, 2)
+}
+
+func TestCompileDirectResponseForRootObjectEntityFetch(t *testing.T) {
+	p := syncResponsePlan(
+		resolve.Sequence(
+			resolve.SingleWithPath(singleFetch("users", "query Users { user { id name } }", []string{"data"}, nil), "query"),
+			resolve.SingleWithPath(entityFetch("profiles", "data", "_entities", "0"), "query.user", resolve.ObjectPath("user")),
+		),
+		rootObject(
+			field("user", objectValue("user",
+				field("name", stringValue("name")),
+				field("age", integerValue("age")),
+			)),
+		),
+	)
+
+	program, err := Compile(p)
+	require.NoError(t, err)
+	require.True(t, program.DirectResponseReady())
+	require.Len(t, program.DirectResponse.Fields, 1)
+	require.Equal(t, uint32(resolve.NodeKindObject), planbytecode.DirectFieldKind(program.DirectResponse.Fields[0].Flags))
+	require.Len(t, program.DirectResponse.Fields[0].Children, 2)
+}
+
+func TestCompileDirectResponseRequiresParentDataBeforeEntityFetch(t *testing.T) {
+	p := syncResponsePlan(
+		resolve.Parallel(
+			resolve.SingleWithPath(singleFetch("users", "query Users { user { id name } }", []string{"data"}, nil), "query"),
+			resolve.SingleWithPath(entityFetch("profiles", "data", "_entities", "0"), "query.user", resolve.ObjectPath("user")),
+		),
+		rootObject(
+			field("user", objectValue("user",
+				field("name", stringValue("name")),
+				field("age", integerValue("age")),
+			)),
+		),
+	)
+
+	program, err := Compile(p)
+	require.NoError(t, err)
+	require.False(t, program.DirectResponseReady())
+	require.True(t, program.FastPathReady())
+}
+
+func TestCompileDirectResponseForNestedBatchEntityFetch(t *testing.T) {
+	p := syncResponsePlan(
+		resolve.Sequence(
+			resolve.SingleWithPath(singleFetch("products", "query Products { products { reviews { author { id } } } }", []string{"data"}, nil), "query"),
+			resolve.SingleWithPath(batchEntityFetch("authors", "data", "_entities"), "query.products.reviews.author", resolve.ArrayPath("products"), resolve.ArrayPath("reviews"), resolve.ObjectPath("author")),
+		),
+		rootObject(
+			field("products", arrayValue("products",
+				rootObject(
+					field("reviews", arrayValue("reviews",
+						rootObject(
+							field("author", objectValue("author",
+								field("name", stringValue("name")),
+							)),
+						),
+					)),
+				),
+			)),
+		),
+	)
+
+	program, err := Compile(p)
+	require.NoError(t, err)
+	require.True(t, program.DirectResponseReady())
+	require.Len(t, program.DirectResponse.Fields, 1)
+	require.Equal(t, uint32(resolve.NodeKindArray), planbytecode.DirectFieldKind(program.DirectResponse.Fields[0].Flags))
+}
+
+func TestKnownVariableSkipIncludeNormalizesToDCEableSelection(t *testing.T) {
+	definition, report := astparser.ParseGraphqlDocumentString(`
+		schema { query: Query }
+		type Query {
+			id: ID
+			name: String
+		}
+	`)
+	require.False(t, report.HasErrors(), report.Error())
+	require.NoError(t, asttransform.MergeDefinitionWithBaseSchema(&definition))
+
+	operation, report := astparser.ParseGraphqlDocumentString(`
+		query Q($withName: Boolean!, $withoutID: Boolean!) {
+			id @skip(if: $withoutID)
+			name @include(if: $withName)
+		}
+	`)
+	require.False(t, report.HasErrors(), report.Error())
+	operation.Input.Variables = []byte(`{"withName":false,"withoutID":true}`)
+
+	normalizer := astnormalization.NewWithOpts(
+		astnormalization.WithRemoveNotMatchingOperationDefinitions(),
+		astnormalization.WithInlineFragmentSpreads(),
+		astnormalization.WithRemoveFragmentDefinitions(),
+		astnormalization.WithRemoveUnusedVariables(),
+	)
+	normalizationReport := &operationreport.Report{}
+	normalizer.NormalizeNamedOperation(&operation, &definition, []byte("Q"), normalizationReport)
+	require.False(t, normalizationReport.HasErrors(), normalizationReport.Error())
+	require.True(t, selectionSetIsEmpty(&operation, operation.OperationDefinitions[0].SelectionSet))
+	require.JSONEq(t, `{}`, string(operation.Input.Variables))
+}
+
+func TestCompileMarksInterpretedOnlyFeatures(t *testing.T) {
+	p := syncResponsePlan(nil, rootObject(&resolve.Field{
+		Name:  []byte("deferred"),
+		Defer: &resolve.DeferField{},
+		Value: &resolve.Array{
+			Path:     []string{"deferred"},
+			SkipItem: func(ctx *resolve.Context, arrayItem *astjson.Value) bool { return false },
+			Item:     stringValue("name"),
+		},
+	}))
+
+	program, err := Compile(p)
+	require.NoError(t, err)
+	require.False(t, program.FastPathReady())
+	require.ElementsMatch(t, []string{"defer", "array_skip_item"}, unsupportedFeatures(program.Unsupported))
+}
+
+func TestCompileSubscriptionRemainsInterpreted(t *testing.T) {
+	program, err := Compile(&plan.SubscriptionResponsePlan{})
+	require.NoError(t, err)
+	require.False(t, program.FastPathReady())
+	require.Equal(t, []planbytecode.UnsupportedFeature{{
+		Feature: "subscription",
+		Reason:  "subscriptions remain on the interpreted resolver path",
+	}}, program.Unsupported)
+}
+
+func opcodes(ops []planbytecode.Op) []planbytecode.Opcode {
+	out := make([]planbytecode.Opcode, len(ops))
+	for i := range ops {
+		out[i] = ops[i].Code
+	}
+	return out
+}
+
+func unsupportedFeatures(features []planbytecode.UnsupportedFeature) []string {
+	out := make([]string, len(features))
+	for i := range features {
+		out[i] = features[i].Feature
+	}
+	return out
+}

--- a/v2/pkg/engine/planbytecode/compiler/fixtures_test.go
+++ b/v2/pkg/engine/planbytecode/compiler/fixtures_test.go
@@ -1,0 +1,130 @@
+package compiler
+
+import (
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+func syncResponsePlan(fetches *resolve.FetchTreeNode, data *resolve.Object) *plan.SynchronousResponsePlan {
+	return &plan.SynchronousResponsePlan{
+		Response: graphqlResponse(fetches, data),
+	}
+}
+
+func graphqlResponse(fetches *resolve.FetchTreeNode, data *resolve.Object) *resolve.GraphQLResponse {
+	return &resolve.GraphQLResponse{
+		Info:    &resolve.GraphQLResponseInfo{},
+		Fetches: fetches,
+		Data:    data,
+	}
+}
+
+func rootObject(fields ...*resolve.Field) *resolve.Object {
+	return &resolve.Object{Fields: fields}
+}
+
+func objectValue(path string, fields ...*resolve.Field) *resolve.Object {
+	return &resolve.Object{
+		Path:   pathOf(path),
+		Fields: fields,
+	}
+}
+
+func arrayValue(path string, item resolve.Node) *resolve.Array {
+	return &resolve.Array{
+		Path: pathOf(path),
+		Item: item,
+	}
+}
+
+func field(name string, value resolve.Node) *resolve.Field {
+	return &resolve.Field{
+		Name:  []byte(name),
+		Value: value,
+	}
+}
+
+func stringValue(path string, nullable ...bool) *resolve.String {
+	return &resolve.String{
+		Path:     pathOf(path),
+		Nullable: optionalBool(nullable),
+	}
+}
+
+func integerValue(path string, nullable ...bool) *resolve.Integer {
+	return &resolve.Integer{
+		Path:     pathOf(path),
+		Nullable: optionalBool(nullable),
+	}
+}
+
+func booleanValue(path string, nullable ...bool) *resolve.Boolean {
+	return &resolve.Boolean{
+		Path:     pathOf(path),
+		Nullable: optionalBool(nullable),
+	}
+}
+
+func staticStringValue(value string) *resolve.StaticString {
+	return &resolve.StaticString{Value: value}
+}
+
+func staticStringAt(path, value string) *resolve.StaticString {
+	return &resolve.StaticString{
+		Path:  pathOf(path),
+		Value: value,
+	}
+}
+
+func batchEntityFetch(subgraphName string, selectDataPath ...string) *resolve.BatchEntityFetch {
+	return &resolve.BatchEntityFetch{
+		PostProcessing: resolve.PostProcessingConfiguration{
+			SelectResponseDataPath: selectDataPath,
+		},
+		Info: &resolve.FetchInfo{
+			DataSourceName: subgraphName,
+		},
+	}
+}
+
+func entityFetch(subgraphName string, selectDataPath ...string) *resolve.EntityFetch {
+	return &resolve.EntityFetch{
+		PostProcessing: resolve.PostProcessingConfiguration{
+			SelectResponseDataPath: selectDataPath,
+		},
+		Info: &resolve.FetchInfo{
+			DataSourceName: subgraphName,
+		},
+	}
+}
+
+func singleFetch(subgraphName, query string, selectDataPath, mergePath []string) *resolve.SingleFetch {
+	return &resolve.SingleFetch{
+		FetchConfiguration: resolve.FetchConfiguration{
+			PostProcessing: resolve.PostProcessingConfiguration{
+				SelectResponseDataPath:   selectDataPath,
+				SelectResponseErrorsPath: []string{"errors"},
+				MergePath:                mergePath,
+			},
+		},
+		FetchDependencies: resolve.FetchDependencies{FetchID: 1},
+		Info: &resolve.FetchInfo{
+			DataSourceID:   subgraphName + "-id",
+			DataSourceName: subgraphName,
+			QueryPlan: &resolve.QueryPlan{
+				Query: query,
+			},
+		},
+	}
+}
+
+func pathOf(path string) []string {
+	if path == "" {
+		return nil
+	}
+	return []string{path}
+}
+
+func optionalBool(values []bool) bool {
+	return len(values) != 0 && values[0]
+}

--- a/v2/pkg/engine/planbytecode/jsonpaste.go
+++ b/v2/pkg/engine/planbytecode/jsonpaste.go
@@ -1,0 +1,402 @@
+package planbytecode
+
+type ByteRange struct {
+	Start int
+	End   int
+}
+
+type ValueRangeStatus uint8
+
+const (
+	ValueRangeNotFound ValueRangeStatus = iota
+	ValueRangeFound
+	ValueRangeUnsupported
+)
+
+func FindValueRange(src []byte, path []string) (ByteRange, bool) {
+	r, status := FindValueRangeStatus(src, path)
+	return r, status == ValueRangeFound
+}
+
+func FindValueRangeStatus(src []byte, path []string) (ByteRange, ValueRangeStatus) {
+	i := skipWS(src, 0)
+
+	if len(path) == 0 {
+		end, ok := skipJSONValue(src, i)
+
+		if !ok {
+			return ByteRange{}, ValueRangeUnsupported
+		}
+
+		return ByteRange{Start: i, End: end}, ValueRangeFound
+	}
+
+	for depth, key := range path {
+		valueStart, valueEnd, status := findObjectFieldValueRange(src, i, key)
+
+		if status != ValueRangeFound {
+			return ByteRange{}, status
+		}
+
+		if depth == len(path)-1 {
+			return ByteRange{Start: valueStart, End: valueEnd}, ValueRangeFound
+		}
+
+		i = skipWS(src, valueStart)
+	}
+
+	return ByteRange{}, ValueRangeNotFound
+}
+
+func ValueRangeIsNull(src []byte, r ByteRange) bool {
+	i := skipWS(src, r.Start)
+	return i+4 <= r.End && src[i] == 'n' && src[i+1] == 'u' && src[i+2] == 'l' && src[i+3] == 'l'
+}
+
+func ValueRangeIsEmptyArray(src []byte, r ByteRange) bool {
+	i := skipWS(src, r.Start)
+
+	if i >= r.End || src[i] != '[' {
+		return false
+	}
+
+	i = skipWS(src, i+1)
+
+	return i < r.End && src[i] == ']'
+}
+
+func ScanArrayValueRanges(
+	src []byte, arrayRange ByteRange, ranges []ByteRange,
+) ([]ByteRange, ValueRangeStatus) {
+	i := skipWS(src, arrayRange.Start)
+
+	if i >= arrayRange.End || src[i] != '[' {
+		return ranges, ValueRangeNotFound
+	}
+
+	i++
+
+	for {
+		i = skipWS(src, i)
+
+		if i >= arrayRange.End {
+			return ranges, ValueRangeUnsupported
+		}
+
+		if src[i] == ']' {
+			return ranges, ValueRangeFound
+		}
+
+		valueStart := i
+		valueEnd, ok := skipJSONValue(src, valueStart)
+
+		if !ok || valueEnd > arrayRange.End {
+			return ranges, ValueRangeUnsupported
+		}
+
+		ranges = append(ranges, ByteRange{Start: valueStart, End: valueEnd})
+
+		i = skipWS(src, valueEnd)
+
+		if i >= arrayRange.End {
+			return ranges, ValueRangeUnsupported
+		}
+
+		switch src[i] {
+		case ',':
+			i++
+		case ']':
+			return ranges, ValueRangeFound
+		default:
+			return ranges, ValueRangeUnsupported
+		}
+	}
+}
+
+func ScanObjectFieldRanges(
+	src []byte, orderedFields []string, ranges []ByteRange,
+) ([]ByteRange, bool) {
+	i := skipWS(src, 0)
+
+	if i >= len(src) || src[i] != '{' {
+		return ranges, false
+	}
+
+	i++
+
+	fieldIdx := 0
+
+	for {
+		i = skipWS(src, i)
+
+		if i >= len(src) {
+			return ranges, false
+		}
+
+		if src[i] == '}' {
+			return ranges, fieldIdx == len(orderedFields)
+		}
+
+		if src[i] != '"' {
+			return ranges, false
+		}
+
+		pairStart := i
+		keyStart := i + 1
+		keyEnd, escaped, ok := skipJSONString(src, i)
+
+		if !ok || escaped {
+			return ranges, false
+		}
+
+		i = skipWS(src, keyEnd+1)
+
+		if i >= len(src) || src[i] != ':' {
+			return ranges, false
+		}
+
+		i = skipWS(src, i+1)
+		valueEnd, ok := skipJSONValue(src, i)
+
+		if !ok {
+			return ranges, false
+		}
+
+		if fieldIdx < len(orderedFields) && bytesEqualString(
+			src[keyStart:keyEnd], orderedFields[fieldIdx],
+		) {
+			ranges = append(ranges, ByteRange{Start: pairStart, End: valueEnd})
+			fieldIdx++
+		} else if nextFieldIndex(src[keyStart:keyEnd], orderedFields[fieldIdx:]) > 0 {
+			return ranges, false
+		}
+
+		i = skipWS(src, valueEnd)
+
+		if i >= len(src) {
+			return ranges, false
+		}
+
+		switch src[i] {
+		case ',':
+			i++
+		case '}':
+			return ranges, fieldIdx == len(orderedFields)
+		default:
+			return ranges, false
+		}
+	}
+}
+
+func AppendObjectFromRanges(dst []byte, src []byte, ranges []ByteRange) []byte {
+	dst = append(dst, '{')
+
+	for i, r := range ranges {
+		if i != 0 {
+			dst = append(dst, ',')
+		}
+
+		dst = append(dst, src[r.Start:r.End]...)
+	}
+
+	dst = append(dst, '}')
+	return dst
+}
+
+func findObjectFieldValueRange(
+	src []byte, i int, field string,
+) (start int, end int, status ValueRangeStatus) {
+	i = skipWS(src, i)
+
+	if i >= len(src) || src[i] != '{' {
+		return 0, 0, ValueRangeNotFound
+	}
+
+	i++
+
+	for {
+		i = skipWS(src, i)
+
+		if i >= len(src) {
+			return 0, 0, ValueRangeUnsupported
+		}
+
+		if src[i] == '}' {
+			return 0, 0, ValueRangeNotFound
+		}
+
+		if src[i] != '"' {
+			return 0, 0, ValueRangeUnsupported
+		}
+
+		keyStart := i + 1
+		keyEnd, escaped, ok := skipJSONString(src, i)
+
+		if !ok || escaped {
+			return 0, 0, ValueRangeUnsupported
+		}
+
+		i = skipWS(src, keyEnd+1)
+
+		if i >= len(src) || src[i] != ':' {
+			return 0, 0, ValueRangeUnsupported
+		}
+
+		valueStart := skipWS(src, i+1)
+		valueEnd, ok := skipJSONValue(src, valueStart)
+
+		if !ok {
+			return 0, 0, ValueRangeUnsupported
+		}
+
+		if bytesEqualString(src[keyStart:keyEnd], field) {
+			return valueStart, valueEnd, ValueRangeFound
+		}
+
+		i = skipWS(src, valueEnd)
+
+		if i >= len(src) {
+			return 0, 0, ValueRangeUnsupported
+		}
+
+		switch src[i] {
+		case ',':
+			i++
+		case '}':
+			return 0, 0, ValueRangeNotFound
+		default:
+			return 0, 0, ValueRangeUnsupported
+		}
+	}
+}
+
+func nextFieldIndex(key []byte, fields []string) int {
+	for i, field := range fields {
+		if bytesEqualString(key, field) {
+			return i
+		}
+	}
+
+	return -1
+}
+
+func bytesEqualString(left []byte, right string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func skipWS(src []byte, i int) int {
+	for i < len(src) {
+		switch src[i] {
+		case ' ', '\n', '\r', '\t':
+			i++
+		default:
+			return i
+		}
+	}
+
+	return i
+}
+
+func skipJSONValue(src []byte, i int) (int, bool) {
+	if i >= len(src) {
+		return i, false
+	}
+
+	switch src[i] {
+	case '"':
+		end, _, ok := skipJSONString(src, i)
+		if !ok {
+			return i, false
+		}
+		return end + 1, true
+	case '{':
+		return skipJSONComposite(src, i, '{', '}')
+	case '[':
+		return skipJSONComposite(src, i, '[', ']')
+	default:
+		return skipJSONScalar(src, i)
+	}
+}
+
+func skipJSONString(src []byte, i int) (end int, escaped bool, ok bool) {
+	if i >= len(src) || src[i] != '"' {
+		return i, false, false
+	}
+
+	i++
+
+	for i < len(src) {
+		switch src[i] {
+		case '\\':
+			escaped = true
+			i += 2
+		case '"':
+			return i, escaped, true
+		default:
+			i++
+		}
+	}
+
+	return i, escaped, false
+}
+
+func skipJSONComposite(src []byte, i int, open, close byte) (int, bool) {
+	if i >= len(src) || src[i] != open {
+		return i, false
+	}
+
+	depth := 1
+	i++
+
+	for i < len(src) {
+		switch src[i] {
+		case '"':
+			end, _, ok := skipJSONString(src, i)
+
+			if !ok {
+				return i, false
+			}
+
+			i = end + 1
+		case open:
+			depth++
+			i++
+		case close:
+			depth--
+			i++
+
+			if depth == 0 {
+				return i, true
+			}
+		default:
+			i++
+		}
+	}
+
+	return i, false
+}
+
+func skipJSONScalar(src []byte, i int) (int, bool) {
+	start := i
+
+	for i < len(src) {
+		switch src[i] {
+		case ',', '}', ']', ' ', '\n', '\r', '\t':
+			return i, i > start
+		default:
+			i++
+		}
+	}
+
+	return i, i > start
+}

--- a/v2/pkg/engine/planbytecode/jsonpaste_test.go
+++ b/v2/pkg/engine/planbytecode/jsonpaste_test.go
@@ -1,0 +1,87 @@
+package planbytecode
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanObjectFieldRangesCopiesRequestedFieldsInSchemaOrder(t *testing.T) {
+	src := []byte(`{"id":"1","name":"Ada","reviews":[{"body":"ok","meta":{"score":10}}],"extra":true}`)
+	ranges := make([]ByteRange, 0, 2)
+
+	ranges, ok := ScanObjectFieldRanges(src, []string{"id", "reviews"}, ranges)
+	require.True(t, ok)
+	require.Equal(t, []ByteRange{
+		{Start: 1, End: 9},
+		{Start: 23, End: 68},
+	}, ranges)
+
+	out := AppendObjectFromRanges(make([]byte, 0, 64), src, ranges)
+	require.JSONEq(t, `{"id":"1","reviews":[{"body":"ok","meta":{"score":10}}]}`, string(out))
+}
+
+func TestScanObjectFieldRangesRejectsOutOfOrderFields(t *testing.T) {
+	src := []byte(`{"name":"Ada","id":"1"}`)
+	ranges := make([]ByteRange, 0, 2)
+
+	_, ok := ScanObjectFieldRanges(src, []string{"id", "name"}, ranges)
+	require.False(t, ok)
+}
+
+func TestScanObjectFieldRangesIsAllocationFreeWithCallerOwnedScratch(t *testing.T) {
+	src := []byte(`{"id":"1","name":"Ada","reviews":[{"body":"ok"}]}`)
+	fields := []string{"id", "name", "reviews"}
+	scratch := make([]ByteRange, 0, len(fields))
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		ranges, ok := ScanObjectFieldRanges(src, fields, scratch[:0])
+		if !ok || len(ranges) != len(fields) {
+			t.Fatalf("unexpected scan result: ranges=%v ok=%v", ranges, ok)
+		}
+	})
+	require.Zero(t, allocs)
+}
+
+func TestFindValueRangeFindsNestedObjectField(t *testing.T) {
+	src := []byte(`{"errors":[],"data":{"_entities":[{"name":"Ada"}],"other":true}}`)
+
+	r, ok := FindValueRange(src, []string{"data", "_entities"})
+	require.True(t, ok)
+	require.JSONEq(t, `[{"name":"Ada"}]`, string(src[r.Start:r.End]))
+
+	r, ok = FindValueRange(src, []string{"errors"})
+	require.True(t, ok)
+	require.True(t, ValueRangeIsEmptyArray(src, r))
+}
+
+func TestFindValueRangeRejectsEscapedObjectKeys(t *testing.T) {
+	src := []byte(`{"da\u0074a":{"id":"1"}}`)
+
+	_, ok := FindValueRange(src, []string{"data"})
+	require.False(t, ok)
+	_, status := FindValueRangeStatus(src, []string{"data"})
+	require.Equal(t, ValueRangeUnsupported, status)
+}
+
+func TestValueRangeIsNull(t *testing.T) {
+	src := []byte(`{"data": null}`)
+
+	r, ok := FindValueRange(src, []string{"data"})
+	require.True(t, ok)
+	require.True(t, ValueRangeIsNull(src, r))
+}
+
+func TestScanArrayValueRanges(t *testing.T) {
+	src := []byte(`{"items":[{"id":1}, null, "x"]}`)
+	r, ok := FindValueRange(src, []string{"items"})
+	require.True(t, ok)
+
+	ranges, status := ScanArrayValueRanges(src, r, nil)
+	require.Equal(t, ValueRangeFound, status)
+	require.Equal(t, []string{`{"id":1}`, `null`, `"x"`}, []string{
+		string(src[ranges[0].Start:ranges[0].End]),
+		string(src[ranges[1].Start:ranges[1].End]),
+		string(src[ranges[2].Start:ranges[2].End]),
+	})
+}

--- a/v2/pkg/engine/resolve/bytecode.go
+++ b/v2/pkg/engine/resolve/bytecode.go
@@ -1,0 +1,1921 @@
+package resolve
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/wundergraph/astjson"
+	"github.com/wundergraph/go-arena"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/planbytecode"
+)
+
+func (r *Resolver) ResolveGraphQLResponseBytecode(ctx *Context, response *GraphQLResponse, program *planbytecode.Program, data []byte, writer io.Writer) (*GraphQLResolveInfo, error) {
+	resp := &GraphQLResolveInfo{}
+
+	start := time.Now()
+	<-r.maxConcurrency
+	resp.ResolveAcquireWaitTime = time.Since(start)
+	defer func() {
+		r.maxConcurrency <- struct{}{}
+	}()
+
+	t := newTools(r.options, r.allowedErrorExtensionFields, r.allowedErrorFields, r.subgraphRequestSingleFlight, nil)
+
+	err := t.resolvable.Init(ctx, data, response.Info.OperationType)
+	if err != nil {
+		return nil, err
+	}
+
+	if !ctx.ExecutionOptions.SkipLoader {
+		loaded := false
+		if bytecodeDirectResponseRuntimeReady(ctx, program) {
+			var rendered bool
+			rendered, err = t.loader.LoadAndRenderGraphQLResponseBytecodeDirect(ctx, response, program, t.resolvable, writer)
+			if err != nil {
+				return nil, err
+			}
+			if rendered {
+				ctx.ActualListSizes = t.resolvable.actualListSizes
+				return resp, nil
+			}
+			loaded = true
+		}
+		if !loaded {
+			err = t.loader.LoadGraphQLResponseDataBytecode(ctx, response, program, t.resolvable)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	rendered, err := t.resolvable.RenderGraphQLResponseBytecode(program, writer)
+	if err != nil {
+		return nil, err
+	}
+	if rendered {
+		ctx.ActualListSizes = t.resolvable.actualListSizes
+		return resp, nil
+	}
+
+	err = t.resolvable.Resolve(ctx.ctx, response.Data, response.Fetches, writer)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx.ActualListSizes = t.resolvable.actualListSizes
+
+	return resp, err
+}
+
+func (r *Resolver) ArenaResolveGraphQLResponseBytecode(ctx *Context, response *GraphQLResponse, program *planbytecode.Program, writer io.Writer) (*GraphQLResolveInfo, error) {
+	resp := &GraphQLResolveInfo{}
+
+	inflight, err := r.inboundRequestSingleFlight.GetOrCreate(ctx, response)
+	if err != nil {
+		return nil, err
+	}
+
+	if inflight != nil && inflight.Data != nil {
+		resp.ResolveDeduplicated = true
+		if ctx.SetDeduplicationData != nil && inflight.SharedData != nil {
+			ctx.SetDeduplicationData(ctx.ctx, inflight.SharedData)
+		}
+		_, err = writer.Write(inflight.Data)
+		return resp, err
+	}
+
+	start := time.Now()
+	<-r.maxConcurrency
+	resp.ResolveAcquireWaitTime = time.Since(start)
+	defer func() {
+		r.maxConcurrency <- struct{}{}
+	}()
+
+	resolveArena := r.resolveArenaPool.Acquire(ctx.Request.ID)
+	t := newTools(r.options, r.allowedErrorExtensionFields, r.allowedErrorFields, r.subgraphRequestSingleFlight, resolveArena.Arena)
+
+	err = t.resolvable.Init(ctx, nil, response.Info.OperationType)
+	if err != nil {
+		r.inboundRequestSingleFlight.FinishErr(inflight, err)
+		r.resolveArenaPool.Release(resolveArena)
+		return nil, err
+	}
+
+	var responseArena *arena.PoolItem
+	var buf *arena.Buffer
+	if !ctx.ExecutionOptions.SkipLoader {
+		loaded := false
+		if bytecodeDirectResponseRuntimeReady(ctx, program) {
+			responseArena = r.responseBufferPool.Acquire(ctx.Request.ID)
+			buf = arena.NewArenaBuffer(responseArena.Arena)
+			var rendered bool
+			rendered, err = t.loader.LoadAndRenderGraphQLResponseBytecodeDirect(ctx, response, program, t.resolvable, buf)
+			if err != nil {
+				r.inboundRequestSingleFlight.FinishErr(inflight, err)
+				r.resolveArenaPool.Release(resolveArena)
+				r.responseBufferPool.Release(responseArena)
+				return nil, err
+			}
+			if rendered {
+				ctx.ActualListSizes = t.resolvable.actualListSizes
+				r.resolveArenaPool.Release(resolveArena)
+				_, err = writer.Write(buf.Bytes())
+				if inflight != nil && ctx.GetDeduplicationData != nil {
+					inflight.SharedData = ctx.GetDeduplicationData(ctx.ctx)
+				}
+				r.inboundRequestSingleFlight.FinishOk(inflight, buf.Bytes())
+				r.responseBufferPool.Release(responseArena)
+				return resp, err
+			}
+			loaded = true
+		}
+		if !loaded {
+			err = t.loader.LoadGraphQLResponseDataBytecode(ctx, response, program, t.resolvable)
+			if err != nil {
+				r.inboundRequestSingleFlight.FinishErr(inflight, err)
+				r.resolveArenaPool.Release(resolveArena)
+				if responseArena != nil {
+					r.responseBufferPool.Release(responseArena)
+				}
+				return nil, err
+			}
+		}
+	}
+
+	if responseArena == nil {
+		responseArena = r.responseBufferPool.Acquire(ctx.Request.ID)
+		buf = arena.NewArenaBuffer(responseArena.Arena)
+	}
+	rendered, err := t.resolvable.RenderGraphQLResponseBytecode(program, buf)
+	if err != nil {
+		r.inboundRequestSingleFlight.FinishErr(inflight, err)
+		r.resolveArenaPool.Release(resolveArena)
+		r.responseBufferPool.Release(responseArena)
+		return nil, err
+	}
+	if rendered {
+		ctx.ActualListSizes = t.resolvable.actualListSizes
+		r.resolveArenaPool.Release(resolveArena)
+		_, err = writer.Write(buf.Bytes())
+		if inflight != nil && ctx.GetDeduplicationData != nil {
+			inflight.SharedData = ctx.GetDeduplicationData(ctx.ctx)
+		}
+		r.inboundRequestSingleFlight.FinishOk(inflight, buf.Bytes())
+		r.responseBufferPool.Release(responseArena)
+		return resp, err
+	}
+
+	err = t.resolvable.Resolve(ctx.ctx, response.Data, response.Fetches, buf)
+	if err != nil {
+		r.inboundRequestSingleFlight.FinishErr(inflight, err)
+		r.resolveArenaPool.Release(resolveArena)
+		r.responseBufferPool.Release(responseArena)
+		return nil, err
+	}
+	ctx.ActualListSizes = t.resolvable.actualListSizes
+
+	r.resolveArenaPool.Release(resolveArena)
+	_, err = writer.Write(buf.Bytes())
+	if inflight != nil && ctx.GetDeduplicationData != nil {
+		inflight.SharedData = ctx.GetDeduplicationData(ctx.ctx)
+	}
+	r.inboundRequestSingleFlight.FinishOk(inflight, buf.Bytes())
+	r.responseBufferPool.Release(responseArena)
+	return resp, err
+}
+
+func (r *Resolvable) RenderGraphQLResponseBytecode(program *planbytecode.Program, writer io.Writer) (bool, error) {
+	if !bytecodeResponseRuntimeReady(r, program) {
+		return false, nil
+	}
+	pc := bytecodeResponseStart(program.Ops)
+	if pc == -1 {
+		return false, nil
+	}
+
+	renderer := bytecodeResponseRenderer{
+		program: program,
+	}
+	buf := r.marshalBuf[:0]
+	if cap(buf) < 1024 {
+		buf = make([]byte, 0, 1024)
+	}
+	buf = append(buf, `{"data":`...)
+	var ok bool
+	buf, pc, ok = renderer.renderValue(buf, pc, r.data)
+	if !ok {
+		r.marshalBuf = buf[:0]
+		return false, nil
+	}
+	if pc >= len(program.Ops) || program.Ops[pc].Code != planbytecode.OpEmitResponse {
+		r.marshalBuf = buf[:0]
+		return false, nil
+	}
+	for _, size := range renderer.listSizes {
+		r.actualListSizes[size.path] += size.size
+	}
+	buf = append(buf, '}')
+	_, err := writer.Write(buf)
+	if err != nil {
+		r.marshalBuf = buf[:0]
+		return false, err
+	}
+	r.marshalBuf = buf[:0]
+	return true, nil
+}
+
+func (l *Loader) LoadGraphQLResponseDataBytecode(ctx *Context, response *GraphQLResponse, program *planbytecode.Program, resolvable *Resolvable) error {
+	if program == nil {
+		return fmt.Errorf("load bytecode response data: nil program")
+	}
+	l.resolvable = resolvable
+	l.ctx = ctx
+	l.info = response.Info
+	l.taintedObjs = make(taintedObjects)
+	return l.resolveBytecode(program)
+}
+
+func (l *Loader) LoadAndRenderGraphQLResponseBytecodeDirect(ctx *Context, response *GraphQLResponse, program *planbytecode.Program, resolvable *Resolvable, writer io.Writer) (bool, error) {
+	if program == nil {
+		return false, fmt.Errorf("load direct bytecode response data: nil program")
+	}
+	l.resolvable = resolvable
+	l.ctx = ctx
+	l.info = response.Info
+	l.taintedObjs = make(taintedObjects)
+
+	var resultScratch [4]bytecodeRawFetchResult
+	results, merged, err := l.collectBytecodeRawFetches(program, resultScratch[:0])
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		for i := range results {
+			if results[i].res != nil {
+				batchEntityToolPool.Put(results[i].res.tools)
+			}
+		}
+	}()
+
+	rendered, err := l.renderDirectResponseBytecode(program, results, writer)
+	if err != nil {
+		return false, err
+	}
+	if rendered {
+		l.finishRawFetchResults(results)
+		return true, nil
+	}
+
+	if merged {
+		l.finishRawFetchResults(results)
+		return false, nil
+	}
+
+	err = l.mergeRawFetchResults(results)
+	if err != nil {
+		return false, err
+	}
+	return false, nil
+}
+
+func (l *Loader) resolveBytecode(program *planbytecode.Program) error {
+	_, err := l.executeBytecodeSpan(program, 0, len(program.Ops))
+	return err
+}
+
+type bytecodeRawFetchResult struct {
+	item  *FetchItem
+	res   *result
+	items []*astjson.Value
+}
+
+func (l *Loader) collectBytecodeRawFetches(program *planbytecode.Program, results []bytecodeRawFetchResult) ([]bytecodeRawFetchResult, bool, error) {
+	if cap(results) < len(program.Fetches) {
+		results = make([]bytecodeRawFetchResult, 0, len(program.Fetches))
+	}
+	results = results[:0]
+	mergeDuringCollect := bytecodeProgramNeedsMergedParentData(program)
+	_, err := l.executeBytecodeRawSpan(program, 0, len(program.Ops), &results, mergeDuringCollect)
+	if err != nil {
+		return nil, mergeDuringCollect, err
+	}
+	return results, mergeDuringCollect, nil
+}
+
+func (l *Loader) executeBytecodeRawSpan(program *planbytecode.Program, pc int, end int, results *[]bytecodeRawFetchResult, mergeDuringCollect bool) (int, error) {
+	for pc < end {
+		op := program.Ops[pc]
+		if bytecodeResponseOpcode(op.Code) {
+			return pc, nil
+		}
+		switch op.Code {
+		case planbytecode.OpNop, planbytecode.OpPasteAtPointer:
+			pc++
+		case planbytecode.OpFetchSubgraph:
+			raw, err := l.loadBytecodeRawFetch(program, op.A)
+			if err != nil {
+				return pc, errors.WithStack(err)
+			}
+			*results = append(*results, raw)
+			if mergeDuringCollect {
+				if err := l.mergeBytecodeRawFetchResult(raw); err != nil {
+					return pc, errors.WithStack(err)
+				}
+			}
+			pc = skipBytecodePaste(program.Ops, pc+1)
+		case planbytecode.OpEnterSequence:
+			leavePC, err := bytecodeGroupLeavePC(program, pc, planbytecode.OpLeaveSequence)
+			if err != nil {
+				return pc, err
+			}
+			_, err = l.executeBytecodeRawSpan(program, pc+1, leavePC, results, mergeDuringCollect)
+			if err != nil {
+				return pc, err
+			}
+			pc = leavePC + 1
+		case planbytecode.OpEnterParallel:
+			leavePC, err := bytecodeGroupLeavePC(program, pc, planbytecode.OpLeaveParallel)
+			if err != nil {
+				return pc, err
+			}
+			err = l.executeBytecodeRawParallel(program, pc+1, leavePC, int(op.A), results, mergeDuringCollect)
+			if err != nil {
+				return pc, err
+			}
+			pc = leavePC + 1
+		case planbytecode.OpLeaveSequence, planbytecode.OpLeaveParallel:
+			return pc, nil
+		default:
+			return pc, fmt.Errorf("execute raw bytecode: unsupported opcode %s at pc %d", op.Code, pc)
+		}
+	}
+	return pc, nil
+}
+
+func (l *Loader) executeBytecodeRawParallel(program *planbytecode.Program, pc int, leavePC int, children int, out *[]bytecodeRawFetchResult, mergeDuringCollect bool) error {
+	if children == 0 {
+		return nil
+	}
+	if !bytecodeParallelDirectFetches(program.Ops, pc, leavePC, children) {
+		_, err := l.executeBytecodeRawSpan(program, pc, leavePC, out, mergeDuringCollect)
+		return err
+	}
+
+	var resultScratch [4]bytecodeRawFetchResult
+	results := resultScratch[:0]
+	if children <= len(resultScratch) {
+		results = resultScratch[:children]
+	} else {
+		results = make([]bytecodeRawFetchResult, children)
+	}
+	var g errgroup.Group
+	cursor := pc
+	for i := 0; i < children; i++ {
+		i := i
+		fetchRef := program.Ops[cursor].A
+		cursor = skipBytecodePaste(program.Ops, cursor+1)
+		g.Go(func() error {
+			raw, err := l.loadBytecodeRawFetch(program, fetchRef)
+			if err != nil {
+				return err
+			}
+			results[i] = raw
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return errors.WithStack(err)
+	}
+	*out = append(*out, results...)
+	if mergeDuringCollect {
+		for i := range results {
+			if err := l.mergeBytecodeRawFetchResult(results[i]); err != nil {
+				return errors.WithStack(err)
+			}
+		}
+	}
+	return nil
+}
+
+func (l *Loader) loadBytecodeRawFetch(program *planbytecode.Program, fetchRef uint32) (bytecodeRawFetchResult, error) {
+	item, err := bytecodeFetchItem(program, fetchRef)
+	if err != nil {
+		return bytecodeRawFetchResult{}, err
+	}
+	items := l.selectItemsForPath(item.FetchPath)
+	res := &result{}
+	err = l.loadFetch(l.ctx.ctx, item.Fetch, item, items, res)
+	if err != nil {
+		return bytecodeRawFetchResult{}, err
+	}
+	return bytecodeRawFetchResult{
+		item:  item,
+		res:   res,
+		items: items,
+	}, nil
+}
+
+func (l *Loader) renderDirectResponseBytecode(program *planbytecode.Program, results []bytecodeRawFetchResult, writer io.Writer) (bool, error) {
+	if !program.DirectResponseReady() {
+		return false, nil
+	}
+	var sourceScratch [3]bytecodeValueSource
+	selected := sourceScratch[:0]
+	if len(results) > len(sourceScratch) {
+		selected = make([]bytecodeValueSource, 0, len(results))
+	}
+	selected, ok := l.directValueSources(results, selected)
+	if !ok {
+		return false, nil
+	}
+
+	buf := l.resolvable.marshalBuf[:0]
+	if cap(buf) < 1024 {
+		buf = make([]byte, 0, 1024)
+	}
+	buf = append(buf, `{"data":{`...)
+	buf, ok = l.renderDirectFields(program, buf, selected, selected, program.DirectResponse.Fields)
+	if !ok {
+		l.resolvable.marshalBuf = buf[:0]
+		return false, nil
+	}
+	buf = append(buf, "}}"...)
+	_, err := writer.Write(buf)
+	if err != nil {
+		l.resolvable.marshalBuf = buf[:0]
+		return false, err
+	}
+	l.resolvable.marshalBuf = buf[:0]
+	return true, nil
+}
+
+type bytecodeValueSource struct {
+	src    []byte
+	value  planbytecode.ByteRange
+	prefix []string
+	target *astjson.Value
+}
+
+func (l *Loader) directValueSources(results []bytecodeRawFetchResult, selected []bytecodeValueSource) ([]bytecodeValueSource, bool) {
+	selected = selected[:0]
+	for i := range results {
+		data, ok := l.selectedDataRange(results[i])
+		if !ok {
+			return nil, false
+		}
+		if results[i].item != nil && len(results[i].item.FetchPath) != 0 {
+			parentSources, ok := l.parentDataDirectSources(results[i], data)
+			if !ok {
+				return nil, false
+			}
+			selected = append(selected, parentSources...)
+			continue
+		}
+		selected = append(selected, data)
+	}
+	return selected, true
+}
+
+func (l *Loader) selectedDataRange(raw bytecodeRawFetchResult) (bytecodeValueSource, bool) {
+	res := raw.res
+	if res == nil ||
+		res.err != nil ||
+		res.authorizationRejected ||
+		res.rateLimitRejected ||
+		res.fetchSkipped ||
+		len(res.out) == 0 ||
+		res.postProcessing.SelectResponseDataPath == nil ||
+		l.allowCustomExtensionProperties {
+		return bytecodeValueSource{}, false
+	}
+	if res.postProcessing.SelectResponseErrorsPath != nil {
+		errorRange, status := planbytecode.FindValueRangeStatus(res.out, res.postProcessing.SelectResponseErrorsPath)
+		if status == planbytecode.ValueRangeUnsupported {
+			return bytecodeValueSource{}, false
+		}
+		if status == planbytecode.ValueRangeFound &&
+			!planbytecode.ValueRangeIsNull(res.out, errorRange) &&
+			!planbytecode.ValueRangeIsEmptyArray(res.out, errorRange) {
+			return bytecodeValueSource{}, false
+		}
+	}
+	dataRange, status := planbytecode.FindValueRangeStatus(res.out, res.postProcessing.SelectResponseDataPath)
+	if status != planbytecode.ValueRangeFound || planbytecode.ValueRangeIsNull(res.out, dataRange) {
+		return bytecodeValueSource{}, false
+	}
+	return bytecodeValueSource{
+		src:    res.out,
+		value:  dataRange,
+		prefix: bytecodeDirectSourcePrefix(raw),
+		target: bytecodeDirectSourceTarget(raw),
+	}, true
+}
+
+func (l *Loader) parentDataDirectSources(raw bytecodeRawFetchResult, data bytecodeValueSource) ([]bytecodeValueSource, bool) {
+	if raw.res == nil || raw.res.nestedMergeItems != nil || raw.item == nil {
+		return nil, false
+	}
+	switch raw.item.Fetch.(type) {
+	case *EntityFetch:
+		if len(raw.items) != 1 {
+			return nil, false
+		}
+		target := bytecodeMergePathTarget(raw.items[0], raw.res.postProcessing.MergePath)
+		if target == nil {
+			return nil, false
+		}
+		data.prefix = nil
+		data.target = target
+		return []bytecodeValueSource{data}, true
+	case *BatchEntityFetch:
+		return l.batchEntityDirectSources(raw, data)
+	default:
+		return nil, false
+	}
+}
+
+func (l *Loader) batchEntityDirectSources(raw bytecodeRawFetchResult, data bytecodeValueSource) ([]bytecodeValueSource, bool) {
+	var rangeScratch [32]planbytecode.ByteRange
+	ranges, status := planbytecode.ScanArrayValueRanges(data.src, data.value, rangeScratch[:0])
+	if status != planbytecode.ValueRangeFound {
+		return nil, false
+	}
+	out := make([]bytecodeValueSource, 0, len(raw.items))
+	if raw.res.batchStats != nil {
+		if len(raw.res.batchStats) != len(ranges) {
+			return nil, false
+		}
+		for responseIndex := range raw.res.batchStats {
+			for _, target := range raw.res.batchStats[responseIndex] {
+				target = bytecodeMergePathTarget(target, raw.res.postProcessing.MergePath)
+				if target == nil {
+					return nil, false
+				}
+				out = append(out, bytecodeValueSource{
+					src:    data.src,
+					value:  ranges[responseIndex],
+					target: target,
+				})
+			}
+		}
+		return out, true
+	}
+	if len(raw.items) != len(ranges) {
+		return nil, false
+	}
+	for i := range raw.items {
+		target := bytecodeMergePathTarget(raw.items[i], raw.res.postProcessing.MergePath)
+		if target == nil {
+			return nil, false
+		}
+		out = append(out, bytecodeValueSource{
+			src:    data.src,
+			value:  ranges[i],
+			target: target,
+		})
+	}
+	return out, true
+}
+
+func (l *Loader) renderDirectFields(program *planbytecode.Program, buf []byte, sources []bytecodeValueSource, allSources []bytecodeValueSource, fields []planbytecode.DirectField) ([]byte, bool) {
+	for i := range fields {
+		if int(fields[i].NameRef) >= len(program.Strings) {
+			return buf, false
+		}
+		if i != 0 {
+			buf = append(buf, ',')
+		}
+		var ok bool
+		buf, ok = bytecodeAppendQuotedProgramString(buf, program, fields[i].NameRef)
+		if !ok {
+			return buf, false
+		}
+		buf = append(buf, ':')
+		buf, ok = l.renderDirectValue(program, buf, sources, allSources, fields[i])
+		if !ok {
+			return buf, false
+		}
+	}
+	return buf, true
+}
+
+func bytecodeAppendQuotedProgramString(buf []byte, program *planbytecode.Program, ref uint32) ([]byte, bool) {
+	if program == nil || int(ref) >= len(program.Strings) {
+		return buf, false
+	}
+	if int(ref) < len(program.QuotedStrings) && program.QuotedStrings[ref] != "" {
+		return append(buf, program.QuotedStrings[ref]...), true
+	}
+	return strconv.AppendQuote(buf, program.Strings[ref]), true
+}
+
+func (l *Loader) renderDirectValue(program *planbytecode.Program, buf []byte, sources []bytecodeValueSource, allSources []bytecodeValueSource, field planbytecode.DirectField) ([]byte, bool) {
+	if planbytecode.DirectFieldIsLiteral(field.Flags) {
+		switch NodeKind(planbytecode.DirectFieldKind(field.Flags)) {
+		case NodeKindNull:
+			return append(buf, "null"...), true
+		default:
+			if int(field.LiteralRef) >= len(program.Strings) {
+				return buf, false
+			}
+			return bytecodeAppendQuotedProgramString(buf, program, field.LiteralRef)
+		}
+	}
+
+	kind := NodeKind(planbytecode.DirectFieldKind(field.Flags))
+	switch kind {
+	case NodeKindObject:
+		return l.renderDirectObject(program, buf, sources, allSources, field)
+	case NodeKindArray:
+		return l.renderDirectArray(program, buf, sources, allSources, field)
+	default:
+		source, ok := l.resolveSingleDirectSource(program, sources, field.PathRef, field.Flags)
+		if !ok {
+			if planbytecode.DirectFieldIsNullable(field.Flags) {
+				return append(buf, "null"...), true
+			}
+			return buf, false
+		}
+		return append(buf, source.src[source.value.Start:source.value.End]...), true
+	}
+}
+
+func (l *Loader) renderDirectObject(program *planbytecode.Program, buf []byte, sources []bytecodeValueSource, allSources []bytecodeValueSource, field planbytecode.DirectField) ([]byte, bool) {
+	var objectSources []bytecodeValueSource
+	if len(sources) == 1 {
+		source, nullFound, found, ok := l.resolveDirectSource(program, sources[0], field.PathRef, field.Flags)
+		if !ok {
+			return buf, false
+		}
+		if !found {
+			if nullFound || planbytecode.DirectFieldIsNullable(field.Flags) {
+				return append(buf, "null"...), true
+			}
+			return buf, false
+		}
+		var sourceScratch [1]bytecodeValueSource
+		objectSources = sourceScratch[:1]
+		objectSources[0] = source
+	} else {
+		var nullFound bool
+		var ok bool
+		var sourceScratch [2]bytecodeValueSource
+		objectSources, nullFound, ok = l.resolveDirectSources(program, sources, field.PathRef, field.Flags, sourceScratch[:0])
+		if !ok {
+			return buf, false
+		}
+		if len(objectSources) == 0 {
+			if nullFound || planbytecode.DirectFieldIsNullable(field.Flags) {
+				return append(buf, "null"...), true
+			}
+			return buf, false
+		}
+	}
+	for i := range objectSources {
+		if !bytecodeValidateObjectValue(objectSources[i].src[objectSources[i].value.Start:objectSources[i].value.End]) {
+			return buf, false
+		}
+	}
+	objectSources = appendDirectTargetOverlays(objectSources, allSources)
+	buf = append(buf, '{')
+	var rendered bool
+	buf, rendered = l.renderDirectFields(program, buf, objectSources, allSources, field.Children)
+	if !rendered {
+		return buf, false
+	}
+	buf = append(buf, '}')
+	return buf, true
+}
+
+func (l *Loader) renderDirectArray(program *planbytecode.Program, buf []byte, sources []bytecodeValueSource, allSources []bytecodeValueSource, field planbytecode.DirectField) ([]byte, bool) {
+	var arraySources []bytecodeValueSource
+	if len(sources) == 1 {
+		source, nullFound, found, ok := l.resolveDirectSource(program, sources[0], field.PathRef, field.Flags)
+		if !ok {
+			return buf, false
+		}
+		if !found {
+			if nullFound || planbytecode.DirectFieldIsNullable(field.Flags) {
+				return append(buf, "null"...), true
+			}
+			return buf, false
+		}
+		return l.renderDirectSingleArraySource(program, buf, source, allSources, field)
+	} else {
+		var nullFound bool
+		var ok bool
+		var sourceScratch [2]bytecodeValueSource
+		arraySources, nullFound, ok = l.resolveDirectSources(program, sources, field.PathRef, field.Flags, sourceScratch[:0])
+		if !ok {
+			return buf, false
+		}
+		if len(arraySources) == 0 {
+			if nullFound || planbytecode.DirectFieldIsNullable(field.Flags) {
+				return append(buf, "null"...), true
+			}
+			return buf, false
+		}
+	}
+
+	var elementRangeScratch [2][]planbytecode.ByteRange
+	elementRanges := elementRangeScratch[:0]
+	if len(arraySources) <= len(elementRangeScratch) {
+		elementRanges = elementRangeScratch[:len(arraySources)]
+	} else {
+		elementRanges = make([][]planbytecode.ByteRange, len(arraySources))
+	}
+	var elementCount int
+	var rangeScratch [2][4]planbytecode.ByteRange
+	for i := range arraySources {
+		var scanScratch []planbytecode.ByteRange
+		if i < len(rangeScratch) {
+			scanScratch = rangeScratch[i][:0]
+		}
+		ranges, status := planbytecode.ScanArrayValueRanges(arraySources[i].src, arraySources[i].value, scanScratch)
+		if status != planbytecode.ValueRangeFound {
+			return buf, false
+		}
+		if i == 0 {
+			elementCount = len(ranges)
+		} else if len(ranges) != elementCount {
+			return buf, false
+		}
+		elementRanges[i] = ranges
+	}
+
+	buf = append(buf, '[')
+	for elementIndex := 0; elementIndex < elementCount; elementIndex++ {
+		if elementIndex != 0 {
+			buf = append(buf, ',')
+		}
+		if len(field.Children) == 0 {
+			if len(arraySources) != 1 {
+				return buf, false
+			}
+			element := bytecodeValueSource{
+				src:    arraySources[0].src,
+				value:  elementRanges[0][elementIndex],
+				target: bytecodeArrayElementTarget(arraySources[0].target, elementIndex),
+			}
+			if !bytecodeValidateDirectValue(element.src[element.value.Start:element.value.End], field.ItemFlags) {
+				return buf, false
+			}
+			buf = append(buf, element.src[element.value.Start:element.value.End]...)
+			continue
+		}
+		var sourceScratch [2]bytecodeValueSource
+		elementSources := sourceScratch[:0]
+		if len(arraySources) <= len(sourceScratch) {
+			elementSources = sourceScratch[:len(arraySources)]
+		} else {
+			elementSources = make([]bytecodeValueSource, len(arraySources))
+		}
+		for sourceIndex := range arraySources {
+			elementSources[sourceIndex] = bytecodeValueSource{
+				src:   arraySources[sourceIndex].src,
+				value: elementRanges[sourceIndex][elementIndex],
+				target: bytecodeArrayElementTarget(
+					arraySources[sourceIndex].target,
+					elementIndex,
+				),
+			}
+			if !bytecodeValidateObjectValue(elementSources[sourceIndex].src[elementSources[sourceIndex].value.Start:elementSources[sourceIndex].value.End]) {
+				return buf, false
+			}
+		}
+		elementSources = appendDirectTargetOverlays(elementSources, allSources)
+		buf = append(buf, '{')
+		var rendered bool
+		buf, rendered = l.renderDirectFields(program, buf, elementSources, allSources, field.Children)
+		if !rendered {
+			return buf, false
+		}
+		buf = append(buf, '}')
+	}
+	buf = append(buf, ']')
+	return buf, true
+}
+
+func (l *Loader) renderDirectSingleArraySource(program *planbytecode.Program, buf []byte, source bytecodeValueSource, allSources []bytecodeValueSource, field planbytecode.DirectField) ([]byte, bool) {
+	var rangeScratch [32]planbytecode.ByteRange
+	ranges, status := planbytecode.ScanArrayValueRanges(source.src, source.value, rangeScratch[:0])
+	if status != planbytecode.ValueRangeFound {
+		return buf, false
+	}
+
+	buf = append(buf, '[')
+	for elementIndex := range ranges {
+		if elementIndex != 0 {
+			buf = append(buf, ',')
+		}
+		element := bytecodeValueSource{
+			src:    source.src,
+			value:  ranges[elementIndex],
+			target: bytecodeArrayElementTarget(source.target, elementIndex),
+		}
+		if len(field.Children) == 0 {
+			if !bytecodeValidateDirectValue(element.src[element.value.Start:element.value.End], field.ItemFlags) {
+				return buf, false
+			}
+			buf = append(buf, element.src[element.value.Start:element.value.End]...)
+			continue
+		}
+		if !bytecodeValidateObjectValue(element.src[element.value.Start:element.value.End]) {
+			return buf, false
+		}
+
+		var sourceScratch [1]bytecodeValueSource
+		elementSources := sourceScratch[:1]
+		elementSources[0] = element
+		elementSources = appendDirectTargetOverlays(elementSources, allSources)
+
+		buf = append(buf, '{')
+		var rendered bool
+		buf, rendered = l.renderDirectFields(program, buf, elementSources, allSources, field.Children)
+		if !rendered {
+			return buf, false
+		}
+		buf = append(buf, '}')
+	}
+	buf = append(buf, ']')
+	return buf, true
+}
+
+func (l *Loader) resolveDirectSource(program *planbytecode.Program, source bytecodeValueSource, pathRef uint32, flags uint32) (bytecodeValueSource, bool, bool, bool) {
+	if int(pathRef) >= len(program.Paths) {
+		return bytecodeValueSource{}, false, false, false
+	}
+	src, path, ok := bytecodeSourceSearch(source, program.Paths[pathRef])
+	if !ok {
+		return bytecodeValueSource{}, false, false, true
+	}
+	valueRange, status := bytecodeFindValueRange(src, path)
+	if status == planbytecode.ValueRangeUnsupported {
+		return bytecodeValueSource{}, false, false, false
+	}
+	if status != planbytecode.ValueRangeFound {
+		return bytecodeValueSource{}, false, false, true
+	}
+	if planbytecode.ValueRangeIsNull(src, valueRange) {
+		if !planbytecode.DirectFieldIsNullable(flags) {
+			return bytecodeValueSource{}, true, false, false
+		}
+		return bytecodeValueSource{}, true, false, true
+	}
+	return bytecodeValueSource{
+		src:    src,
+		value:  valueRange,
+		target: bytecodeSourceChildTarget(source, path),
+	}, false, true, true
+}
+
+func (l *Loader) resolveSingleDirectSource(program *planbytecode.Program, sources []bytecodeValueSource, pathRef uint32, flags uint32) (bytecodeValueSource, bool) {
+	if int(pathRef) >= len(program.Paths) {
+		return bytecodeValueSource{}, false
+	}
+	var out bytecodeValueSource
+	var found bool
+	var nullFound bool
+	for i := range sources {
+		src, path, ok := bytecodeSourceSearch(sources[i], program.Paths[pathRef])
+		if !ok {
+			continue
+		}
+		valueRange, status := bytecodeFindValueRange(src, path)
+		if status == planbytecode.ValueRangeUnsupported {
+			return bytecodeValueSource{}, false
+		}
+		if status != planbytecode.ValueRangeFound {
+			continue
+		}
+		if planbytecode.ValueRangeIsNull(src, valueRange) {
+			nullFound = true
+			continue
+		}
+		if found {
+			return bytecodeValueSource{}, false
+		}
+		out = bytecodeValueSource{src: src, value: valueRange}
+		out.target = bytecodeSourceChildTarget(sources[i], path)
+		found = true
+	}
+	if nullFound && found {
+		return bytecodeValueSource{}, false
+	}
+	if nullFound {
+		return bytecodeValueSource{}, false
+	}
+	if !found {
+		return bytecodeValueSource{}, false
+	}
+	if !bytecodeValidateDirectValue(out.src[out.value.Start:out.value.End], flags) {
+		return bytecodeValueSource{}, false
+	}
+	return out, true
+}
+
+func (l *Loader) resolveDirectSources(program *planbytecode.Program, sources []bytecodeValueSource, pathRef uint32, flags uint32, out []bytecodeValueSource) ([]bytecodeValueSource, bool, bool) {
+	if int(pathRef) >= len(program.Paths) {
+		return nil, false, false
+	}
+	out = out[:0]
+	var nullFound bool
+	for i := range sources {
+		src, path, ok := bytecodeSourceSearch(sources[i], program.Paths[pathRef])
+		if !ok {
+			continue
+		}
+		valueRange, status := bytecodeFindValueRange(src, path)
+		if status == planbytecode.ValueRangeUnsupported {
+			return nil, false, false
+		}
+		if status != planbytecode.ValueRangeFound {
+			continue
+		}
+		if planbytecode.ValueRangeIsNull(src, valueRange) {
+			nullFound = true
+			continue
+		}
+		out = append(out, bytecodeValueSource{
+			src:    src,
+			value:  valueRange,
+			target: bytecodeSourceChildTarget(sources[i], path),
+		})
+	}
+	if nullFound && len(out) != 0 {
+		return nil, false, false
+	}
+	if nullFound && !planbytecode.DirectFieldIsNullable(flags) {
+		return nil, false, false
+	}
+	return out, nullFound, true
+}
+
+func bytecodeSourceSearch(source bytecodeValueSource, path []string) ([]byte, []string, bool) {
+	src := source.src[source.value.Start:source.value.End]
+	if len(source.prefix) == 0 {
+		return src, path, true
+	}
+	if len(path) < len(source.prefix) {
+		return nil, nil, false
+	}
+	for i := range source.prefix {
+		if path[i] != source.prefix[i] {
+			return nil, nil, false
+		}
+	}
+	return src, path[len(source.prefix):], true
+}
+
+func bytecodeFindValueRange(src []byte, path []string) (planbytecode.ByteRange, planbytecode.ValueRangeStatus) {
+	if len(path) == 0 {
+		return planbytecode.FindValueRangeStatus(src, nil)
+	}
+	return planbytecode.FindValueRangeStatus(src, path)
+}
+
+func bytecodeDirectSourceTarget(raw bytecodeRawFetchResult) *astjson.Value {
+	if len(raw.items) != 1 {
+		return nil
+	}
+	if raw.res == nil {
+		return raw.items[0]
+	}
+	return bytecodeMergePathTarget(raw.items[0], raw.res.postProcessing.MergePath)
+}
+
+func bytecodeMergePathTarget(target *astjson.Value, mergePath []string) *astjson.Value {
+	if target == nil {
+		return nil
+	}
+	if len(mergePath) == 0 {
+		return target
+	}
+	return target.Get(mergePath...)
+}
+
+func bytecodeSourceChildTarget(source bytecodeValueSource, path []string) *astjson.Value {
+	if source.target == nil {
+		return nil
+	}
+	if len(path) == 0 {
+		return source.target
+	}
+	return source.target.Get(path...)
+}
+
+func bytecodeArrayElementTarget(target *astjson.Value, index int) *astjson.Value {
+	if target == nil || target.Type() != astjson.TypeArray {
+		return nil
+	}
+	values := target.GetArray()
+	if index < 0 || index >= len(values) {
+		return nil
+	}
+	return values[index]
+}
+
+func appendDirectTargetOverlays(current []bytecodeValueSource, all []bytecodeValueSource) []bytecodeValueSource {
+	for i := range all {
+		if all[i].target == nil || bytecodeDirectSourceInSet(current, all[i]) {
+			continue
+		}
+		for j := range current {
+			if current[j].target == all[i].target {
+				current = append(current, all[i])
+				break
+			}
+		}
+	}
+	return current
+}
+
+func bytecodeDirectSourceInSet(sources []bytecodeValueSource, candidate bytecodeValueSource) bool {
+	for i := range sources {
+		if sources[i].src == nil && candidate.src == nil {
+			if sources[i].target == candidate.target &&
+				sources[i].value == candidate.value &&
+				slicesEqual(sources[i].prefix, candidate.prefix) {
+				return true
+			}
+			continue
+		}
+		if len(sources[i].src) != 0 &&
+			len(candidate.src) != 0 &&
+			&sources[i].src[0] == &candidate.src[0] &&
+			sources[i].target == candidate.target &&
+			sources[i].value == candidate.value &&
+			slicesEqual(sources[i].prefix, candidate.prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func slicesEqual(left []string, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func bytecodeValidateDirectValue(src []byte, flags uint32) bool {
+	i := bytecodeSkipJSONWS(src, 0)
+	if i >= len(src) {
+		return false
+	}
+	if bytecodeValueStartsWith(src[i:], "null") {
+		return planbytecode.DirectFieldIsNullable(flags)
+	}
+	switch NodeKind(planbytecode.DirectFieldKind(flags)) {
+	case NodeKindString:
+		return src[i] == '"'
+	case NodeKindBoolean:
+		return bytecodeValueStartsWith(src[i:], "true") || bytecodeValueStartsWith(src[i:], "false")
+	case NodeKindInteger, NodeKindFloat, NodeKindBigInt:
+		return src[i] == '-' || (src[i] >= '0' && src[i] <= '9')
+	case NodeKindScalar:
+		return true
+	default:
+		return false
+	}
+}
+
+func bytecodeValidateObjectValue(src []byte) bool {
+	i := bytecodeSkipJSONWS(src, 0)
+	return i < len(src) && src[i] == '{'
+}
+
+func bytecodeValueStartsWith(src []byte, value string) bool {
+	if len(src) < len(value) {
+		return false
+	}
+	for i := range value {
+		if src[i] != value[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func bytecodeSkipJSONWS(src []byte, i int) int {
+	for i < len(src) {
+		switch src[i] {
+		case ' ', '\n', '\r', '\t':
+			i++
+		default:
+			return i
+		}
+	}
+	return i
+}
+
+func bytecodeDirectSourcePrefix(raw bytecodeRawFetchResult) []string {
+	var prefix []string
+	if raw.item != nil && len(raw.item.FetchPath) != 0 {
+		prefix = bytecodeFetchPathPrefix(raw.item.FetchPath)
+	}
+	if raw.res != nil && len(raw.res.postProcessing.MergePath) != 0 {
+		prefix = append(prefix, raw.res.postProcessing.MergePath...)
+	}
+	return prefix
+}
+
+func bytecodeFetchPathPrefix(path []FetchItemPathElement) []string {
+	var prefix []string
+	for i := range path {
+		prefix = append(prefix, path[i].Path...)
+	}
+	return prefix
+}
+
+func (l *Loader) mergeRawFetchResults(results []bytecodeRawFetchResult) error {
+	for i := range results {
+		if err := l.mergeBytecodeRawFetchResult(results[i]); err != nil {
+			return errors.WithStack(err)
+		}
+		l.finishRawFetchResult(results[i])
+	}
+	return nil
+}
+
+func (l *Loader) mergeBytecodeRawFetchResult(raw bytecodeRawFetchResult) error {
+	if raw.res.nestedMergeItems != nil {
+		for j := range raw.res.nestedMergeItems {
+			err := l.mergeResultBytecode(raw.item, raw.res.nestedMergeItems[j], raw.items[j:j+1])
+			if err != nil {
+				return errors.WithStack(err)
+			}
+		}
+		return nil
+	}
+	return l.mergeResultBytecode(raw.item, raw.res, raw.items)
+}
+
+func (l *Loader) finishRawFetchResults(results []bytecodeRawFetchResult) {
+	for i := range results {
+		l.finishRawFetchResult(results[i])
+	}
+}
+
+func (l *Loader) finishRawFetchResult(raw bytecodeRawFetchResult) {
+	if raw.res == nil {
+		return
+	}
+	if raw.res.nestedMergeItems != nil {
+		for j := range raw.res.nestedMergeItems {
+			l.callOnFinished(raw.res.nestedMergeItems[j])
+		}
+		return
+	}
+	l.callOnFinished(raw.res)
+}
+
+func bytecodeProgramNeedsMergedParentData(program *planbytecode.Program) bool {
+	if program == nil {
+		return false
+	}
+	for i := range program.Fetches {
+		item, ok := program.Fetches[i].Item.(*FetchItem)
+		if ok && item != nil && len(item.FetchPath) != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func bytecodeDirectResponseRuntimeReady(ctx *Context, program *planbytecode.Program) bool {
+	if !program.DirectResponseReady() {
+		return false
+	}
+	if bytecodeProgramNeedsMergedParentData(program) {
+		return false
+	}
+	if ctx == nil {
+		return false
+	}
+	if ctx.fieldRenderer != nil ||
+		ctx.authorizer != nil ||
+		len(ctx.RenameTypeNames) != 0 ||
+		ctx.ExecutionOptions.IncludeQueryPlanInResponse ||
+		(ctx.TracingOptions.Enable && ctx.TracingOptions.IncludeTraceOutputInResponseExtensions) ||
+		(ctx.RateLimitOptions.Enable && ctx.RateLimitOptions.IncludeStatsInResponseExtension) {
+		return false
+	}
+	return true
+}
+
+func bytecodeResponseRuntimeReady(r *Resolvable, program *planbytecode.Program) bool {
+	if r == nil || r.ctx == nil || !program.FastPathReady() {
+		return false
+	}
+	if r.ctx.ExecutionOptions.SkipLoader ||
+		r.ctx.fieldRenderer != nil ||
+		r.ctx.authorizer != nil ||
+		len(r.ctx.RenameTypeNames) != 0 ||
+		r.ctx.ExecutionOptions.IncludeQueryPlanInResponse ||
+		(r.ctx.TracingOptions.Enable && r.ctx.TracingOptions.IncludeTraceOutputInResponseExtensions) ||
+		(r.ctx.RateLimitOptions.Enable && r.ctx.RateLimitOptions.IncludeStatsInResponseExtension) ||
+		r.options.ApolloCompatibilityTruncateFloatValues ||
+		r.hasErrors() ||
+		r.valueCompletion != nil ||
+		len(r.subgraphExtensions) != 0 {
+		return false
+	}
+	return true
+}
+
+type bytecodeResponseRenderer struct {
+	program   *planbytecode.Program
+	listSizes []bytecodeListSize
+	fieldPath [32]string
+	depth     int
+}
+
+type bytecodeListSize struct {
+	path string
+	size int
+}
+
+func (r *bytecodeResponseRenderer) renderValue(buf []byte, pc int, parent *astjson.Value) ([]byte, int, bool) {
+	if pc >= len(r.program.Ops) {
+		return buf, pc, false
+	}
+
+	switch r.program.Ops[pc].Code {
+	case planbytecode.OpEnterObject:
+		return r.renderObject(buf, pc, parent)
+	case planbytecode.OpEnterArray:
+		return r.renderArray(buf, pc, parent)
+	case planbytecode.OpProjectField:
+		return r.renderProjectedValue(buf, r.program.Ops[pc], parent, pc+1)
+	case planbytecode.OpEmitLiteral:
+		return r.renderLiteral(buf, r.program.Ops[pc], pc+1)
+	default:
+		return buf, pc, false
+	}
+}
+
+func (r *bytecodeResponseRenderer) renderObject(buf []byte, pc int, parent *astjson.Value) ([]byte, int, bool) {
+	if parent == nil {
+		return buf, pc, false
+	}
+	op := r.program.Ops[pc]
+	path, ok := r.pathRef(op.A)
+	if !ok {
+		return buf, pc, false
+	}
+	if op.B == 0 && len(path) == 0 {
+		return append(buf, "{}"...), r.skipValue(pc), true
+	}
+	value := parent.Get(path...)
+	if astjson.ValueIsNull(value) {
+		if op.C != 0 {
+			return append(buf, "null"...), r.skipValue(pc), true
+		}
+		return buf, pc, false
+	}
+	if value.Type() != astjson.TypeObject {
+		return buf, pc, false
+	}
+
+	buf = append(buf, '{')
+	childPC := pc + 1
+	for fieldIndex := uint32(0); fieldIndex < op.B; fieldIndex++ {
+		if childPC >= len(r.program.Ops) || r.program.Ops[childPC].Code != planbytecode.OpProjectField {
+			return buf, childPC, false
+		}
+		fieldOp := r.program.Ops[childPC]
+		name, ok := r.string(fieldOp.A)
+		if !ok {
+			return buf, childPC, false
+		}
+		if fieldIndex != 0 {
+			buf = append(buf, ',')
+		}
+		buf, ok = bytecodeAppendQuotedProgramString(buf, r.program, fieldOp.A)
+		if !ok {
+			return buf, childPC, false
+		}
+		buf = append(buf, ':')
+
+		if !r.pushField(name) {
+			return buf, childPC, false
+		}
+		nextPC := childPC + 1
+		if r.projectHasNestedValue(fieldOp, nextPC) {
+			var rendered bool
+			buf, childPC, rendered = r.renderValue(buf, nextPC, value)
+			if !rendered {
+				r.popField()
+				return buf, childPC, false
+			}
+		} else {
+			var rendered bool
+			buf, childPC, rendered = r.renderProjectedValue(buf, fieldOp, value, nextPC)
+			if !rendered {
+				r.popField()
+				return buf, childPC, false
+			}
+		}
+		r.popField()
+	}
+	if childPC >= len(r.program.Ops) || r.program.Ops[childPC].Code != planbytecode.OpLeaveObject {
+		return buf, childPC, false
+	}
+	buf = append(buf, '}')
+	return buf, childPC + 1, true
+}
+
+func (r *bytecodeResponseRenderer) renderArray(buf []byte, pc int, parent *astjson.Value) ([]byte, int, bool) {
+	if parent == nil {
+		return buf, pc, false
+	}
+	op := r.program.Ops[pc]
+	path, ok := r.pathRef(op.A)
+	if !ok {
+		return buf, pc, false
+	}
+	leavePC := r.skipValue(pc) - 1
+	if pc+1 == leavePC {
+		return append(buf, "[]"...), leavePC + 1, true
+	}
+	value := parent.Get(path...)
+	if astjson.ValueIsNull(value) {
+		if op.C != 0 {
+			return append(buf, "null"...), r.skipValue(pc), true
+		}
+		return buf, pc, false
+	}
+	if value.Type() != astjson.TypeArray {
+		return buf, pc, false
+	}
+	values := value.GetArray()
+	if key := strings.Join(r.fieldPath[:r.depth], "."); key != "" {
+		r.listSizes = append(r.listSizes, bytecodeListSize{path: key, size: len(values)})
+	}
+
+	itemPC := pc + 1
+	if itemPC >= leavePC {
+		return buf, pc, false
+	}
+
+	buf = append(buf, '[')
+	for i, item := range values {
+		if i != 0 {
+			buf = append(buf, ',')
+		}
+		var rendered bool
+		var nextPC int
+		buf, nextPC, rendered = r.renderValue(buf, itemPC, item)
+		if !rendered || nextPC != leavePC {
+			return buf, nextPC, false
+		}
+	}
+	buf = append(buf, ']')
+	return buf, leavePC + 1, true
+}
+
+func (r *bytecodeResponseRenderer) renderProjectedValue(buf []byte, op planbytecode.Op, parent *astjson.Value, nextPC int) ([]byte, int, bool) {
+	if parent == nil {
+		return buf, nextPC, false
+	}
+	path, ok := r.pathRef(op.B)
+	if !ok {
+		return buf, nextPC, false
+	}
+	value := parent.Get(path...)
+	flags := op.C
+	if astjson.ValueIsNull(value) {
+		if bytecodeNodeNullable(flags) {
+			return append(buf, "null"...), nextPC, true
+		}
+		return buf, nextPC, false
+	}
+	if !bytecodeValidateASTJSONValue(value, flags) {
+		return buf, nextPC, false
+	}
+	return value.MarshalTo(buf), nextPC, true
+}
+
+func (r *bytecodeResponseRenderer) renderLiteral(buf []byte, op planbytecode.Op, nextPC int) ([]byte, int, bool) {
+	switch NodeKind(op.C) {
+	case NodeKindNull:
+		return append(buf, "null"...), nextPC, true
+	case NodeKindStaticString:
+		var ok bool
+		buf, ok = bytecodeAppendQuotedProgramString(buf, r.program, op.A)
+		if !ok {
+			return buf, nextPC, false
+		}
+		return buf, nextPC, true
+	default:
+		return buf, nextPC, false
+	}
+}
+
+func (r *bytecodeResponseRenderer) projectHasNestedValue(fieldOp planbytecode.Op, nextPC int) bool {
+	if nextPC >= len(r.program.Ops) {
+		return false
+	}
+	next := r.program.Ops[nextPC].Code
+	switch NodeKind(bytecodeNodeKind(fieldOp.C)) {
+	case NodeKindObject, NodeKindEmptyObject:
+		return next == planbytecode.OpEnterObject
+	case NodeKindArray, NodeKindEmptyArray:
+		return next == planbytecode.OpEnterArray
+	case NodeKindStaticString:
+		return next == planbytecode.OpEmitLiteral
+	default:
+		return false
+	}
+}
+
+func (r *bytecodeResponseRenderer) skipValue(pc int) int {
+	if pc >= len(r.program.Ops) {
+		return pc
+	}
+	switch r.program.Ops[pc].Code {
+	case planbytecode.OpEnterObject:
+		cursor := pc + 1
+		for fieldIndex := uint32(0); fieldIndex < r.program.Ops[pc].B && cursor < len(r.program.Ops); fieldIndex++ {
+			fieldOp := r.program.Ops[cursor]
+			if fieldOp.Code != planbytecode.OpProjectField {
+				return cursor
+			}
+			cursor++
+			if r.projectHasNestedValue(fieldOp, cursor) {
+				cursor = r.skipValue(cursor)
+			}
+		}
+		if cursor < len(r.program.Ops) && r.program.Ops[cursor].Code == planbytecode.OpLeaveObject {
+			return cursor + 1
+		}
+		return cursor
+	case planbytecode.OpEnterArray:
+		cursor := r.skipValue(pc + 1)
+		if cursor < len(r.program.Ops) && r.program.Ops[cursor].Code == planbytecode.OpLeaveArray {
+			return cursor + 1
+		}
+		return cursor
+	default:
+		return pc + 1
+	}
+}
+
+func (r *bytecodeResponseRenderer) string(ref uint32) (string, bool) {
+	if int(ref) >= len(r.program.Strings) {
+		return "", false
+	}
+	return r.program.Strings[ref], true
+}
+
+func (r *bytecodeResponseRenderer) pushField(name string) bool {
+	if r.depth >= len(r.fieldPath) {
+		return false
+	}
+	r.fieldPath[r.depth] = name
+	r.depth++
+	return true
+}
+
+func (r *bytecodeResponseRenderer) popField() {
+	r.depth--
+	r.fieldPath[r.depth] = ""
+}
+
+func (r *bytecodeResponseRenderer) pathRef(ref uint32) ([]string, bool) {
+	if int(ref) >= len(r.program.Paths) {
+		return nil, false
+	}
+	return r.program.Paths[ref], true
+}
+
+func bytecodeResponseStart(ops []planbytecode.Op) int {
+	for i := range ops {
+		switch ops[i].Code {
+		case planbytecode.OpEnterObject:
+			return i
+		case planbytecode.OpEmitResponse:
+			return -1
+		}
+	}
+	return -1
+}
+
+func bytecodeValidateASTJSONValue(value *astjson.Value, flags uint32) bool {
+	switch NodeKind(bytecodeNodeKind(flags)) {
+	case NodeKindNull:
+		return astjson.ValueIsNull(value)
+	case NodeKindString:
+		return value.Type() == astjson.TypeString
+	case NodeKindBoolean:
+		return value.Type() == astjson.TypeTrue || value.Type() == astjson.TypeFalse
+	case NodeKindInteger, NodeKindFloat, NodeKindBigInt:
+		return value.Type() == astjson.TypeNumber
+	case NodeKindScalar:
+		return true
+	default:
+		return false
+	}
+}
+
+func bytecodeNodeKind(flags uint32) uint32 {
+	return flags & 0x0000ffff
+}
+
+func bytecodeNodeNullable(flags uint32) bool {
+	return flags&(1<<16) != 0
+}
+
+func (l *Loader) executeBytecodeSpan(program *planbytecode.Program, pc int, end int) (int, error) {
+	for pc < end {
+		op := program.Ops[pc]
+		if bytecodeResponseOpcode(op.Code) {
+			return pc, nil
+		}
+		switch op.Code {
+		case planbytecode.OpNop, planbytecode.OpPasteAtPointer:
+			pc++
+		case planbytecode.OpFetchSubgraph:
+			item, err := bytecodeFetchItem(program, op.A)
+			if err != nil {
+				return pc, err
+			}
+			if err := l.resolveSingleBytecode(item); err != nil {
+				return pc, errors.WithStack(err)
+			}
+			pc = skipBytecodePaste(program.Ops, pc+1)
+		case planbytecode.OpEnterSequence:
+			leavePC, err := bytecodeGroupLeavePC(program, pc, planbytecode.OpLeaveSequence)
+			if err != nil {
+				return pc, err
+			}
+			_, err = l.executeBytecodeSpan(program, pc+1, leavePC)
+			if err != nil {
+				return pc, err
+			}
+			pc = leavePC + 1
+		case planbytecode.OpEnterParallel:
+			leavePC, err := bytecodeGroupLeavePC(program, pc, planbytecode.OpLeaveParallel)
+			if err != nil {
+				return pc, err
+			}
+			if err := l.executeBytecodeParallel(program, pc+1, leavePC, int(op.A)); err != nil {
+				return pc, err
+			}
+			pc = leavePC + 1
+		case planbytecode.OpLeaveSequence, planbytecode.OpLeaveParallel:
+			return pc, nil
+		default:
+			return pc, fmt.Errorf("execute bytecode: unsupported opcode %s at pc %d", op.Code, pc)
+		}
+	}
+	return pc, nil
+}
+
+func (l *Loader) executeBytecodeParallel(program *planbytecode.Program, pc int, leavePC int, children int) error {
+	if children == 0 {
+		return nil
+	}
+
+	if !bytecodeParallelDirectFetches(program.Ops, pc, leavePC, children) {
+		_, err := l.executeBytecodeSpan(program, pc, leavePC)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	results := make([]*result, children)
+	defer func() {
+		for i := range results {
+			if results[i] != nil {
+				batchEntityToolPool.Put(results[i].tools)
+			}
+		}
+	}()
+
+	itemsItems := make([][]*astjson.Value, children)
+	g, gCtx := errgroup.WithContext(l.ctx.ctx)
+	cursor := pc
+	for i := 0; i < children; i++ {
+		i := i
+		item, err := bytecodeFetchItem(program, program.Ops[cursor].A)
+		if err != nil {
+			return err
+		}
+		results[i] = &result{}
+		itemsItems[i] = l.selectItemsForPath(item.FetchPath)
+		f := item.Fetch
+		items := itemsItems[i]
+		res := results[i]
+		cursor = skipBytecodePaste(program.Ops, cursor+1)
+		g.Go(func() error {
+			return l.loadFetch(gCtx, f, item, items, res)
+		})
+	}
+
+	err := g.Wait()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	cursor = pc
+	for i := range results {
+		item, err := bytecodeFetchItem(program, program.Ops[cursor].A)
+		if err != nil {
+			return err
+		}
+		cursor = skipBytecodePaste(program.Ops, cursor+1)
+		if results[i].nestedMergeItems != nil {
+			for j := range results[i].nestedMergeItems {
+				err = l.mergeResultBytecode(item, results[i].nestedMergeItems[j], itemsItems[i][j:j+1])
+				l.callOnFinished(results[i].nestedMergeItems[j])
+				if err != nil {
+					return errors.WithStack(err)
+				}
+			}
+			continue
+		}
+		err = l.mergeResultBytecode(item, results[i], itemsItems[i])
+		l.callOnFinished(results[i])
+		if err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	return nil
+}
+
+func (l *Loader) resolveSingleBytecode(item *FetchItem) error {
+	if item == nil {
+		return nil
+	}
+	items := l.selectItemsForPath(item.FetchPath)
+
+	switch f := item.Fetch.(type) {
+	case *SingleFetch:
+		res := &result{}
+		err := l.loadSingleFetch(l.ctx.ctx, f, item, items, res)
+		if err != nil {
+			return err
+		}
+		err = l.mergeResultBytecode(item, res, items)
+		l.callOnFinished(res)
+		return err
+	case *BatchEntityFetch:
+		res := &result{}
+		defer batchEntityToolPool.Put(res.tools)
+		err := l.loadBatchEntityFetch(l.ctx.ctx, item, f, items, res)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		err = l.mergeResultBytecode(item, res, items)
+		l.callOnFinished(res)
+		return err
+	case *EntityFetch:
+		res := &result{}
+		err := l.loadEntityFetch(l.ctx.ctx, item, f, items, res)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		err = l.mergeResultBytecode(item, res, items)
+		l.callOnFinished(res)
+		return err
+	default:
+		return nil
+	}
+}
+
+func (l *Loader) mergeResultBytecode(fetchItem *FetchItem, res *result, items []*astjson.Value) error {
+	err := l.mergeResultDataRange(fetchItem, res, items)
+	if err == nil {
+		return nil
+	}
+	if err == errBytecodeFastMergeUnsupported {
+		return l.mergeResult(fetchItem, res, items)
+	}
+	return err
+}
+
+var errBytecodeFastMergeUnsupported = fmt.Errorf("bytecode fast merge unsupported")
+
+func (l *Loader) mergeResultDataRange(fetchItem *FetchItem, res *result, items []*astjson.Value) error {
+	if res.err != nil ||
+		res.authorizationRejected ||
+		res.rateLimitRejected ||
+		res.fetchSkipped ||
+		len(res.out) == 0 ||
+		l.allowCustomExtensionProperties ||
+		res.postProcessing.SelectResponseDataPath == nil {
+		return errBytecodeFastMergeUnsupported
+	}
+
+	if res.postProcessing.SelectResponseErrorsPath != nil {
+		errorRange, status := planbytecode.FindValueRangeStatus(res.out, res.postProcessing.SelectResponseErrorsPath)
+		if status == planbytecode.ValueRangeUnsupported {
+			return errBytecodeFastMergeUnsupported
+		}
+		if status == planbytecode.ValueRangeFound &&
+			!planbytecode.ValueRangeIsNull(res.out, errorRange) &&
+			!planbytecode.ValueRangeIsEmptyArray(res.out, errorRange) {
+			return errBytecodeFastMergeUnsupported
+		}
+	}
+
+	dataRange, status := planbytecode.FindValueRangeStatus(res.out, res.postProcessing.SelectResponseDataPath)
+	if status != planbytecode.ValueRangeFound || planbytecode.ValueRangeIsNull(res.out, dataRange) {
+		return errBytecodeFastMergeUnsupported
+	}
+
+	responseData, err := astjson.ParseBytesWithArena(l.jsonArena, res.out[dataRange.Start:dataRange.End])
+	if err != nil {
+		return errBytecodeFastMergeUnsupported
+	}
+
+	return l.mergeResponseDataNoErrors(fetchItem, res, items, responseData)
+}
+
+func (l *Loader) mergeResponseDataNoErrors(fetchItem *FetchItem, res *result, items []*astjson.Value, responseData *astjson.Value) error {
+	if len(items) == 0 {
+		if responseData.Type() != astjson.TypeObject {
+			return l.renderErrorsFailedToFetch(fetchItem, res, invalidGraphQLResponseShape)
+		}
+		l.resolvable.data = responseData
+		return nil
+	}
+	if len(items) == 1 && res.batchStats == nil {
+		var err error
+		items[0], _, err = astjson.MergeValuesWithPath(l.jsonArena, items[0], responseData, res.postProcessing.MergePath...)
+		if err != nil {
+			return errors.WithStack(ErrMergeResult{
+				Subgraph: res.ds.Name,
+				Reason:   err,
+				Path:     fetchItem.ResponsePath,
+			})
+		}
+		return nil
+	}
+
+	batch := responseData.GetArray()
+	if batch == nil {
+		return l.renderErrorsFailedToFetch(fetchItem, res, invalidGraphQLResponseShape)
+	}
+
+	if res.batchStats != nil {
+		if len(res.batchStats) != len(batch) {
+			return l.renderErrorsFailedToFetch(fetchItem, res, fmt.Sprintf(invalidBatchItemCount, len(res.batchStats), len(batch)))
+		}
+		for batchIndex, targets := range res.batchStats {
+			src := batch[batchIndex]
+			for _, target := range targets {
+				_, _, err := astjson.MergeValuesWithPath(l.jsonArena, target, src, res.postProcessing.MergePath...)
+				if err != nil {
+					return errors.WithStack(ErrMergeResult{
+						Subgraph: res.ds.Name,
+						Reason:   err,
+						Path:     fetchItem.ResponsePath,
+					})
+				}
+			}
+		}
+		return nil
+	}
+
+	if batchCount, itemCount := len(batch), len(items); batchCount != itemCount {
+		return l.renderErrorsFailedToFetch(fetchItem, res, fmt.Sprintf(invalidBatchItemCount, itemCount, batchCount))
+	}
+	for i := range items {
+		var err error
+		items[i], _, err = astjson.MergeValuesWithPath(l.jsonArena, items[i], batch[i], res.postProcessing.MergePath...)
+		if err != nil {
+			return errors.WithStack(ErrMergeResult{
+				Subgraph: res.ds.Name,
+				Reason:   err,
+				Path:     fetchItem.ResponsePath,
+			})
+		}
+	}
+	return nil
+}
+
+func bytecodeFetchItem(program *planbytecode.Program, ref uint32) (*FetchItem, error) {
+	if int(ref) >= len(program.Fetches) {
+		return nil, fmt.Errorf("bytecode fetch ref %d out of range", ref)
+	}
+	item, ok := program.Fetches[ref].Item.(*FetchItem)
+	if !ok || item == nil {
+		return nil, fmt.Errorf("bytecode fetch ref %d does not contain *resolve.FetchItem", ref)
+	}
+	if item.Fetch == nil {
+		return nil, fmt.Errorf("bytecode fetch ref %d has nil fetch", ref)
+	}
+	return item, nil
+}
+
+func skipBytecodePaste(ops []planbytecode.Op, pc int) int {
+	if pc < len(ops) && ops[pc].Code == planbytecode.OpPasteAtPointer {
+		return pc + 1
+	}
+	return pc
+}
+
+func bytecodeGroupLeavePC(program *planbytecode.Program, pc int, leave planbytecode.Opcode) (int, error) {
+	if pc >= len(program.Ops) {
+		return pc, fmt.Errorf("bytecode group pc %d out of range", pc)
+	}
+	if cached := int(program.Ops[pc].B); cached > pc && cached < len(program.Ops) && program.Ops[cached].Code == leave {
+		return cached, nil
+	}
+	return scanBytecodeGroupLeave(program.Ops, pc, leave)
+}
+
+func scanBytecodeGroupLeave(ops []planbytecode.Op, pc int, leave planbytecode.Opcode) (int, error) {
+	depth := 1
+	for cursor := pc + 1; cursor < len(ops); cursor++ {
+		switch ops[cursor].Code {
+		case planbytecode.OpEnterSequence, planbytecode.OpEnterParallel:
+			depth++
+		case planbytecode.OpLeaveSequence, planbytecode.OpLeaveParallel:
+			depth--
+			if depth == 0 {
+				if ops[cursor].Code != leave {
+					return cursor, fmt.Errorf("bytecode group starting at pc %d closed with %s, expected %s", pc, ops[cursor].Code, leave)
+				}
+				return cursor, nil
+			}
+		}
+	}
+	return pc, fmt.Errorf("bytecode group starting at pc %d missing %s", pc, leave)
+}
+
+func skipBytecodeChild(ops []planbytecode.Op, pc int) (int, error) {
+	if pc >= len(ops) {
+		return pc, fmt.Errorf("skip bytecode child: pc %d out of range", pc)
+	}
+	switch ops[pc].Code {
+	case planbytecode.OpFetchSubgraph:
+		return skipBytecodePaste(ops, pc+1), nil
+	case planbytecode.OpEnterSequence:
+		return skipBytecodeGroup(ops, pc+1, planbytecode.OpEnterSequence, planbytecode.OpLeaveSequence)
+	case planbytecode.OpEnterParallel:
+		return skipBytecodeGroup(ops, pc+1, planbytecode.OpEnterParallel, planbytecode.OpLeaveParallel)
+	default:
+		return pc + 1, nil
+	}
+}
+
+func skipBytecodeGroup(ops []planbytecode.Op, pc int, enter planbytecode.Opcode, leave planbytecode.Opcode) (int, error) {
+	depth := 1
+	for pc < len(ops) {
+		switch ops[pc].Code {
+		case enter:
+			depth++
+		case leave:
+			depth--
+			if depth == 0 {
+				return pc + 1, nil
+			}
+		}
+		pc++
+	}
+	return pc, fmt.Errorf("skip bytecode group: missing %s", leave)
+}
+
+func bytecodeParallelDirectFetches(ops []planbytecode.Op, pc int, leavePC int, children int) bool {
+	cursor := pc
+	for i := 0; i < children; i++ {
+		if cursor >= leavePC || cursor >= len(ops) || ops[cursor].Code != planbytecode.OpFetchSubgraph {
+			return false
+		}
+		cursor = skipBytecodePaste(ops, cursor+1)
+	}
+	return cursor == leavePC
+}
+
+func bytecodeResponseOpcode(code planbytecode.Opcode) bool {
+	switch code {
+	case planbytecode.OpEnterObject,
+		planbytecode.OpLeaveObject,
+		planbytecode.OpEnterArray,
+		planbytecode.OpLeaveArray,
+		planbytecode.OpProjectField,
+		planbytecode.OpEmitLiteral,
+		planbytecode.OpEmitResponse:
+		return true
+	default:
+		return false
+	}
+}

--- a/v2/pkg/engine/resolve/bytecode_test.go
+++ b/v2/pkg/engine/resolve/bytecode_test.go
@@ -1,0 +1,1097 @@
+package resolve
+
+import (
+	"bytes"
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/planbytecode"
+)
+
+func TestResolveGraphQLResponseBytecodeMatchesFetchTree(t *testing.T) {
+	expectedResponse, _ := bytecodeTestResponse()
+	actualResponse, actualProgram := bytecodeTestResponse()
+
+	ctx := NewContext(context.Background())
+	resolver := newResolver(context.Background())
+
+	var expected bytes.Buffer
+	_, err := resolver.ResolveGraphQLResponse(ctx, expectedResponse, nil, &expected)
+	require.NoError(t, err)
+
+	ctx = NewContext(context.Background())
+	var actual bytes.Buffer
+	_, err = resolver.ResolveGraphQLResponseBytecode(ctx, actualResponse, actualProgram, nil, &actual)
+	require.NoError(t, err)
+
+	require.Equal(t, expected.String(), actual.String())
+	require.Equal(t, `{"data":{"a":1,"b":2,"c":3}}`, actual.String())
+}
+
+func TestResolveGraphQLResponseBytecodeFallsBackOnSubgraphErrors(t *testing.T) {
+	expectedResponse, _ := bytecodeTestResponseWithRootError()
+	actualResponse, actualProgram := bytecodeTestResponseWithRootError()
+
+	ctx := NewContext(context.Background())
+	resolver := newResolver(context.Background())
+
+	var expected bytes.Buffer
+	_, err := resolver.ResolveGraphQLResponse(ctx, expectedResponse, nil, &expected)
+	require.NoError(t, err)
+
+	ctx = NewContext(context.Background())
+	var actual bytes.Buffer
+	_, err = resolver.ResolveGraphQLResponseBytecode(ctx, actualResponse, actualProgram, nil, &actual)
+	require.NoError(t, err)
+
+	require.Equal(t, expected.String(), actual.String())
+	require.Contains(t, actual.String(), "downstream")
+}
+
+func TestResolveGraphQLResponseBytecodeDirectNestedObjectAndArray(t *testing.T) {
+	expectedResponse, _ := bytecodeNestedTestResponse()
+	actualResponse, actualProgram := bytecodeNestedTestResponse()
+
+	ctx := NewContext(context.Background())
+	resolver := newResolver(context.Background())
+
+	var expected bytes.Buffer
+	_, err := resolver.ResolveGraphQLResponse(ctx, expectedResponse, nil, &expected)
+	require.NoError(t, err)
+
+	ctx = NewContext(context.Background())
+	var actual bytes.Buffer
+	_, err = resolver.ResolveGraphQLResponseBytecode(ctx, actualResponse, actualProgram, nil, &actual)
+	require.NoError(t, err)
+
+	require.Equal(t, expected.String(), actual.String())
+	require.Equal(t, `{"data":{"user":{"id":"1","name":"Ada","age":37,"posts":[{"title":"First","score":10},{"title":"Second","score":20}]}}}`, actual.String())
+}
+
+func TestResolveGraphQLResponseBytecodeDirectMergePath(t *testing.T) {
+	expectedResponse, _ := bytecodeMergePathTestResponse()
+	actualResponse, actualProgram := bytecodeMergePathTestResponse()
+
+	ctx := NewContext(context.Background())
+	resolver := newResolver(context.Background())
+
+	var expected bytes.Buffer
+	_, err := resolver.ResolveGraphQLResponse(ctx, expectedResponse, nil, &expected)
+	require.NoError(t, err)
+
+	ctx = NewContext(context.Background())
+	var actual bytes.Buffer
+	_, err = resolver.ResolveGraphQLResponseBytecode(ctx, actualResponse, actualProgram, nil, &actual)
+	require.NoError(t, err)
+
+	require.Equal(t, expected.String(), actual.String())
+	require.Equal(t, `{"data":{"user":{"id":"1","age":37}}}`, actual.String())
+}
+
+func TestResolveGraphQLResponseBytecodeDirectRootArrayBatchEntityFetch(t *testing.T) {
+	expectedResponse, _ := bytecodeBatchEntityTestResponse()
+	actualResponse, actualProgram := bytecodeBatchEntityTestResponse()
+
+	ctx := NewContext(context.Background())
+	resolver := newResolver(context.Background())
+
+	var expected bytes.Buffer
+	_, err := resolver.ResolveGraphQLResponse(ctx, expectedResponse, nil, &expected)
+	require.NoError(t, err)
+
+	ctx = NewContext(context.Background())
+	var actual bytes.Buffer
+	_, err = resolver.ResolveGraphQLResponseBytecode(ctx, actualResponse, actualProgram, nil, &actual)
+	require.NoError(t, err)
+
+	require.Equal(t, expected.String(), actual.String())
+	require.Equal(t, `{"data":{"products":[{"name":"Table","stock":8},{"name":"Couch","stock":2}]}}`, actual.String())
+}
+
+func TestResolveGraphQLResponseBytecodeDirectRootObjectEntityFetch(t *testing.T) {
+	expectedResponse, _ := bytecodeEntityTestResponse()
+	actualResponse, actualProgram := bytecodeEntityTestResponse()
+
+	ctx := NewContext(context.Background())
+	resolver := newResolver(context.Background())
+
+	var expected bytes.Buffer
+	_, err := resolver.ResolveGraphQLResponse(ctx, expectedResponse, nil, &expected)
+	require.NoError(t, err)
+
+	ctx = NewContext(context.Background())
+	var actual bytes.Buffer
+	_, err = resolver.ResolveGraphQLResponseBytecode(ctx, actualResponse, actualProgram, nil, &actual)
+	require.NoError(t, err)
+
+	require.Equal(t, expected.String(), actual.String())
+	require.Equal(t, `{"data":{"user":{"name":"Ada","age":37}}}`, actual.String())
+}
+
+func TestResolveGraphQLResponseBytecodeDirectNestedDedupBatchEntityFetch(t *testing.T) {
+	expectedResponse, _ := bytecodeNestedBatchEntityTestResponse()
+	actualResponse, actualProgram := bytecodeNestedBatchEntityTestResponse()
+
+	ctx := NewContext(context.Background())
+	resolver := newResolver(context.Background())
+
+	var expected bytes.Buffer
+	_, err := resolver.ResolveGraphQLResponse(ctx, expectedResponse, nil, &expected)
+	require.NoError(t, err)
+
+	ctx = NewContext(context.Background())
+	var actual bytes.Buffer
+	_, err = resolver.ResolveGraphQLResponseBytecode(ctx, actualResponse, actualProgram, nil, &actual)
+	require.NoError(t, err)
+
+	require.Equal(t, expected.String(), actual.String())
+	require.Equal(t, `{"data":{"products":[{"name":"Table","reviews":[{"body":"Love Table","author":{"name":"user-1"}},{"body":"Prefer Desk","author":{"name":"user-2"}}]},{"name":"Couch","reviews":[{"body":"Too expensive","author":{"name":"user-1"}}]}]}}`, actual.String())
+}
+
+func TestLoadAndRenderGraphQLResponseBytecodeDirectNestedDedupBatchEntityFetch(t *testing.T) {
+	response, program := bytecodeNestedBatchEntityTestResponse()
+	ctx := NewContext(context.Background())
+	resolvable := NewResolvable(nil, ResolvableOptions{})
+	loader := &Loader{}
+
+	err := resolvable.Init(ctx, nil, ast.OperationTypeQuery)
+	require.NoError(t, err)
+
+	var actual bytes.Buffer
+	rendered, err := loader.LoadAndRenderGraphQLResponseBytecodeDirect(ctx, response, program, resolvable, &actual)
+	require.NoError(t, err)
+	require.True(t, rendered)
+	require.Equal(t, `{"data":{"products":[{"name":"Table","reviews":[{"body":"Love Table","author":{"name":"user-1"}},{"body":"Prefer Desk","author":{"name":"user-2"}}]},{"name":"Couch","reviews":[{"body":"Too expensive","author":{"name":"user-1"}}]}]}}`, actual.String())
+}
+
+func TestResolvableRenderGraphQLResponseBytecodeNestedObjectAndArray(t *testing.T) {
+	response, program := bytecodeNestedTestResponse()
+	program.DirectResponse = nil
+
+	ctx := NewContext(context.Background())
+	resolvable := NewResolvable(nil, ResolvableOptions{})
+	loader := &Loader{}
+
+	err := resolvable.Init(ctx, nil, ast.OperationTypeQuery)
+	require.NoError(t, err)
+	err = loader.LoadGraphQLResponseDataBytecode(ctx, response, program, resolvable)
+	require.NoError(t, err)
+
+	var actual bytes.Buffer
+	rendered, err := resolvable.RenderGraphQLResponseBytecode(program, &actual)
+	require.NoError(t, err)
+	require.True(t, rendered)
+	require.Equal(t, `{"data":{"user":{"id":"1","name":"Ada","age":37,"posts":[{"title":"First","score":10},{"title":"Second","score":20}]}}}`, actual.String())
+	require.Equal(t, 2, resolvable.actualListSizes["user.posts"])
+}
+
+func TestResolvableRenderGraphQLResponseBytecodeFallsBackWhenErrorsExist(t *testing.T) {
+	response, program := bytecodeTestResponseWithRootError()
+	program.DirectResponse = nil
+
+	ctx := NewContext(context.Background())
+	resolvable := NewResolvable(nil, ResolvableOptions{})
+	loader := &Loader{}
+
+	err := resolvable.Init(ctx, nil, ast.OperationTypeQuery)
+	require.NoError(t, err)
+	err = loader.LoadGraphQLResponseDataBytecode(ctx, response, program, resolvable)
+	require.NoError(t, err)
+
+	var actual bytes.Buffer
+	rendered, err := resolvable.RenderGraphQLResponseBytecode(program, &actual)
+	require.NoError(t, err)
+	require.False(t, rendered)
+	require.Empty(t, actual.String())
+}
+
+func TestLoaderLoadGraphQLResponseDataBytecodeExecutesParallelFetches(t *testing.T) {
+	response, program := bytecodeTestResponse()
+	ctx := NewContext(context.Background())
+	resolvable := NewResolvable(nil, ResolvableOptions{})
+	loader := &Loader{}
+
+	err := resolvable.Init(ctx, nil, ast.OperationTypeQuery)
+	require.NoError(t, err)
+	err = loader.LoadGraphQLResponseDataBytecode(ctx, response, program, resolvable)
+	require.NoError(t, err)
+
+	require.Equal(t, "1", resolvable.data.Get("a").String())
+	require.Equal(t, "2", resolvable.data.Get("b").String())
+	require.Equal(t, "3", resolvable.data.Get("c").String())
+}
+
+func BenchmarkLoaderLoadGraphQLResponseDataFetchTree(b *testing.B) {
+	response, _ := bytecodeTestResponse()
+	benchmarkBytecodeLoader(b, response, nil)
+}
+
+func BenchmarkLoaderLoadGraphQLResponseDataBytecode(b *testing.B) {
+	response, program := bytecodeTestResponse()
+	benchmarkBytecodeLoader(b, response, program)
+}
+
+func BenchmarkResolveGraphQLResponseFetchTree(b *testing.B) {
+	response, _ := bytecodeTestResponse()
+	benchmarkResolveGraphQLResponse(b, response, nil)
+}
+
+func BenchmarkResolveGraphQLResponseBytecode(b *testing.B) {
+	response, program := bytecodeTestResponse()
+	benchmarkResolveGraphQLResponse(b, response, program)
+}
+
+func BenchmarkResolveGraphQLResponseBytecodeResponseOps(b *testing.B) {
+	response, program := bytecodeTestResponse()
+	program.DirectResponse = nil
+	benchmarkResolveGraphQLResponse(b, response, program)
+}
+
+func BenchmarkResolveGraphQLResponseNestedFetchTree(b *testing.B) {
+	response, _ := bytecodeNestedTestResponse()
+	benchmarkResolveGraphQLResponseWithExpected(b, response, nil, `{"data":{"user":{"id":"1","name":"Ada","age":37,"posts":[{"title":"First","score":10},{"title":"Second","score":20}]}}}`)
+}
+
+func BenchmarkResolveGraphQLResponseNestedBytecode(b *testing.B) {
+	response, program := bytecodeNestedTestResponse()
+	benchmarkResolveGraphQLResponseWithExpected(b, response, program, `{"data":{"user":{"id":"1","name":"Ada","age":37,"posts":[{"title":"First","score":10},{"title":"Second","score":20}]}}}`)
+}
+
+func BenchmarkResolveGraphQLResponseNestedBytecodeResponseOps(b *testing.B) {
+	response, program := bytecodeNestedTestResponse()
+	program.DirectResponse = nil
+	benchmarkResolveGraphQLResponseWithExpected(b, response, program, `{"data":{"user":{"id":"1","name":"Ada","age":37,"posts":[{"title":"First","score":10},{"title":"Second","score":20}]}}}`)
+}
+
+func BenchmarkResolveGraphQLResponseBatchEntityFetchTree(b *testing.B) {
+	response, _ := bytecodeBatchEntityTestResponse()
+	benchmarkResolveGraphQLResponseWithExpected(b, response, nil, `{"data":{"products":[{"name":"Table","stock":8},{"name":"Couch","stock":2}]}}`)
+}
+
+func BenchmarkResolveGraphQLResponseBatchEntityBytecode(b *testing.B) {
+	response, program := bytecodeBatchEntityTestResponse()
+	benchmarkResolveGraphQLResponseWithExpected(b, response, program, `{"data":{"products":[{"name":"Table","stock":8},{"name":"Couch","stock":2}]}}`)
+}
+
+func BenchmarkResolveGraphQLResponseBatchEntityBytecodeResponseOps(b *testing.B) {
+	response, program := bytecodeBatchEntityTestResponse()
+	program.DirectResponse = nil
+	benchmarkResolveGraphQLResponseWithExpected(b, response, program, `{"data":{"products":[{"name":"Table","stock":8},{"name":"Couch","stock":2}]}}`)
+}
+
+func BenchmarkResolveGraphQLResponseEntityFetchTree(b *testing.B) {
+	response, _ := bytecodeEntityTestResponse()
+	benchmarkResolveGraphQLResponseWithExpected(b, response, nil, `{"data":{"user":{"name":"Ada","age":37}}}`)
+}
+
+func BenchmarkResolveGraphQLResponseEntityBytecode(b *testing.B) {
+	response, program := bytecodeEntityTestResponse()
+	benchmarkResolveGraphQLResponseWithExpected(b, response, program, `{"data":{"user":{"name":"Ada","age":37}}}`)
+}
+
+func BenchmarkResolveGraphQLResponseEntityBytecodeResponseOps(b *testing.B) {
+	response, program := bytecodeEntityTestResponse()
+	program.DirectResponse = nil
+	benchmarkResolveGraphQLResponseWithExpected(b, response, program, `{"data":{"user":{"name":"Ada","age":37}}}`)
+}
+
+func BenchmarkResolveGraphQLResponseNestedBatchEntityFetchTree(b *testing.B) {
+	response, _ := bytecodeNestedBatchEntityTestResponse()
+	benchmarkResolveGraphQLResponseWithExpected(b, response, nil, `{"data":{"products":[{"name":"Table","reviews":[{"body":"Love Table","author":{"name":"user-1"}},{"body":"Prefer Desk","author":{"name":"user-2"}}]},{"name":"Couch","reviews":[{"body":"Too expensive","author":{"name":"user-1"}}]}]}}`)
+}
+
+func BenchmarkResolveGraphQLResponseNestedBatchEntityBytecode(b *testing.B) {
+	response, program := bytecodeNestedBatchEntityTestResponse()
+	benchmarkResolveGraphQLResponseWithExpected(b, response, program, `{"data":{"products":[{"name":"Table","reviews":[{"body":"Love Table","author":{"name":"user-1"}},{"body":"Prefer Desk","author":{"name":"user-2"}}]},{"name":"Couch","reviews":[{"body":"Too expensive","author":{"name":"user-1"}}]}]}}`)
+}
+
+func BenchmarkResolveGraphQLResponseNestedBatchEntityBytecodeResponseOps(b *testing.B) {
+	response, program := bytecodeNestedBatchEntityTestResponse()
+	program.DirectResponse = nil
+	benchmarkResolveGraphQLResponseWithExpected(b, response, program, `{"data":{"products":[{"name":"Table","reviews":[{"body":"Love Table","author":{"name":"user-1"}},{"body":"Prefer Desk","author":{"name":"user-2"}}]},{"name":"Couch","reviews":[{"body":"Too expensive","author":{"name":"user-1"}}]}]}}`)
+}
+
+func benchmarkBytecodeLoader(b *testing.B, response *GraphQLResponse, program *planbytecode.Program) {
+	ctx := NewContext(context.Background())
+	resolvable := NewResolvable(nil, ResolvableOptions{})
+	loader := &Loader{}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		loader.Free()
+		resolvable.Reset()
+		err := resolvable.Init(ctx, nil, ast.OperationTypeQuery)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if program == nil {
+			err = loader.LoadGraphQLResponseData(ctx, response, resolvable)
+		} else {
+			err = loader.LoadGraphQLResponseDataBytecode(ctx, response, program, resolvable)
+		}
+		if err != nil {
+			b.Fatal(err)
+		}
+		if resolvable.data.Get("c") == nil {
+			b.Fatal("missing merged field")
+		}
+	}
+}
+
+func benchmarkResolveGraphQLResponse(b *testing.B, response *GraphQLResponse, program *planbytecode.Program) {
+	benchmarkResolveGraphQLResponseWithExpected(b, response, program, `{"data":{"a":1,"b":2,"c":3}}`)
+}
+
+func benchmarkResolveGraphQLResponseWithExpected(b *testing.B, response *GraphQLResponse, program *planbytecode.Program, expected string) {
+	resolver := newResolver(context.Background())
+	program = bytecodeTestQuoteProgramStrings(program)
+	var out bytes.Buffer
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ctx := NewContext(context.Background())
+		out.Reset()
+		var err error
+		if program == nil {
+			_, err = resolver.ResolveGraphQLResponse(ctx, response, nil, &out)
+		} else {
+			_, err = resolver.ResolveGraphQLResponseBytecode(ctx, response, program, nil, &out)
+		}
+		if err != nil {
+			b.Fatal(err)
+		}
+		if out.String() != expected {
+			b.Fatalf("unexpected response: %s", out.String())
+		}
+	}
+}
+
+func bytecodeTestQuoteProgramStrings(program *planbytecode.Program) *planbytecode.Program {
+	if program == nil || len(program.QuotedStrings) == len(program.Strings) {
+		return program
+	}
+	program.QuotedStrings = make([]string, len(program.Strings))
+	for i := range program.Strings {
+		program.QuotedStrings[i] = strconv.Quote(program.Strings[i])
+	}
+	return program
+}
+
+func bytecodeTestNodeFlags(kind NodeKind, nullable bool) uint32 {
+	return planbytecode.EncodeDirectFieldFlags(uint32(kind), nullable, false)
+}
+
+func bytecodeTestResponse() (*GraphQLResponse, *planbytecode.Program) {
+	root := &FetchItem{
+		Fetch: &SingleFetch{
+			InputTemplate: InputTemplate{
+				Segments: []TemplateSegment{{Data: []byte(`{}`), SegmentType: StaticSegmentType}},
+			},
+			FetchConfiguration: FetchConfiguration{
+				DataSource: FakeDataSource(`{"data":{"a":1}}`),
+				PostProcessing: PostProcessingConfiguration{
+					SelectResponseDataPath: []string{"data"},
+				},
+			},
+			Info: &FetchInfo{DataSourceName: "root"},
+		},
+	}
+	left := &FetchItem{
+		Fetch: &SingleFetch{
+			InputTemplate: InputTemplate{
+				Segments: []TemplateSegment{{Data: []byte(`{}`), SegmentType: StaticSegmentType}},
+			},
+			FetchConfiguration: FetchConfiguration{
+				DataSource: FakeDataSource(`{"data":{"b":2}}`),
+				PostProcessing: PostProcessingConfiguration{
+					SelectResponseDataPath: []string{"data"},
+				},
+			},
+			Info: &FetchInfo{DataSourceName: "left"},
+		},
+	}
+	right := &FetchItem{
+		Fetch: &SingleFetch{
+			InputTemplate: InputTemplate{
+				Segments: []TemplateSegment{{Data: []byte(`{}`), SegmentType: StaticSegmentType}},
+			},
+			FetchConfiguration: FetchConfiguration{
+				DataSource: FakeDataSource(`{"data":{"c":3}}`),
+				PostProcessing: PostProcessingConfiguration{
+					SelectResponseDataPath: []string{"data"},
+				},
+			},
+			Info: &FetchInfo{DataSourceName: "right"},
+		},
+	}
+
+	response := &GraphQLResponse{
+		Info: &GraphQLResponseInfo{OperationType: ast.OperationTypeQuery},
+		Fetches: Sequence(
+			&FetchTreeNode{Kind: FetchTreeNodeKindSingle, Item: root},
+			Parallel(
+				&FetchTreeNode{Kind: FetchTreeNodeKindSingle, Item: left},
+				&FetchTreeNode{Kind: FetchTreeNodeKindSingle, Item: right},
+			),
+		),
+		Data: &Object{
+			Fields: []*Field{
+				{Name: []byte("a"), Value: &Integer{Path: []string{"a"}}},
+				{Name: []byte("b"), Value: &Integer{Path: []string{"b"}}},
+				{Name: []byte("c"), Value: &Integer{Path: []string{"c"}}},
+			},
+		},
+	}
+	program := &planbytecode.Program{
+		Strings: []string{"a", "b", "c"},
+		Paths:   [][]string{nil, {"a"}, {"b"}, {"c"}},
+		Ops: []planbytecode.Op{
+			{Code: planbytecode.OpEnterSequence, A: 2, B: 9},
+			{Code: planbytecode.OpFetchSubgraph, A: 0},
+			{Code: planbytecode.OpPasteAtPointer, A: 0},
+			{Code: planbytecode.OpEnterParallel, A: 2, B: 8},
+			{Code: planbytecode.OpFetchSubgraph, A: 1},
+			{Code: planbytecode.OpPasteAtPointer, A: 1},
+			{Code: planbytecode.OpFetchSubgraph, A: 2},
+			{Code: planbytecode.OpPasteAtPointer, A: 2},
+			{Code: planbytecode.OpLeaveParallel},
+			{Code: planbytecode.OpLeaveSequence},
+			{Code: planbytecode.OpEnterObject, A: 0, B: 3},
+			{Code: planbytecode.OpProjectField, A: 0, B: 1, C: bytecodeTestNodeFlags(NodeKindInteger, false)},
+			{Code: planbytecode.OpProjectField, A: 1, B: 2, C: bytecodeTestNodeFlags(NodeKindInteger, false)},
+			{Code: planbytecode.OpProjectField, A: 2, B: 3, C: bytecodeTestNodeFlags(NodeKindInteger, false)},
+			{Code: planbytecode.OpLeaveObject},
+			{Code: planbytecode.OpEmitResponse},
+		},
+		Fetches: []planbytecode.Fetch{
+			{Item: root},
+			{Item: left},
+			{Item: right},
+		},
+		DirectResponse: &planbytecode.DirectResponse{
+			Fields: []planbytecode.DirectField{
+				{NameRef: 0, PathRef: 1, Flags: planbytecode.EncodeDirectFieldFlags(uint32(NodeKindInteger), false, false)},
+				{NameRef: 1, PathRef: 2, Flags: planbytecode.EncodeDirectFieldFlags(uint32(NodeKindInteger), false, false)},
+				{NameRef: 2, PathRef: 3, Flags: planbytecode.EncodeDirectFieldFlags(uint32(NodeKindInteger), false, false)},
+			},
+		},
+	}
+	return response, program
+}
+
+func bytecodeTestResponseWithRootError() (*GraphQLResponse, *planbytecode.Program) {
+	response, program := bytecodeTestResponse()
+	root := response.Fetches.ChildNodes[0].Item.Fetch.(*SingleFetch)
+	root.FetchConfiguration.DataSource = FakeDataSource(`{"errors":[{"message":"downstream"}],"data":{"a":1}}`)
+	root.PostProcessing.SelectResponseErrorsPath = []string{"errors"}
+	return response, program
+}
+
+func bytecodeNestedTestResponse() (*GraphQLResponse, *planbytecode.Program) {
+	root := &FetchItem{
+		Fetch: &SingleFetch{
+			InputTemplate: InputTemplate{
+				Segments: []TemplateSegment{{Data: []byte(`{}`), SegmentType: StaticSegmentType}},
+			},
+			FetchConfiguration: FetchConfiguration{
+				DataSource: FakeDataSource(`{"data":{"user":{"id":"1","name":"Ada","posts":[{"title":"First"},{"title":"Second"}]}}}`),
+				PostProcessing: PostProcessingConfiguration{
+					SelectResponseDataPath: []string{"data"},
+				},
+			},
+			Info: &FetchInfo{DataSourceName: "root"},
+		},
+	}
+	extra := &FetchItem{
+		Fetch: &SingleFetch{
+			InputTemplate: InputTemplate{
+				Segments: []TemplateSegment{{Data: []byte(`{}`), SegmentType: StaticSegmentType}},
+			},
+			FetchConfiguration: FetchConfiguration{
+				DataSource: FakeDataSource(`{"data":{"user":{"age":37,"posts":[{"score":10},{"score":20}]}}}`),
+				PostProcessing: PostProcessingConfiguration{
+					SelectResponseDataPath: []string{"data"},
+				},
+			},
+			Info: &FetchInfo{DataSourceName: "extra"},
+		},
+	}
+
+	response := &GraphQLResponse{
+		Info: &GraphQLResponseInfo{OperationType: ast.OperationTypeQuery},
+		Fetches: Sequence(
+			&FetchTreeNode{Kind: FetchTreeNodeKindSingle, Item: root},
+			&FetchTreeNode{Kind: FetchTreeNodeKindSingle, Item: extra},
+		),
+		Data: &Object{
+			Fields: []*Field{
+				{
+					Name: []byte("user"),
+					Value: &Object{
+						Path: []string{"user"},
+						Fields: []*Field{
+							{Name: []byte("id"), Value: &String{Path: []string{"id"}}},
+							{Name: []byte("name"), Value: &String{Path: []string{"name"}}},
+							{Name: []byte("age"), Value: &Integer{Path: []string{"age"}}},
+							{
+								Name: []byte("posts"),
+								Value: &Array{
+									Path: []string{"posts"},
+									Item: &Object{
+										Fields: []*Field{
+											{Name: []byte("title"), Value: &String{Path: []string{"title"}}},
+											{Name: []byte("score"), Value: &Integer{Path: []string{"score"}}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	program := &planbytecode.Program{
+		Strings: []string{"user", "id", "name", "age", "posts", "title", "score"},
+		Paths:   [][]string{nil, {"user"}, {"id"}, {"name"}, {"age"}, {"posts"}, {"title"}, {"score"}},
+		Ops: []planbytecode.Op{
+			{Code: planbytecode.OpEnterSequence, A: 2, B: 5},
+			{Code: planbytecode.OpFetchSubgraph, A: 0},
+			{Code: planbytecode.OpPasteAtPointer, A: 0},
+			{Code: planbytecode.OpFetchSubgraph, A: 1},
+			{Code: planbytecode.OpPasteAtPointer, A: 1},
+			{Code: planbytecode.OpLeaveSequence},
+			{Code: planbytecode.OpEnterObject, A: 0, B: 1},
+			{Code: planbytecode.OpProjectField, A: 0, B: 1, C: bytecodeTestNodeFlags(NodeKindObject, false)},
+			{Code: planbytecode.OpEnterObject, A: 1, B: 4},
+			{Code: planbytecode.OpProjectField, A: 1, B: 2, C: bytecodeTestNodeFlags(NodeKindString, false)},
+			{Code: planbytecode.OpProjectField, A: 2, B: 3, C: bytecodeTestNodeFlags(NodeKindString, false)},
+			{Code: planbytecode.OpProjectField, A: 3, B: 4, C: bytecodeTestNodeFlags(NodeKindInteger, false)},
+			{Code: planbytecode.OpProjectField, A: 4, B: 5, C: bytecodeTestNodeFlags(NodeKindArray, false)},
+			{Code: planbytecode.OpEnterArray, A: 5},
+			{Code: planbytecode.OpEnterObject, A: 0, B: 2},
+			{Code: planbytecode.OpProjectField, A: 5, B: 6, C: bytecodeTestNodeFlags(NodeKindString, false)},
+			{Code: planbytecode.OpProjectField, A: 6, B: 7, C: bytecodeTestNodeFlags(NodeKindInteger, false)},
+			{Code: planbytecode.OpLeaveObject},
+			{Code: planbytecode.OpLeaveArray},
+			{Code: planbytecode.OpLeaveObject},
+			{Code: planbytecode.OpLeaveObject},
+			{Code: planbytecode.OpEmitResponse},
+		},
+		Fetches: []planbytecode.Fetch{
+			{Item: root},
+			{Item: extra},
+		},
+		DirectResponse: &planbytecode.DirectResponse{
+			Fields: []planbytecode.DirectField{
+				{
+					NameRef: 0,
+					PathRef: 1,
+					Flags:   planbytecode.EncodeDirectFieldFlags(uint32(NodeKindObject), false, false),
+					Children: []planbytecode.DirectField{
+						{NameRef: 1, PathRef: 2, Flags: planbytecode.EncodeDirectFieldFlags(uint32(NodeKindString), false, false)},
+						{NameRef: 2, PathRef: 3, Flags: planbytecode.EncodeDirectFieldFlags(uint32(NodeKindString), false, false)},
+						{NameRef: 3, PathRef: 4, Flags: planbytecode.EncodeDirectFieldFlags(uint32(NodeKindInteger), false, false)},
+						{
+							NameRef:   4,
+							PathRef:   5,
+							Flags:     planbytecode.EncodeDirectFieldFlags(uint32(NodeKindArray), false, false),
+							ItemFlags: planbytecode.EncodeDirectFieldFlags(uint32(NodeKindObject), false, false),
+							Children: []planbytecode.DirectField{
+								{NameRef: 5, PathRef: 6, Flags: planbytecode.EncodeDirectFieldFlags(uint32(NodeKindString), false, false)},
+								{NameRef: 6, PathRef: 7, Flags: planbytecode.EncodeDirectFieldFlags(uint32(NodeKindInteger), false, false)},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return response, program
+}
+
+func bytecodeMergePathTestResponse() (*GraphQLResponse, *planbytecode.Program) {
+	root := &FetchItem{
+		Fetch: &SingleFetch{
+			InputTemplate: InputTemplate{
+				Segments: []TemplateSegment{{Data: []byte(`{}`), SegmentType: StaticSegmentType}},
+			},
+			FetchConfiguration: FetchConfiguration{
+				DataSource: FakeDataSource(`{"data":{"user":{"id":"1"}}}`),
+				PostProcessing: PostProcessingConfiguration{
+					SelectResponseDataPath: []string{"data"},
+				},
+			},
+			Info: &FetchInfo{DataSourceName: "root"},
+		},
+	}
+	extra := &FetchItem{
+		Fetch: &SingleFetch{
+			InputTemplate: InputTemplate{
+				Segments: []TemplateSegment{{Data: []byte(`{}`), SegmentType: StaticSegmentType}},
+			},
+			FetchConfiguration: FetchConfiguration{
+				DataSource: FakeDataSource(`{"data":{"age":37}}`),
+				PostProcessing: PostProcessingConfiguration{
+					SelectResponseDataPath: []string{"data"},
+					MergePath:              []string{"user"},
+				},
+			},
+			Info: &FetchInfo{DataSourceName: "extra"},
+		},
+	}
+
+	response := &GraphQLResponse{
+		Info: &GraphQLResponseInfo{OperationType: ast.OperationTypeQuery},
+		Fetches: Sequence(
+			&FetchTreeNode{Kind: FetchTreeNodeKindSingle, Item: root},
+			&FetchTreeNode{Kind: FetchTreeNodeKindSingle, Item: extra},
+		),
+		Data: &Object{
+			Fields: []*Field{
+				{
+					Name: []byte("user"),
+					Value: &Object{
+						Path: []string{"user"},
+						Fields: []*Field{
+							{Name: []byte("id"), Value: &String{Path: []string{"id"}}},
+							{Name: []byte("age"), Value: &Integer{Path: []string{"age"}}},
+						},
+					},
+				},
+			},
+		},
+	}
+	program := &planbytecode.Program{
+		Strings: []string{"user", "id", "age"},
+		Paths:   [][]string{nil, {"user"}, {"id"}, {"age"}},
+		Ops: []planbytecode.Op{
+			{Code: planbytecode.OpEnterSequence, A: 2, B: 5},
+			{Code: planbytecode.OpFetchSubgraph, A: 0},
+			{Code: planbytecode.OpPasteAtPointer, A: 0},
+			{Code: planbytecode.OpFetchSubgraph, A: 1},
+			{Code: planbytecode.OpPasteAtPointer, A: 1},
+			{Code: planbytecode.OpLeaveSequence},
+			{Code: planbytecode.OpEnterObject, A: 0, B: 1},
+			{Code: planbytecode.OpProjectField, A: 0, B: 1, C: bytecodeTestNodeFlags(NodeKindObject, false)},
+			{Code: planbytecode.OpEnterObject, A: 1, B: 2},
+			{Code: planbytecode.OpProjectField, A: 1, B: 2, C: bytecodeTestNodeFlags(NodeKindString, false)},
+			{Code: planbytecode.OpProjectField, A: 2, B: 3, C: bytecodeTestNodeFlags(NodeKindInteger, false)},
+			{Code: planbytecode.OpLeaveObject},
+			{Code: planbytecode.OpLeaveObject},
+			{Code: planbytecode.OpEmitResponse},
+		},
+		Fetches: []planbytecode.Fetch{
+			{Item: root},
+			{Item: extra},
+		},
+		DirectResponse: &planbytecode.DirectResponse{
+			Fields: []planbytecode.DirectField{
+				{
+					NameRef: 0,
+					PathRef: 1,
+					Flags:   planbytecode.EncodeDirectFieldFlags(uint32(NodeKindObject), false, false),
+					Children: []planbytecode.DirectField{
+						{NameRef: 1, PathRef: 2, Flags: planbytecode.EncodeDirectFieldFlags(uint32(NodeKindString), false, false)},
+						{NameRef: 2, PathRef: 3, Flags: planbytecode.EncodeDirectFieldFlags(uint32(NodeKindInteger), false, false)},
+					},
+				},
+			},
+		},
+	}
+	return response, program
+}
+
+func bytecodeBatchEntityTestResponse() (*GraphQLResponse, *planbytecode.Program) {
+	root := &FetchItem{
+		Fetch: &SingleFetch{
+			InputTemplate: InputTemplate{
+				Segments: []TemplateSegment{{Data: []byte(`{}`), SegmentType: StaticSegmentType}},
+			},
+			FetchConfiguration: FetchConfiguration{
+				DataSource: FakeDataSource(`{"data":{"products":[{"name":"Table","upc":"1"},{"name":"Couch","upc":"2"}]}}`),
+				PostProcessing: PostProcessingConfiguration{
+					SelectResponseDataPath: []string{"data"},
+				},
+			},
+			Info: &FetchInfo{DataSourceName: "products"},
+		},
+	}
+	stock := &FetchItem{
+		FetchPath: []FetchItemPathElement{ArrayPath("products")},
+		Fetch: &BatchEntityFetch{
+			Input: BatchInput{
+				Header: InputTemplate{
+					Segments: []TemplateSegment{{Data: []byte(`[`), SegmentType: StaticSegmentType}},
+				},
+				Items: []InputTemplate{
+					{
+						Segments: []TemplateSegment{
+							{
+								SegmentType:  VariableSegmentType,
+								VariableKind: ResolvableObjectVariableKind,
+								Renderer: NewGraphQLVariableResolveRenderer(&Object{
+									Fields: []*Field{
+										{Name: []byte("upc"), Value: &String{Path: []string{"upc"}}},
+									},
+								}),
+							},
+						},
+					},
+				},
+				Separator: InputTemplate{
+					Segments: []TemplateSegment{{Data: []byte(`,`), SegmentType: StaticSegmentType}},
+				},
+				Footer: InputTemplate{
+					Segments: []TemplateSegment{{Data: []byte(`]`), SegmentType: StaticSegmentType}},
+				},
+			},
+			DataSource: FakeDataSource(`{"data":{"_entities":[{"stock":8},{"stock":2}]}}`),
+			PostProcessing: PostProcessingConfiguration{
+				SelectResponseDataPath: []string{"data", "_entities"},
+			},
+			Info: &FetchInfo{DataSourceName: "stock"},
+		},
+	}
+
+	response := &GraphQLResponse{
+		Info: &GraphQLResponseInfo{OperationType: ast.OperationTypeQuery},
+		Fetches: Sequence(
+			&FetchTreeNode{Kind: FetchTreeNodeKindSingle, Item: root},
+			&FetchTreeNode{Kind: FetchTreeNodeKindSingle, Item: stock},
+		),
+		Data: &Object{
+			Fields: []*Field{
+				{
+					Name: []byte("products"),
+					Value: &Array{
+						Path: []string{"products"},
+						Item: &Object{
+							Fields: []*Field{
+								{Name: []byte("name"), Value: &String{Path: []string{"name"}}},
+								{Name: []byte("stock"), Value: &Integer{Path: []string{"stock"}}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	program := &planbytecode.Program{
+		Strings: []string{"products", "name", "stock"},
+		Paths:   [][]string{nil, {"products"}, {"name"}, {"stock"}},
+		Ops: []planbytecode.Op{
+			{Code: planbytecode.OpEnterSequence, A: 2, B: 5},
+			{Code: planbytecode.OpFetchSubgraph, A: 0},
+			{Code: planbytecode.OpPasteAtPointer, A: 0},
+			{Code: planbytecode.OpFetchSubgraph, A: 1},
+			{Code: planbytecode.OpPasteAtPointer, A: 1},
+			{Code: planbytecode.OpLeaveSequence},
+			{Code: planbytecode.OpEnterObject, A: 0, B: 1},
+			{Code: planbytecode.OpProjectField, A: 0, B: 1, C: bytecodeTestNodeFlags(NodeKindArray, false)},
+			{Code: planbytecode.OpEnterArray, A: 1},
+			{Code: planbytecode.OpEnterObject, A: 0, B: 2},
+			{Code: planbytecode.OpProjectField, A: 1, B: 2, C: bytecodeTestNodeFlags(NodeKindString, false)},
+			{Code: planbytecode.OpProjectField, A: 2, B: 3, C: bytecodeTestNodeFlags(NodeKindInteger, false)},
+			{Code: planbytecode.OpLeaveObject},
+			{Code: planbytecode.OpLeaveArray},
+			{Code: planbytecode.OpLeaveObject},
+			{Code: planbytecode.OpEmitResponse},
+		},
+		Fetches: []planbytecode.Fetch{
+			{Item: root},
+			{Item: stock},
+		},
+		DirectResponse: &planbytecode.DirectResponse{
+			Fields: []planbytecode.DirectField{
+				{
+					NameRef:   0,
+					PathRef:   1,
+					Flags:     planbytecode.EncodeDirectFieldFlags(uint32(NodeKindArray), false, false),
+					ItemFlags: planbytecode.EncodeDirectFieldFlags(uint32(NodeKindObject), false, false),
+					Children: []planbytecode.DirectField{
+						{NameRef: 1, PathRef: 2, Flags: planbytecode.EncodeDirectFieldFlags(uint32(NodeKindString), false, false)},
+						{NameRef: 2, PathRef: 3, Flags: planbytecode.EncodeDirectFieldFlags(uint32(NodeKindInteger), false, false)},
+					},
+				},
+			},
+		},
+	}
+	return response, program
+}
+
+func bytecodeEntityTestResponse() (*GraphQLResponse, *planbytecode.Program) {
+	root := &FetchItem{
+		Fetch: &SingleFetch{
+			InputTemplate: InputTemplate{
+				Segments: []TemplateSegment{{Data: []byte(`{}`), SegmentType: StaticSegmentType}},
+			},
+			FetchConfiguration: FetchConfiguration{
+				DataSource: FakeDataSource(`{"data":{"user":{"id":"1","name":"Ada"}}}`),
+				PostProcessing: PostProcessingConfiguration{
+					SelectResponseDataPath: []string{"data"},
+				},
+			},
+			Info: &FetchInfo{DataSourceName: "users"},
+		},
+	}
+	profile := &FetchItem{
+		FetchPath: []FetchItemPathElement{ObjectPath("user")},
+		Fetch: &EntityFetch{
+			Input: EntityInput{
+				Header: InputTemplate{
+					Segments: []TemplateSegment{{Data: []byte(`[`), SegmentType: StaticSegmentType}},
+				},
+				Item: InputTemplate{
+					Segments: []TemplateSegment{
+						{
+							SegmentType:  VariableSegmentType,
+							VariableKind: ResolvableObjectVariableKind,
+							Renderer: NewGraphQLVariableResolveRenderer(&Object{
+								Fields: []*Field{
+									{Name: []byte("id"), Value: &String{Path: []string{"id"}}},
+								},
+							}),
+						},
+					},
+				},
+				Footer: InputTemplate{
+					Segments: []TemplateSegment{{Data: []byte(`]`), SegmentType: StaticSegmentType}},
+				},
+			},
+			DataSource: FakeDataSource(`{"data":{"_entities":[{"age":37}]}}`),
+			PostProcessing: PostProcessingConfiguration{
+				SelectResponseDataPath: []string{"data", "_entities", "0"},
+			},
+			Info: &FetchInfo{DataSourceName: "profiles"},
+		},
+	}
+
+	response := &GraphQLResponse{
+		Info: &GraphQLResponseInfo{OperationType: ast.OperationTypeQuery},
+		Fetches: Sequence(
+			&FetchTreeNode{Kind: FetchTreeNodeKindSingle, Item: root},
+			&FetchTreeNode{Kind: FetchTreeNodeKindSingle, Item: profile},
+		),
+		Data: &Object{
+			Fields: []*Field{
+				{
+					Name: []byte("user"),
+					Value: &Object{
+						Path: []string{"user"},
+						Fields: []*Field{
+							{Name: []byte("name"), Value: &String{Path: []string{"name"}}},
+							{Name: []byte("age"), Value: &Integer{Path: []string{"age"}}},
+						},
+					},
+				},
+			},
+		},
+	}
+	program := &planbytecode.Program{
+		Strings: []string{"user", "name", "age"},
+		Paths:   [][]string{nil, {"user"}, {"name"}, {"age"}},
+		Ops: []planbytecode.Op{
+			{Code: planbytecode.OpEnterSequence, A: 2, B: 5},
+			{Code: planbytecode.OpFetchSubgraph, A: 0},
+			{Code: planbytecode.OpPasteAtPointer, A: 0},
+			{Code: planbytecode.OpFetchSubgraph, A: 1},
+			{Code: planbytecode.OpPasteAtPointer, A: 1},
+			{Code: planbytecode.OpLeaveSequence},
+			{Code: planbytecode.OpEnterObject, A: 0, B: 1},
+			{Code: planbytecode.OpProjectField, A: 0, B: 1, C: bytecodeTestNodeFlags(NodeKindObject, false)},
+			{Code: planbytecode.OpEnterObject, A: 1, B: 2},
+			{Code: planbytecode.OpProjectField, A: 1, B: 2, C: bytecodeTestNodeFlags(NodeKindString, false)},
+			{Code: planbytecode.OpProjectField, A: 2, B: 3, C: bytecodeTestNodeFlags(NodeKindInteger, false)},
+			{Code: planbytecode.OpLeaveObject},
+			{Code: planbytecode.OpLeaveObject},
+			{Code: planbytecode.OpEmitResponse},
+		},
+		Fetches: []planbytecode.Fetch{
+			{Item: root},
+			{Item: profile},
+		},
+		DirectResponse: &planbytecode.DirectResponse{
+			Fields: []planbytecode.DirectField{
+				{
+					NameRef: 0,
+					PathRef: 1,
+					Flags:   planbytecode.EncodeDirectFieldFlags(uint32(NodeKindObject), false, false),
+					Children: []planbytecode.DirectField{
+						{NameRef: 1, PathRef: 2, Flags: planbytecode.EncodeDirectFieldFlags(uint32(NodeKindString), false, false)},
+						{NameRef: 2, PathRef: 3, Flags: planbytecode.EncodeDirectFieldFlags(uint32(NodeKindInteger), false, false)},
+					},
+				},
+			},
+		},
+	}
+	return response, program
+}
+
+func bytecodeNestedBatchEntityTestResponse() (*GraphQLResponse, *planbytecode.Program) {
+	root := &FetchItem{
+		Fetch: &SingleFetch{
+			InputTemplate: InputTemplate{
+				Segments: []TemplateSegment{{Data: []byte(`{}`), SegmentType: StaticSegmentType}},
+			},
+			FetchConfiguration: FetchConfiguration{
+				DataSource: FakeDataSource(`{"data":{"products":[{"name":"Table","reviews":[{"body":"Love Table","author":{"id":"1"}},{"body":"Prefer Desk","author":{"id":"2"}}]},{"name":"Couch","reviews":[{"body":"Too expensive","author":{"id":"1"}}]}]}}`),
+				PostProcessing: PostProcessingConfiguration{
+					SelectResponseDataPath: []string{"data"},
+				},
+			},
+			Info: &FetchInfo{DataSourceName: "products"},
+		},
+	}
+	authors := &FetchItem{
+		FetchPath: []FetchItemPathElement{ArrayPath("products"), ArrayPath("reviews"), ObjectPath("author")},
+		Fetch: &BatchEntityFetch{
+			Input: BatchInput{
+				Header: InputTemplate{
+					Segments: []TemplateSegment{{Data: []byte(`[`), SegmentType: StaticSegmentType}},
+				},
+				Items: []InputTemplate{
+					{
+						Segments: []TemplateSegment{
+							{
+								SegmentType:  VariableSegmentType,
+								VariableKind: ResolvableObjectVariableKind,
+								Renderer: NewGraphQLVariableResolveRenderer(&Object{
+									Fields: []*Field{
+										{Name: []byte("id"), Value: &String{Path: []string{"id"}}},
+									},
+								}),
+							},
+						},
+					},
+				},
+				Separator: InputTemplate{
+					Segments: []TemplateSegment{{Data: []byte(`,`), SegmentType: StaticSegmentType}},
+				},
+				Footer: InputTemplate{
+					Segments: []TemplateSegment{{Data: []byte(`]`), SegmentType: StaticSegmentType}},
+				},
+			},
+			DataSource: FakeDataSource(`{"data":{"_entities":[{"name":"user-1"},{"name":"user-2"}]}}`),
+			PostProcessing: PostProcessingConfiguration{
+				SelectResponseDataPath: []string{"data", "_entities"},
+			},
+			Info: &FetchInfo{DataSourceName: "authors"},
+		},
+	}
+
+	response := &GraphQLResponse{
+		Info: &GraphQLResponseInfo{OperationType: ast.OperationTypeQuery},
+		Fetches: Sequence(
+			&FetchTreeNode{Kind: FetchTreeNodeKindSingle, Item: root},
+			&FetchTreeNode{Kind: FetchTreeNodeKindSingle, Item: authors},
+		),
+		Data: &Object{
+			Fields: []*Field{
+				{
+					Name: []byte("products"),
+					Value: &Array{
+						Path: []string{"products"},
+						Item: &Object{
+							Fields: []*Field{
+								{Name: []byte("name"), Value: &String{Path: []string{"name"}}},
+								{
+									Name: []byte("reviews"),
+									Value: &Array{
+										Path: []string{"reviews"},
+										Item: &Object{
+											Fields: []*Field{
+												{Name: []byte("body"), Value: &String{Path: []string{"body"}}},
+												{
+													Name: []byte("author"),
+													Value: &Object{
+														Path: []string{"author"},
+														Fields: []*Field{
+															{Name: []byte("name"), Value: &String{Path: []string{"name"}}},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	program := &planbytecode.Program{
+		Strings: []string{"products", "name", "reviews", "body", "author"},
+		Paths:   [][]string{nil, {"products"}, {"name"}, {"reviews"}, {"body"}, {"author"}},
+		Ops: []planbytecode.Op{
+			{Code: planbytecode.OpEnterSequence, A: 2, B: 5},
+			{Code: planbytecode.OpFetchSubgraph, A: 0},
+			{Code: planbytecode.OpPasteAtPointer, A: 0},
+			{Code: planbytecode.OpFetchSubgraph, A: 1},
+			{Code: planbytecode.OpPasteAtPointer, A: 1},
+			{Code: planbytecode.OpLeaveSequence},
+			{Code: planbytecode.OpEnterObject, A: 0, B: 1},
+			{Code: planbytecode.OpProjectField, A: 0, B: 1, C: bytecodeTestNodeFlags(NodeKindArray, false)},
+			{Code: planbytecode.OpEnterArray, A: 1},
+			{Code: planbytecode.OpEnterObject, A: 0, B: 2},
+			{Code: planbytecode.OpProjectField, A: 1, B: 2, C: bytecodeTestNodeFlags(NodeKindString, false)},
+			{Code: planbytecode.OpProjectField, A: 2, B: 3, C: bytecodeTestNodeFlags(NodeKindArray, false)},
+			{Code: planbytecode.OpEnterArray, A: 3},
+			{Code: planbytecode.OpEnterObject, A: 0, B: 2},
+			{Code: planbytecode.OpProjectField, A: 3, B: 4, C: bytecodeTestNodeFlags(NodeKindString, false)},
+			{Code: planbytecode.OpProjectField, A: 4, B: 5, C: bytecodeTestNodeFlags(NodeKindObject, false)},
+			{Code: planbytecode.OpEnterObject, A: 5, B: 1},
+			{Code: planbytecode.OpProjectField, A: 1, B: 2, C: bytecodeTestNodeFlags(NodeKindString, false)},
+			{Code: planbytecode.OpLeaveObject},
+			{Code: planbytecode.OpLeaveObject},
+			{Code: planbytecode.OpLeaveArray},
+			{Code: planbytecode.OpLeaveObject},
+			{Code: planbytecode.OpLeaveArray},
+			{Code: planbytecode.OpLeaveObject},
+			{Code: planbytecode.OpEmitResponse},
+		},
+		Fetches: []planbytecode.Fetch{
+			{Item: root},
+			{Item: authors},
+		},
+		DirectResponse: &planbytecode.DirectResponse{
+			Fields: []planbytecode.DirectField{
+				{
+					NameRef:   0,
+					PathRef:   1,
+					Flags:     planbytecode.EncodeDirectFieldFlags(uint32(NodeKindArray), false, false),
+					ItemFlags: planbytecode.EncodeDirectFieldFlags(uint32(NodeKindObject), false, false),
+					Children: []planbytecode.DirectField{
+						{NameRef: 1, PathRef: 2, Flags: planbytecode.EncodeDirectFieldFlags(uint32(NodeKindString), false, false)},
+						{
+							NameRef:   2,
+							PathRef:   3,
+							Flags:     planbytecode.EncodeDirectFieldFlags(uint32(NodeKindArray), false, false),
+							ItemFlags: planbytecode.EncodeDirectFieldFlags(uint32(NodeKindObject), false, false),
+							Children: []planbytecode.DirectField{
+								{NameRef: 3, PathRef: 4, Flags: planbytecode.EncodeDirectFieldFlags(uint32(NodeKindString), false, false)},
+								{
+									NameRef: 4,
+									PathRef: 5,
+									Flags:   planbytecode.EncodeDirectFieldFlags(uint32(NodeKindObject), false, false),
+									Children: []planbytecode.DirectField{
+										{NameRef: 1, PathRef: 2, Flags: planbytecode.EncodeDirectFieldFlags(uint32(NodeKindString), false, false)},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return response, program
+}


### PR DESCRIPTION
@coderabbitai summary

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.

This commit introduces a new bytecode compilation and execution mechanism for GraphQL responses, enhancing performance and flexibility. It includes the implementation of various benchmarks and tests to ensure correctness and efficiency in processing GraphQL queries. New structures and functions for handling bytecode operations, including direct responses and nested object handling, have been added to improve the overall architecture of the engine.

> I just made this because of my answer on your form about what I would do about the code. I realized my answer was making a lot of assumptions, so I wanted to know if they were correct. Please ignore if this is not a direction you are interested in at this time :)

Using the final `-count=3` benchmark run on Apple M4 Max:

| Scenario                              |   Original    | Final Bytecode | Speedup |         B/op    |  allocs/op  |
|---------------------------|-----------:|---------------:|--------:|--------------:|-----------:|
| Loader only                         | 3845 ns/op |     3691 ns/op |   1.04x  | 3096 -> 2736 |   60 -> 51 |
| Flat query resolve               | 4661 ns/op |     4205 ns/op |   1.11x   | 4368 -> 4584 |   77 -> 44 |
| Nested static query            | 2945 ns/op |     1970 ns/op |   1.50x  | 4968 -> 4160  |   99 -> 33 |
| Batch entity query              | 3383 ns/op |     2885 ns/op |   1.17x  | 5811 -> 6228   |   98 -> 79 |
| Object entity query             | 2021 ns/op |     1799 ns/op  |   1.12x  | 3388 -> 4069  |   69 -> 56 |
| Nested batch entity query | 5946 ns/op |     4732 ns/op |   1.26x  | 7947 -> 8044  | 143 -> 121 |

Command used:

```sh
go test ./pkg/engine/resolve -run '^$' -bench 'BenchmarkResolveGraphQLResponse|BenchmarkLoaderLoadGraphQLResponseData' -benchmem -count=3
```

Interpretation: the best case is the static-shape nested query, where the bytecode direct renderer gets almost exactly the 1.5x target and cuts allocs by two thirds. Entity cases are more modest because they still pay ASTJSON merge/fetch-input costs, but they consistently reduce alloc count and still land around 1.12x-1.26x faster.
