### PR TITLE
fix(sse): skip empty keepalive events

### DIFF
--- a/v2/pkg/engine/datasource/graphql_datasource/subscriptionclient/transport/sse_conn.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/subscriptionclient/transport/sse_conn.go
@@ -55,8 +55,10 @@ func (c *sseConnection) readLoop() {
 		// Parse the raw event bytes into event type and data
 		eventType, data := c.parseEventBytes(eventBytes)
 
-		// Skip empty events (e.g., keep-alive comments)
-		if eventType == "" && data == nil {
+		// Skip empty events and empty non-terminal events. Some SSE servers send
+		// keepalives as comments or as named events without data; those should
+		// not be forwarded to the GraphQL response parser.
+		if len(data) == 0 && eventType != "complete" {
 			continue
 		}
 
@@ -142,7 +144,7 @@ func (c *sseConnection) parseEvent(eventType string, data []byte) *common.Messag
 		// Unknown event type or no event type specified - treat as data
 		// This handles servers that send data without an event type
 		if len(data) == 0 {
-			return &common.Message{Type: common.MessageTypeComplete}
+			return &common.Message{Type: common.MessageTypeUnknown}
 		}
 		var resp common.ExecutionResult
 		if err := json.Unmarshal(data, &resp); err != nil {

--- a/v2/pkg/engine/datasource/graphql_datasource/subscriptionclient/transport/sse_conn_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/subscriptionclient/transport/sse_conn_test.go
@@ -83,6 +83,34 @@ func TestSSEConnection_ReadLoop(t *testing.T) {
 		messages := collect(100 * time.Millisecond)
 		assert.Len(t, messages, 2, "should receive exactly 2 messages before stopping")
 	})
+
+	t.Run("skips empty keepalive events", func(t *testing.T) {
+		body := io.NopCloser(strings.NewReader(
+			":\n\n" +
+				": keepalive\n\n" +
+				"event: next\n\n" +
+				"event: next\ndata:\n\n" +
+				"event: next\n: internal keepalive\ndata: {\"data\":\ndata: {\"time\":\"12:00\"}}\n\n" +
+				"event: complete\n\n",
+		))
+		resp := &http.Response{Body: body}
+		handler, receive := collectingHandler()
+		wrappedHandler, collect := waitForMessages(handler)
+		conn := newSSEConnection(resp, wrappedHandler)
+
+		go conn.readLoop()
+
+		msg1 := receive(t, 1*time.Second)
+		require.NotNil(t, msg1.Payload)
+		assert.Equal(t, common.MessageTypeData, msg1.Type)
+		assert.JSONEq(t, `{"time":"12:00"}`, string(msg1.Payload.Data))
+
+		msg2 := receive(t, 1*time.Second)
+		assert.Equal(t, common.MessageTypeComplete, msg2.Type)
+
+		messages := collect(100 * time.Millisecond)
+		assert.Len(t, messages, 2, "empty SSE keepalives should not be delivered")
+	})
 }
 
 func TestSSEConnection_Close(t *testing.T) {


### PR DESCRIPTION
## Summary
- skip empty SSE keepalive/comment events before forwarding to the GraphQL response parser
- keep empty unnamed SSE events as unknown instead of treating them as completion
- add coverage for comment keepalives, named empty events, and terminal complete events

## Tests
- go test ./pkg/engine/datasource/graphql_datasource/subscriptionclient/transport