### PR TITLE
fix: multiply with 0 for empty lists in actual costs

### DIFF
--- a/execution/engine/execution_engine_cost_test.go
+++ b/execution/engine/execution_engine_cost_test.go
@@ -594,10 +594,8 @@ func TestExecutionEngine_Cost(t *testing.T) {
 				expectedResponse: `{"data":{"hero":{"friends":[]}}}`,
 				// Estimated with default list size 10: hero(7) + 10 * (7 + 2 + 2) = 117
 				expectedEstimatedCost: intPtr(117),
-				// Actual with empty list: hero(7) + 1 * (7 + 2 + 2) = 18
-				// We consider empty lists as lists containing one item to account for the
-				// resolver work.
-				expectedActualCost: intPtr(18),
+				// Actual with empty list: hero(7) + 0 * (7 + 2 + 2) = 7
+				expectedActualCost: intPtr(7),
 			},
 			computeCosts(),
 		))

--- a/v2/pkg/engine/plan/cost.go
+++ b/v2/pkg/engine/plan/cost.go
@@ -617,12 +617,9 @@ func (node *CostTreeNode) costsAndMultiplier(configs map[DSHash]*DataSourceCostC
 			}
 			// We compute average to avoid double counting for nested lists
 			multiplier = float64(totalCount) / float64(parentCount)
-		} else {
-			// If the list is empty, that would mean 0 cost for the field's resolver.
-			// That is not very accurate because we called the resolver of this field anyway.
-			// We will add fields and children costs by using this multiplier:
-			multiplier = 1.0
 		}
+		// If the list is empty, it means 0 cost for the field's resolver.
+		// That may be non-conservative, but it reflects the actual cost of work done.
 		return
 	}
 	if multiplier == 0 {


### PR DESCRIPTION
Empty lists would highly overcharge for the empty lists where each element is expensive. Initially I thouhgt that it is a good idea to charge a least for one element, but now being exposed to the ways the actual costs are being used, I am convinced that we should not charge for non-existent data.

