### PR TITLE
chore: extract test improvements from entity caching PR

### DIFF
--- a/execution/engine/config_factory_proxy_test.go
+++ b/execution/engine/config_factory_proxy_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestProxyEngineConfigFactory_EngineConfiguration(t *testing.T) {
+	t.Parallel()
 	engineCtx := context.Background()
 
 	schema, err := graphql.NewSchemaFromString(graphqlGeneratorSchema)
@@ -57,6 +58,7 @@ func TestProxyEngineConfigFactory_EngineConfiguration(t *testing.T) {
 	}
 
 	t.Run("engine config with unknown subscription type", func(t *testing.T) {
+		t.Parallel()
 		upstreamConfig := ProxyUpstreamConfig{
 			URL:    "http://localhost:8080",
 			Method: http.MethodGet,
@@ -136,6 +138,7 @@ func TestProxyEngineConfigFactory_EngineConfiguration(t *testing.T) {
 	})
 
 	t.Run("engine config with specific WS subscription type", func(t *testing.T) {
+		t.Parallel()
 		upstreamConfig := ProxyUpstreamConfig{
 			URL:    "http://localhost:8080",
 			Method: http.MethodGet,
@@ -216,6 +219,7 @@ func TestProxyEngineConfigFactory_EngineConfiguration(t *testing.T) {
 	})
 
 	t.Run("engine config with SSE subscription type", func(t *testing.T) {
+		t.Parallel()
 		upstreamConfig := ProxyUpstreamConfig{
 			URL:    "http://localhost:8080",
 			Method: http.MethodGet,

--- a/execution/engine/engine_config_test.go
+++ b/execution/engine/engine_config_test.go
@@ -75,7 +75,7 @@ func TestGraphQLDataSourceGenerator_Generate(t *testing.T) {
 	client := &http.Client{}
 	streamingClient := &http.Client{}
 	engineCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	t.Cleanup(cancel)
 
 	doc, report := astparser.ParseGraphqlDocumentString(graphqlGeneratorSchema)
 	require.Falsef(t, report.HasErrors(), "document parser report has errors")
@@ -106,6 +106,7 @@ func TestGraphQLDataSourceGenerator_Generate(t *testing.T) {
 	}
 
 	t.Run("without subscription configuration", func(t *testing.T) {
+		t.Parallel()
 		dataSourceConfig := mustConfiguration(t, graphqlDataSource.ConfigurationInput{
 			Fetch: &graphqlDataSource.FetchConfiguration{
 				URL:    "http://localhost:8080",
@@ -137,6 +138,7 @@ func TestGraphQLDataSourceGenerator_Generate(t *testing.T) {
 	})
 
 	t.Run("with subscription configuration (SSE)", func(t *testing.T) {
+		t.Parallel()
 		dataSourceConfig := mustConfiguration(t, graphqlDataSource.ConfigurationInput{
 			Fetch: &graphqlDataSource.FetchConfiguration{
 				URL:    "http://localhost:8080",
@@ -174,10 +176,12 @@ func TestGraphQLDataSourceGenerator_Generate(t *testing.T) {
 }
 
 func TestGraphqlFieldConfigurationsGenerator_Generate(t *testing.T) {
+	t.Parallel()
 	schema, err := graphql.NewSchemaFromString(graphqlGeneratorSchema)
 	require.NoError(t, err)
 
 	t.Run("should generate field configs without predefined field configs", func(t *testing.T) {
+		t.Parallel()
 		fieldConfigurations := newGraphQLFieldConfigsGenerator(schema).Generate()
 		sort.Slice(fieldConfigurations, func(i, j int) bool { // make the resulting slice deterministic again
 			return fieldConfigurations[i].TypeName < fieldConfigurations[j].TypeName
@@ -218,6 +222,7 @@ func TestGraphqlFieldConfigurationsGenerator_Generate(t *testing.T) {
 	})
 
 	t.Run("should generate field configs with predefined field configs", func(t *testing.T) {
+		t.Parallel()
 		predefinedFieldConfigs := plan.FieldConfigurations{
 			{
 				TypeName:  "User",

--- a/execution/engine/engine_config_test.go
+++ b/execution/engine/engine_config_test.go
@@ -15,7 +15,9 @@ import (
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
 )
 
+//nolint:tparallel // Subtests mutate shared engineConfig state within the parent test.
 func TestNewConfiguration(t *testing.T) {
+	t.Parallel()
 	var engineConfig Configuration
 
 	t.Run("should create a new engine v2 config", func(t *testing.T) {
@@ -72,6 +74,7 @@ func TestNewConfiguration(t *testing.T) {
 }
 
 func TestGraphQLDataSourceGenerator_Generate(t *testing.T) {
+	t.Parallel()
 	client := &http.Client{}
 	streamingClient := &http.Client{}
 	engineCtx, cancel := context.WithCancel(context.Background())

--- a/execution/engine/execution_engine_cost_test.go
+++ b/execution/engine/execution_engine_cost_test.go
@@ -12,7 +12,10 @@ import (
 
 func TestExecutionEngine_Cost(t *testing.T) {
 
+	t.Parallel()
+
 	t.Run("common on star wars scheme", func(t *testing.T) {
+		t.Parallel()
 		rootNodes := []plan.TypeField{
 			{TypeName: "Query", FieldNames: []string{"hero", "droid", "search"}},
 			{TypeName: "Human", FieldNames: []string{"name", "height", "friends"}},
@@ -886,6 +889,7 @@ func TestExecutionEngine_Cost(t *testing.T) {
 	})
 
 	t.Run("union types", func(t *testing.T) {
+		t.Parallel()
 		unionSchema := `
 			type Query {
 			   search(term: String!): [SearchResult!]
@@ -1057,6 +1061,7 @@ func TestExecutionEngine_Cost(t *testing.T) {
 	})
 
 	t.Run("listSize", func(t *testing.T) {
+		t.Parallel()
 		listSchema := `
 			input Search {
                 pagination: Page
@@ -2031,6 +2036,7 @@ func TestExecutionEngine_Cost(t *testing.T) {
 	})
 
 	t.Run("nested lists with compounding multipliers", func(t *testing.T) {
+		t.Parallel()
 		nestedSchema := `
 			type Query {
 			   users(first: Int): [User!]
@@ -2812,6 +2818,7 @@ func TestExecutionEngine_Cost(t *testing.T) {
 	})
 
 	t.Run("sizedFields", func(t *testing.T) {
+		t.Parallel()
 		connSchema := `
 			type Query {
 				users(first: Int, last: Int): UserConnection!
@@ -3429,6 +3436,7 @@ func TestExecutionEngine_Cost(t *testing.T) {
 	})
 
 	t.Run("sizedFields on abstract types", func(t *testing.T) {
+		t.Parallel()
 		t.Run("parent returns interface, child via inline fragment", func(t *testing.T) {
 			s2Schema := `
 					interface Connection {
@@ -3617,6 +3625,7 @@ func TestExecutionEngine_Cost(t *testing.T) {
 		})
 
 		t.Run("sizedFields on interface field", func(t *testing.T) {
+			t.Parallel()
 			s4Schema := `
 					interface Paginated {
 						items(first: Int): ItemConnection
@@ -3853,6 +3862,7 @@ func TestExecutionEngine_Cost(t *testing.T) {
 		})
 
 		t.Run("sizedField returns list of abstract type", func(t *testing.T) {
+			t.Parallel()
 			s7Schema := `
 					interface Publishable {
 						id: ID!

--- a/execution/engine/execution_engine_grpc_test.go
+++ b/execution/engine/execution_engine_grpc_test.go
@@ -226,9 +226,11 @@ func executeOperation(t *testing.T, grpcClient grpc.ClientConnInterface, operati
 }
 
 func TestGRPCSubgraphExecution(t *testing.T) {
+	t.Parallel()
 	conn := setupGRPCTestGoPluginServer(t)
 
 	t.Run("running simple query should work", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "UserQuery",
 			Variables:     nil,
@@ -241,6 +243,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should run query with variable", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "UserQuery",
 			Variables: stringify(map[string]any{
@@ -262,6 +265,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should run complex query", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "ComplexFilterTypeQuery",
 			Variables: stringify(map[string]any{
@@ -289,6 +293,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should run query with two arguments and no variables and mapping for field names", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "QueryWithTwoArguments",
 			Query:         `query QueryWithTwoArguments { typeFilterWithArguments(filterField1: "test1", filterField2: "test2") { id name filterField1 filterField2 } }`,
@@ -300,6 +305,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should run query with a complex input type and no variables and mapping for field names", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "ComplexFilterTypeQuery",
 			Query:         `query ComplexFilterTypeQuery { complexFilterType(filter: { filter: { name: "test", filterField1: "test1", filterField2: "test2", pagination: { page: 1, perPage: 10 } } }) { id name } }`,
@@ -311,6 +317,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should run query with a complex input type and variables with different name", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "ComplexFilterTypeQuery",
 			Variables: stringify(map[string]any{
@@ -331,6 +338,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should run query with a type filter with arguments and variables", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "TypeWithMultipleFilterFieldsQuery",
 			Variables: stringify(map[string]any{
@@ -348,6 +356,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should run query with a nested type", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "NestedTypeQuery",
 			Query:         `query NestedTypeQuery { nestedType { id name b { id name c { id name } } } }`,
@@ -359,6 +368,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should run query with a recursive type", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "RecursiveTypeQuery",
 			Query:         `query RecursiveTypeQuery { recursiveType { id name recursiveType { id recursiveType { id name } name } } }`,
@@ -371,6 +381,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should stop when no mapping is found for the operation request", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "UserQuery",
 			Query:         `query UserQuery { user(id: "1") { id name } }`,
@@ -394,6 +405,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 
 	// Category tests to verify enum handling
 	t.Run("should correctly handle query for all categories with enum values", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "CategoriesQuery",
 			Query:         `query CategoriesQuery { categories { id name kind } }`,
@@ -410,6 +422,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should correctly handle query for categories by specific enum kind", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "CategoriesByKindQuery",
 			Variables: stringify(map[string]any{
@@ -435,6 +448,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should correctly handle filter categories with enum and pagination", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "FilterCategoriesQuery",
 			Variables: stringify(map[string]any{
@@ -466,6 +480,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should handle all enum values with explicit mapping", func(t *testing.T) {
+		t.Parallel()
 		// Test each enum value explicitly
 		enumValues := []string{"BOOK", "ELECTRONICS", "FURNITURE", "OTHER"}
 
@@ -502,6 +517,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should handle nullable fields", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "NullableFieldsTypeQuery",
 			Query:         `query NullableFieldsTypeQuery { nullableFieldsType { id optionalString optionalInt optionalFloat optionalBoolean requiredString requiredInt } }`,
@@ -514,6 +530,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should handle nullable fields query by ID with full data", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "NullableFieldsTypeByIdQuery",
 			Variables: stringify(map[string]any{
@@ -540,6 +557,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should handle nullable fields query by ID with partial data", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "NullableFieldsTypeByIdQuery",
 			Variables: stringify(map[string]any{
@@ -566,6 +584,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should handle nullable fields query by ID with minimal data", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "NullableFieldsTypeByIdQuery",
 			Variables: stringify(map[string]any{
@@ -592,6 +611,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should handle nullable fields query by ID returning null for not found", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "NullableFieldsTypeByIdQuery",
 			Variables: stringify(map[string]any{
@@ -614,6 +634,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should handle query for all nullable fields types", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "AllNullableFieldsTypesQuery",
 			Query: `query AllNullableFieldsTypesQuery { 
@@ -637,6 +658,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should handle nullable fields query with filter", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "NullableFieldsTypeWithFilterQuery",
 			Variables: stringify(map[string]any{
@@ -673,6 +695,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should handle create nullable fields type mutation", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "CreateNullableFieldsTypeMutation",
 			Variables: stringify(map[string]any{
@@ -715,6 +738,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should handle create nullable fields type mutation with minimal input", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "CreateNullableFieldsTypeMutation",
 			Variables: stringify(map[string]any{
@@ -753,6 +777,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should handle update nullable fields type mutation", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "UpdateNullableFieldsTypeMutation",
 			Variables: stringify(map[string]any{
@@ -786,6 +811,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should handle update nullable fields type mutation returning null for non-existent ID", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "UpdateNullableFieldsTypeMutation",
 			Variables: stringify(map[string]any{
@@ -814,6 +840,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 
 	// BlogPost and Author list tests
 	t.Run("should handle BlogPost query with scalar lists", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "BlogPostScalarListsQuery",
 			Query: `query BlogPostScalarListsQuery { 
@@ -845,6 +872,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should handle BlogPost query with nested scalar lists", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "BlogPostNestedScalarListsQuery",
 			Query: `query BlogPostNestedScalarListsQuery { 
@@ -866,6 +894,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should handle BlogPost query with complex lists", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "BlogPostComplexListsQuery",
 			Query: `query BlogPostComplexListsQuery { 
@@ -907,6 +936,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should handle BlogPost query with nested complex lists", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "BlogPostNestedComplexListsQuery",
 			Query: `query BlogPostNestedComplexListsQuery { 
@@ -936,6 +966,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should handle BlogPost query by ID", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "BlogPostByIdQuery",
 			Variables: stringify(map[string]any{
@@ -968,6 +999,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should handle BlogPost filtered query", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "BlogPostFilteredQuery",
 			Variables: stringify(map[string]any{
@@ -1004,6 +1036,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should handle Author query with scalar lists", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "AuthorScalarListsQuery",
 			Query: `query AuthorScalarListsQuery { 
@@ -1027,6 +1060,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should handle Author query with nested scalar lists", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "AuthorNestedScalarListsQuery",
 			Query: `query AuthorNestedScalarListsQuery { 
@@ -1046,6 +1080,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should handle Author query with complex lists", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "AuthorComplexListsQuery",
 			Query: `query AuthorComplexListsQuery { 
@@ -1089,6 +1124,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should handle Author query with nested complex lists", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "AuthorNestedComplexListsQuery",
 			Query: `query AuthorNestedComplexListsQuery { 
@@ -1123,6 +1159,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should handle Author query by ID", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "AuthorByIdQuery",
 			Variables: stringify(map[string]any{
@@ -1154,6 +1191,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should handle Author filtered query", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "AuthorFilteredQuery",
 			Variables: stringify(map[string]any{
@@ -1188,6 +1226,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should handle BlogPost creation mutation with complex input lists", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "CreateBlogPostMutation",
 			Variables: stringify(map[string]any{
@@ -1294,6 +1333,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should handle Author creation mutation with complex input lists", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "CreateAuthorMutation",
 			Variables: stringify(map[string]any{
@@ -1377,6 +1417,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should handle all BlogPosts query with lists", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "AllBlogPostsQuery",
 			Query: `query AllBlogPostsQuery { 
@@ -1408,6 +1449,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should handle all Authors query with lists", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "AllAuthorsQuery",
 			Query: `query AllAuthorsQuery { 
@@ -1435,6 +1477,7 @@ func TestGRPCSubgraphExecution(t *testing.T) {
 	})
 
 	t.Run("should handle empty and nullable list items", func(t *testing.T) {
+		t.Parallel()
 		operation := graphql.Request{
 			OperationName: "EmptyAndNullableListItems",
 			Query: `query EmptyAndNullableListItems {

--- a/execution/engine/execution_engine_grpc_test.go
+++ b/execution/engine/execution_engine_grpc_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package engine
 

--- a/execution/engine/execution_engine_helpers_test.go
+++ b/execution/engine/execution_engine_helpers_test.go
@@ -92,7 +92,7 @@ func createConditionalTestRoundTripper(t *testing.T, testCase conditionalTestCas
 	}
 }
 
-func stringify(any interface{}) []byte {
+func stringify(any any) []byte {
 	out, _ := json.Marshal(any)
 	return out
 }

--- a/execution/engine/execution_engine_test.go
+++ b/execution/engine/execution_engine_test.go
@@ -2158,7 +2158,6 @@ func TestExecutionEngine_Execute(t *testing.T) {
 				expectedResponse: `{"data":{"heroDefault":"R2D2","heroDefaultRequired":"R2D2"}}`,
 			},
 		))
-
 	})
 
 	t.Run("execute query with data source on field with interface return type", runWithoutError(
@@ -4628,7 +4627,6 @@ func TestExecutionEngine_Execute(t *testing.T) {
 	})
 
 	t.Run("execute operation with nested fetch on one of the types", func(t *testing.T) {
-
 		t.Parallel()
 
 		definition := `
@@ -4972,7 +4970,6 @@ func TestExecutionEngine_Execute(t *testing.T) {
 	})
 
 	t.Run("validation of optional @requires dependencies", func(t *testing.T) {
-
 		t.Parallel()
 
 		t.Run("execute operation with @requires and @external", func(t *testing.T) {
@@ -6003,7 +6000,6 @@ func BenchmarkIntrospection(b *testing.B) {
 		}
 	}
 
-	ctx = context.Background()
 	req := graphql.StarwarsRequestForQuery(b, starwars.FileIntrospectionQuery)
 
 	writer := graphql.NewEngineResultWriter()
@@ -6031,7 +6027,6 @@ func BenchmarkIntrospection(b *testing.B) {
 			pool.Put(bc)
 		}
 	})
-
 }
 
 func BenchmarkExecutionEngine(b *testing.B) {
@@ -6085,7 +6080,6 @@ func BenchmarkExecutionEngine(b *testing.B) {
 		}
 	}
 
-	ctx = context.Background()
 	req := graphql.Request{
 		Query: "{hello}",
 	}
@@ -6115,7 +6109,6 @@ func BenchmarkExecutionEngine(b *testing.B) {
 			pool.Put(bc)
 		}
 	})
-
 }
 
 func newFederationEngineStaticConfig(ctx context.Context, setup *federationtesting.FederationSetup) (engine *ExecutionEngine, schema *graphql.Schema, err error) {

--- a/execution/engine/execution_engine_test.go
+++ b/execution/engine/execution_engine_test.go
@@ -63,6 +63,7 @@ func mustFactory(t testing.TB, httpClient *http.Client) plan.PlannerFactory[grap
 
 func runExecutionTest(testCase ExecutionEngineTestCase, withError bool, expectedErrorMessage string, options ...executionTestOptions) func(t *testing.T) {
 	return func(t *testing.T) {
+		t.Parallel()
 		t.Helper()
 
 		if testCase.skipReason != "" {
@@ -240,6 +241,7 @@ func TestEngineResponseWriter_AsHTTPResponse(t *testing.T) {
 }
 
 func TestWithAdditionalHttpHeaders(t *testing.T) {
+	t.Parallel()
 	reqHeader := http.Header{
 		http.CanonicalHeaderKey("X-Other-Key"):       []string{"x-other-value"},
 		http.CanonicalHeaderKey("Date"):              []string{"date-value"},
@@ -250,6 +252,7 @@ func TestWithAdditionalHttpHeaders(t *testing.T) {
 	}
 
 	t.Run("should add all headers to request without excluded keys", func(t *testing.T) {
+		t.Parallel()
 		c := resolve.NewContext(context.Background())
 		c.Request = resolve.Request{
 			Header: nil,
@@ -266,6 +269,7 @@ func TestWithAdditionalHttpHeaders(t *testing.T) {
 	})
 
 	t.Run("should only add headers that are not excluded", func(t *testing.T) {
+		t.Parallel()
 		c := resolve.NewContext(context.Background())
 		c.Request = resolve.Request{
 			Header: nil,
@@ -355,6 +359,7 @@ func relaxFieldSelectionMergingNullability() executionTestOptions {
 }
 
 func TestExecutionEngine_Execute(t *testing.T) {
+	t.Parallel()
 	t.Run("apollo router compatibility subrequest HTTP error enabled", runWithoutError(
 		ExecutionEngineTestCase{
 			schema:    graphql.StarwarsSchema(t),
@@ -543,6 +548,7 @@ func TestExecutionEngine_Execute(t *testing.T) {
 	))
 
 	t.Run("introspection", func(t *testing.T) {
+		t.Parallel()
 		schema := graphql.StarwarsSchema(t)
 
 		t.Run("execute type introspection query", runWithoutError(
@@ -1859,6 +1865,7 @@ func TestExecutionEngine_Execute(t *testing.T) {
 	))
 
 	t.Run("execute operation with default arguments", func(t *testing.T) {
+		t.Parallel()
 		t.Run("query variables with default value", runWithoutError(
 			ExecutionEngineTestCase{
 				schema: heroWithArgumentSchema(t),
@@ -2329,6 +2336,7 @@ func TestExecutionEngine_Execute(t *testing.T) {
 	))
 
 	t.Run("invalid and inaccessible enum values", func(t *testing.T) {
+		t.Parallel()
 		schema, err := graphql.NewSchemaFromString(enumSDL)
 		require.NoError(t, err)
 
@@ -4458,7 +4466,9 @@ func TestExecutionEngine_Execute(t *testing.T) {
 	})
 
 	t.Run("variables", func(t *testing.T) {
+		t.Parallel()
 		t.Run("operation with optional input fields", func(t *testing.T) {
+			t.Parallel()
 			schemaString := `
 				type Query {
 					field(arg: Input): String
@@ -4592,6 +4602,8 @@ func TestExecutionEngine_Execute(t *testing.T) {
 	})
 
 	t.Run("execute operation with nested fetch on one of the types", func(t *testing.T) {
+
+		t.Parallel()
 
 		definition := `
 			type User implements Node {
@@ -4935,7 +4947,10 @@ func TestExecutionEngine_Execute(t *testing.T) {
 
 	t.Run("validation of optional @requires dependencies", func(t *testing.T) {
 
+		t.Parallel()
+
 		t.Run("execute operation with @requires and @external", func(t *testing.T) {
+			t.Parallel()
 			definition := `
 				type User {
 					id: ID!
@@ -5096,6 +5111,7 @@ func TestExecutionEngine_Execute(t *testing.T) {
 		})
 
 		t.Run("do not validate non-nullable @requires dependencies", func(t *testing.T) {
+			t.Parallel()
 			definition := `
 				type Query {
 					accounts: [User!]!
@@ -5263,6 +5279,7 @@ func TestExecutionEngine_Execute(t *testing.T) {
 		})
 
 		t.Run("validate nullable @requires dependencies", func(t *testing.T) {
+			t.Parallel()
 			definition := `
 				type Query {
 					accounts: [User!]!
@@ -5430,6 +5447,7 @@ func TestExecutionEngine_Execute(t *testing.T) {
 		})
 
 		t.Run("validate nested nullable @requires dependencies", func(t *testing.T) {
+			t.Parallel()
 			definition := `
 				type Query {
 					accounts: [User!]!
@@ -5633,6 +5651,7 @@ func TestExecutionEngine_Execute(t *testing.T) {
 	})
 
 	t.Run("field merging with different nullability on non-overlapping union types", func(t *testing.T) {
+		t.Parallel()
 		unionSchema := `
 			union Entity = User | Organization
 			type Query { entity: Entity }
@@ -5786,6 +5805,7 @@ func testConditionalNetHttpClient(t *testing.T, testCase conditionalTestCase) *h
 }
 
 func TestExecutionEngine_GetCachedPlan(t *testing.T) {
+	t.Parallel()
 	schema, err := graphql.NewSchemaFromString(testSubscriptionDefinition)
 	require.NoError(t, err)
 
@@ -5849,12 +5869,20 @@ func TestExecutionEngine_GetCachedPlan(t *testing.T) {
 		),
 	})
 
-	engine, err := NewExecutionEngine(context.Background(), abstractlogger.NoopLogger, engineConfig, resolve.ResolverOptions{
-		MaxConcurrency: 1024,
-	})
-	require.NoError(t, err)
+	newEngine := func(t *testing.T) *ExecutionEngine {
+		t.Helper()
+
+		engine, err := NewExecutionEngine(context.Background(), abstractlogger.NoopLogger, engineConfig, resolve.ResolverOptions{
+			MaxConcurrency: 1024,
+		})
+		require.NoError(t, err)
+
+		return engine
+	}
 
 	t.Run("should reuse cached plan", func(t *testing.T) {
+		t.Parallel()
+		engine := newEngine(t)
 		t.Cleanup(engine.executionPlanCache.Purge)
 		require.Equal(t, 0, engine.executionPlanCache.Len())
 
@@ -5883,6 +5911,8 @@ func TestExecutionEngine_GetCachedPlan(t *testing.T) {
 	})
 
 	t.Run("should create new plan and cache it", func(t *testing.T) {
+		t.Parallel()
+		engine := newEngine(t)
 		t.Cleanup(engine.executionPlanCache.Purge)
 		require.Equal(t, 0, engine.executionPlanCache.Len())
 

--- a/execution/engine/execution_engine_test.go
+++ b/execution/engine/execution_engine_test.go
@@ -135,7 +135,7 @@ func runExecutionTest(testCase ExecutionEngineTestCase, withError bool, expected
 		}
 
 		if testCase.expectedJSONResponse != "" {
-			assert.JSONEq(t, testCase.expectedJSONResponse, actualResponse)
+			assert.Equal(t, compactJSONForAssert(t, testCase.expectedJSONResponse), compactJSONForAssert(t, actualResponse))
 		}
 
 		if testCase.expectedResponse != "" {
@@ -178,8 +178,25 @@ func mustGraphqlDataSourceConfiguration(t *testing.T, id string, factory plan.Pl
 	return cfg
 }
 
+func mustGraphqlDataSourceConfigurationWithName(t *testing.T, id, name string, factory plan.PlannerFactory[graphql_datasource.Configuration], metadata *plan.DataSourceMetadata, customConfig graphql_datasource.Configuration) plan.DataSourceConfiguration[graphql_datasource.Configuration] {
+	t.Helper()
+
+	cfg, err := plan.NewDataSourceConfigurationWithName[graphql_datasource.Configuration](
+		id,
+		name,
+		factory,
+		metadata,
+		customConfig,
+	)
+	require.NoError(t, err)
+
+	return cfg
+}
+
 func TestEngineResponseWriter_AsHTTPResponse(t *testing.T) {
+	t.Parallel()
 	t.Run("no compression", func(t *testing.T) {
+		t.Parallel()
 		rw := graphql.NewEngineResultWriter()
 		_, err := rw.Write([]byte(`{"key": "value"}`))
 		require.NoError(t, err)
@@ -197,14 +214,16 @@ func TestEngineResponseWriter_AsHTTPResponse(t *testing.T) {
 	})
 
 	t.Run("compression based on content encoding header", func(t *testing.T) {
-		rw := graphql.NewEngineResultWriter()
-		_, err := rw.Write([]byte(`{"key": "value"}`))
-		require.NoError(t, err)
-
-		headers := make(http.Header)
-		headers.Set("Content-Type", "application/json")
+		t.Parallel()
 
 		t.Run("gzip", func(t *testing.T) {
+			t.Parallel()
+			rw := graphql.NewEngineResultWriter()
+			_, err := rw.Write([]byte(`{"key": "value"}`))
+			require.NoError(t, err)
+
+			headers := make(http.Header)
+			headers.Set("Content-Type", "application/json")
 			headers.Set(httpclient.ContentEncodingHeader, "gzip")
 
 			response := rw.AsHTTPResponse(http.StatusOK, headers)
@@ -223,6 +242,13 @@ func TestEngineResponseWriter_AsHTTPResponse(t *testing.T) {
 		})
 
 		t.Run("deflate", func(t *testing.T) {
+			t.Parallel()
+			rw := graphql.NewEngineResultWriter()
+			_, err := rw.Write([]byte(`{"key": "value"}`))
+			require.NoError(t, err)
+
+			headers := make(http.Header)
+			headers.Set("Content-Type", "application/json")
 			headers.Set(httpclient.ContentEncodingHeader, "deflate")
 
 			response := rw.AsHTTPResponse(http.StatusOK, headers)
@@ -1356,7 +1382,7 @@ func TestExecutionEngine_Execute(t *testing.T) {
 	t.Run("execute operation with variables for arguments", runWithoutError(
 		ExecutionEngineTestCase{
 			schema:    graphql.StarwarsSchema(t),
-			operation: graphql.LoadStarWarsQuery(starwars.FileDroidWithArgAndVarQuery, map[string]interface{}{"droidID": "R2D2"}),
+			operation: graphql.LoadStarWarsQuery(starwars.FileDroidWithArgAndVarQuery, map[string]any{"droidID": "R2D2"}),
 			dataSources: []plan.DataSource{
 				mustGraphqlDataSourceConfiguration(t,
 					"id",
@@ -1419,7 +1445,7 @@ func TestExecutionEngine_Execute(t *testing.T) {
 		operation: func(t *testing.T) graphql.Request {
 			return graphql.Request{
 				OperationName: "MyHeroes",
-				Variables: stringify(map[string]interface{}{
+				Variables: stringify(map[string]any{
 					"heroNames": []string{"Luke Skywalker", "R2-D2"},
 				}),
 				Query: `query MyHeroes($heroNames: [String!]!){
@@ -1673,7 +1699,7 @@ func TestExecutionEngine_Execute(t *testing.T) {
 		operation: func(t *testing.T) graphql.Request {
 			return graphql.Request{
 				OperationName: "",
-				Variables:     stringify(map[string]interface{}{}),
+				Variables:     stringify(map[string]any{}),
 				Query: `query{
 						charactersByIds(ids: 1) {
 							name
@@ -1742,7 +1768,7 @@ func TestExecutionEngine_Execute(t *testing.T) {
 		operation: func(t *testing.T) graphql.Request {
 			return graphql.Request{
 				OperationName: "",
-				Variables: stringify(map[string]interface{}{
+				Variables: stringify(map[string]any{
 					"ids": 1,
 				}),
 				Query: `query($ids: [Int]) { charactersByIds(ids: $ids) { name } }`,
@@ -1932,7 +1958,7 @@ func TestExecutionEngine_Execute(t *testing.T) {
 				operation: func(t *testing.T) graphql.Request {
 					return graphql.Request{
 						OperationName: "queryVariables",
-						Variables: stringify(map[string]interface{}{
+						Variables: stringify(map[string]any{
 							"name":         "Luke",
 							"nameOptional": "Skywalker",
 						}),
@@ -5955,8 +5981,7 @@ func BenchmarkIntrospection(b *testing.B) {
 	require.NoError(b, err)
 	expectedResponse := buf.Bytes()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := b.Context()
 	type benchCase struct {
 		engine *ExecutionEngine
 		writer *graphql.EngineResultWriter
@@ -5987,7 +6012,7 @@ func BenchmarkIntrospection(b *testing.B) {
 	require.Equal(b, string(expectedResponse), writer.String())
 
 	pool := sync.Pool{
-		New: func() interface{} {
+		New: func() any {
 			return newBenchCase()
 		},
 	}
@@ -6010,8 +6035,7 @@ func BenchmarkIntrospection(b *testing.B) {
 }
 
 func BenchmarkExecutionEngine(b *testing.B) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := b.Context()
 	type benchCase struct {
 		engine *ExecutionEngine
 		writer *graphql.EngineResultWriter
@@ -6072,7 +6096,7 @@ func BenchmarkExecutionEngine(b *testing.B) {
 	require.Equal(b, "{\"data\":{\"hello\":\"world\"}}", writer.String())
 
 	pool := sync.Pool{
-		New: func() interface{} {
+		New: func() any {
 			return newBenchCase()
 		},
 	}

--- a/execution/engine/extractor_test.go
+++ b/execution/engine/extractor_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestExtractor_ExtractFieldsFromRequest(t *testing.T) {
+	t.Parallel()
 	schema, err := graphql.NewSchemaFromString(testDefinition)
 	require.NoError(t, err)
 

--- a/execution/engine/graphql_client_test.go
+++ b/execution/engine/graphql_client_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/wundergraph/graphql-go-tools/execution/subscription"
 )
 
-type queryVariables map[string]interface{}
+type queryVariables map[string]any
 
 func requestBody(t *testing.T, query string, variables queryVariables) []byte {
 	var variableJsonBytes []byte

--- a/execution/engine/json_assert_test.go
+++ b/execution/engine/json_assert_test.go
@@ -1,0 +1,20 @@
+package engine
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func compactJSONForAssert(t testing.TB, input string) string {
+	t.Helper()
+
+	var value any
+	err := json.Unmarshal([]byte(input), &value)
+	require.NoError(t, err)
+
+	normalized, err := json.Marshal(value)
+	require.NoError(t, err)
+	return string(normalized)
+}

--- a/execution/engine/local_type_field_extractor_test.go
+++ b/execution/engine/local_type_field_extractor_test.go
@@ -21,6 +21,7 @@ func sortNodesAndFields(nodes []plan.TypeField) {
 }
 
 func TestLocalTypeFieldExtractor_GetAllNodes(t *testing.T) {
+	t.Parallel()
 	run := func(t *testing.T, SDL string, expectedRoot, expectedChild []plan.TypeField) {
 		t.Helper()
 
@@ -38,6 +39,7 @@ func TestLocalTypeFieldExtractor_GetAllNodes(t *testing.T) {
 	}
 
 	t.Run("only root operation", func(t *testing.T) {
+		t.Parallel()
 		run(t, `
 			extend type Query {
 				me: User
@@ -66,6 +68,7 @@ func TestLocalTypeFieldExtractor_GetAllNodes(t *testing.T) {
 			})
 	})
 	t.Run("orphan pair", func(t *testing.T) {
+		t.Parallel()
 		run(t, `
 			extend type Query {
 				me: User
@@ -94,6 +97,7 @@ func TestLocalTypeFieldExtractor_GetAllNodes(t *testing.T) {
 			})
 	})
 	t.Run("orphan cycle", func(t *testing.T) {
+		t.Parallel()
 		run(t, `
 			extend type Query {
 				me: User
@@ -123,6 +127,7 @@ func TestLocalTypeFieldExtractor_GetAllNodes(t *testing.T) {
 			})
 	})
 	t.Run("nested child nodes", func(t *testing.T) {
+		t.Parallel()
 		run(t, `
 			extend type Query {
 				me: User
@@ -151,6 +156,7 @@ func TestLocalTypeFieldExtractor_GetAllNodes(t *testing.T) {
 			})
 	})
 	t.Run("child node only available via nested child", func(t *testing.T) {
+		t.Parallel()
 		run(t, `
 			extend type Query {
 				me: User
@@ -179,6 +185,7 @@ func TestLocalTypeFieldExtractor_GetAllNodes(t *testing.T) {
 			})
 	})
 	t.Run("interface", func(t *testing.T) {
+		t.Parallel()
 		run(t, `
 			extend type Query {
 				me: User
@@ -221,6 +228,7 @@ func TestLocalTypeFieldExtractor_GetAllNodes(t *testing.T) {
 			})
 	})
 	t.Run("interface with key directive", func(t *testing.T) {
+		t.Parallel()
 		run(t, `
 			extend type Query {
 				me: User
@@ -266,6 +274,7 @@ func TestLocalTypeFieldExtractor_GetAllNodes(t *testing.T) {
 			})
 	})
 	t.Run("extended interface", func(t *testing.T) {
+		t.Parallel()
 		t.Log("Bug: The concrete types that implement an interface should also be included")
 
 		run(t, `
@@ -310,6 +319,7 @@ func TestLocalTypeFieldExtractor_GetAllNodes(t *testing.T) {
 			})
 	})
 	t.Run("union", func(t *testing.T) {
+		t.Parallel()
 		run(t, `
 			extend type Query {
 				me: User
@@ -347,6 +357,7 @@ func TestLocalTypeFieldExtractor_GetAllNodes(t *testing.T) {
 			})
 	})
 	t.Run("union + interface", func(t *testing.T) {
+		t.Parallel()
 		run(t, `
 			type Query {
 				histories: [History]
@@ -381,6 +392,7 @@ func TestLocalTypeFieldExtractor_GetAllNodes(t *testing.T) {
 			})
 	})
 	t.Run("extended union", func(t *testing.T) {
+		t.Parallel()
 		run(t, `
 			extend type Query {
 				me: User
@@ -418,6 +430,7 @@ func TestLocalTypeFieldExtractor_GetAllNodes(t *testing.T) {
 			})
 	})
 	t.Run("local union extension", func(t *testing.T) {
+		t.Parallel()
 		run(t, `
 			extend type Query {
 				me: User
@@ -463,6 +476,7 @@ func TestLocalTypeFieldExtractor_GetAllNodes(t *testing.T) {
 			})
 	})
 	t.Run("nested Entity definition", func(t *testing.T) {
+		t.Parallel()
 		run(t, `
 			extend type Query {
 				me: User
@@ -488,6 +502,7 @@ func TestLocalTypeFieldExtractor_GetAllNodes(t *testing.T) {
 			})
 	})
 	t.Run("local type extension", func(t *testing.T) {
+		t.Parallel()
 		run(t, `
            extend type Query {
                    reviews(IDs: [ID!]!): [Review!]
@@ -530,6 +545,7 @@ func TestLocalTypeFieldExtractor_GetAllNodes(t *testing.T) {
 			})
 	})
 	t.Run("local type extension defined before local type", func(t *testing.T) {
+		t.Parallel()
 		run(t, `
            extend type Query {
                    reviews(IDs: [ID!]!): [Review!]
@@ -572,6 +588,7 @@ func TestLocalTypeFieldExtractor_GetAllNodes(t *testing.T) {
 			})
 	})
 	t.Run("union types", func(t *testing.T) {
+		t.Parallel()
 		run(t, `
 			extend type Query {
 				search(name: String!): SearchResult
@@ -612,6 +629,7 @@ func TestLocalTypeFieldExtractor_GetAllNodes(t *testing.T) {
 			})
 	})
 	t.Run("interface types", func(t *testing.T) {
+		t.Parallel()
 		run(t, `
 			extend type Query {
 				search(name: String!): Character

--- a/execution/engine/local_type_field_extractor_test.go
+++ b/execution/engine/local_type_field_extractor_test.go
@@ -670,7 +670,7 @@ func BenchmarkGetAllNodes(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		extractor := NewLocalTypeFieldExtractor(&document)
 		extractor.GetAllNodes()
 	}

--- a/execution/engine/lookup_test.go
+++ b/execution/engine/lookup_test.go
@@ -9,17 +9,21 @@ import (
 )
 
 func TestCreateTypeFieldLookupKey(t *testing.T) {
+	t.Parallel()
 	lookupKey := CreateTypeFieldLookupKey("Query", "hello")
 	assert.Equal(t, TypeFieldLookupKey("Query.hello"), lookupKey)
 }
 
 func TestCreateTypeFieldArgumentsLookupMap(t *testing.T) {
+	t.Parallel()
 	t.Run("should return nil if slice is empty", func(t *testing.T) {
+		t.Parallel()
 		lookupMap := CreateTypeFieldArgumentsLookupMap([]graphql.TypeFieldArguments{})
 		assert.Nil(t, lookupMap)
 	})
 
 	t.Run("should return a lookup map", func(t *testing.T) {
+		t.Parallel()
 		typeFieldArgs := []graphql.TypeFieldArguments{
 			{
 				TypeName:      "Query",

--- a/execution/engine/skipped_fetch_test.go
+++ b/execution/engine/skipped_fetch_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestSkippedFetchOnNullParent(t *testing.T) {
+	t.Parallel()
 	// Users subgraph: returns null for the "user" field.
 	usersServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/execution/graphql/normalization_test.go
+++ b/execution/graphql/normalization_test.go
@@ -14,7 +14,9 @@ import (
 )
 
 func TestRequest_Normalize(t *testing.T) {
+	t.Parallel()
 	t.Run("should return error when schema is nil", func(t *testing.T) {
+		t.Parallel()
 		request := Request{
 			OperationName: "Hello",
 			Variables:     nil,
@@ -29,6 +31,7 @@ func TestRequest_Normalize(t *testing.T) {
 	})
 
 	t.Run("should successfully normalize request with fragments", func(t *testing.T) {
+		t.Parallel()
 		schema := StarwarsSchema(t)
 		request := StarwarsRequestForQuery(t, starwars.FileFragmentsQuery)
 		request.OperationName = "Fragments"
@@ -77,6 +80,7 @@ func TestRequest_Normalize(t *testing.T) {
 	}
 
 	t.Run("should successfully normalize single query with arguments", func(t *testing.T) {
+		t.Parallel()
 		request := StarwarsRequestForQuery(t, starwars.FileDroidWithArgQuery)
 
 		runNormalization(t, &request, `{"a":"R2D2"}`, `query($a: ID!){
@@ -87,6 +91,7 @@ func TestRequest_Normalize(t *testing.T) {
 	})
 
 	t.Run("should successfully normalize query and remove unused variables", func(t *testing.T) {
+		t.Parallel()
 		request := Request{
 			OperationName: "MySearch",
 			Variables: stringify(map[string]interface{}{
@@ -106,6 +111,7 @@ func TestRequest_Normalize(t *testing.T) {
 	})
 
 	t.Run("should successfully normalize query and remove variables with no value provided", func(t *testing.T) {
+		t.Parallel()
 		request := Request{
 			OperationName: "MySearch",
 			Variables: stringify(map[string]interface{}{
@@ -123,6 +129,7 @@ func TestRequest_Normalize(t *testing.T) {
 	})
 
 	t.Run("should successfully normalize multiple queries with arguments", func(t *testing.T) {
+		t.Parallel()
 		request := StarwarsRequestForQuery(t, starwars.FileMultiQueriesWithArguments)
 		request.OperationName = "GetDroid"
 
@@ -135,6 +142,7 @@ func TestRequest_Normalize(t *testing.T) {
 	})
 
 	t.Run("input coercion for lists without variables", func(t *testing.T) {
+		t.Parallel()
 		schema := InputCoercionForListSchema(t)
 		request := Request{
 			OperationName: "charactersByIds",
@@ -149,6 +157,7 @@ func TestRequest_Normalize(t *testing.T) {
 	})
 
 	t.Run("input coercion for lists with variable extraction", func(t *testing.T) {
+		t.Parallel()
 		schema := InputCoercionForListSchema(t)
 		request := Request{
 			OperationName: "GetCharactersByIds",
@@ -163,6 +172,7 @@ func TestRequest_Normalize(t *testing.T) {
 	})
 
 	t.Run("input coercion for lists with variables", func(t *testing.T) {
+		t.Parallel()
 		schema := InputCoercionForListSchema(t)
 		request := Request{
 			OperationName: "charactersByIds",
@@ -180,7 +190,9 @@ func TestRequest_Normalize(t *testing.T) {
 }
 
 func Test_normalizationResultFromReport(t *testing.T) {
+	t.Parallel()
 	t.Run("should return successful result when report does not have errors", func(t *testing.T) {
+		t.Parallel()
 		report := operationreport.Report{}
 		result, err := NormalizationResultFromReport(report)
 
@@ -189,6 +201,7 @@ func Test_normalizationResultFromReport(t *testing.T) {
 	})
 
 	t.Run("should return graphql errors and internal error when report contains them", func(t *testing.T) {
+		t.Parallel()
 		internalErr := errors.New("errors occurred")
 		externalErr := operationreport.ExternalError{
 			Message:   "graphql error",

--- a/execution/graphql/request_fields_validator_test.go
+++ b/execution/graphql/request_fields_validator_test.go
@@ -9,10 +9,13 @@ import (
 )
 
 func TestFieldsValidator_Validate(t *testing.T) {
-	schema := StarwarsSchema(t)
-	request := StarwarsRequestForQuery(t, starwars.FileSimpleHeroQuery)
+	t.Parallel()
 
 	t.Run("should invalidate if blocked fields are used", func(t *testing.T) {
+		t.Parallel()
+
+		schema := StarwarsSchema(t)
+		request := StarwarsRequestForQuery(t, starwars.FileSimpleHeroQuery)
 
 		blockedFields := []Type{
 			{
@@ -29,6 +32,10 @@ func TestFieldsValidator_Validate(t *testing.T) {
 	})
 
 	t.Run("should validate if non-blocked fields are used", func(t *testing.T) {
+		t.Parallel()
+
+		schema := StarwarsSchema(t)
+		request := StarwarsRequestForQuery(t, starwars.FileSimpleHeroQuery)
 
 		blockedFields := []Type{
 			{
@@ -46,11 +53,14 @@ func TestFieldsValidator_Validate(t *testing.T) {
 }
 
 func TestFieldsValidator_ValidateByFieldList(t *testing.T) {
-	schema := StarwarsSchema(t)
-	request := StarwarsRequestForQuery(t, starwars.FileSimpleHeroQuery)
+	t.Parallel()
 
 	t.Run("block list", func(t *testing.T) {
+		t.Parallel()
 		t.Run("should invalidate if blocked fields are used", func(t *testing.T) {
+			t.Parallel()
+			schema := StarwarsSchema(t)
+			request := StarwarsRequestForQuery(t, starwars.FileSimpleHeroQuery)
 			blockList := FieldRestrictionList{
 				Kind: BlockList,
 				Types: []Type{
@@ -69,6 +79,9 @@ func TestFieldsValidator_ValidateByFieldList(t *testing.T) {
 		})
 
 		t.Run("should validate if non-blocked fields are used", func(t *testing.T) {
+			t.Parallel()
+			schema := StarwarsSchema(t)
+			request := StarwarsRequestForQuery(t, starwars.FileSimpleHeroQuery)
 			blockList := FieldRestrictionList{
 				Kind: BlockList,
 				Types: []Type{
@@ -88,7 +101,11 @@ func TestFieldsValidator_ValidateByFieldList(t *testing.T) {
 	})
 
 	t.Run("allow list", func(t *testing.T) {
+		t.Parallel()
 		t.Run("should invalidate if a field which is not allowed is used", func(t *testing.T) {
+			t.Parallel()
+			schema := StarwarsSchema(t)
+			request := StarwarsRequestForQuery(t, starwars.FileSimpleHeroQuery)
 			allowList := FieldRestrictionList{
 				Kind: AllowList,
 				Types: []Type{
@@ -111,6 +128,9 @@ func TestFieldsValidator_ValidateByFieldList(t *testing.T) {
 		})
 
 		t.Run("should validate if all fields are allowed", func(t *testing.T) {
+			t.Parallel()
+			schema := StarwarsSchema(t)
+			request := StarwarsRequestForQuery(t, starwars.FileSimpleHeroQuery)
 			allowList := FieldRestrictionList{
 				Kind: AllowList,
 				Types: []Type{

--- a/execution/graphql/request_test.go
+++ b/execution/graphql/request_test.go
@@ -12,7 +12,9 @@ import (
 )
 
 func TestUnmarshalRequest(t *testing.T) {
+	t.Parallel()
 	t.Run("should return error when request is empty", func(t *testing.T) {
+		t.Parallel()
 		requestBytes := []byte("")
 		requestBuffer := bytes.NewBuffer(requestBytes)
 
@@ -24,6 +26,7 @@ func TestUnmarshalRequest(t *testing.T) {
 	})
 
 	t.Run("should successfully unmarshal request", func(t *testing.T) {
+		t.Parallel()
 		requestBytes := []byte(`{"operationName": "Hello", "variables": "", "query": "query Hello { hello }"}`)
 		requestBuffer := bytes.NewBuffer(requestBytes)
 
@@ -37,6 +40,7 @@ func TestUnmarshalRequest(t *testing.T) {
 }
 
 func TestRequest_Print(t *testing.T) {
+	t.Parallel()
 	query := "query Hello { hello }"
 	request := Request{
 		OperationName: "Hello",
@@ -53,6 +57,7 @@ func TestRequest_Print(t *testing.T) {
 }
 
 func TestRequest_parseQueryOnce(t *testing.T) {
+	t.Parallel()
 	request := func() *Request {
 		return &Request{
 			OperationName: "Hello",
@@ -62,6 +67,7 @@ func TestRequest_parseQueryOnce(t *testing.T) {
 	}
 
 	t.Run("valid query", func(t *testing.T) {
+		t.Parallel()
 		req := request()
 		report := req.parseQueryOnce()
 		assert.False(t, report.HasErrors())
@@ -69,6 +75,7 @@ func TestRequest_parseQueryOnce(t *testing.T) {
 	})
 
 	t.Run("should not parse again", func(t *testing.T) {
+		t.Parallel()
 		req := request()
 		report := req.parseQueryOnce()
 		assert.False(t, report.HasErrors())
@@ -80,6 +87,7 @@ func TestRequest_parseQueryOnce(t *testing.T) {
 	})
 
 	t.Run("should not set is parsed for invalid query", func(t *testing.T) {
+		t.Parallel()
 		req := request()
 		req.Query = "{"
 		report := req.parseQueryOnce()
@@ -89,7 +97,9 @@ func TestRequest_parseQueryOnce(t *testing.T) {
 }
 
 func TestRequest_CalculateComplexity(t *testing.T) {
+	t.Parallel()
 	t.Run("should successfully calculate the complexity of request", func(t *testing.T) {
+		t.Parallel()
 		schema := StarwarsSchema(t)
 		request := StarwarsRequestForQuery(t, starwars.FileSimpleHeroQuery)
 
@@ -118,6 +128,7 @@ func TestRequest_CalculateComplexity(t *testing.T) {
 	})
 
 	t.Run("should successfully calculate the complexity of request with multiple query fields", func(t *testing.T) {
+		t.Parallel()
 		schema := StarwarsSchema(t)
 		request := StarwarsRequestForQuery(t, starwars.FileHeroWithAliasesQuery)
 
@@ -156,8 +167,10 @@ func TestRequest_CalculateComplexity(t *testing.T) {
 }
 
 func TestRequest_IsIntrospectionQuery(t *testing.T) {
+	t.Parallel()
 	run := func(queryPayload string, expectedIsIntrospection bool) func(t *testing.T) {
 		return func(t *testing.T) {
+			t.Parallel()
 			t.Helper()
 
 			var request Request
@@ -171,6 +184,7 @@ func TestRequest_IsIntrospectionQuery(t *testing.T) {
 	}
 
 	t.Run("schema introspection query", func(t *testing.T) {
+		t.Parallel()
 		t.Run("with operation name IntrospectionQuery", run(namedIntrospectionQuery, true))
 		t.Run("without operation name IntrospectionQuery but as single query", run(singleNamedIntrospectionQueryWithoutOperationName, true))
 		t.Run("with empty operation name", run(silentIntrospectionQuery, true))
@@ -182,11 +196,13 @@ func TestRequest_IsIntrospectionQuery(t *testing.T) {
 	})
 
 	t.Run("type introspection query", func(t *testing.T) {
+		t.Parallel()
 		t.Run("as single introspection", run(typeIntrospectionQuery, true))
 		t.Run("with multiple queries in payload", run(typeIntrospectionQueryWithMultipleQueries, true))
 	})
 
 	t.Run("not introspection query", func(t *testing.T) {
+		t.Parallel()
 		t.Run("query with operation name IntrospectionQuery", run(nonIntrospectionQueryWithIntrospectionQueryName, false))
 		t.Run("Foo query", run(nonIntrospectionQuery, false))
 		t.Run("Foo mutation", run(mutationQuery, false))

--- a/execution/graphql/request_test.go
+++ b/execution/graphql/request_test.go
@@ -216,69 +216,62 @@ func TestRequest_IsIntrospectionQuery(t *testing.T) {
 }
 
 func TestRequest_OperationType(t *testing.T) {
-	request := Request{
-		OperationName: "",
-		Variables:     nil,
-		Query:         "query HelloQuery { hello: String } mutation HelloMutation { hello: String } subscription HelloSubscription { hello: String }",
-	}
+	t.Parallel()
+
+	multiOpQuery := "query HelloQuery { hello: String } mutation HelloMutation { hello: String } subscription HelloSubscription { hello: String }"
 
 	t.Run("should return operation type 'Query'", func(t *testing.T) {
-		request.OperationName = "HelloQuery"
+		t.Parallel()
+		request := Request{OperationName: "HelloQuery", Query: multiOpQuery}
 		opType, err := request.OperationType()
 		assert.NoError(t, err)
 		assert.Equal(t, OperationTypeQuery, opType)
 	})
 
 	t.Run("should return operation type 'Mutation'", func(t *testing.T) {
-		request.OperationName = "HelloMutation"
+		t.Parallel()
+		request := Request{OperationName: "HelloMutation", Query: multiOpQuery}
 		opType, err := request.OperationType()
 		assert.NoError(t, err)
 		assert.Equal(t, OperationTypeMutation, opType)
 	})
 
 	t.Run("should return operation type 'Subscription'", func(t *testing.T) {
-		request.OperationName = "HelloSubscription"
+		t.Parallel()
+		request := Request{OperationName: "HelloSubscription", Query: multiOpQuery}
 		opType, err := request.OperationType()
 		assert.NoError(t, err)
 		assert.Equal(t, OperationTypeSubscription, opType)
 	})
 
 	t.Run("should return operation type 'Unknown' on error", func(t *testing.T) {
-		emptyRequest := Request{
-			Query: "Broken Query",
-		}
-		opType, err := emptyRequest.OperationType()
+		t.Parallel()
+		request := Request{Query: "Broken Query"}
+		opType, err := request.OperationType()
 		assert.Error(t, err)
 		assert.Equal(t, OperationTypeUnknown, opType)
 	})
 
 	t.Run("should return operation type 'Unknown' when empty and parsable", func(t *testing.T) {
-		emptyRequest := Request{}
-		opType, err := emptyRequest.OperationType()
+		t.Parallel()
+		request := Request{}
+		opType, err := request.OperationType()
 		assert.NoError(t, err)
 		assert.Equal(t, OperationTypeUnknown, opType)
 	})
 
 	t.Run("should return operation type 'Query' if no name and a single operation is provided", func(t *testing.T) {
-		singleOperationQueryRequest := Request{
-			OperationName: "",
-			Variables:     nil,
-			Query:         "{ hello: String }",
-		}
-
-		opType, err := singleOperationQueryRequest.OperationType()
+		t.Parallel()
+		request := Request{Query: "{ hello: String }"}
+		opType, err := request.OperationType()
 		assert.NoError(t, err)
 		assert.Equal(t, OperationTypeQuery, opType)
 	})
 
 	t.Run("should return operation type 'Mutation' if mutation is the only operation", func(t *testing.T) {
-		singleOperationMutationRequest := Request{
-			OperationName: "",
-			Variables:     nil,
-			Query:         "mutation HelloMutation { hello: String }",
-		}
-
-		opType, err := singleOperationMutationRequest.OperationType()
+		t.Parallel()
+		request := Request{Query: "mutation HelloMutation { hello: String }"}
+		opType, err := request.OperationType()
 		assert.NoError(t, err)
 		assert.Equal(t, OperationTypeMutation, opType)
 	})

--- a/execution/graphql/schema_test.go
+++ b/execution/graphql/schema_test.go
@@ -14,7 +14,9 @@ import (
 )
 
 func TestNewSchemaFromReader(t *testing.T) {
+	t.Parallel()
 	t.Run("should return error when an error occurs internally", func(t *testing.T) {
+		t.Parallel()
 		schemaBytes := []byte("query: Query")
 		schemaReader := bytes.NewBuffer(schemaBytes)
 		schema, err := NewSchemaFromReader(schemaReader)
@@ -24,6 +26,7 @@ func TestNewSchemaFromReader(t *testing.T) {
 	})
 
 	t.Run("should successfully read from io.Reader", func(t *testing.T) {
+		t.Parallel()
 		schemaBytes := []byte("schema { query: Query } type Query { hello: String }")
 		schemaReader := bytes.NewBuffer(schemaBytes)
 		schema, err := NewSchemaFromReader(schemaReader)
@@ -34,7 +37,9 @@ func TestNewSchemaFromReader(t *testing.T) {
 }
 
 func TestNewSchemaFromString(t *testing.T) {
+	t.Parallel()
 	t.Run("should return error when an error occurs internally", func(t *testing.T) {
+		t.Parallel()
 		schemaBytes := []byte("query: Query")
 		schema, err := NewSchemaFromString(string(schemaBytes))
 
@@ -43,6 +48,7 @@ func TestNewSchemaFromString(t *testing.T) {
 	})
 
 	t.Run("should successfully read from string", func(t *testing.T) {
+		t.Parallel()
 		schemaBytes := []byte("schema { query: Query } type Query { hello: String }")
 		schema, err := NewSchemaFromString(string(schemaBytes))
 
@@ -52,7 +58,9 @@ func TestNewSchemaFromString(t *testing.T) {
 }
 
 func TestSchema_Normalize(t *testing.T) {
+	t.Parallel()
 	t.Run("should successfully normalize schema", func(t *testing.T) {
+		t.Parallel()
 		parsedSchema, err := NewSchemaFromString("type Query { me: String } extend type Query { you: String }")
 		require.NoError(t, err)
 
@@ -72,8 +80,10 @@ func TestSchema_Normalize(t *testing.T) {
 }
 
 func TestSchema_HasQueryType(t *testing.T) {
+	t.Parallel()
 	run := func(schema string, expectation bool) func(t *testing.T) {
 		return func(t *testing.T) {
+			t.Parallel()
 			parsedSchema, err := createSchema([]byte(schema), false)
 			require.NoError(t, err)
 
@@ -83,6 +93,7 @@ func TestSchema_HasQueryType(t *testing.T) {
 	}
 
 	t.Run("schema without base definition", func(t *testing.T) {
+		t.Parallel()
 		t.Run("should return false when there is no query type present", run(`
 				schema {
 					mutation: Mutation
@@ -104,8 +115,10 @@ func TestSchema_HasQueryType(t *testing.T) {
 }
 
 func TestSchema_QueryTypeName(t *testing.T) {
+	t.Parallel()
 	run := func(schema string, expectation string) func(t *testing.T) {
 		return func(t *testing.T) {
+			t.Parallel()
 			parsedSchema, err := NewSchemaFromString(schema)
 			require.NoError(t, err)
 
@@ -143,8 +156,10 @@ func TestSchema_QueryTypeName(t *testing.T) {
 }
 
 func TestSchema_HasMutationType(t *testing.T) {
+	t.Parallel()
 	run := func(schema string, expectation bool) func(t *testing.T) {
 		return func(t *testing.T) {
+			t.Parallel()
 			parsedSchema, err := NewSchemaFromString(schema)
 			require.NoError(t, err)
 
@@ -173,8 +188,10 @@ func TestSchema_HasMutationType(t *testing.T) {
 }
 
 func TestSchema_MutationTypeName(t *testing.T) {
+	t.Parallel()
 	run := func(schema string, expectation string) func(t *testing.T) {
 		return func(t *testing.T) {
+			t.Parallel()
 			parsedSchema, err := NewSchemaFromString(schema)
 			require.NoError(t, err)
 
@@ -212,8 +229,10 @@ func TestSchema_MutationTypeName(t *testing.T) {
 }
 
 func TestSchema_HasSubscriptionType(t *testing.T) {
+	t.Parallel()
 	run := func(schema string, expectation bool) func(t *testing.T) {
 		return func(t *testing.T) {
+			t.Parallel()
 			parsedSchema, err := NewSchemaFromString(schema)
 			require.NoError(t, err)
 
@@ -242,8 +261,10 @@ func TestSchema_HasSubscriptionType(t *testing.T) {
 }
 
 func TestSchema_SubscriptionTypeName(t *testing.T) {
+	t.Parallel()
 	run := func(schema string, expectation string) func(t *testing.T) {
 		return func(t *testing.T) {
+			t.Parallel()
 			parsedSchema, err := NewSchemaFromString(schema)
 			require.NoError(t, err)
 
@@ -281,6 +302,7 @@ func TestSchema_SubscriptionTypeName(t *testing.T) {
 }
 
 func TestSchema_Document(t *testing.T) {
+	t.Parallel()
 	schemaBytes := []byte("schema { query: Query } type Query { hello: String }")
 	schema, err := NewSchemaFromString(string(schemaBytes))
 	require.NoError(t, err)
@@ -299,8 +321,10 @@ func TestSchema_Document(t *testing.T) {
 }
 
 func TestValidateSchemaString(t *testing.T) {
+	t.Parallel()
 	run := func(schema string, expectedValid bool, expectedValidationErrorCount int) func(t *testing.T) {
 		return func(t *testing.T) {
+			t.Parallel()
 			validationResult, err := ValidateSchemaString(schema)
 			assert.NoError(t, err)
 			assert.Equal(t, expectedValid, validationResult.Valid)
@@ -346,8 +370,10 @@ func TestValidateSchemaString(t *testing.T) {
 }
 
 func TestSchema_Validate(t *testing.T) {
+	t.Parallel()
 	run := func(schema string, expectedValid bool, expectedValidationErrorCount int) func(t *testing.T) {
 		return func(t *testing.T) {
+			t.Parallel()
 			parsedSchema, err := NewSchemaFromString(schema)
 			require.NoError(t, err)
 
@@ -390,10 +416,12 @@ func TestSchema_Validate(t *testing.T) {
 }
 
 func TestSchema_GetAllFieldArguments(t *testing.T) {
+	t.Parallel()
 	schema, err := NewSchemaFromString(schemaWithChildren)
 	require.NoError(t, err)
 
 	t.Run("should get all field arguments without skip function", func(t *testing.T) {
+		t.Parallel()
 		fieldArguments := schema.GetAllFieldArguments()
 		expectedFieldArguments := []TypeFieldArguments{
 			{
@@ -456,6 +484,7 @@ func TestSchema_GetAllFieldArguments(t *testing.T) {
 	})
 
 	t.Run("should get all field arguments excluding skipped fields by skip field funcs", func(t *testing.T) {
+		t.Parallel()
 		fieldArguments := schema.GetAllFieldArguments(NewSkipReservedNamesFunc())
 		expectedFieldArguments := []TypeFieldArguments{
 			{
@@ -489,15 +518,18 @@ func TestSchema_GetAllFieldArguments(t *testing.T) {
 }
 
 func TestSchema_GetAllNestedFieldChildrenFromTypeField(t *testing.T) {
+	t.Parallel()
 	schema, err := NewSchemaFromString(schemaWithChildren)
 	require.NoError(t, err)
 
 	t.Run("should return nil when type or field does not exist", func(t *testing.T) {
+		t.Parallel()
 		typeFields := schema.GetAllNestedFieldChildrenFromTypeField("Not", "existent")
 		assert.Equal(t, []TypeFields(nil), typeFields)
 	})
 
 	t.Run("should get field children without skip function", func(t *testing.T) {
+		t.Parallel()
 		typeFields := schema.GetAllNestedFieldChildrenFromTypeField("Query", "withChildren")
 		expectedTypeFields := []TypeFields{
 			{
@@ -514,6 +546,7 @@ func TestSchema_GetAllNestedFieldChildrenFromTypeField(t *testing.T) {
 	})
 
 	t.Run("should get field children without skip function on field with interface type", func(t *testing.T) {
+		t.Parallel()
 		typeFields := schema.GetAllNestedFieldChildrenFromTypeField("Query", "idType")
 		expectedTypeFields := []TypeFields{
 			{
@@ -534,6 +567,7 @@ func TestSchema_GetAllNestedFieldChildrenFromTypeField(t *testing.T) {
 	})
 
 	t.Run("should get field children with skip function for engine v2 data source config", func(t *testing.T) {
+		t.Parallel()
 		dsCfg, _ := plan.NewDataSourceConfiguration[any](
 			"test",
 			nil,
@@ -561,6 +595,7 @@ func TestSchema_GetAllNestedFieldChildrenFromTypeField(t *testing.T) {
 	})
 
 	t.Run("should get field children from schema with recursive references", func(t *testing.T) {
+		t.Parallel()
 		schema := CreateCountriesSchema(t)
 
 		typeFields := schema.GetAllNestedFieldChildrenFromTypeField("Query", "countries")
@@ -587,6 +622,7 @@ func TestSchema_GetAllNestedFieldChildrenFromTypeField(t *testing.T) {
 	})
 
 	t.Run("should get field children from schema with recursive references on field with interface type", func(t *testing.T) {
+		t.Parallel()
 		schema := CreateCountriesSchema(t)
 
 		typeFields := schema.GetAllNestedFieldChildrenFromTypeField("Query", "codeType")

--- a/execution/graphql/schema_validation_errors_test.go
+++ b/execution/graphql/schema_validation_errors_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestSchemaValidationErrors_Error(t *testing.T) {
+	t.Parallel()
 	validationErrs := SchemaValidationErrors{
 		SchemaValidationError{
 			Message: "there can be only one query type in schema",
@@ -17,6 +18,7 @@ func TestSchemaValidationErrors_Error(t *testing.T) {
 }
 
 func TestSchemaValidationErrors_Count(t *testing.T) {
+	t.Parallel()
 	validationErrs := SchemaValidationErrors{
 		SchemaValidationError{
 			Message: "there can be only one query type in schema",
@@ -27,6 +29,7 @@ func TestSchemaValidationErrors_Count(t *testing.T) {
 }
 
 func TestSchemaValidationErrors_ErrorByIndex(t *testing.T) {
+	t.Parallel()
 	existingValidationError := SchemaValidationError{
 		Message: "there can be only one query type in schema",
 	}
@@ -40,6 +43,7 @@ func TestSchemaValidationErrors_ErrorByIndex(t *testing.T) {
 }
 
 func TestSchemaValidationError_Error(t *testing.T) {
+	t.Parallel()
 	validationError := SchemaValidationError{
 		Message: "there can be only one query type in schema",
 	}

--- a/execution/graphql/validation_test.go
+++ b/execution/graphql/validation_test.go
@@ -14,7 +14,9 @@ import (
 )
 
 func TestRequest_ValidateForSchema(t *testing.T) {
+	t.Parallel()
 	t.Run("should return error when schema is nil", func(t *testing.T) {
+		t.Parallel()
 		request := Request{
 			OperationName: "Hello",
 			Variables:     nil,
@@ -28,6 +30,7 @@ func TestRequest_ValidateForSchema(t *testing.T) {
 	})
 
 	t.Run("should return gql errors no valid operation is in the the request", func(t *testing.T) {
+		t.Parallel()
 		request := Request{}
 
 		schema, err := NewSchemaFromString("schema { query: Query } type Query { hello: String }")
@@ -40,6 +43,7 @@ func TestRequest_ValidateForSchema(t *testing.T) {
 	})
 
 	t.Run("should return gql errors when validation fails", func(t *testing.T) {
+		t.Parallel()
 		request := Request{
 			OperationName: "Goodbye",
 			Variables:     nil,
@@ -56,6 +60,7 @@ func TestRequest_ValidateForSchema(t *testing.T) {
 	})
 
 	t.Run("should successfully validate even when schema definition is missing", func(t *testing.T) {
+		t.Parallel()
 		request := Request{
 			OperationName: "Hello",
 			Variables:     nil,
@@ -72,6 +77,7 @@ func TestRequest_ValidateForSchema(t *testing.T) {
 	})
 
 	t.Run("should return valid result for introspection query after normalization", func(t *testing.T) {
+		t.Parallel()
 		schema := StarwarsSchema(t)
 		request := StarwarsRequestForQuery(t, starwars.FileIntrospectionQuery)
 
@@ -87,6 +93,7 @@ func TestRequest_ValidateForSchema(t *testing.T) {
 	})
 
 	t.Run("should return valid result when validation is successful", func(t *testing.T) {
+		t.Parallel()
 		schema := StarwarsSchema(t)
 		request := StarwarsRequestForQuery(t, starwars.FileSimpleHeroQuery)
 
@@ -98,7 +105,9 @@ func TestRequest_ValidateForSchema(t *testing.T) {
 }
 
 func TestRequest_ValidateRestrictedFields(t *testing.T) {
+	t.Parallel()
 	t.Run("should return error when schema is nil", func(t *testing.T) {
+		t.Parallel()
 		request := Request{}
 		result, err := request.ValidateRestrictedFields(nil, nil)
 		assert.Error(t, err)
@@ -107,6 +116,7 @@ func TestRequest_ValidateRestrictedFields(t *testing.T) {
 	})
 
 	t.Run("should allow request when no restrictions set", func(t *testing.T) {
+		t.Parallel()
 		schema := StarwarsSchema(t)
 		request := StarwarsRequestForQuery(t, starwars.FileSimpleHeroQuery)
 
@@ -116,6 +126,7 @@ func TestRequest_ValidateRestrictedFields(t *testing.T) {
 	})
 
 	t.Run("when restrictions set", func(t *testing.T) {
+		t.Parallel()
 		schema := StarwarsSchema(t)
 		restrictedFields := []Type{
 			{Name: "Query", Fields: []string{"droid"}},
@@ -125,7 +136,9 @@ func TestRequest_ValidateRestrictedFields(t *testing.T) {
 		}
 
 		t.Run("should allow request", func(t *testing.T) {
+			t.Parallel()
 			t.Run("when only allowed fields requested", func(t *testing.T) {
+				t.Parallel()
 				request := StarwarsRequestForQuery(t, starwars.FileSimpleHeroQuery)
 				result, err := request.ValidateRestrictedFields(schema, restrictedFields)
 				assert.NoError(t, err)
@@ -141,7 +154,9 @@ func TestRequest_ValidateRestrictedFields(t *testing.T) {
 		})
 
 		t.Run("should disallow request", func(t *testing.T) {
+			t.Parallel()
 			t.Run("when query is restricted", func(t *testing.T) {
+				t.Parallel()
 				request := StarwarsRequestForQuery(t, starwars.FileDroidWithArgAndVarQuery)
 				result, err := request.ValidateRestrictedFields(schema, restrictedFields)
 				assert.NoError(t, err)
@@ -154,6 +169,7 @@ func TestRequest_ValidateRestrictedFields(t *testing.T) {
 			})
 
 			t.Run("when mutation is restricted", func(t *testing.T) {
+				t.Parallel()
 				request := StarwarsRequestForQuery(t, starwars.FileCreateReviewMutation)
 				result, err := request.ValidateRestrictedFields(schema, restrictedFields)
 				assert.NoError(t, err)
@@ -162,6 +178,7 @@ func TestRequest_ValidateRestrictedFields(t *testing.T) {
 			})
 
 			t.Run("when type field is restricted", func(t *testing.T) {
+				t.Parallel()
 				request := StarwarsRequestForQuery(t, starwars.FileUnionQuery)
 				result, err := request.ValidateRestrictedFields(schema, restrictedFields)
 				assert.NoError(t, err)
@@ -170,6 +187,7 @@ func TestRequest_ValidateRestrictedFields(t *testing.T) {
 			})
 
 			t.Run("when mutation response type has restricted field", func(t *testing.T) {
+				t.Parallel()
 				restrictedFields := []Type{
 					{Name: "Review", Fields: []string{"id"}},
 				}
@@ -186,9 +204,11 @@ func TestRequest_ValidateRestrictedFields(t *testing.T) {
 }
 
 func TestRequest_ValidateFieldRestrictions(t *testing.T) {
+	t.Parallel()
 	validator := DefaultFieldsValidator{}
 
 	t.Run("should return error when schema is nil", func(t *testing.T) {
+		t.Parallel()
 		request := Request{}
 		result, err := request.ValidateFieldRestrictions(nil, FieldRestrictionList{}, validator)
 		assert.Error(t, err)
@@ -197,6 +217,7 @@ func TestRequest_ValidateFieldRestrictions(t *testing.T) {
 	})
 
 	t.Run("should allow request when no restrictions set", func(t *testing.T) {
+		t.Parallel()
 		schema := StarwarsSchema(t)
 		request := StarwarsRequestForQuery(t, starwars.FileSimpleHeroQuery)
 
@@ -208,6 +229,7 @@ func TestRequest_ValidateFieldRestrictions(t *testing.T) {
 	})
 
 	t.Run("when restrictions set", func(t *testing.T) {
+		t.Parallel()
 		schema := StarwarsSchema(t)
 		restrictedFields := []Type{
 			{Name: "Query", Fields: []string{"droid"}},
@@ -217,7 +239,9 @@ func TestRequest_ValidateFieldRestrictions(t *testing.T) {
 		}
 
 		t.Run("should allow request", func(t *testing.T) {
+			t.Parallel()
 			t.Run("when only allowed fields requested", func(t *testing.T) {
+				t.Parallel()
 				request := StarwarsRequestForQuery(t, starwars.FileSimpleHeroQuery)
 				result, err := request.ValidateFieldRestrictions(schema, FieldRestrictionList{
 					Kind:  BlockList,
@@ -236,7 +260,9 @@ func TestRequest_ValidateFieldRestrictions(t *testing.T) {
 		})
 
 		t.Run("should disallow request", func(t *testing.T) {
+			t.Parallel()
 			t.Run("when query is restricted", func(t *testing.T) {
+				t.Parallel()
 				request := StarwarsRequestForQuery(t, starwars.FileDroidWithArgAndVarQuery)
 				result, err := request.ValidateFieldRestrictions(schema, FieldRestrictionList{
 					Kind:  BlockList,
@@ -252,6 +278,7 @@ func TestRequest_ValidateFieldRestrictions(t *testing.T) {
 			})
 
 			t.Run("when mutation is restricted", func(t *testing.T) {
+				t.Parallel()
 				request := StarwarsRequestForQuery(t, starwars.FileCreateReviewMutation)
 				result, err := request.ValidateFieldRestrictions(schema, FieldRestrictionList{
 					Kind:  BlockList,
@@ -263,6 +290,7 @@ func TestRequest_ValidateFieldRestrictions(t *testing.T) {
 			})
 
 			t.Run("when type field is restricted", func(t *testing.T) {
+				t.Parallel()
 				request := StarwarsRequestForQuery(t, starwars.FileUnionQuery)
 				result, err := request.ValidateFieldRestrictions(schema, FieldRestrictionList{
 					Kind:  BlockList,
@@ -274,6 +302,7 @@ func TestRequest_ValidateFieldRestrictions(t *testing.T) {
 			})
 
 			t.Run("when mutation response type has restricted field", func(t *testing.T) {
+				t.Parallel()
 				restrictedFields := []Type{
 					{Name: "Review", Fields: []string{"id"}},
 				}
@@ -293,7 +322,9 @@ func TestRequest_ValidateFieldRestrictions(t *testing.T) {
 }
 
 func Test_operationValidationResultFromReport(t *testing.T) {
+	t.Parallel()
 	t.Run("should return result for valid when report does not have errors", func(t *testing.T) {
+		t.Parallel()
 		report := operationreport.Report{}
 		result, err := operationValidationResultFromReport(report)
 
@@ -302,6 +333,7 @@ func Test_operationValidationResultFromReport(t *testing.T) {
 	})
 
 	t.Run("should return validation error and internal error when report contain them", func(t *testing.T) {
+		t.Parallel()
 		internalErr := errors.New("errors occurred")
 		externalErr := operationreport.ExternalError{
 			Message:   "graphql error",

--- a/execution/subscription/context_test.go
+++ b/execution/subscription/context_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestNewInitialHttpRequestContext(t *testing.T) {
+	t.Parallel()
 	ctx, cancelFn := context.WithCancel(context.Background())
 	defer cancelFn()
 
@@ -52,6 +53,7 @@ func TestSubscriptionCancellations(t *testing.T) {
 }
 
 func TestSubscriptionIdsShouldBeUnique(t *testing.T) {
+	t.Parallel()
 	sc := subscriptionCancellations{}
 	var ctx context.Context
 	var err error

--- a/execution/subscription/context_test.go
+++ b/execution/subscription/context_test.go
@@ -24,7 +24,9 @@ func TestNewInitialHttpRequestContext(t *testing.T) {
 	assert.Equal(t, req, initialReqCtx.Request)
 }
 
+//nolint:tparallel // Subtests intentionally share the same cancellation map and context state.
 func TestSubscriptionCancellations(t *testing.T) {
+	t.Parallel()
 	cancellations := subscriptionCancellations{}
 	var ctx context.Context
 	var err error

--- a/execution/subscription/engine_test.go
+++ b/execution/subscription/engine_test.go
@@ -18,8 +18,11 @@ import (
 )
 
 func TestExecutorEngine_StartOperation(t *testing.T) {
+	t.Parallel()
 	t.Run("execute non-subscription operation", func(t *testing.T) {
+		t.Parallel()
 		t.Run("on execution failure", func(t *testing.T) {
+			t.Parallel()
 			wg := &sync.WaitGroup{}
 			wg.Add(2)
 
@@ -94,6 +97,7 @@ func TestExecutorEngine_StartOperation(t *testing.T) {
 		})
 
 		t.Run("on execution success", func(t *testing.T) {
+			t.Parallel()
 			wg := &sync.WaitGroup{}
 			wg.Add(2)
 
@@ -168,7 +172,9 @@ func TestExecutorEngine_StartOperation(t *testing.T) {
 	})
 
 	t.Run("execute subscription operation", func(t *testing.T) {
+		t.Parallel()
 		t.Run("on execution failure", func(t *testing.T) {
+			t.Parallel()
 			if runtime.GOOS == "windows" {
 				t.Skip("this test fails on Windows due to different timings than unix, consider fixing it at some point")
 			}
@@ -230,6 +236,7 @@ func TestExecutorEngine_StartOperation(t *testing.T) {
 		})
 
 		t.Run("on execution success", func(t *testing.T) {
+			t.Parallel()
 			if runtime.GOOS == "windows" {
 				t.Skip("this test fails on Windows due to different timings than unix, consider fixing it at some point")
 			}
@@ -295,6 +302,7 @@ func TestExecutorEngine_StartOperation(t *testing.T) {
 	})
 
 	t.Run("error on duplicate id", func(t *testing.T) {
+		t.Parallel()
 		wg := &sync.WaitGroup{}
 		wg.Add(1)
 
@@ -368,6 +376,7 @@ func TestExecutorEngine_StartOperation(t *testing.T) {
 }
 
 func TestExecutorEngine_StopSubscription(t *testing.T) {
+	t.Parallel()
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 
@@ -436,6 +445,7 @@ func TestExecutorEngine_StopSubscription(t *testing.T) {
 }
 
 func TestExecutorEngine_TerminateAllConnections(t *testing.T) {
+	t.Parallel()
 	wg := &sync.WaitGroup{}
 	wg.Add(3)
 

--- a/execution/subscription/handler_test.go
+++ b/execution/subscription/handler_test.go
@@ -14,7 +14,9 @@ import (
 )
 
 func TestUniversalProtocolHandler_Handle(t *testing.T) {
+	t.Parallel()
 	t.Run("should terminate when client is disconnected", func(t *testing.T) {
+		t.Parallel()
 		wg := &sync.WaitGroup{}
 		wg.Add(1)
 
@@ -62,6 +64,7 @@ func TestUniversalProtocolHandler_Handle(t *testing.T) {
 	})
 
 	t.Run("should terminate when reading on closed connection", func(t *testing.T) {
+		t.Parallel()
 		wg := &sync.WaitGroup{}
 		wg.Add(1)
 
@@ -112,6 +115,7 @@ func TestUniversalProtocolHandler_Handle(t *testing.T) {
 	})
 
 	t.Run("should sent event on client read error", func(t *testing.T) {
+		t.Parallel()
 		wg := &sync.WaitGroup{}
 		wg.Add(1)
 
@@ -164,6 +168,7 @@ func TestUniversalProtocolHandler_Handle(t *testing.T) {
 	})
 
 	t.Run("should handover message to protocol handler", func(t *testing.T) {
+		t.Parallel()
 		wg := &sync.WaitGroup{}
 		wg.Add(1)
 
@@ -217,7 +222,9 @@ func TestUniversalProtocolHandler_Handle(t *testing.T) {
 	})
 
 	t.Run("read error time out", func(t *testing.T) {
+		t.Parallel()
 		t.Run("should stop handler when read error timer runs out", func(t *testing.T) {
+			t.Parallel()
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
 
@@ -270,6 +277,7 @@ func TestUniversalProtocolHandler_Handle(t *testing.T) {
 		})
 
 		t.Run("should continue running handler after intermittent read error", func(t *testing.T) {
+			t.Parallel()
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
 

--- a/execution/subscription/legacy_handler_test.go
+++ b/execution/subscription/legacy_handler_test.go
@@ -41,7 +41,9 @@ func (w *websocketHook) OnBeforeStart(reqCtx context.Context, operation *graphql
 	return nil
 }
 
+//nolint:tparallel // Subtests share websocket clients, hooks, and test servers; parallel execution is unsafe here.
 func TestHandler_Handle(t *testing.T) {
+	t.Parallel()
 	t.Run("engine v2", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/execution/subscription/time_out_test.go
+++ b/execution/subscription/time_out_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 func TestTimeOutChecker(t *testing.T) {
+	t.Parallel()
 	t.Run("should stop timer if context is done before", func(t *testing.T) {
+		t.Parallel()
 		timeOutActionExecuted := false
 		timeOutAction := func() {
 			timeOutActionExecuted = true
@@ -33,6 +35,7 @@ func TestTimeOutChecker(t *testing.T) {
 	})
 
 	t.Run("should stop process if timer runs out", func(t *testing.T) {
+		t.Parallel()
 		wg := &sync.WaitGroup{}
 		wg.Add(1)
 

--- a/execution/subscription/websocket/client_test.go
+++ b/execution/subscription/websocket/client_test.go
@@ -215,19 +215,29 @@ func TestClient_ReadFromClient(t *testing.T) {
 }
 
 func TestClient_IsConnected(t *testing.T) {
-	_, connToClient := net.Pipe()
-	websocketClient := NewClient(abstractlogger.NoopLogger, connToClient)
+	t.Parallel()
 
 	t.Run("should return true when a connection is established", func(t *testing.T) {
+		t.Parallel()
+		_, connToClient := net.Pipe()
+		t.Cleanup(func() {
+			_ = connToClient.Close()
+		})
+		websocketClient := NewClient(abstractlogger.NoopLogger, connToClient)
+
 		isConnected := websocketClient.IsConnected()
 		assert.True(t, isConnected)
 	})
 
 	t.Run("should return false when a connection is closed", func(t *testing.T) {
+		t.Parallel()
+		_, connToClient := net.Pipe()
+		websocketClient := NewClient(abstractlogger.NoopLogger, connToClient)
+
 		err := connToClient.Close()
 		require.NoError(t, err)
 
-		websocketClient.isClosedConnection = true
+		websocketClient.changeConnectionStateToClosed()
 
 		isConnected := websocketClient.IsConnected()
 		assert.False(t, isConnected)

--- a/execution/subscription/websocket/client_test.go
+++ b/execution/subscription/websocket/client_test.go
@@ -27,7 +27,9 @@ type testServerWebsocketResponse struct {
 }
 
 func TestClient_WriteToClient(t *testing.T) {
+	t.Parallel()
 	t.Run("should write successfully to client", func(t *testing.T) {
+		t.Parallel()
 		connToServer, connToClient := net.Pipe()
 		websocketClient := NewClient(abstractlogger.NoopLogger, connToClient)
 		messageToClient := []byte(`{
@@ -50,8 +52,11 @@ func TestClient_WriteToClient(t *testing.T) {
 	})
 
 	t.Run("should not write to client when connection is closed", func(t *testing.T) {
+		t.Parallel()
 		t.Run("when not wrapped", func(t *testing.T) {
+			t.Parallel()
 			t.Run("io: read/write on closed pipe", func(t *testing.T) {
+				t.Parallel()
 				connToServer, connToClient := net.Pipe()
 				websocketClient := NewClient(abstractlogger.NoopLogger, connToClient)
 				err := connToServer.Close()
@@ -64,7 +69,9 @@ func TestClient_WriteToClient(t *testing.T) {
 		})
 
 		t.Run("when wrapped", func(t *testing.T) {
+			t.Parallel()
 			t.Run("io: read/write on closed pipe", func(t *testing.T) {
+				t.Parallel()
 				connToClient := FakeConn{}
 				wrappedErr := fmt.Errorf("outside wrapper: %w",
 					fmt.Errorf("inner wrapper: %w",
@@ -83,7 +90,9 @@ func TestClient_WriteToClient(t *testing.T) {
 }
 
 func TestClient_ReadFromClient(t *testing.T) {
+	t.Parallel()
 	t.Run("should successfully read from client", func(t *testing.T) {
+		t.Parallel()
 		connToServer, connToClient := net.Pipe()
 		websocketClient := NewClient(abstractlogger.NoopLogger, connToClient)
 
@@ -105,7 +114,9 @@ func TestClient_ReadFromClient(t *testing.T) {
 		assert.Equal(t, messageToServer, messageFromClient)
 	})
 	t.Run("should detect a closed connection", func(t *testing.T) {
+		t.Parallel()
 		t.Run("before read", func(t *testing.T) {
+			t.Parallel()
 			_, connToClient := net.Pipe()
 			websocketClient := NewClient(abstractlogger.NoopLogger, connToClient)
 			defer connToClient.Close()
@@ -117,7 +128,9 @@ func TestClient_ReadFromClient(t *testing.T) {
 			}, 1*time.Second, 2*time.Millisecond)
 		})
 		t.Run("when not wrapped", func(t *testing.T) {
+			t.Parallel()
 			t.Run("io.EOF", func(t *testing.T) {
+				t.Parallel()
 				connToServer, connToClient := net.Pipe()
 				websocketClient := NewClient(abstractlogger.NoopLogger, connToClient)
 				err := connToServer.Close()
@@ -128,6 +141,7 @@ func TestClient_ReadFromClient(t *testing.T) {
 				assert.True(t, websocketClient.isClosedConnection)
 			})
 			t.Run("io: read/write on closed pipe", func(t *testing.T) {
+				t.Parallel()
 				connToClient := &FakeConn{}
 				connToClient.setReadReturns(0, io.ErrClosedPipe)
 				websocketClient := NewClient(abstractlogger.NoopLogger, connToClient)
@@ -137,6 +151,7 @@ func TestClient_ReadFromClient(t *testing.T) {
 				assert.True(t, websocketClient.isClosedConnection)
 			})
 			t.Run("unexpected EOF", func(t *testing.T) {
+				t.Parallel()
 				connToClient := &FakeConn{}
 				connToClient.setReadReturns(0, io.ErrUnexpectedEOF)
 				websocketClient := NewClient(abstractlogger.NoopLogger, connToClient)
@@ -148,7 +163,9 @@ func TestClient_ReadFromClient(t *testing.T) {
 		})
 
 		t.Run("when wrapped", func(t *testing.T) {
+			t.Parallel()
 			t.Run("io.EOF", func(t *testing.T) {
+				t.Parallel()
 				connToClient := &FakeConn{}
 				wrappedErr := fmt.Errorf("outside wrapper: %w",
 					fmt.Errorf("inner wrapper: %w",
@@ -163,6 +180,7 @@ func TestClient_ReadFromClient(t *testing.T) {
 				assert.True(t, websocketClient.isClosedConnection)
 			})
 			t.Run("io: read/write on closed pipe", func(t *testing.T) {
+				t.Parallel()
 				connToClient := &FakeConn{}
 				wrappedErr := fmt.Errorf("outside wrapper: %w",
 					fmt.Errorf("inner wrapper: %w",
@@ -177,6 +195,7 @@ func TestClient_ReadFromClient(t *testing.T) {
 				assert.True(t, websocketClient.isClosedConnection)
 			})
 			t.Run("unexpected EOF", func(t *testing.T) {
+				t.Parallel()
 				connToClient := &FakeConn{}
 				wrappedErr := fmt.Errorf("outside wrapper: %w",
 					fmt.Errorf("inner wrapper: %w",
@@ -216,10 +235,12 @@ func TestClient_IsConnected(t *testing.T) {
 }
 
 func TestClient_Disconnect(t *testing.T) {
+	t.Parallel()
 	_, connToClient := net.Pipe()
 	websocketClient := NewClient(abstractlogger.NoopLogger, connToClient)
 
 	t.Run("should disconnect and indicate a closed connection", func(t *testing.T) {
+		t.Parallel()
 		err := websocketClient.Disconnect()
 		assert.NoError(t, err)
 		assert.Equal(t, true, websocketClient.isClosedConnection)
@@ -227,7 +248,9 @@ func TestClient_Disconnect(t *testing.T) {
 }
 
 func TestClient_DisconnectWithReason(t *testing.T) {
+	t.Parallel()
 	t.Run("disconnect with invalid reason", func(t *testing.T) {
+		t.Parallel()
 		connToServer, connToClient := net.Pipe()
 		websocketClient := NewClient(abstractlogger.NoopLogger, connToClient)
 		serverResponseChan := make(chan testServerWebsocketResponse)
@@ -255,6 +278,7 @@ func TestClient_DisconnectWithReason(t *testing.T) {
 	})
 
 	t.Run("disconnect with reason", func(t *testing.T) {
+		t.Parallel()
 		connToServer, connToClient := net.Pipe()
 		websocketClient := NewClient(abstractlogger.NoopLogger, connToClient)
 		serverResponseChan := make(chan testServerWebsocketResponse)
@@ -282,6 +306,7 @@ func TestClient_DisconnectWithReason(t *testing.T) {
 	})
 
 	t.Run("disconnect with compiled reason", func(t *testing.T) {
+		t.Parallel()
 		connToServer, connToClient := net.Pipe()
 		websocketClient := NewClient(abstractlogger.NoopLogger, connToClient)
 		serverResponseChan := make(chan testServerWebsocketResponse)
@@ -310,9 +335,11 @@ func TestClient_DisconnectWithReason(t *testing.T) {
 }
 
 func TestClient_isClosedConnectionError(t *testing.T) {
+	t.Parallel()
 	_, connToClient := net.Pipe()
 
 	t.Run("should not close connection when it is not a closed connection error", func(t *testing.T) {
+		t.Parallel()
 		websocketClient := NewClient(abstractlogger.NoopLogger, connToClient)
 		require.False(t, websocketClient.isClosedConnection)
 
@@ -321,6 +348,7 @@ func TestClient_isClosedConnectionError(t *testing.T) {
 	})
 
 	t.Run("should close connection when it is a closed connection error", func(t *testing.T) {
+		t.Parallel()
 		websocketClient := NewClient(abstractlogger.NoopLogger, connToClient)
 		require.False(t, websocketClient.isClosedConnection)
 

--- a/execution/subscription/websocket/handler_test.go
+++ b/execution/subscription/websocket/handler_test.go
@@ -26,8 +26,10 @@ import (
 )
 
 func TestHandleWithOptions(t *testing.T) {
+	t.Parallel()
 	t.Skip("timing not compatible with async rewrite of resolver")
 	t.Run("should handle protocol graphql-ws", func(t *testing.T) {
+		t.Parallel()
 		if runtime.GOOS == "windows" {
 			t.Skip("this test fails on Windows due to different timings than unix, consider fixing it at some point")
 		}
@@ -106,6 +108,7 @@ func TestHandleWithOptions(t *testing.T) {
 	})
 
 	t.Run("should handle protocol graphql-transport-ws", func(t *testing.T) {
+		t.Parallel()
 		chatServer := httptest.NewServer(subscriptiontesting.ChatGraphQLEndpointHandler())
 		defer chatServer.Close()
 
@@ -181,6 +184,7 @@ func TestHandleWithOptions(t *testing.T) {
 	})
 
 	t.Run("should handle on before start error", func(t *testing.T) {
+		t.Parallel()
 		chatServer := httptest.NewServer(subscriptiontesting.ChatGraphQLEndpointHandler())
 		defer chatServer.Close()
 
@@ -228,8 +232,10 @@ func TestHandleWithOptions(t *testing.T) {
 }
 
 func TestWithProtocolFromRequestHeaders(t *testing.T) {
+	t.Parallel()
 	runTest := func(headerKey string, headerValue string, expectedProtocol Protocol) func(t *testing.T) {
 		return func(t *testing.T) {
+			t.Parallel()
 			request, err := http.NewRequest("", "", nil)
 			require.NoError(t, err)
 			request.Header.Set(headerKey, headerValue)
@@ -247,6 +253,7 @@ func TestWithProtocolFromRequestHeaders(t *testing.T) {
 	t.Run("should fallback to default protocol", runTest(HeaderSecWebSocketProtocol, "something-else", DefaultProtocol))
 	t.Run("should fallback to default protocol when header is missing", runTest("Different-Header-Key", "missing-header", DefaultProtocol))
 	t.Run("should fallback to default protocol when request is nil", func(t *testing.T) {
+		t.Parallel()
 		options := &HandleOptions{}
 		optionFunc := WithProtocolFromRequestHeaders(nil)
 		optionFunc(options)

--- a/execution/subscription/websocket/protocol_graphql_transport_ws_test.go
+++ b/execution/subscription/websocket/protocol_graphql_transport_ws_test.go
@@ -17,7 +17,9 @@ import (
 )
 
 func TestGraphQLTransportWSMessageReader_Read(t *testing.T) {
+	t.Parallel()
 	t.Run("should read a minimal message", func(t *testing.T) {
+		t.Parallel()
 		data := []byte(`{ "type": "connection_init" }`)
 		expectedMessage := &GraphQLTransportWSMessage{
 			Type: "connection_init",
@@ -32,6 +34,7 @@ func TestGraphQLTransportWSMessageReader_Read(t *testing.T) {
 	})
 
 	t.Run("should message with json payload", func(t *testing.T) {
+		t.Parallel()
 		data := []byte(`{ "id": "1", "type": "connection_init", "payload": { "Authorization": "Bearer ey123" } }`)
 		expectedMessage := &GraphQLTransportWSMessage{
 			Id:      "1",
@@ -48,6 +51,7 @@ func TestGraphQLTransportWSMessageReader_Read(t *testing.T) {
 	})
 
 	t.Run("should read and deserialize subscribe message", func(t *testing.T) {
+		t.Parallel()
 		data := []byte(`{ 
   "id": "1", 
   "type": "subscribe", 
@@ -89,7 +93,9 @@ func TestGraphQLTransportWSMessageReader_Read(t *testing.T) {
 }
 
 func TestGraphQLTransportWSMessageWriter_WriteConnectionAck(t *testing.T) {
+	t.Parallel()
 	t.Run("should return error when error occurs on underlying call", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(true)
 		writer := GraphQLTransportWSMessageWriter{
 			logger: abstractlogger.Noop{},
@@ -100,6 +106,7 @@ func TestGraphQLTransportWSMessageWriter_WriteConnectionAck(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("should successfully write ack message to client", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		writer := GraphQLTransportWSMessageWriter{
 			logger: abstractlogger.Noop{},
@@ -114,7 +121,9 @@ func TestGraphQLTransportWSMessageWriter_WriteConnectionAck(t *testing.T) {
 }
 
 func TestGraphQLTransportWSMessageWriter_WritePing(t *testing.T) {
+	t.Parallel()
 	t.Run("should return error when error occurs on underlying call", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(true)
 		writer := GraphQLTransportWSMessageWriter{
 			logger: abstractlogger.Noop{},
@@ -125,6 +134,7 @@ func TestGraphQLTransportWSMessageWriter_WritePing(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("should successfully write ping message to client", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		writer := GraphQLTransportWSMessageWriter{
 			logger: abstractlogger.Noop{},
@@ -137,6 +147,7 @@ func TestGraphQLTransportWSMessageWriter_WritePing(t *testing.T) {
 		assert.Equal(t, expectedMessage, testClient.readMessageToClient())
 	})
 	t.Run("should successfully write ping message with payload to client", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		writer := GraphQLTransportWSMessageWriter{
 			logger: abstractlogger.Noop{},
@@ -151,7 +162,9 @@ func TestGraphQLTransportWSMessageWriter_WritePing(t *testing.T) {
 }
 
 func TestGraphQLTransportWSMessageWriter_WritePong(t *testing.T) {
+	t.Parallel()
 	t.Run("should return error when error occurs on underlying call", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(true)
 		writer := GraphQLTransportWSMessageWriter{
 			logger: abstractlogger.Noop{},
@@ -162,6 +175,7 @@ func TestGraphQLTransportWSMessageWriter_WritePong(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("should successfully write pong message to client", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		writer := GraphQLTransportWSMessageWriter{
 			logger: abstractlogger.Noop{},
@@ -174,6 +188,7 @@ func TestGraphQLTransportWSMessageWriter_WritePong(t *testing.T) {
 		assert.Equal(t, expectedMessage, testClient.readMessageToClient())
 	})
 	t.Run("should successfully write pong message with payload to client", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		writer := GraphQLTransportWSMessageWriter{
 			logger: abstractlogger.Noop{},
@@ -188,7 +203,9 @@ func TestGraphQLTransportWSMessageWriter_WritePong(t *testing.T) {
 }
 
 func TestGraphQLTransportWSMessageWriter_WriteNext(t *testing.T) {
+	t.Parallel()
 	t.Run("should return error when error occurs on underlying call", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(true)
 		writer := GraphQLTransportWSMessageWriter{
 			logger: abstractlogger.Noop{},
@@ -199,6 +216,7 @@ func TestGraphQLTransportWSMessageWriter_WriteNext(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("should successfully write next message with payload to client", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		writer := GraphQLTransportWSMessageWriter{
 			logger: abstractlogger.Noop{},
@@ -213,7 +231,9 @@ func TestGraphQLTransportWSMessageWriter_WriteNext(t *testing.T) {
 }
 
 func TestGraphQLTransportWSMessageWriter_WriteError(t *testing.T) {
+	t.Parallel()
 	t.Run("should return error when error occurs on underlying call", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(true)
 		writer := GraphQLTransportWSMessageWriter{
 			logger: abstractlogger.Noop{},
@@ -224,6 +244,7 @@ func TestGraphQLTransportWSMessageWriter_WriteError(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("should successfully write error message with payload to client", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		writer := GraphQLTransportWSMessageWriter{
 			logger: abstractlogger.Noop{},
@@ -239,7 +260,9 @@ func TestGraphQLTransportWSMessageWriter_WriteError(t *testing.T) {
 }
 
 func TestGraphQLTransportWSMessageWriter_WriteComplete(t *testing.T) {
+	t.Parallel()
 	t.Run("should return error when error occurs on underlying call", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(true)
 		writer := GraphQLTransportWSMessageWriter{
 			logger: abstractlogger.Noop{},
@@ -250,6 +273,7 @@ func TestGraphQLTransportWSMessageWriter_WriteComplete(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("should successfully write complete message to client", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		writer := GraphQLTransportWSMessageWriter{
 			logger: abstractlogger.Noop{},
@@ -264,7 +288,9 @@ func TestGraphQLTransportWSMessageWriter_WriteComplete(t *testing.T) {
 }
 
 func TestGraphQLTransportWSEventHandler_Emit(t *testing.T) {
+	t.Parallel()
 	t.Run("should write on completed", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		eventHandler := NewTestGraphQLTransportWSEventHandler(testClient)
 		eventHandler.Emit(subscription.EventTypeOnSubscriptionCompleted, "1", nil, nil)
@@ -272,6 +298,7 @@ func TestGraphQLTransportWSEventHandler_Emit(t *testing.T) {
 		assert.Equal(t, expectedMessage, testClient.readMessageToClient())
 	})
 	t.Run("should write on data", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		eventHandler := NewTestGraphQLTransportWSEventHandler(testClient)
 		eventHandler.Emit(subscription.EventTypeOnSubscriptionData, "1", []byte(`{ "data": { "hello": "world" } }`), nil)
@@ -279,6 +306,7 @@ func TestGraphQLTransportWSEventHandler_Emit(t *testing.T) {
 		assert.Equal(t, expectedMessage, testClient.readMessageToClient())
 	})
 	t.Run("should write on non-subscription execution result", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		eventHandler := NewTestGraphQLTransportWSEventHandler(testClient)
 		go func() {
@@ -296,6 +324,7 @@ func TestGraphQLTransportWSEventHandler_Emit(t *testing.T) {
 		}, 1*time.Second, 2*time.Millisecond)
 	})
 	t.Run("should write on error", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		eventHandler := NewTestGraphQLTransportWSEventHandler(testClient)
 		eventHandler.Emit(subscription.EventTypeOnError, "1", nil, errors.New("error occurred"))
@@ -303,6 +332,7 @@ func TestGraphQLTransportWSEventHandler_Emit(t *testing.T) {
 		assert.Equal(t, expectedMessage, testClient.readMessageToClient())
 	})
 	t.Run("should execute the OnConnectionOpened event function", func(t *testing.T) {
+		t.Parallel()
 		counter := 0
 		testClient := NewTestClient(false)
 		eventHandler := NewTestGraphQLTransportWSEventHandler(testClient)
@@ -313,6 +343,7 @@ func TestGraphQLTransportWSEventHandler_Emit(t *testing.T) {
 		assert.Equal(t, counter, 1)
 	})
 	t.Run("should disconnect on duplicated subscriber id", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		eventHandler := NewTestGraphQLTransportWSEventHandler(testClient)
 		eventHandler.Emit(subscription.EventTypeOnDuplicatedSubscriberID, "1", nil, errors.New("subscriber already exists"))
@@ -321,7 +352,9 @@ func TestGraphQLTransportWSEventHandler_Emit(t *testing.T) {
 }
 
 func TestGraphQLTransportWSWriteEventHandler_HandleWriteEvent(t *testing.T) {
+	t.Parallel()
 	t.Run("should write connection_ack", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		writeEventHandler := NewTestGraphQLTransportWSEventHandler(testClient)
 		writeEventHandler.HandleWriteEvent(GraphQLTransportWSMessageTypeConnectionAck, "", nil, nil)
@@ -329,6 +362,7 @@ func TestGraphQLTransportWSWriteEventHandler_HandleWriteEvent(t *testing.T) {
 		assert.Equal(t, expectedMessage, testClient.readMessageToClient())
 	})
 	t.Run("should write ping", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		writeEventHandler := NewTestGraphQLTransportWSEventHandler(testClient)
 		writeEventHandler.HandleWriteEvent(GraphQLTransportWSMessageTypePing, "", nil, nil)
@@ -336,6 +370,7 @@ func TestGraphQLTransportWSWriteEventHandler_HandleWriteEvent(t *testing.T) {
 		assert.Equal(t, expectedMessage, testClient.readMessageToClient())
 	})
 	t.Run("should write pong", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		writeEventHandler := NewTestGraphQLTransportWSEventHandler(testClient)
 		writeEventHandler.HandleWriteEvent(GraphQLTransportWSMessageTypePong, "", nil, nil)
@@ -343,6 +378,7 @@ func TestGraphQLTransportWSWriteEventHandler_HandleWriteEvent(t *testing.T) {
 		assert.Equal(t, expectedMessage, testClient.readMessageToClient())
 	})
 	t.Run("should close connection on invalid type", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		writeEventHandler := NewTestGraphQLTransportWSEventHandler(testClient)
 		writeEventHandler.HandleWriteEvent(GraphQLTransportWSMessageType("invalid"), "", nil, nil)
@@ -351,7 +387,9 @@ func TestGraphQLTransportWSWriteEventHandler_HandleWriteEvent(t *testing.T) {
 }
 
 func TestProtocolGraphQLTransportWSHandler_Handle(t *testing.T) {
+	t.Parallel()
 	t.Run("should close connection when an unexpected message type is used", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		protocol := NewTestProtocolGraphQLTransportWSHandler(testClient)
 
@@ -367,7 +405,9 @@ func TestProtocolGraphQLTransportWSHandler_Handle(t *testing.T) {
 	})
 
 	t.Run("for connection_init", func(t *testing.T) {
+		t.Parallel()
 		t.Run("should time out if no connection_init message is sent", func(t *testing.T) {
+			t.Parallel()
 			if runtime.GOOS == "windows" {
 				t.Skip("this test fails on Windows due to different timings than unix, consider fixing it at some point")
 			}
@@ -383,6 +423,7 @@ func TestProtocolGraphQLTransportWSHandler_Handle(t *testing.T) {
 		})
 
 		t.Run("should close connection after multiple connection_init messages", func(t *testing.T) {
+			t.Parallel()
 			testClient := NewTestClient(false)
 			protocol := NewTestProtocolGraphQLTransportWSHandler(testClient)
 			protocol.connectionInitTimeOutDuration = 50 * time.Millisecond
@@ -434,6 +475,7 @@ func TestProtocolGraphQLTransportWSHandler_Handle(t *testing.T) {
 		})
 
 		t.Run("should not time out if connection_init message is sent before time out", func(t *testing.T) {
+			t.Parallel()
 			if runtime.GOOS == "windows" {
 				t.Skip("this test fails on Windows due to different timings than unix, consider fixing it at some point")
 			}
@@ -470,6 +512,7 @@ func TestProtocolGraphQLTransportWSHandler_Handle(t *testing.T) {
 	})
 
 	t.Run("should return pong on ping", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		protocol := NewTestProtocolGraphQLTransportWSHandler(testClient)
 
@@ -490,6 +533,7 @@ func TestProtocolGraphQLTransportWSHandler_Handle(t *testing.T) {
 	})
 
 	t.Run("should handle subscribe", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		protocol := NewTestProtocolGraphQLTransportWSHandler(testClient)
 
@@ -513,6 +557,7 @@ func TestProtocolGraphQLTransportWSHandler_Handle(t *testing.T) {
 	})
 
 	t.Run("should handle complete", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		protocol := NewTestProtocolGraphQLTransportWSHandler(testClient)
 
@@ -532,6 +577,7 @@ func TestProtocolGraphQLTransportWSHandler_Handle(t *testing.T) {
 	})
 
 	t.Run("should allow pong messages from client", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		protocol := NewTestProtocolGraphQLTransportWSHandler(testClient)
 
@@ -551,6 +597,7 @@ func TestProtocolGraphQLTransportWSHandler_Handle(t *testing.T) {
 	})
 
 	t.Run("should not panic on broken input", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		protocol := NewTestProtocolGraphQLTransportWSHandler(testClient)
 

--- a/execution/subscription/websocket/protocol_graphql_ws_test.go
+++ b/execution/subscription/websocket/protocol_graphql_ws_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestGraphQLWSMessageReader_Read(t *testing.T) {
+	t.Parallel()
 	data := []byte(`{ "id": "1", "type": "connection_init", "payload": { "headers": { "key": "value" } } }`)
 	expectedMessage := &GraphQLWSMessage{
 		Id:      "1",
@@ -33,7 +34,9 @@ func TestGraphQLWSMessageReader_Read(t *testing.T) {
 }
 
 func TestGraphQLWSMessageWriter_WriteData(t *testing.T) {
+	t.Parallel()
 	t.Run("should return error when error occurs on underlying call", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(true)
 		writer := GraphQLWSMessageWriter{
 			logger: abstractlogger.Noop{},
@@ -44,6 +47,7 @@ func TestGraphQLWSMessageWriter_WriteData(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("should successfully write message data to client", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		writer := GraphQLWSMessageWriter{
 			logger: abstractlogger.Noop{},
@@ -58,7 +62,9 @@ func TestGraphQLWSMessageWriter_WriteData(t *testing.T) {
 }
 
 func TestGraphQLWSMessageWriter_WriteComplete(t *testing.T) {
+	t.Parallel()
 	t.Run("should return error when error occurs on underlying call", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(true)
 		writer := GraphQLWSMessageWriter{
 			logger: abstractlogger.Noop{},
@@ -69,6 +75,7 @@ func TestGraphQLWSMessageWriter_WriteComplete(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("should successfully write complete message to client", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		writer := GraphQLWSMessageWriter{
 			logger: abstractlogger.Noop{},
@@ -83,7 +90,9 @@ func TestGraphQLWSMessageWriter_WriteComplete(t *testing.T) {
 }
 
 func TestGraphQLWSMessageWriter_WriteKeepAlive(t *testing.T) {
+	t.Parallel()
 	t.Run("should return error when error occurs on underlying call", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(true)
 		writer := GraphQLWSMessageWriter{
 			logger: abstractlogger.Noop{},
@@ -94,6 +103,7 @@ func TestGraphQLWSMessageWriter_WriteKeepAlive(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("should successfully write keep-alive (ka) message to client", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		writer := GraphQLWSMessageWriter{
 			logger: abstractlogger.Noop{},
@@ -108,7 +118,9 @@ func TestGraphQLWSMessageWriter_WriteKeepAlive(t *testing.T) {
 }
 
 func TestGraphQLWSMessageWriter_WriteTerminate(t *testing.T) {
+	t.Parallel()
 	t.Run("should return error when error occurs on underlying call", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(true)
 		writer := GraphQLWSMessageWriter{
 			logger: abstractlogger.Noop{},
@@ -119,6 +131,7 @@ func TestGraphQLWSMessageWriter_WriteTerminate(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("should successfully write terminate message to client", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		writer := GraphQLWSMessageWriter{
 			logger: abstractlogger.Noop{},
@@ -133,7 +146,9 @@ func TestGraphQLWSMessageWriter_WriteTerminate(t *testing.T) {
 }
 
 func TestGraphQLWSMessageWriter_WriteConnectionError(t *testing.T) {
+	t.Parallel()
 	t.Run("should return error when error occurs on underlying call", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(true)
 		writer := GraphQLWSMessageWriter{
 			logger: abstractlogger.Noop{},
@@ -144,6 +159,7 @@ func TestGraphQLWSMessageWriter_WriteConnectionError(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("should successfully write connection error message to client", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		writer := GraphQLWSMessageWriter{
 			logger: abstractlogger.Noop{},
@@ -158,7 +174,9 @@ func TestGraphQLWSMessageWriter_WriteConnectionError(t *testing.T) {
 }
 
 func TestGraphQLWSMessageWriter_WriteError(t *testing.T) {
+	t.Parallel()
 	t.Run("should return error when error occurs on underlying call", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(true)
 		writer := GraphQLWSMessageWriter{
 			logger: abstractlogger.Noop{},
@@ -170,6 +188,7 @@ func TestGraphQLWSMessageWriter_WriteError(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("should successfully write error message to client", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		writer := GraphQLWSMessageWriter{
 			logger: abstractlogger.Noop{},
@@ -185,7 +204,9 @@ func TestGraphQLWSMessageWriter_WriteError(t *testing.T) {
 }
 
 func TestGraphQLWSMessageWriter_WriteAck(t *testing.T) {
+	t.Parallel()
 	t.Run("should return error when error occurs on underlying call", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(true)
 		writer := GraphQLWSMessageWriter{
 			logger: abstractlogger.Noop{},
@@ -196,6 +217,7 @@ func TestGraphQLWSMessageWriter_WriteAck(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("should successfully write ack message to client", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		writer := GraphQLWSMessageWriter{
 			logger: abstractlogger.Noop{},
@@ -210,7 +232,9 @@ func TestGraphQLWSMessageWriter_WriteAck(t *testing.T) {
 }
 
 func TestGraphQLWSWriteEventHandler_Emit(t *testing.T) {
+	t.Parallel()
 	t.Run("should write on completed", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		writeEventHandler := NewTestGraphQLWSWriteEventHandler(testClient)
 		writeEventHandler.Emit(subscription.EventTypeOnSubscriptionCompleted, "1", nil, nil)
@@ -218,6 +242,7 @@ func TestGraphQLWSWriteEventHandler_Emit(t *testing.T) {
 		assert.Equal(t, expectedMessage, testClient.readMessageToClient())
 	})
 	t.Run("should write on data", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		writeEventHandler := NewTestGraphQLWSWriteEventHandler(testClient)
 		writeEventHandler.Emit(subscription.EventTypeOnSubscriptionData, "1", []byte(`{ "data": { "hello": "world" } }`), nil)
@@ -225,6 +250,7 @@ func TestGraphQLWSWriteEventHandler_Emit(t *testing.T) {
 		assert.Equal(t, expectedMessage, testClient.readMessageToClient())
 	})
 	t.Run("should write on error", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		writeEventHandler := NewTestGraphQLWSWriteEventHandler(testClient)
 		writeEventHandler.Emit(subscription.EventTypeOnError, "1", nil, errors.New("error occurred"))
@@ -232,6 +258,7 @@ func TestGraphQLWSWriteEventHandler_Emit(t *testing.T) {
 		assert.Equal(t, expectedMessage, testClient.readMessageToClient())
 	})
 	t.Run("should write on duplicated subscriber id", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		writeEventHandler := NewTestGraphQLWSWriteEventHandler(testClient)
 		writeEventHandler.Emit(subscription.EventTypeOnDuplicatedSubscriberID, "1", nil, subscription.ErrSubscriberIDAlreadyExists)
@@ -239,6 +266,7 @@ func TestGraphQLWSWriteEventHandler_Emit(t *testing.T) {
 		assert.Equal(t, expectedMessage, testClient.readMessageToClient())
 	})
 	t.Run("should write on connection_error", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		writeEventHandler := NewTestGraphQLWSWriteEventHandler(testClient)
 		writeEventHandler.Emit(subscription.EventTypeOnConnectionError, "", nil, errors.New("connection error occurred"))
@@ -246,6 +274,7 @@ func TestGraphQLWSWriteEventHandler_Emit(t *testing.T) {
 		assert.Equal(t, expectedMessage, testClient.readMessageToClient())
 	})
 	t.Run("should write on non-subscription execution result", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		writeEventHandler := NewTestGraphQLWSWriteEventHandler(testClient)
 		go func() {
@@ -265,7 +294,9 @@ func TestGraphQLWSWriteEventHandler_Emit(t *testing.T) {
 }
 
 func TestGraphQLWSWriteEventHandler_HandleWriteEvent(t *testing.T) {
+	t.Parallel()
 	t.Run("should write keep_alive", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		writeEventHandler := NewTestGraphQLWSWriteEventHandler(testClient)
 		writeEventHandler.HandleWriteEvent(GraphQLWSMessageTypeConnectionKeepAlive, "", nil, nil)
@@ -273,6 +304,7 @@ func TestGraphQLWSWriteEventHandler_HandleWriteEvent(t *testing.T) {
 		assert.Equal(t, expectedMessage, testClient.readMessageToClient())
 	})
 	t.Run("should write ack", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		writeEventHandler := NewTestGraphQLWSWriteEventHandler(testClient)
 		writeEventHandler.HandleWriteEvent(GraphQLWSMessageTypeConnectionAck, "", nil, nil)
@@ -282,7 +314,9 @@ func TestGraphQLWSWriteEventHandler_HandleWriteEvent(t *testing.T) {
 }
 
 func TestProtocolGraphQLWSHandler_Handle(t *testing.T) {
+	t.Parallel()
 	t.Run("should return connection_error when an unexpected message type is used", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		protocol := NewTestProtocolGraphQLWSHandler(testClient)
 
@@ -299,6 +333,7 @@ func TestProtocolGraphQLWSHandler_Handle(t *testing.T) {
 	})
 
 	t.Run("should terminate connections on connection_terminate from client", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		protocol := NewTestProtocolGraphQLWSHandler(testClient)
 
@@ -314,6 +349,7 @@ func TestProtocolGraphQLWSHandler_Handle(t *testing.T) {
 	})
 
 	t.Run("should init connection and respond with ack and ka", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		protocol := NewTestProtocolGraphQLWSHandler(testClient)
 		protocol.keepAliveInterval = 5 * time.Millisecond
@@ -340,6 +376,7 @@ func TestProtocolGraphQLWSHandler_Handle(t *testing.T) {
 	})
 
 	t.Run("should start an operation on start from client", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		protocol := NewTestProtocolGraphQLWSHandler(testClient)
 
@@ -355,6 +392,7 @@ func TestProtocolGraphQLWSHandler_Handle(t *testing.T) {
 	})
 
 	t.Run("should stop a subscription on stop from client", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		protocol := NewTestProtocolGraphQLWSHandler(testClient)
 
@@ -370,6 +408,7 @@ func TestProtocolGraphQLWSHandler_Handle(t *testing.T) {
 	})
 
 	t.Run("should not panic on broken input", func(t *testing.T) {
+		t.Parallel()
 		testClient := NewTestClient(false)
 		protocol := NewTestProtocolGraphQLWSHandler(testClient)
 

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
@@ -8393,21 +8393,18 @@ type testSubscriptionUpdater struct {
 func (t *testSubscriptionUpdater) AwaitUpdates(tt *testing.T, timeout time.Duration, count int) {
 	tt.Helper()
 
-	ticker := time.NewTicker(timeout)
-	defer ticker.Stop()
+	deadline := time.Now().Add(timeout)
 	for {
-		time.Sleep(10 * time.Millisecond)
-		select {
-		case <-ticker.C:
-			tt.Fatalf("timed out waiting for updates")
-		default:
-			t.mux.Lock()
-			if len(t.updates) == count {
-				t.mux.Unlock()
-				return
-			}
-			t.mux.Unlock()
+		t.mux.Lock()
+		got := len(t.updates)
+		t.mux.Unlock()
+		if got == count {
+			return
 		}
+		if time.Now().After(deadline) {
+			tt.Fatalf("timed out waiting for updates: got %d, want %d", got, count)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 
@@ -8435,21 +8432,18 @@ func (t *testSubscriptionUpdater) AwaitErrors(tt *testing.T, timeout time.Durati
 func (t *testSubscriptionUpdater) AwaitDone(tt *testing.T, timeout time.Duration) {
 	tt.Helper()
 
-	ticker := time.NewTicker(timeout)
-	defer ticker.Stop()
+	deadline := time.Now().Add(timeout)
 	for {
-		time.Sleep(10 * time.Millisecond)
-		select {
-		case <-ticker.C:
-			tt.Fatalf("timed out waiting for done")
-		default:
-			t.mux.Lock()
-			if t.done {
-				t.mux.Unlock()
-				return
-			}
-			t.mux.Unlock()
+		t.mux.Lock()
+		isDone := t.done
+		t.mux.Unlock()
+		if isDone {
+			return
 		}
+		if time.Now().After(deadline) {
+			tt.Fatalf("timed out waiting for done")
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 

--- a/v2/pkg/engine/resolve/inbound_request_singleflight_test.go
+++ b/v2/pkg/engine/resolve/inbound_request_singleflight_test.go
@@ -78,10 +78,8 @@ func TestInboundSingleFlight_FollowerReceivesLeaderError(t *testing.T) {
 	// The follower calls GetOrCreate which blocks on inflight.Done.
 	// We wait for followerCount to confirm it has entered before calling FinishErr.
 	var wg sync.WaitGroup
-	wg.Add(1)
 
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		followerCtx := NewContext(context.Background())
 		followerCtx.Request.ID = 2
 
@@ -89,7 +87,7 @@ func TestInboundSingleFlight_FollowerReceivesLeaderError(t *testing.T) {
 		if followerErr == nil {
 			t.Error("expected error from follower after leader FinishErr")
 		}
-	}()
+	})
 
 	// Poll until the follower has actually registered inside GetOrCreate.
 	deadline := time.After(3 * time.Second)

--- a/v2/pkg/engine/resolve/inbound_request_singleflight_test.go
+++ b/v2/pkg/engine/resolve/inbound_request_singleflight_test.go
@@ -37,7 +37,7 @@ func TestInboundSingleFlight_ConcurrentFollowerTimeout(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(numFollowers)
 
-	for i := 0; i < numFollowers; i++ {
+	for range numFollowers {
 		go func() {
 			defer wg.Done()
 			ctx, cancel := context.WithCancel(context.Background())

--- a/v2/pkg/engine/resolve/json_assert_test.go
+++ b/v2/pkg/engine/resolve/json_assert_test.go
@@ -1,0 +1,20 @@
+package resolve
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func compactJSONForAssert(t testing.TB, input string) string {
+	t.Helper()
+
+	var value any
+	err := json.Unmarshal([]byte(input), &value)
+	require.NoError(t, err)
+
+	normalized, err := json.Marshal(value)
+	require.NoError(t, err)
+	return string(normalized)
+}

--- a/v2/pkg/engine/resolve/loader_hooks_test.go
+++ b/v2/pkg/engine/resolve/loader_hooks_test.go
@@ -104,8 +104,7 @@ func TestLoaderHooks_FetchPipeline(t *testing.T) {
 	t.Run("Subgraph errors are available on resolve context when error propagation is disabled", func(t *testing.T) {
 
 		ctrl := gomock.NewController(t)
-		rCtx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		rCtx := t.Context()
 		r := New(rCtx, ResolverOptions{
 			MaxConcurrency:               1024,
 			Debug:                        false,

--- a/v2/pkg/engine/resolve/loader_test.go
+++ b/v2/pkg/engine/resolve/loader_test.go
@@ -1020,7 +1020,7 @@ func BenchmarkLoader_LoadGraphQLResponseData(b *testing.B) {
 	b.SetBytes(int64(len(expected)))
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		loader.Free()
 		resolvable.Reset()
 		err := resolvable.Init(ctx, nil, ast.OperationTypeQuery)
@@ -1521,8 +1521,11 @@ func TestRewriteErrorPaths(t *testing.T) {
 			for i, expectedError := range tc.expectedErrors {
 				expectedData := expectedError.MarshalTo(nil)
 				actualData := values[i].MarshalTo(nil)
-				assert.JSONEq(t, string(expectedData), string(actualData),
-					"Error %d should match expected", i)
+				assert.Equal(t,
+					compactJSONForAssert(t, string(expectedData)),
+					compactJSONForAssert(t, string(actualData)),
+					"Error %d should match expected", i,
+				)
 			}
 		})
 	}
@@ -2094,7 +2097,7 @@ func TestLoader_OptionallyOmitErrorLocations(t *testing.T) {
 			actualJSON := inputValue.MarshalTo(nil)
 
 			// Compare with expected
-			assert.JSONEq(t, tt.expectedJSON, string(actualJSON))
+			assert.Equal(t, compactJSONForAssert(t, tt.expectedJSON), compactJSONForAssert(t, string(actualJSON)))
 		})
 	}
 }

--- a/v2/pkg/engine/resolve/loader_test.go
+++ b/v2/pkg/engine/resolve/loader_test.go
@@ -1495,7 +1495,6 @@ func TestRewriteErrorPaths(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc // capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			// Create FetchItem with the test response path elements
 			fetchItem := &FetchItem{

--- a/v2/pkg/engine/resolve/resolvable_test.go
+++ b/v2/pkg/engine/resolve/resolvable_test.go
@@ -827,7 +827,7 @@ func BenchmarkResolvable_Resolve(b *testing.B) {
 	b.SetBytes(int64(len(expected)))
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		out.Reset()
 		err = res.Resolve(context.Background(), object, nil, out)
 		if err != nil {
@@ -913,7 +913,7 @@ func BenchmarkResolvable_ResolveWithErrorBubbleUp(b *testing.B) {
 	b.SetBytes(int64(len(expected)))
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		out.Reset()
 		err = res.Resolve(context.Background(), object, nil, out)
 		if err != nil {

--- a/v2/pkg/engine/resolve/resolve_arena_gc_test.go
+++ b/v2/pkg/engine/resolve/resolve_arena_gc_test.go
@@ -21,7 +21,7 @@ import (
 // keeping an object alive, the GC will collect it and subsequent access will
 // SIGSEGV or return corrupted data.
 func forceGC() {
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		runtime.GC()
 	}
 }
@@ -48,7 +48,7 @@ func newTestResolver(t *testing.T, opts ResolverOptions) *Resolver {
 func resolveWithGCPressure(t *testing.T, resolver *Resolver, setupCtx func() *Context, setupResp func() *GraphQLResponse) string {
 	t.Helper()
 	var lastOutput string
-	for i := 0; i < gcIterations; i++ {
+	for i := range gcIterations {
 		response := setupResp()
 		resolveCtx := setupCtx()
 		forceGC()
@@ -72,8 +72,7 @@ func TestArenaGCSafety_FetchError(t *testing.T) {
 			return resp
 		},
 	)
-	assert.Contains(t, output, `"errors"`)
-	assert.Contains(t, output, `"data"`)
+	assert.Equal(t, `{"errors":[{"message":"Failed to fetch from Subgraph 'testService' at Path 'query'."}],"data":{"field":null}}`, output)
 }
 
 func TestArenaGCSafety_EmptyResponse(t *testing.T) {
@@ -85,7 +84,7 @@ func TestArenaGCSafety_EmptyResponse(t *testing.T) {
 			return resp
 		},
 	)
-	assert.Contains(t, output, `"errors"`)
+	assert.Equal(t, `{"errors":[{"message":"Failed to fetch from Subgraph 'testService' at Path 'query', Reason: empty response."}],"data":{"field":null}}`, output)
 }
 
 func TestArenaGCSafety_InvalidJSON(t *testing.T) {
@@ -97,7 +96,7 @@ func TestArenaGCSafety_InvalidJSON(t *testing.T) {
 			return resp
 		},
 	)
-	assert.Contains(t, output, `"errors"`)
+	assert.Equal(t, `{"errors":[{"message":"Failed to fetch from Subgraph 'testService' at Path 'query', Reason: invalid JSON."}],"data":{"field":null}}`, output)
 }
 
 func TestArenaGCSafety_InvalidShape(t *testing.T) {
@@ -109,7 +108,7 @@ func TestArenaGCSafety_InvalidShape(t *testing.T) {
 			return resp
 		},
 	)
-	assert.Contains(t, output, `"errors"`)
+	assert.Equal(t, `{"errors":[{"message":"Failed to fetch from Subgraph 'testService' at Path 'query', Reason: no data or errors in response."}],"data":{"field":null}}`, output)
 }
 
 func TestArenaGCSafety_SubgraphErrorsWrapMode(t *testing.T) {
@@ -121,7 +120,7 @@ func TestArenaGCSafety_SubgraphErrorsWrapMode(t *testing.T) {
 			return resp
 		},
 	)
-	assert.Contains(t, output, `"errors"`)
+	assert.Equal(t, `{"errors":[{"message":"Failed to fetch from Subgraph 'testService' at Path 'query'.","extensions":{"errors":[{"message":"downstream error"}]}}],"data":{"field":null}}`, output)
 }
 
 func TestArenaGCSafety_SubgraphErrorsPassthrough(t *testing.T) {
@@ -135,8 +134,7 @@ func TestArenaGCSafety_SubgraphErrorsPassthrough(t *testing.T) {
 			return resp
 		},
 	)
-	assert.Contains(t, output, `"errors"`)
-	assert.Contains(t, output, `downstream error`)
+	assert.Equal(t, `{"errors":[{"message":"downstream error"}],"data":{"field":null}}`, output)
 }
 
 func TestArenaGCSafety_SubgraphErrorsWithExtensionCode(t *testing.T) {
@@ -152,8 +150,7 @@ func TestArenaGCSafety_SubgraphErrorsWithExtensionCode(t *testing.T) {
 		},
 	)
 	// The extension code is set on errors; verify the output is valid
-	assert.Contains(t, output, `"errors"`)
-	assert.Contains(t, output, `downstream error`)
+	assert.Equal(t, `{"errors":[{"message":"downstream error"}],"data":{"field":null}}`, output)
 }
 
 func TestArenaGCSafety_SubgraphErrorsWithServiceName(t *testing.T) {
@@ -168,7 +165,7 @@ func TestArenaGCSafety_SubgraphErrorsWithServiceName(t *testing.T) {
 			return resp
 		},
 	)
-	assert.Contains(t, output, `testService`)
+	assert.Equal(t, `{"errors":[{"message":"downstream error","extensions":{"serviceName":"testService"}}],"data":{"field":null}}`, output)
 }
 
 func TestArenaGCSafety_SubgraphErrorsWithExtensionCodeAndServiceName(t *testing.T) {
@@ -184,8 +181,7 @@ func TestArenaGCSafety_SubgraphErrorsWithExtensionCodeAndServiceName(t *testing.
 			return resp
 		},
 	)
-	assert.Contains(t, output, `"errors"`)
-	assert.Contains(t, output, `testService`)
+	assert.Equal(t, `{"errors":[{"message":"downstream error","extensions":{"serviceName":"testService"}}],"data":{"field":null}}`, output)
 }
 
 func TestArenaGCSafety_AuthorizationRejected(t *testing.T) {
@@ -209,8 +205,7 @@ func TestArenaGCSafety_AuthorizationRejected(t *testing.T) {
 			return resp
 		},
 	)
-	assert.Contains(t, output, `"errors"`)
-	assert.Contains(t, output, `Unauthorized`)
+	assert.Equal(t, `{"errors":[{"message":"Unauthorized request to Subgraph 'testService' at Path 'query', Reason: not allowed.","extensions":{"code":"UNAUTHORIZED_FIELD_OR_TYPE"}}],"data":{"field":null}}`, output)
 }
 
 func TestArenaGCSafety_RateLimitRejected(t *testing.T) {
@@ -231,8 +226,7 @@ func TestArenaGCSafety_RateLimitRejected(t *testing.T) {
 			return resp
 		},
 	)
-	assert.Contains(t, output, `"errors"`)
-	assert.Contains(t, output, `Rate limit`)
+	assert.Equal(t, `{"errors":[{"message":"Rate limit exceeded for Subgraph 'testService' at Path 'query', Reason: rate limit exceeded."}],"data":{"field":null}}`, output)
 }
 
 func TestArenaGCSafety_RateLimitWithExtensionCode(t *testing.T) {
@@ -256,7 +250,7 @@ func TestArenaGCSafety_RateLimitWithExtensionCode(t *testing.T) {
 			return resp
 		},
 	)
-	assert.Contains(t, output, `RATE_LIMIT_EXCEEDED`)
+	assert.Equal(t, `{"errors":[{"message":"Rate limit exceeded for Subgraph 'testService' at Path 'query', Reason: rate limit exceeded.","extensions":{"code":"RATE_LIMIT_EXCEEDED"}}],"data":{"field":null}}`, output)
 }
 
 // --- Successful data merge tests ---
@@ -270,8 +264,7 @@ func TestArenaGCSafety_MergeResult(t *testing.T) {
 			return resp
 		},
 	)
-	assert.Contains(t, output, `hello world`)
-	assert.NotContains(t, output, `"errors"`)
+	assert.Equal(t, `{"data":{"field":"hello world"}}`, output)
 }
 
 // --- Resolvable SetNull path tests ---
@@ -322,7 +315,7 @@ func TestArenaGCSafety_NullableFieldNull(t *testing.T) {
 			}
 		},
 	)
-	assert.Contains(t, output, `"obj":null`)
+	assert.Equal(t, `{"data":{"obj":null}}`, output)
 }
 
 func TestArenaGCSafety_NonNullableFieldNull(t *testing.T) {
@@ -375,8 +368,7 @@ func TestArenaGCSafety_NonNullableFieldNull(t *testing.T) {
 		},
 	)
 	// The non-nullable field being null should bubble up to null the wrapper object
-	assert.Contains(t, output, `"wrapper":null`)
-	assert.Contains(t, output, `"errors"`)
+	assert.Equal(t, `{"errors":[{"message":"Cannot return null for non-nullable field 'Query.wrapper.name'.","path":["wrapper","name"]}],"data":{"wrapper":null}}`, output)
 }
 
 // --- Authorization skip errors (TrueValue) test ---
@@ -447,8 +439,7 @@ func TestArenaGCSafety_AuthRejectionNullableField(t *testing.T) {
 			}
 		},
 	)
-	assert.Contains(t, output, `"name"`)
-	assert.Contains(t, output, `"data"`)
+	assert.Equal(t, `{"data":{"user":{"name":"Alice","secret":"classified"}}}`, output)
 }
 
 // --- Nested fetch tree tests ---
@@ -515,8 +506,7 @@ func TestArenaGCSafety_SequenceWithErrorThenSuccess(t *testing.T) {
 			}
 		},
 	)
-	assert.Contains(t, output, `first fetch failed`)
-	assert.Contains(t, output, `ok`)
+	assert.Equal(t, `{"errors":[{"message":"first fetch failed"}],"data":{"field":null,"other":"ok"}}`, output)
 }
 
 func TestArenaGCSafety_ParallelFetches(t *testing.T) {
@@ -590,8 +580,7 @@ func TestArenaGCSafety_ParallelFetches(t *testing.T) {
 			}
 		},
 	)
-	assert.Contains(t, output, `Bob`)
-	assert.Contains(t, output, `Widget`)
+	assert.Equal(t, `{"data":{"user":{"name":"Bob"},"product":{"title":"Widget"}}}`, output)
 }
 
 // --- Array nullability tests (SetNull for arrays) ---
@@ -641,7 +630,7 @@ func TestArenaGCSafety_NullableArrayWithNullItem(t *testing.T) {
 		},
 	)
 	// Non-nullable item being null should propagate to null the nullable array
-	assert.Contains(t, output, `"items":null`)
+	assert.Equal(t, `{"errors":[{"message":"Cannot return null for non-nullable field 'Query.items'.","path":["items",0]}],"data":{"items":null}}`, output)
 }
 
 // --- Mixed success and error responses ---
@@ -660,8 +649,7 @@ func TestArenaGCSafety_PartialDataWithErrors(t *testing.T) {
 			return resp
 		},
 	)
-	assert.Contains(t, output, `partial value`)
-	assert.Contains(t, output, `partial failure`)
+	assert.Equal(t, `{"errors":[{"message":"partial failure","path":["field"]}],"data":{"field":"partial value"}}`, output)
 }
 
 // --- Large/stress tests ---
@@ -674,7 +662,7 @@ func TestArenaGCSafety_ManyErrors(t *testing.T) {
 
 	// Build a response with 20 errors
 	var errMsgs []string
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		errMsgs = append(errMsgs, `{"message":"error `+strings.Repeat("x", 100)+`"}`)
 	}
 	errorsJSON := "[" + strings.Join(errMsgs, ",") + "]"
@@ -686,7 +674,7 @@ func TestArenaGCSafety_ManyErrors(t *testing.T) {
 			return resp
 		},
 	)
-	assert.Contains(t, output, `"errors"`)
+	assert.Equal(t, `{"errors":[{"message":"error xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},{"message":"error xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},{"message":"error xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},{"message":"error xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},{"message":"error xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},{"message":"error xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},{"message":"error xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},{"message":"error xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},{"message":"error xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},{"message":"error xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},{"message":"error xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},{"message":"error xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},{"message":"error xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},{"message":"error xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},{"message":"error xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},{"message":"error xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},{"message":"error xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},{"message":"error xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},{"message":"error xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},{"message":"error xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}],"data":{"field":null}}`, output)
 }
 
 // --- Verify JSON validity ---
@@ -722,14 +710,14 @@ func TestArenaGCSafety_OutputIsValidJSON(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			resolver := newTestResolver(t, tc.opts)
-			for i := 0; i < gcIterations; i++ {
+			for i := range gcIterations {
 				resp, _ := gcTestResponse(FakeDataSource(tc.data))
 				ctx := NewContext(context.Background())
 				forceGC()
 				buf := &bytes.Buffer{}
 				_, err := resolver.ArenaResolveGraphQLResponse(ctx, resp, buf)
 				require.NoError(t, err)
-				var parsed map[string]interface{}
+				var parsed map[string]any
 				require.NoError(t, json.Unmarshal(buf.Bytes(), &parsed), "invalid JSON on iteration %d: %s", i, buf.String())
 			}
 		})
@@ -785,8 +773,7 @@ func TestArenaGCSafety_StatusCodeFallback(t *testing.T) {
 			return resp
 		},
 	)
-	assert.Contains(t, output, `"errors"`)
-	assert.Contains(t, output, `503`)
+	assert.Equal(t, `{"errors":[{"message":"503: Service Unavailable","extensions":{"statusCode":503}}],"data":{"field":null}}`, output)
 }
 
 func TestArenaGCSafety_ApolloRouterCompatError(t *testing.T) {
@@ -805,7 +792,7 @@ func TestArenaGCSafety_ApolloRouterCompatError(t *testing.T) {
 			return resp
 		},
 	)
-	assert.Contains(t, output, `SUBREQUEST_HTTP_ERROR`)
+	assert.Equal(t, `{"errors":[{"message":"HTTP fetch failed from 'testService': 500: Internal Server Error","path":[],"extensions":{"code":"SUBREQUEST_HTTP_ERROR","service":"testService","reason":"500: Internal Server Error","http":{"status":500}}},{"message":"bad","extensions":{"statusCode":500}}],"data":{"field":null}}`, output)
 }
 
 func TestArenaGCSafety_SubgraphStatusCodeInExtensions(t *testing.T) {
@@ -823,8 +810,7 @@ func TestArenaGCSafety_SubgraphStatusCodeInExtensions(t *testing.T) {
 			return resp
 		},
 	)
-	assert.Contains(t, output, `"statusCode"`)
-	assert.Contains(t, output, `502`)
+	assert.Equal(t, `{"errors":[{"message":"fail","extensions":{"statusCode":502}}],"data":{"field":null}}`, output)
 }
 
 // --- Group B: Loader error filtering codepaths ---
@@ -842,8 +828,7 @@ func TestArenaGCSafety_OmitErrorExtensions(t *testing.T) {
 			return resp
 		},
 	)
-	assert.Contains(t, output, `"errors"`)
-	assert.NotContains(t, output, `"extensions"`)
+	assert.Equal(t, `{"errors":[{"message":"err"}],"data":{"field":null}}`, output)
 }
 
 func TestArenaGCSafety_OmitErrorLocations(t *testing.T) {
@@ -858,7 +843,7 @@ func TestArenaGCSafety_OmitErrorLocations(t *testing.T) {
 			return resp
 		},
 	)
-	assert.Contains(t, output, `"locations"`)
+	assert.Equal(t, `{"errors":[{"message":"err","locations":[{"line":1,"column":2}]}],"data":{"field":null}}`, output)
 }
 
 func TestArenaGCSafety_OmitAllErrorLocations(t *testing.T) {
@@ -890,8 +875,7 @@ func TestArenaGCSafety_AllowedExtensionFields(t *testing.T) {
 			return resp
 		},
 	)
-	assert.Contains(t, output, `"code"`)
-	assert.NotContains(t, output, `"secret"`)
+	assert.Equal(t, `{"errors":[{"message":"err","extensions":{"code":"X"}}],"data":{"field":null}}`, output)
 }
 
 func TestArenaGCSafety_WrapModeWithPropagation(t *testing.T) {
@@ -907,8 +891,7 @@ func TestArenaGCSafety_WrapModeWithPropagation(t *testing.T) {
 			return resp
 		},
 	)
-	assert.Contains(t, output, `"errors"`)
-	assert.Contains(t, output, `inner`)
+	assert.Equal(t, `{"errors":[{"message":"Failed to fetch from Subgraph 'testService' at Path 'query'.","extensions":{"errors":[{"message":"inner"}]}}],"data":{"field":null}}`, output)
 }
 
 // --- Group C: Resolvable scalar walk functions ---
@@ -925,8 +908,7 @@ func TestArenaGCSafety_BooleanField(t *testing.T) {
 			)
 		},
 	)
-	assert.Contains(t, output, `true`)
-	assert.NotContains(t, output, `"errors"`)
+	assert.Equal(t, `{"data":{"active":true}}`, output)
 }
 
 func TestArenaGCSafety_IntegerField(t *testing.T) {
@@ -941,7 +923,7 @@ func TestArenaGCSafety_IntegerField(t *testing.T) {
 			)
 		},
 	)
-	assert.Contains(t, output, `42`)
+	assert.Equal(t, `{"data":{"count":42}}`, output)
 }
 
 func TestArenaGCSafety_FloatField(t *testing.T) {
@@ -956,7 +938,7 @@ func TestArenaGCSafety_FloatField(t *testing.T) {
 			)
 		},
 	)
-	assert.Contains(t, output, `9.99`)
+	assert.Equal(t, `{"data":{"price":9.99}}`, output)
 }
 
 func TestArenaGCSafety_FloatTruncation(t *testing.T) {
@@ -975,7 +957,7 @@ func TestArenaGCSafety_FloatTruncation(t *testing.T) {
 		},
 	)
 	// Whole-number float should be truncated to int representation
-	assert.Contains(t, output, `"price":10`)
+	assert.Equal(t, `{"data":{"price":10}}`, output)
 }
 
 func TestArenaGCSafety_BigIntField(t *testing.T) {
@@ -990,7 +972,7 @@ func TestArenaGCSafety_BigIntField(t *testing.T) {
 			)
 		},
 	)
-	assert.Contains(t, output, `9007199254740993`)
+	assert.Equal(t, `{"data":{"id":9007199254740993}}`, output)
 }
 
 func TestArenaGCSafety_ScalarField(t *testing.T) {
@@ -1005,7 +987,7 @@ func TestArenaGCSafety_ScalarField(t *testing.T) {
 			)
 		},
 	)
-	assert.Contains(t, output, `"key"`)
+	assert.Equal(t, `{"data":{"meta":{"key":"value"}}}`, output)
 }
 
 func TestArenaGCSafety_EnumValid(t *testing.T) {
@@ -1020,7 +1002,7 @@ func TestArenaGCSafety_EnumValid(t *testing.T) {
 			)
 		},
 	)
-	assert.Contains(t, output, `"ACTIVE"`)
+	assert.Equal(t, `{"data":{"status":"ACTIVE"}}`, output)
 }
 
 func TestArenaGCSafety_EnumInvalid(t *testing.T) {
@@ -1036,7 +1018,7 @@ func TestArenaGCSafety_EnumInvalid(t *testing.T) {
 			)
 		},
 	)
-	assert.Contains(t, output, `"errors"`)
+	assert.Equal(t, `{"errors":[{"message":"Enum \"Status\" cannot represent value: \"UNKNOWN\"","path":["status"],"extensions":{"code":"INTERNAL_SERVER_ERROR"}}],"data":{"status":null}}`, output)
 }
 
 func TestArenaGCSafety_StringUnescapeResponseJson(t *testing.T) {
@@ -1052,7 +1034,7 @@ func TestArenaGCSafety_StringUnescapeResponseJson(t *testing.T) {
 			)
 		},
 	)
-	assert.Contains(t, output, `nested`)
+	assert.Equal(t, `{"data":{"payload":{"nested":"value"}}}`, output)
 }
 
 func TestArenaGCSafety_CustomNode(t *testing.T) {
@@ -1068,7 +1050,7 @@ func TestArenaGCSafety_CustomNode(t *testing.T) {
 			)
 		},
 	)
-	assert.Contains(t, output, `"hello"`)
+	assert.Equal(t, `{"data":{"custom":"hello"}}`, output)
 }
 
 func TestArenaGCSafety_ArrayObjectItemWalkFail(t *testing.T) {
@@ -1121,8 +1103,7 @@ func TestArenaGCSafety_ArrayObjectItemWalkFail(t *testing.T) {
 			}
 		},
 	)
-	assert.Contains(t, output, `"ok"`)
-	assert.Contains(t, output, `null`)
+	assert.Equal(t, `{"errors":[{"message":"Cannot return null for non-nullable field 'Query.items.name'.","path":["items",1,"name"]}],"data":{"items":[{"name":"ok"},null]}}`, output)
 }
 
 func TestArenaGCSafety_ValueCompletion(t *testing.T) {
@@ -1174,8 +1155,7 @@ func TestArenaGCSafety_ValueCompletion(t *testing.T) {
 			}
 		},
 	)
-	assert.Contains(t, output, `"extensions"`)
-	assert.Contains(t, output, `"valueCompletion"`)
+	assert.Equal(t, `{"data":{"wrapper":null},"extensions":{"valueCompletion":[{"message":"Cannot return null for non-nullable field .required.","path":["wrapper","required"],"extensions":{"code":"INVALID_GRAPHQL"}}]}}`, output)
 }
 
 // --- Group D: Type-mismatch error paths ---
@@ -1193,7 +1173,7 @@ func TestArenaGCSafety_BooleanTypeMismatch(t *testing.T) {
 			)
 		},
 	)
-	assert.Contains(t, output, `"errors"`)
+	assert.Equal(t, `{"errors":[{"message":"Bool cannot represent non-boolean value: \"\"not_a_bool\"\"","path":["active"]}],"data":null}`, output)
 }
 
 func TestArenaGCSafety_IntegerTypeMismatch(t *testing.T) {
@@ -1208,7 +1188,7 @@ func TestArenaGCSafety_IntegerTypeMismatch(t *testing.T) {
 			)
 		},
 	)
-	assert.Contains(t, output, `"errors"`)
+	assert.Equal(t, `{"errors":[{"message":"Int cannot represent non-integer value: \"\"not_a_number\"\"","path":["count"]}],"data":null}`, output)
 }
 
 func TestArenaGCSafety_FloatTypeMismatch(t *testing.T) {
@@ -1223,7 +1203,7 @@ func TestArenaGCSafety_FloatTypeMismatch(t *testing.T) {
 			)
 		},
 	)
-	assert.Contains(t, output, `"errors"`)
+	assert.Equal(t, `{"errors":[{"message":"Float cannot represent non-float value: \"\"not_a_float\"\"","path":["price"]}],"data":null}`, output)
 }
 
 func TestArenaGCSafety_StringTypeMismatch(t *testing.T) {
@@ -1238,5 +1218,5 @@ func TestArenaGCSafety_StringTypeMismatch(t *testing.T) {
 			)
 		},
 	)
-	assert.Contains(t, output, `"errors"`)
+	assert.Equal(t, `{"errors":[{"message":"String cannot represent non-string value: \"123\"","path":["name"]}],"data":null}`, output)
 }

--- a/v2/pkg/engine/resolve/resolve_arena_gc_test.go
+++ b/v2/pkg/engine/resolve/resolve_arena_gc_test.go
@@ -859,7 +859,7 @@ func TestArenaGCSafety_OmitAllErrorLocations(t *testing.T) {
 			return resp
 		},
 	)
-	assert.NotContains(t, output, `"locations"`)
+	assert.Equal(t, `{"errors":[{"message":"err"}],"data":{"field":null}}`, output)
 }
 
 func TestArenaGCSafety_AllowedExtensionFields(t *testing.T) {

--- a/v2/pkg/engine/resolve/resolve_federation_test.go
+++ b/v2/pkg/engine/resolve/resolve_federation_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 type TestingTB interface {
-	Errorf(format string, args ...interface{})
+	Errorf(format string, args ...any)
 	Helper()
 	FailNow()
 }

--- a/v2/pkg/engine/resolve/resolve_mock_test.go
+++ b/v2/pkg/engine/resolve/resolve_mock_test.go
@@ -46,7 +46,7 @@ func (m *MockDataSource) Load(arg0 context.Context, arg1 http.Header, arg2 []byt
 }
 
 // Load indicates an expected call of Load.
-func (mr *MockDataSourceMockRecorder) Load(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockDataSourceMockRecorder) Load(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Load", reflect.TypeOf((*MockDataSource)(nil).Load), arg0, arg1, arg2)
 }
@@ -61,7 +61,7 @@ func (m *MockDataSource) LoadWithFiles(arg0 context.Context, arg1 http.Header, a
 }
 
 // LoadWithFiles indicates an expected call of LoadWithFiles.
-func (mr *MockDataSourceMockRecorder) LoadWithFiles(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockDataSourceMockRecorder) LoadWithFiles(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadWithFiles", reflect.TypeOf((*MockDataSource)(nil).LoadWithFiles), arg0, arg1, arg2, arg3)
 }

--- a/v2/pkg/engine/resolve/subgraph_request_singleflight_test.go
+++ b/v2/pkg/engine/resolve/subgraph_request_singleflight_test.go
@@ -178,8 +178,8 @@ func TestSubgraphRequestSingleFlight_SizeHintRollingWindow(t *testing.T) {
 	fetchItem := newFetchItem(fetchInfo)
 
 	var fetchKey uint64
-	for i := 0; i < 50; i++ {
-		item, shared := flight.GetOrCreateItem(fetchItem, []byte(fmt.Sprintf("body-%d", i)), 0)
+	for i := range 50 {
+		item, shared := flight.GetOrCreateItem(fetchItem, fmt.Appendf(nil, "body-%d", i), 0)
 		if shared {
 			t.Fatalf("expected leader for iteration %d", i)
 		}

--- a/v2/pkg/engine/resolve/tainted_objects_test.go
+++ b/v2/pkg/engine/resolve/tainted_objects_test.go
@@ -13,56 +13,56 @@ func TestSelectObjectAndIndex(t *testing.T) {
 	tests := []struct {
 		name           string
 		responseJSON   string
-		pathElements   []interface{} // Can be strings or numbers
-		expectedEntity string        // JSON string of expected entity, or "nil" for nil
+		pathElements   []any  // Can be strings or numbers
+		expectedEntity string // JSON string of expected entity, or "nil" for nil
 		expectedIndex  int
 	}{
 		{
 			name:           "complex federation-like structure",
 			responseJSON:   `[{"__typename": "User", "id": "1", "name": "John"}, {"__typename": "User", "id": "2", "name": null}]`,
-			pathElements:   []interface{}{1},
+			pathElements:   []any{1},
 			expectedEntity: `{"__typename": "User", "id": "2", "name": null}`,
 			expectedIndex:  1,
 		},
 		{
 			name:           "mixed path with number then string",
 			responseJSON:   `[{"user": {"name": "John"}}, {"user": {"name": "Jane"}}]`,
-			pathElements:   []interface{}{1, "user"},
+			pathElements:   []any{1, "user"},
 			expectedEntity: `{"name": "Jane"}`,
 			expectedIndex:  1,
 		},
 		{
 			name:           "multiple numbers in path",
 			responseJSON:   `[[{"name": "A"}, {"name": "B"}], [{"name": "C"}, {"name": "D"}]]`,
-			pathElements:   []interface{}{1, 0},
+			pathElements:   []any{1, 0},
 			expectedEntity: `{"name": "C"}`,
 			expectedIndex:  1,
 		},
 		{
 			name:           "path leads to non-existent key",
 			responseJSON:   `[{"user": {"name": "John"}}]`,
-			pathElements:   []interface{}{0, "user", "nonexistent"},
+			pathElements:   []any{0, "user", "nonexistent"},
 			expectedEntity: "nil",
 			expectedIndex:  -1,
 		},
 		{
 			name:           "negative index is an error",
 			responseJSON:   `[{"name": "A"}, {"name": "negative"}]`,
-			pathElements:   []interface{}{-2},
+			pathElements:   []any{-2},
 			expectedEntity: "nil",
 			expectedIndex:  -1,
 		},
 		{
 			name:           "out of bound index is an error",
 			responseJSON:   `[{"name": "A"}, {"name": "negative"}]`,
-			pathElements:   []interface{}{9},
+			pathElements:   []any{9},
 			expectedEntity: "nil",
 			expectedIndex:  -1,
 		},
 		{
 			name:           "empty path is an error",
 			responseJSON:   `[{"name": "A"}, {"name": "negative"}]`,
-			pathElements:   []interface{}{},
+			pathElements:   []any{},
 			expectedEntity: "nil",
 			expectedIndex:  -1,
 		},
@@ -97,10 +97,15 @@ func TestSelectObjectAndIndex(t *testing.T) {
 				expectedEntity, err := astjson.ParseBytes([]byte(tt.expectedEntity))
 				assert.NoError(t, err, "Failed to parse expected entity JSON")
 
-				// Compare JSON representations
+				// Compare the full entity shape with canonical JSON so object key order
+				// differences do not hide value regressions.
 				actualJSON := entity.MarshalTo(nil)
 				expectedJSON := expectedEntity.MarshalTo(nil)
-				assert.JSONEq(t, string(expectedJSON), string(actualJSON), "Entity content mismatch")
+				assert.Equal(t,
+					compactJSONForAssert(t, string(expectedJSON)),
+					compactJSONForAssert(t, string(actualJSON)),
+					"Entity content mismatch",
+				)
 			}
 		})
 	}


### PR DESCRIPTION
I have started slow work of extracting improvements 
from the [Entity caching PR](https://github.com/wundergraph/graphql-go-tools/pull/1259/) where it was possible. 