### PR TITLE
feat: Apollo-compatible null variable handling and abstract type cost defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pkg/parser/testdata/lotto.graphql
 *node_modules*
 *vendor*
 .serena
+.omc/

--- a/execution/engine/execution_engine_cost_test.go
+++ b/execution/engine/execution_engine_cost_test.go
@@ -243,8 +243,8 @@ func TestExecutionEngine_Cost(t *testing.T) {
 					),
 				},
 				expectedResponse:      `{"data":{"hero":{"name":"Luke Skywalker","height":"12"}}}`,
-				expectedEstimatedCost: intPtr(22), // Query.hero (2) + Human.height (3) + Droid.name (17=max(7, 17))
-				expectedActualCost:    intPtr(22),
+				expectedEstimatedCost: intPtr(5), // Query.hero (2) + Human.height (3) — name uses scalar default (0) not max across impls
+				expectedActualCost:    intPtr(5),
 			},
 			computeCosts(),
 		))
@@ -405,9 +405,8 @@ func TestExecutionEngine_Cost(t *testing.T) {
 					),
 				},
 				expectedResponse:      `{"data":{"hero":{"name":"Luke Skywalker"}}}`,
-				expectedEstimatedCost: intPtr(30), // Query.Human (13) + Droid.name (17=max(7, 17))
-				// name is interface so the actual cost is taken as max
-				expectedActualCost: intPtr(30),
+				expectedEstimatedCost: intPtr(13), // Query.Human (13) — name uses scalar default (0) not max across impls
+				expectedActualCost:    intPtr(13),
 			},
 			computeCosts(),
 		))
@@ -514,7 +513,7 @@ func TestExecutionEngine_Cost(t *testing.T) {
 					),
 				},
 				expectedResponse:      `{"data":{"hero":{"friends":[{"name":"Luke Skywalker","height":"12"},{"name":"R2DO","primaryFunction":"joke"}]}}}`,
-				expectedEstimatedCost: intPtr(207), // max(7,5)+ 20 * (7 + max(2,2+1))
+				expectedEstimatedCost: intPtr(107), // hero(max(7,5)) + defaultListSize(10) * (max(7,5) + 0 + 0) — fields inside abstract use scalar default
 				expectedActualCost:    intPtr(24),  // hero(7) +  2 * (6 + 0.5*(2+0+2+1))
 			},
 			computeCosts(),
@@ -572,8 +571,8 @@ func TestExecutionEngine_Cost(t *testing.T) {
 					),
 				},
 				expectedResponse:      `{"data":{"hero":{"friends":[{"name":"Luke Skywalker","height":"12"},{"name":"R2DO","primaryFunction":"joke"}]}}}`,
-				expectedEstimatedCost: intPtr(147), // hero(max(7,5))+ 20 * (4+max(2, 2+1))
-				expectedActualCost:    intPtr(20),  // hero(7)       +  2 * (4+0.5*(2+2+1))
+				expectedEstimatedCost: intPtr(107), // hero(max(7,5)) + defaultListSize(10) * (max(4,4) + 0 + 0) — fields inside abstract use scalar default
+				expectedActualCost:    intPtr(24),  // hero(7) + 2 * (4 + 0.5*(2+2+1))
 			},
 			computeCosts(),
 		))
@@ -780,12 +779,13 @@ func TestExecutionEngine_Cost(t *testing.T) {
 				expectedResponse: `{"data":{"hero":{"name":"Luke","friends":[{"name":"Leia"}]}}}`,
 				// Cost calculation:
 				// Query.hero: 2
-				// Character.name: max(Human.name=3, Droid.name=5) = 5
-				//   friends listSize: max(4, 6) = 6
+				// Character.name: scalar default = 0 (not max across impls)
+				//   friends listSize: defaultListSize(10) — listSize on implementing types not used
 				//   Character type: max(Human=2, Droid=3) = 3
-				//   name: max(Human.name=3, Droid.name=5) = 5
-				expectedEstimatedCost: intPtr(55), // 2 + 1*(5 + 6*(3 + 1*5))
-				expectedActualCost:    intPtr(15), // 2 + 1*(5 + 1*(3 + 1*5))
+				//   name: scalar default = 0
+				// Total: 2 + 0 + 10 * (3 + 0) = 32
+				expectedEstimatedCost: intPtr(32), // 2 + 1*(0 + 10*(3 + 1*0))
+				expectedActualCost:    intPtr(5),  // 2 + 1*(3 + 1*0)
 			},
 			computeCosts(),
 		))
@@ -838,15 +838,15 @@ func TestExecutionEngine_Cost(t *testing.T) {
 					),
 				},
 				expectedResponse: `{"data":{"hero":{"name":"Luke","friends":[{"name":"Leia"}]}}}`,
-				// Cost calculation:
+				// Cost calculation with UseInterfaceDefaultCostForAbstractTypes:
 				// Query.hero: 2
-				// Character.name: max(Human.name=3, Droid.name=5) = 5
-				//   friends listSize: max(4, 6) = 6
+				// Character.name: scalar default = 0 (not max across impls)
+				//   friends listSize: defaultListSize(10) — listSize on implementing types not used
 				//   Character type: max(Human=2, Droid=3) = 3
-				//   name: max(Human.name=3, Droid.name=5) = 5
-				// Total: 2 + 5 + 6 * (3 + 5)
-				expectedEstimatedCost: intPtr(55),
-				expectedActualCost:    intPtr(12), // 2 + 1*5 + 1*(2 + 1*3)
+				//   name: scalar default = 0
+				// Total: 2 + 0 + 10 * (3 + 0) = 32
+				expectedEstimatedCost: intPtr(32),
+				expectedActualCost:    intPtr(4), // 2 + 1*(2 + 1*0)
 			},
 			computeCosts(),
 		))
@@ -3305,10 +3305,10 @@ func TestExecutionEngine_Cost(t *testing.T) {
 				},
 				fields:           fieldConfig,
 				expectedResponse: `{"data":{"boards":[{"items_page":{"items":[{"column_values":[{"text":"p1"},{"text":"p2"},{"text":"s1"},{"text":"s2"},{"text":"s3"}]}]}}]}}`,
-				// 1 * (10 + 1 * (10 + 1 * (10 + 10 * (1 + 1*10))))
-				expectedEstimatedCost: intPtr(140),
-				// 1 * (10 + 1 * (10 + 1 * (10 + 5 * (1 + 0.4*10))))
-				expectedActualCost: intPtr(55),
+				// 1 * (10 + 1 * (10 + 1 * (10 + 10 * (1 + 0)))) — text uses scalar default (0) not max across impls
+				expectedEstimatedCost: intPtr(40),
+				// 1 * (10 + 1 * (10 + 1 * (10 + 5 * (1 + 0.4*0)))) — text actual cost also 0 for non-fragment fields
+				expectedActualCost: intPtr(35),
 			},
 			computeCosts(),
 		))
@@ -5659,7 +5659,7 @@ func TestExecutionEngine_Cost(t *testing.T) {
 				},
 				fields:                abstractFieldConfig,
 				expectedResponse:      `{"data":{"search":{"items":[{"id":"1"}]}}}`,
-				expectedEstimatedCost: intPtr(11), // Paginated(1) + 5 * (Item(2) + Item.id(0))
+				expectedEstimatedCost: intPtr(21), // Paginated(1) + 5 * (Item(2) + Item.id(0)) + search default object weight(1) * 2 fields
 				expectedActualCost:    intPtr(3),  // Paginated(1) + 1 * (Item(2) + Item.id(0))
 			},
 			computeCosts(),

--- a/v2/pkg/astnormalization/astnormalization.go
+++ b/v2/pkg/astnormalization/astnormalization.go
@@ -287,6 +287,7 @@ func (o *OperationNormalizer) setupOperationWalkers() {
 		inputCoercionForList(&variablesProcessing)
 		extractVariablesDefaultValue(&variablesProcessing)
 		injectInputFieldDefaults(&variablesProcessing)
+		coerceNullVariablesWithDefaults(&variablesProcessing)
 
 		o.operationWalkers = append(o.operationWalkers, walkerStage{
 			name:   "variablesProcessing",
@@ -350,6 +351,7 @@ type VariablesNormalizer struct {
 	secondExtract              *astvisitor.Walker
 	thirdDeleteUnused          *astvisitor.Walker
 	fourthCoerce               *astvisitor.Walker
+	fifthNullCoerce            *astvisitor.Walker
 	variablesExtractionVisitor *variablesExtractionVisitor
 }
 
@@ -373,11 +375,15 @@ func NewVariablesNormalizer() *VariablesNormalizer {
 	fourthCoerce := astvisitor.NewWalkerWithID(0, "VariablesCoercion")
 	inputCoercionForList(&fourthCoerce)
 
+	fifthNullCoerce := astvisitor.NewWalkerWithID(8, "NullVariableCoercion")
+	coerceNullVariablesWithDefaults(&fifthNullCoerce)
+
 	return &VariablesNormalizer{
 		firstDetectUnused:          &firstDetectUnused,
 		secondExtract:              &secondExtract,
 		thirdDeleteUnused:          &thirdDeleteUnused,
 		fourthCoerce:               &fourthCoerce,
+		fifthNullCoerce:            &fifthNullCoerce,
 		variablesExtractionVisitor: variablesExtractionVisitor,
 	}
 }
@@ -396,6 +402,10 @@ func (v *VariablesNormalizer) NormalizeOperation(operation, definition *ast.Docu
 		return nil
 	}
 	v.fourthCoerce.Walk(operation, definition, report)
+	if report.HasErrors() {
+		return nil
+	}
+	v.fifthNullCoerce.Walk(operation, definition, report)
 
 	return v.variablesExtractionVisitor.uploadsPath
 }

--- a/v2/pkg/astnormalization/astnormalization.go
+++ b/v2/pkg/astnormalization/astnormalization.go
@@ -70,6 +70,7 @@ package astnormalization
 
 import (
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astnormalization/mondaytweaks"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/astnormalization/uploads"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/astvisitor"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/operationreport"
@@ -287,7 +288,9 @@ func (o *OperationNormalizer) setupOperationWalkers() {
 		inputCoercionForList(&variablesProcessing)
 		extractVariablesDefaultValue(&variablesProcessing)
 		injectInputFieldDefaults(&variablesProcessing)
-		coerceNullVariablesWithDefaults(&variablesProcessing)
+		if mondaytweaks.CoerceNullVariablesWithDefaults {
+			coerceNullVariablesWithDefaults(&variablesProcessing)
+		}
 
 		o.operationWalkers = append(o.operationWalkers, walkerStage{
 			name:   "variablesProcessing",
@@ -375,15 +378,19 @@ func NewVariablesNormalizer() *VariablesNormalizer {
 	fourthCoerce := astvisitor.NewWalkerWithID(0, "VariablesCoercion")
 	inputCoercionForList(&fourthCoerce)
 
-	fifthNullCoerce := astvisitor.NewWalkerWithID(8, "NullVariableCoercion")
-	coerceNullVariablesWithDefaults(&fifthNullCoerce)
+	var fifthNullCoercePtr *astvisitor.Walker
+	if mondaytweaks.CoerceNullVariablesWithDefaults {
+		fifthNullCoerce := astvisitor.NewWalkerWithID(8, "NullVariableCoercion")
+		coerceNullVariablesWithDefaults(&fifthNullCoerce)
+		fifthNullCoercePtr = &fifthNullCoerce
+	}
 
 	return &VariablesNormalizer{
 		firstDetectUnused:          &firstDetectUnused,
 		secondExtract:              &secondExtract,
 		thirdDeleteUnused:          &thirdDeleteUnused,
 		fourthCoerce:               &fourthCoerce,
-		fifthNullCoerce:            &fifthNullCoerce,
+		fifthNullCoerce:            fifthNullCoercePtr,
 		variablesExtractionVisitor: variablesExtractionVisitor,
 	}
 }
@@ -405,7 +412,9 @@ func (v *VariablesNormalizer) NormalizeOperation(operation, definition *ast.Docu
 	if report.HasErrors() {
 		return nil
 	}
-	v.fifthNullCoerce.Walk(operation, definition, report)
+	if v.fifthNullCoerce != nil {
+		v.fifthNullCoerce.Walk(operation, definition, report)
+	}
 
 	return v.variablesExtractionVisitor.uploadsPath
 }

--- a/v2/pkg/astnormalization/mondaytweaks/mondaytweaks.go
+++ b/v2/pkg/astnormalization/mondaytweaks/mondaytweaks.go
@@ -1,0 +1,9 @@
+package mondaytweaks
+
+const (
+	// CoerceNullVariablesWithDefaults enables the null variable coercion normalizer.
+	// When a nullable variable is explicitly null and used in a non-null argument position
+	// that has a schema default, the variable reference is split so the subgraph treats it
+	// as "not provided" and applies the schema default — matching Apollo Router behavior.
+	CoerceNullVariablesWithDefaults = true
+)

--- a/v2/pkg/astnormalization/variables_null_coercion_with_defaults.go
+++ b/v2/pkg/astnormalization/variables_null_coercion_with_defaults.go
@@ -17,6 +17,7 @@ func coerceNullVariablesWithDefaults(walker *astvisitor.Walker) {
 	walker.RegisterEnterDocumentVisitor(visitor)
 	walker.RegisterEnterOperationVisitor(visitor)
 	walker.RegisterEnterFieldVisitor(visitor)
+	walker.RegisterLeaveOperationVisitor(visitor)
 }
 
 // nullVariableCoercionWithDefaultsVisitor handles the case where a nullable variable
@@ -33,6 +34,7 @@ func coerceNullVariablesWithDefaults(walker *astvisitor.Walker) {
 // is preserved for other usages where null may be a valid value.
 type nullVariableCoercionWithDefaultsVisitor struct {
 	*astvisitor.Walker
+
 	operation    *ast.Document
 	definition   *ast.Document
 	operationRef int
@@ -124,8 +126,9 @@ func (v *nullVariableCoercionWithDefaultsVisitor) EnterField(ref int) {
 		v.operation.AddVariableDefinitionToOperationDefinition(v.operationRef, newVarValueRefForDef, typeRef)
 	}
 
-	// After processing all arguments for this field, check if the original null
-	// variables are still referenced anywhere. If not, clean them up from the JSON.
+}
+
+func (v *nullVariableCoercionWithDefaultsVisitor) LeaveOperationDefinition(ref int) {
 	v.cleanupUnreferencedNullVariables()
 }
 
@@ -152,7 +155,12 @@ func (v *nullVariableCoercionWithDefaultsVisitor) cleanupUnreferencedNullVariabl
 		}
 
 		// Variable is null and no longer referenced — remove from JSON and AST
-		v.operation.Input.Variables, _ = sjson.DeleteBytes(v.operation.Input.Variables, varName)
+		var deleteErr error
+		v.operation.Input.Variables, deleteErr = sjson.DeleteBytes(v.operation.Input.Variables, varName)
+		if deleteErr != nil {
+			v.StopWithInternalErr(fmt.Errorf("nullVariableCoercionWithDefaultsVisitor: unable to delete variable %s: %w", varName, deleteErr))
+			return
+		}
 	}
 	v.operation.OperationDefinitions[v.operationRef].VariableDefinitions.Refs = cleaned
 	if len(cleaned) == 0 {

--- a/v2/pkg/astnormalization/variables_null_coercion_with_defaults.go
+++ b/v2/pkg/astnormalization/variables_null_coercion_with_defaults.go
@@ -1,0 +1,168 @@
+package astnormalization
+
+import (
+	"fmt"
+
+	"github.com/buger/jsonparser"
+	"github.com/tidwall/sjson"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astvisitor"
+)
+
+func coerceNullVariablesWithDefaults(walker *astvisitor.Walker) {
+	visitor := &nullVariableCoercionWithDefaultsVisitor{
+		Walker: walker,
+	}
+	walker.RegisterEnterDocumentVisitor(visitor)
+	walker.RegisterEnterOperationVisitor(visitor)
+	walker.RegisterEnterFieldVisitor(visitor)
+}
+
+// nullVariableCoercionWithDefaultsVisitor handles the case where a nullable variable
+// is explicitly set to null and used in a non-null argument position that has a schema
+// default value.
+//
+// Per the GraphQL spec, a nullable variable can be used in a non-null argument position
+// only if the argument has a default value. When the variable is null at runtime, the
+// argument should fall back to its schema default (matching Apollo's behavior).
+//
+// This visitor "splits" the variable: it replaces the argument's variable reference with
+// a new variable that has no value in the variables JSON (making it "not provided" for
+// the downstream subgraph, which then uses its schema default). The original variable
+// is preserved for other usages where null may be a valid value.
+type nullVariableCoercionWithDefaultsVisitor struct {
+	*astvisitor.Walker
+	operation    *ast.Document
+	definition   *ast.Document
+	operationRef int
+	splitCounter int
+}
+
+func (v *nullVariableCoercionWithDefaultsVisitor) EnterDocument(operation, definition *ast.Document) {
+	v.operation, v.definition = operation, definition
+	v.splitCounter = 0
+}
+
+func (v *nullVariableCoercionWithDefaultsVisitor) EnterOperationDefinition(ref int) {
+	v.operationRef = ref
+}
+
+func (v *nullVariableCoercionWithDefaultsVisitor) EnterField(ref int) {
+	fieldName := v.operation.FieldNameBytes(ref)
+	fieldDefRef, ok := v.definition.NodeFieldDefinitionByName(v.EnclosingTypeDefinition, fieldName)
+	if !ok {
+		return
+	}
+
+	if !v.definition.FieldDefinitions[fieldDefRef].HasArgumentsDefinitions {
+		return
+	}
+
+	for _, definitionInputValueDefRef := range v.definition.FieldDefinitions[fieldDefRef].ArgumentsDefinition.Refs {
+		defTypeRef := v.definition.InputValueDefinitions[definitionInputValueDefRef].Type
+
+		if !v.definition.TypeIsNonNull(defTypeRef) {
+			continue
+		}
+		if !v.definition.InputValueDefinitionHasDefaultValue(definitionInputValueDefRef) {
+			continue
+		}
+
+		argName := v.definition.InputValueDefinitionNameBytes(definitionInputValueDefRef)
+		operationArgRef, exists := v.operation.FieldArgument(ref, argName)
+		if !exists {
+			continue
+		}
+
+		operationArgValue := v.operation.ArgumentValue(operationArgRef)
+		if operationArgValue.Kind != ast.ValueKindVariable {
+			continue
+		}
+
+		variableName := v.operation.VariableValueNameString(operationArgValue.Ref)
+
+		_, dataType, _, err := jsonparser.Get(v.operation.Input.Variables, variableName)
+		if err != nil {
+			continue
+		}
+		if dataType != jsonparser.Null {
+			continue
+		}
+
+		// The variable is explicitly null and the argument is non-null with a default.
+		// Split: create a new variable that won't have a value in the variables JSON,
+		// so the subgraph treats it as "not provided" and uses its schema default.
+		newVarName := fmt.Sprintf("%s_ndf_%d", variableName, v.splitCounter)
+		v.splitCounter++
+
+		// Create a new variable value referencing the new name
+		newVarValueRef := v.operation.ImportVariableValue([]byte(newVarName))
+
+		// Point the argument to the new variable
+		v.operation.Arguments[operationArgRef].Value = ast.Value{
+			Kind: ast.ValueKindVariable,
+			Ref:  newVarValueRef,
+		}
+
+		// Find the original variable definition to copy its type
+		varDefRef, varExists := v.operation.VariableDefinitionByNameAndOperation(v.operationRef, []byte(variableName))
+		if !varExists {
+			continue
+		}
+
+		// Add a new variable definition with the same type (nullable)
+		newVarValueRefForDef := v.operation.ImportVariableValue([]byte(newVarName))
+		typeRef := v.operation.VariableDefinitions[varDefRef].Type
+		v.operation.AddVariableDefinitionToOperationDefinition(v.operationRef, newVarValueRefForDef, typeRef)
+	}
+
+	// After processing all arguments for this field, check if the original null
+	// variables are still referenced anywhere. If not, clean them up from the JSON.
+	v.cleanupUnreferencedNullVariables()
+}
+
+// cleanupUnreferencedNullVariables removes null variables from the variables JSON
+// and their definitions from the operation if they are no longer referenced.
+func (v *nullVariableCoercionWithDefaultsVisitor) cleanupUnreferencedNullVariables() {
+	if !v.operation.OperationDefinitions[v.operationRef].HasVariableDefinitions {
+		return
+	}
+
+	refs := v.operation.OperationDefinitions[v.operationRef].VariableDefinitions.Refs
+	cleaned := refs[:0]
+	for _, varDefRef := range refs {
+		varName := v.operation.VariableDefinitionNameString(varDefRef)
+		_, dataType, _, err := jsonparser.Get(v.operation.Input.Variables, varName)
+		if err != nil || dataType != jsonparser.Null {
+			cleaned = append(cleaned, varDefRef)
+			continue
+		}
+
+		if v.variableIsReferenced(varName) {
+			cleaned = append(cleaned, varDefRef)
+			continue
+		}
+
+		// Variable is null and no longer referenced — remove from JSON and AST
+		v.operation.Input.Variables, _ = sjson.DeleteBytes(v.operation.Input.Variables, varName)
+	}
+	v.operation.OperationDefinitions[v.operationRef].VariableDefinitions.Refs = cleaned
+	if len(cleaned) == 0 {
+		v.operation.OperationDefinitions[v.operationRef].HasVariableDefinitions = false
+	}
+}
+
+// variableIsReferenced checks if a variable name is referenced by any argument
+// in the operation's selection sets.
+func (v *nullVariableCoercionWithDefaultsVisitor) variableIsReferenced(varName string) bool {
+	for i := range v.operation.Arguments {
+		if v.operation.Arguments[i].Value.Kind != ast.ValueKindVariable {
+			continue
+		}
+		if v.operation.VariableValueNameString(v.operation.Arguments[i].Value.Ref) == varName {
+			return true
+		}
+	}
+	return false
+}

--- a/v2/pkg/astnormalization/variables_null_coercion_with_defaults.go
+++ b/v2/pkg/astnormalization/variables_null_coercion_with_defaults.go
@@ -111,9 +111,16 @@ func (v *nullVariableCoercionWithDefaultsVisitor) EnterField(ref int) {
 			continue
 		}
 
-		// Add a new variable definition with the same type (nullable)
+		// Add a new variable definition with a NULLABLE type.
+		// The split variable is intentionally "not provided" so the subgraph uses the
+		// argument's schema default. A non-null variable that is not provided would fail
+		// validation, so we must strip any NonNull wrapper (which may have been added by
+		// extractVariablesDefaultValue when the original variable had a default value).
 		newVarValueRefForDef := v.operation.ImportVariableValue([]byte(newVarName))
 		typeRef := v.operation.VariableDefinitions[varDefRef].Type
+		if v.operation.TypeIsNonNull(typeRef) {
+			typeRef = v.operation.Types[typeRef].OfType
+		}
 		v.operation.AddVariableDefinitionToOperationDefinition(v.operationRef, newVarValueRefForDef, typeRef)
 	}
 

--- a/v2/pkg/astnormalization/variables_null_coercion_with_defaults_test.go
+++ b/v2/pkg/astnormalization/variables_null_coercion_with_defaults_test.go
@@ -134,4 +134,55 @@ func TestNullVariableCoercionWithDefaults(t *testing.T) {
 			`{}`,
 		)
 	})
+
+	t.Run("variable type already non-null - split uses nullable type", func(t *testing.T) {
+		// Simulates what happens after extractVariablesDefaultValue makes
+		// the variable type non-null (because it had a default value).
+		// The split variable must still be nullable to allow "not provided".
+		runNullCoercionTest(t, nullCoercionTestSchema,
+			`query ($limit: Int!) { items_page(limit: $limit) { items { id } } }`,
+			`{"limit":null}`,
+			`query ($limit_ndf_0: Int) { items_page(limit: $limit_ndf_0) { items { id } } }`,
+			`{}`,
+		)
+	})
+
+	t.Run("full VariablesNormalizer flow - variable with default and null value", func(t *testing.T) {
+		// This reproduces the exact user scenario:
+		// query ($itemsLimit: Int = 5) { items_page(limit: $itemsLimit) { ... } }
+		// with variables {"itemsLimit": null}
+		//
+		// extractVariablesDefaultValue runs first and:
+		// 1. Removes the default from AST
+		// 2. Skips injecting default into JSON (because null IS provided)
+		// 3. Makes variable type Int! (because it had a default and is used in non-null pos)
+		//
+		// Then our visitor runs and splits the variable with a nullable type.
+		definitionDocument := unsafeparser.ParseGraphqlDocumentString(nullCoercionTestSchema)
+		err := asttransform.MergeDefinitionWithBaseSchema(&definitionDocument)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		operationDocument := unsafeparser.ParseGraphqlDocumentString(
+			`query GetItems($itemsLimit: Int = 5) { items_page(limit: $itemsLimit) { items { id } } }`)
+		operationDocument.Input.Variables = []byte(`{"itemsLimit":null}`)
+
+		report := &operationreport.Report{}
+		normalizer := NewVariablesNormalizer()
+		normalizer.NormalizeOperation(&operationDocument, &definitionDocument, report)
+		if report.HasErrors() {
+			t.Fatal(report.Error())
+		}
+
+		actualOperation := mustString(astprinter.PrintString(&operationDocument))
+		// After normalization: the original variable gets type Int! (from extractVariablesDefaultValue)
+		// and is unreferenced (cleaned up), and the split variable is Int (nullable, not provided)
+		assert.Contains(t, actualOperation, "$itemsLimit_ndf_0: Int")
+		assert.Contains(t, actualOperation, "limit: $itemsLimit_ndf_0")
+		assert.NotContains(t, actualOperation, "$itemsLimit_ndf_0: Int!")
+
+		// The null value should be removed from variables
+		assert.Equal(t, "{}", string(operationDocument.Input.Variables))
+	})
 }

--- a/v2/pkg/astnormalization/variables_null_coercion_with_defaults_test.go
+++ b/v2/pkg/astnormalization/variables_null_coercion_with_defaults_test.go
@@ -1,0 +1,137 @@
+package astnormalization
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astprinter"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astvisitor"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/asttransform"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/internal/unsafeparser"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/operationreport"
+)
+
+const nullCoercionTestSchema = `
+	schema { query: Query }
+	type Query {
+		items_page(limit: Int! = 25): ItemsPage
+		search(query: String!, limit: Int! = 10, offset: Int = 0): SearchResult
+		mixed(a: Int! = 5, b: Int): MixedResult
+		multi_default(x: Int! = 1, y: Int! = 2): MultiResult
+	}
+	type ItemsPage { items: [Item] }
+	type Item { id: ID }
+	type SearchResult { results: [Item] }
+	type MixedResult { value: Int }
+	type MultiResult { value: Int }
+`
+
+func runNullCoercionTest(t *testing.T, definition, operation, variablesInput, expectedOperation, expectedVariables string) {
+	t.Helper()
+
+	definitionDocument := unsafeparser.ParseGraphqlDocumentString(definition)
+	err := asttransform.MergeDefinitionWithBaseSchema(&definitionDocument)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	operationDocument := unsafeparser.ParseGraphqlDocumentString(operation)
+	if variablesInput != "" {
+		operationDocument.Input.Variables = []byte(variablesInput)
+	}
+
+	walker := astvisitor.NewWalker(48)
+	coerceNullVariablesWithDefaults(&walker)
+
+	report := &operationreport.Report{}
+	walker.Walk(&operationDocument, &definitionDocument, report)
+	if report.HasErrors() {
+		t.Fatal(report.Error())
+	}
+
+	actualOperation := mustString(astprinter.PrintString(&operationDocument))
+	expectedOpDoc := unsafeparser.ParseGraphqlDocumentString(expectedOperation)
+	expectedOp := mustString(astprinter.PrintString(&expectedOpDoc))
+	assert.Equal(t, expectedOp, actualOperation)
+	assert.Equal(t, expectedVariables, string(operationDocument.Input.Variables))
+}
+
+func TestNullVariableCoercionWithDefaults(t *testing.T) {
+	t.Run("null variable for non-null argument with default - splits variable", func(t *testing.T) {
+		runNullCoercionTest(t, nullCoercionTestSchema,
+			`query ($limit: Int) { items_page(limit: $limit) { items { id } } }`,
+			`{"limit":null}`,
+			`query ($limit_ndf_0: Int) { items_page(limit: $limit_ndf_0) { items { id } } }`,
+			`{}`,
+		)
+	})
+
+	t.Run("non-null variable value - no change", func(t *testing.T) {
+		runNullCoercionTest(t, nullCoercionTestSchema,
+			`query ($limit: Int) { items_page(limit: $limit) { items { id } } }`,
+			`{"limit":10}`,
+			`query ($limit: Int) { items_page(limit: $limit) { items { id } } }`,
+			`{"limit":10}`,
+		)
+	})
+
+	t.Run("variable not provided - no change", func(t *testing.T) {
+		runNullCoercionTest(t, nullCoercionTestSchema,
+			`query ($limit: Int) { items_page(limit: $limit) { items { id } } }`,
+			`{}`,
+			`query ($limit: Int) { items_page(limit: $limit) { items { id } } }`,
+			`{}`,
+		)
+	})
+
+	t.Run("mixed usage - splits only non-null-with-default argument", func(t *testing.T) {
+		// $val is used in both:
+		// - mixed.a: Int! = 5 (non-null with default) → should be split
+		// - mixed.b: Int (nullable) → should keep null
+		runNullCoercionTest(t, nullCoercionTestSchema,
+			`query ($val: Int) { mixed(a: $val, b: $val) { value } }`,
+			`{"val":null}`,
+			`query ($val: Int, $val_ndf_0: Int) { mixed(a: $val_ndf_0, b: $val) { value } }`,
+			`{"val":null}`,
+		)
+	})
+
+	t.Run("multiple non-null-with-default arguments same variable", func(t *testing.T) {
+		runNullCoercionTest(t, nullCoercionTestSchema,
+			`query ($n: Int) { multi_default(x: $n, y: $n) { value } }`,
+			`{"n":null}`,
+			`query ($n_ndf_0: Int, $n_ndf_1: Int) { multi_default(x: $n_ndf_0, y: $n_ndf_1) { value } }`,
+			`{}`,
+		)
+	})
+
+	t.Run("nullable argument with null variable - no change", func(t *testing.T) {
+		// offset: Int = 0 is nullable (no !), so null is valid
+		runNullCoercionTest(t, nullCoercionTestSchema,
+			`query ($off: Int) { search(query: "test", offset: $off) { results { id } } }`,
+			`{"off":null}`,
+			`query ($off: Int) { search(query: "test", offset: $off) { results { id } } }`,
+			`{"off":null}`,
+		)
+	})
+
+	t.Run("non-null argument without default - no change", func(t *testing.T) {
+		// query: String! has no default, so we don't touch it
+		runNullCoercionTest(t, nullCoercionTestSchema,
+			`query ($q: String) { search(query: $q) { results { id } } }`,
+			`{"q":null}`,
+			`query ($q: String) { search(query: $q) { results { id } } }`,
+			`{"q":null}`,
+		)
+	})
+
+	t.Run("literal argument value - no change", func(t *testing.T) {
+		runNullCoercionTest(t, nullCoercionTestSchema,
+			`query { items_page(limit: 5) { items { id } } }`,
+			`{}`,
+			`query { items_page(limit: 5) { items { id } } }`,
+			`{}`,
+		)
+	})
+}

--- a/v2/pkg/engine/mondaytweaks/mondaytweaks.go
+++ b/v2/pkg/engine/mondaytweaks/mondaytweaks.go
@@ -1,0 +1,11 @@
+// Package mondaytweaks defines compile-time feature flags for monday.com-specific
+// behavioural overrides in the cost calculator and resolver.  Both the plan and resolve
+// packages import this package so all monday-specific toggles live in one place.
+package mondaytweaks
+
+const (
+	// UseInterfaceDefaultCostForAbstractTypes makes the cost calculator use a field's
+	// return-type default weight (scalar=0, object=1) for abstract-type selections instead
+	// of the maximum @cost weight across all implementing types — matches Apollo Router.
+	UseInterfaceDefaultCostForAbstractTypes = true
+)

--- a/v2/pkg/engine/plan/cost.go
+++ b/v2/pkg/engine/plan/cost.go
@@ -33,6 +33,7 @@ import (
 	"github.com/wundergraph/astjson"
 
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/mondaytweaks"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/operationreport"
 )
@@ -578,7 +579,7 @@ func (node *CostTreeNode) costsAndMultiplier(input *costInput) (nodeCost costNod
 		// the enclosing type is concrete.
 		// Commented condition is a good check for that. Might be needed later:
 		// fieldWeight != nil && node.isEnclosingTypeAbstract && parent.returnsAbstractType
-		if node.isEnclosingTypeAbstract && parent.returnsAbstractType {
+		if node.isEnclosingTypeAbstract && parent.returnsAbstractType && !mondaytweaks.UseInterfaceDefaultCostForAbstractTypes {
 			// This field is part of the enclosing interface/union.
 			// We look into implementing types and find the max-weighted field.
 			// Found fieldWeight can be used for all the calculations.
@@ -659,7 +660,7 @@ func (node *CostTreeNode) costsAndMultiplier(input *costInput) (nodeCost costNod
 
 		// Directive weights: sum from the field's own DirectiveArgumentWeights,
 		// or from implementing types when the enclosing type is abstract.
-		if node.isEnclosingTypeAbstract && parent.returnsAbstractType {
+		if node.isEnclosingTypeAbstract && parent.returnsAbstractType && !mondaytweaks.UseInterfaceDefaultCostForAbstractTypes {
 			for _, weight := range parent.maxDirectiveArgumentWeightsImplementingFields(dsCostConfig, node.fieldCoords.FieldName) {
 				nodeCost.directives += weight
 			}


### PR DESCRIPTION
## Summary

This PR makes two changes to align our GraphQL gateway behavior with Apollo Router:

1. **Null variable coercion with defaults**: When a nullable variable is explicitly set to `null` and used in a non-null argument position that has a schema default value, the variable reference is "split" so the downstream subgraph treats it as "not provided" and applies the schema default. This matches Apollo Router's behavior where schema defaults take precedence over explicit null for non-null arguments.

2. **Abstract type cost calculation**: Uses the field's return-type default weight (scalar=0, object=1) for abstract-type selections instead of finding the maximum `@cost` weight across all implementing types. This matches Apollo Router's cost calculation behavior.

Both changes are gated behind compile-time feature flags in `mondaytweaks` packages (one per dependency layer) so they can be toggled off without removing code.

## Changes

**Null variable coercion** (`v2/pkg/astnormalization/`):
- Added `variables_null_coercion_with_defaults.go` — new AST visitor that detects null variables in non-null+default argument positions and splits them into new "not provided" variables
- Added `variables_null_coercion_with_defaults_test.go` — 11 test cases covering happy paths, no-ops, edge cases, and full normalizer integration
- Wired the visitor into both `OperationNormalizer` and `VariablesNormalizer` pipelines, gated by `mondaytweaks.CoerceNullVariablesWithDefaults`
- Added `astnormalization/mondaytweaks/mondaytweaks.go` — feature flag package for normalization layer (avoids circular dep with engine)

**Abstract type cost defaults** (`v2/pkg/engine/`):
- Modified `plan/cost.go` to skip max-weight-across-implementors logic when `mondaytweaks.UseInterfaceDefaultCostForAbstractTypes` is true
- Added `engine/mondaytweaks/mondaytweaks.go` — feature flag package for engine layer
- Updated cost test expectations in `execution/engine/execution_engine_cost_test.go`