### PR TITLE
fix: remove connections from transport connection pool

### DIFF
--- a/v2/pkg/engine/datasource/graphql_datasource/subscriptionclient/transport/sse_conn.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/subscriptionclient/transport/sse_conn.go
@@ -21,12 +21,14 @@ type sseConnection struct {
 	resp    *http.Response
 	handler common.Handler
 	closed  atomic.Bool
+	onClose func() // Callback function to notify parent transport that the connection was closed.
 }
 
-func newSSEConnection(resp *http.Response, handler common.Handler) *sseConnection {
+func newSSEConnection(resp *http.Response, handler common.Handler, onClose func()) *sseConnection {
 	return &sseConnection{
 		resp:    resp,
 		handler: handler,
+		onClose: onClose,
 	}
 }
 
@@ -161,8 +163,11 @@ func (c *sseConnection) sendError(err error) {
 
 func (c *sseConnection) cleanup() {
 	c.closed.Store(true)
-
 	c.resp.Body.Close()
+
+	if c.onClose != nil {
+		c.onClose()
+	}
 }
 
 // closeConn terminates the SSE connection.

--- a/v2/pkg/engine/datasource/graphql_datasource/subscriptionclient/transport/sse_conn_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/subscriptionclient/transport/sse_conn_test.go
@@ -21,7 +21,7 @@ func TestSSEConnection_ReadLoop(t *testing.T) {
 		))
 		resp := &http.Response{Body: body}
 		handler, receive := collectingHandler()
-		conn := newSSEConnection(resp, handler)
+		conn := newSSEConnection(resp, handler, nil)
 
 		go conn.readLoop()
 
@@ -35,7 +35,7 @@ func TestSSEConnection_ReadLoop(t *testing.T) {
 		body := io.NopCloser(strings.NewReader(""))
 		resp := &http.Response{Body: body}
 		handler, receive := collectingHandler()
-		conn := newSSEConnection(resp, handler)
+		conn := newSSEConnection(resp, handler, nil)
 
 		go conn.readLoop()
 
@@ -48,7 +48,7 @@ func TestSSEConnection_ReadLoop(t *testing.T) {
 		body := &errorReader{err: io.ErrUnexpectedEOF}
 		resp := &http.Response{Body: io.NopCloser(body)}
 		handler, receive := collectingHandler()
-		conn := newSSEConnection(resp, handler)
+		conn := newSSEConnection(resp, handler, nil)
 
 		go conn.readLoop()
 
@@ -66,7 +66,7 @@ func TestSSEConnection_ReadLoop(t *testing.T) {
 		resp := &http.Response{Body: body}
 		handler, receive := collectingHandler()
 		wrappedHandler, collect := waitForMessages(handler)
-		conn := newSSEConnection(resp, wrappedHandler)
+		conn := newSSEConnection(resp, wrappedHandler, nil)
 
 		go conn.readLoop()
 
@@ -91,7 +91,7 @@ func TestSSEConnection_Close(t *testing.T) {
 		body := &trackingCloser{Reader: pr}
 		resp := &http.Response{Body: body}
 		handler, _ := collectingHandler()
-		conn := newSSEConnection(resp, handler)
+		conn := newSSEConnection(resp, handler, nil)
 
 		go conn.readLoop()
 
@@ -107,7 +107,7 @@ func TestSSEConnection_Close(t *testing.T) {
 		body := io.NopCloser(strings.NewReader(""))
 		resp := &http.Response{Body: body}
 		handler, _ := collectingHandler()
-		conn := newSSEConnection(resp, handler)
+		conn := newSSEConnection(resp, handler, nil)
 
 		conn.closeConn()
 		conn.closeConn() // second call is a no-op

--- a/v2/pkg/engine/datasource/graphql_datasource/subscriptionclient/transport/sse_transport.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/subscriptionclient/transport/sse_transport.go
@@ -131,9 +131,9 @@ func (t *SSETransport) Subscribe(ctx context.Context, req *common.Request, opts 
 
 	// Create connection
 	var conn *sseConnection
-	// Connections receiving a terminal message will be closed but the connection itself will
-	// not be removed from the transport's connection map until the transport is closed.
-	// This ensures to properly clean up stale connections even when the transport is still active.
+	// When a connection's read loop terminates (terminal message, EOF, or read error),
+	// the onClose callback immediately removes it from the transport's connection map.
+	// This prevents naturally-completed streams from leaking until the transport is closed.
 	conn = newSSEConnection(resp, handler, func() { t.removeConn(conn) })
 
 	t.mu.Lock()

--- a/v2/pkg/engine/datasource/graphql_datasource/subscriptionclient/transport/sse_transport.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/subscriptionclient/transport/sse_transport.go
@@ -130,7 +130,11 @@ func (t *SSETransport) Subscribe(ctx context.Context, req *common.Request, opts 
 	)
 
 	// Create connection
-	conn := newSSEConnection(resp, handler)
+	var conn *sseConnection
+	// Connections receiving a terminal message will be closed but the connection itself will
+	// not be removed from the transport's connection map until the transport is closed.
+	// This ensures to properly clean up stale connections even when the transport is still active.
+	conn = newSSEConnection(resp, handler, func() { t.removeConn(conn) })
 
 	t.mu.Lock()
 	t.conns[conn] = struct{}{}

--- a/v2/pkg/engine/datasource/graphql_datasource/subscriptionclient/transport/sse_transport_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/subscriptionclient/transport/sse_transport_test.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -198,6 +199,66 @@ func TestSSETransport_Subscribe(t *testing.T) {
 		assert.Equal(t, common.MessageTypeComplete, msg.Type)
 		assert.Nil(t, msg.Err)
 		assert.Nil(t, msg.Payload)
+
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			require.Equal(c, 0, tr.ConnCount(), "Naturally closed connections should be removed from the transport")
+		}, time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("Should kepp connections that are not naturally closed", func(t *testing.T) {
+		t.Parallel()
+
+		keepAliveChan := make(chan struct{})
+		defer close(keepAliveChan)
+
+		keepAliveServer := newSSEServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+
+			flusher := w.(http.Flusher)
+
+			fmt.Fprintf(w, "event: next\ndata: {\"data\": {\"user\": {\"name\": \"Bob\"}}}\n\n")
+			flusher.Flush()
+
+			<-keepAliveChan
+		})
+
+		completeServer := newSSEServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+
+			fmt.Fprintf(w, "event: complete\ndata:\n\n")
+		})
+
+		tr := NewSSETransport(t.Context(), http.DefaultClient, nil)
+
+		handler, receive := collectingHandler()
+
+		cancel1, err1 := tr.Subscribe(context.Background(), &common.Request{
+			Query: "subscription { user { name } }",
+		}, common.Options{Endpoint: keepAliveServer.URL, SSEMethod: common.SSEMethodPOST}, handler)
+		require.NoError(t, err1)
+		defer cancel1()
+
+		cancel2, err2 := tr.Subscribe(context.Background(), &common.Request{
+			Query: "subscription { user { name } }",
+		}, common.Options{Endpoint: completeServer.URL, SSEMethod: common.SSEMethodPOST}, handler)
+		require.NoError(t, err2)
+		defer cancel2()
+
+		msgs := make([]*common.Message, 0, 2)
+
+		msgs = append(msgs, receive(t, time.Second))
+		msgs = append(msgs, receive(t, time.Second))
+
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			require.Equal(c, 2, len(msgs), "Should receive 2 messages")
+			require.True(c, slices.ContainsFunc(msgs, func(msg *common.Message) bool {
+				return msg.Type == common.MessageTypeComplete
+			}))
+
+			require.Equal(c, 1, tr.ConnCount(), "Connection with done event should have been removed")
+		}, time.Second, 10*time.Millisecond)
 	})
 
 	t.Run("handles multi-line data", func(t *testing.T) {

--- a/v2/pkg/engine/datasource/graphql_datasource/subscriptionclient/transport/ws_transport.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/subscriptionclient/transport/ws_transport.go
@@ -266,7 +266,7 @@ func (t *WSTransport) dial(ctx context.Context, key uint64, opts common.Options)
 
 	wsConn.SetReadLimit(t.opts.ReadLimit)
 
-	proto, err := t.negotiateSubprotocol(opts.WSSubprotocol, wsConn.Subprotocol())
+	proto, err := t.negotiateSubprotocol(opts.WSSubprotocol, common.WSSubprotocol(wsConn.Subprotocol()))
 	if err != nil {
 		t.opts.Logger.Error("wsTransport.dial",
 			abstractlogger.String("endpoint", opts.Endpoint),
@@ -308,8 +308,8 @@ func (t *WSTransport) dial(ctx context.Context, key uint64, opts common.Options)
 	return conn, nil
 }
 
-func (t *WSTransport) negotiateSubprotocol(requested common.WSSubprotocol, accepted string) (protocol.Protocol, error) {
-	if requested != common.SubprotocolAuto && accepted != string(requested) {
+func (t *WSTransport) negotiateSubprotocol(requested common.WSSubprotocol, accepted common.WSSubprotocol) (protocol.Protocol, error) {
+	if requested != common.SubprotocolAuto && accepted != requested {
 		return nil, ErrInvalidSubprotocol(accepted)
 	}
 

--- a/v2/pkg/engine/datasource/graphql_datasource/subscriptionclient/transport/ws_transport.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/subscriptionclient/transport/ws_transport.go
@@ -309,12 +309,18 @@ func (t *WSTransport) dial(ctx context.Context, key uint64, opts common.Options)
 }
 
 func (t *WSTransport) negotiateSubprotocol(requested common.WSSubprotocol, accepted string) (protocol.Protocol, error) {
-	if requested != common.SubprotocolAuto {
-		if accepted != string(requested) {
-			return nil, ErrInvalidSubprotocol(accepted)
-		}
+	if requested != common.SubprotocolAuto && accepted != string(requested) {
+		return nil, ErrInvalidSubprotocol(accepted)
 	}
 
+	// In auto mode the server must still echo back a valid subprotocol; an
+	// empty or unknown value falls through to the error below.
+	//
+	// Note: a previous client treated an empty response header in auto mode as
+	// graphql-ws to stay compatible with legacy upstreams (and intermediaries
+	// that strip the Sec-WebSocket-Protocol header). That fallback was
+	// intentionally removed. Re-add it here if such compatibility is needed
+	// again.
 	switch common.WSSubprotocol(accepted) {
 	case common.SubprotocolGraphQLTransportWS:
 		return protocol.NewGraphQLTransportWS(), nil

--- a/v2/pkg/engine/datasource/graphql_datasource/subscriptionclient/transport/ws_transport_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/subscriptionclient/transport/ws_transport_test.go
@@ -864,6 +864,49 @@ func TestWSTransport_LegacyProtocol(t *testing.T) {
 		assert.Equal(t, common.MessageTypeComplete, msg.Type)
 	})
 
+	t.Run("auto prefers modern when server supports both", func(t *testing.T) {
+		t.Parallel()
+
+		// Server supports both protocols. The client offers them in preference
+		// order (graphql-transport-ws first); coder/websocket selects the first
+		// client-offered subprotocol the server also accepts, so the modern
+		// protocol must win even though the server would happily speak legacy.
+		var negotiated atomic.Value
+		server := newDualProtocolWSServer(t, &negotiated, func(ctx context.Context, conn *websocket.Conn) {
+			var msg map[string]any
+			require.NoError(t, wsjson.Read(ctx, conn, &msg))
+			// Modern protocol uses "subscribe"; legacy would use "start".
+			assert.Equal(t, "subscribe", msg["type"])
+
+			_ = wsjson.Write(ctx, conn, map[string]any{
+				"id":      msg["id"],
+				"type":    "next",
+				"payload": map[string]any{"data": map[string]any{"value": 7}},
+			})
+			_ = wsjson.Write(ctx, conn, map[string]any{
+				"id":   msg["id"],
+				"type": "complete",
+			})
+		})
+
+		tr := newTestWSTransport(t, WSTransportOptions{})
+
+		handler, receive := collectingHandler()
+		cancel, err := tr.Subscribe(context.Background(), &common.Request{
+			Query: "subscription { test }",
+		}, common.Options{
+			Endpoint:      server.URL,
+			Transport:     common.TransportWS,
+			WSSubprotocol: common.SubprotocolAuto, // Auto-negotiate
+		}, handler)
+		require.NoError(t, err)
+		defer cancel()
+
+		msg := receive(t, time.Second)
+		assert.Contains(t, string(msg.Payload.Data), "7")
+		assert.Equal(t, "graphql-transport-ws", negotiated.Load())
+	})
+
 	t.Run("auto-negotiates to legacy when modern unavailable", func(t *testing.T) {
 		t.Parallel()
 
@@ -1223,67 +1266,89 @@ func newLegacyGraphQLWSServer(t *testing.T, handler func(ctx context.Context, co
 	return server
 }
 
+// newDualProtocolWSServer accepts both subprotocols, letting the handshake
+// resolve the choice from the client's offered preference order. The
+// negotiated subprotocol is recorded into negotiated so tests can assert which
+// one won.
+func newDualProtocolWSServer(t *testing.T, negotiated *atomic.Value, handler func(ctx context.Context, conn *websocket.Conn)) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+			Subprotocols: []string{"graphql-transport-ws", "graphql-ws"},
+		})
+		if err != nil {
+			return
+		}
+		defer conn.Close(websocket.StatusNormalClosure, "")
+
+		negotiated.Store(conn.Subprotocol())
+
+		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+		defer cancel()
+
+		// Handle connection_init
+		var initMsg map[string]any
+		if err := wsjson.Read(ctx, conn, &initMsg); err != nil {
+			return
+		}
+		if initMsg["type"] != "connection_init" {
+			return
+		}
+		_ = wsjson.Write(ctx, conn, map[string]string{"type": "connection_ack"})
+
+		handler(ctx, conn)
+	}))
+
+	t.Cleanup(server.Close)
+	return server
+}
+
+// TestWSTransport_negotiateSubprotocol covers mapping a single server-accepted
+// subprotocol to a protocol implementation. Selection among multiple offered
+// subprotocols is not done here: the client offers an ordered preference list
+// (common.WSSubprotocol.Subprotocols, exercised by TestWSSubprotocol_Subprotocols)
+// and the server collapses it to exactly one value during the handshake per
+// RFC 6455, so negotiateSubprotocol only ever sees that single accepted value.
+// The end-to-end "client preference wins when the server supports both" path is
+// covered by the "auto prefers modern when server supports both" subtest.
 func TestWSTransport_negotiateSubprotocol(t *testing.T) {
 	t.Parallel()
 
 	tr := &WSTransport{}
 
-	graphQLWSProto := protocol.NewGraphQLWS()
-	graphQLTransportWSProto := protocol.NewGraphQLTransportWS()
+	t.Run("auto + graphql-transport-ws accepted picks transport-ws", func(t *testing.T) {
+		t.Parallel()
+		proto, err := tr.negotiateSubprotocol(common.SubprotocolAuto, common.SubprotocolGraphQLTransportWS)
+		require.NoError(t, err)
+		assert.IsType(t, protocol.NewGraphQLTransportWS(), proto)
+	})
 
-	cases := []struct {
-		name      string
-		requested common.WSSubprotocol
-		accepted  common.WSSubprotocol
-		wantErr   bool
-		// wantSameTypeAs is the reference instance whose dynamic type the
-		// returned protocol must match.
-		wantSameTypeAs protocol.Protocol
-	}{
-		{
-			name:      "auto + empty accepted fails",
-			requested: common.SubprotocolAuto,
-			accepted:  "",
-			wantErr:   true,
-		},
-		{
-			name:           "auto + graphql-transport-ws accepted picks transport-ws",
-			requested:      common.SubprotocolAuto,
-			accepted:       common.SubprotocolGraphQLTransportWS,
-			wantSameTypeAs: graphQLTransportWSProto,
-		},
-		{
-			name:           "auto + graphql-ws accepted picks graphql-ws",
-			requested:      common.SubprotocolAuto,
-			accepted:       common.SubprotocolGraphQLWS,
-			wantSameTypeAs: graphQLWSProto,
-		},
-		{
-			name:      "explicit graphql-ws but server echoes nothing fails",
-			requested: common.SubprotocolGraphQLWS,
-			accepted:  "",
-			wantErr:   true,
-		},
-		{
-			name:      "explicit graphql-transport-ws but server echoes graphql-ws fails",
-			requested: common.SubprotocolGraphQLTransportWS,
-			accepted:  common.SubprotocolGraphQLWS,
-			wantErr:   true,
-		},
-	}
+	t.Run("auto + graphql-ws accepted picks graphql-ws", func(t *testing.T) {
+		t.Parallel()
+		proto, err := tr.negotiateSubprotocol(common.SubprotocolAuto, common.SubprotocolGraphQLWS)
+		require.NoError(t, err)
+		assert.IsType(t, protocol.NewGraphQLWS(), proto)
+	})
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			proto, err := tr.negotiateSubprotocol(tc.requested, tc.accepted)
-			if tc.wantErr {
-				require.Error(t, err)
-				assert.Nil(t, proto)
-				return
-			}
-			require.NoError(t, err)
-			require.NotNil(t, proto)
-			assert.IsType(t, tc.wantSameTypeAs, proto)
-		})
-	}
+	t.Run("auto + empty accepted fails: server echoed no subprotocol", func(t *testing.T) {
+		t.Parallel()
+		proto, err := tr.negotiateSubprotocol(common.SubprotocolAuto, "")
+		require.ErrorIs(t, err, ErrInvalidSubprotocol(""))
+		assert.Nil(t, proto)
+	})
+
+	t.Run("explicit graphql-ws + empty accepted fails: server echoed no subprotocol", func(t *testing.T) {
+		t.Parallel()
+		proto, err := tr.negotiateSubprotocol(common.SubprotocolGraphQLWS, "")
+		require.ErrorIs(t, err, ErrInvalidSubprotocol(""))
+		assert.Nil(t, proto)
+	})
+
+	t.Run("explicit graphql-transport-ws + graphql-ws accepted fails: server echoed a different subprotocol than requested", func(t *testing.T) {
+		t.Parallel()
+		proto, err := tr.negotiateSubprotocol(common.SubprotocolGraphQLTransportWS, common.SubprotocolGraphQLWS)
+		require.ErrorIs(t, err, ErrInvalidSubprotocol(common.SubprotocolGraphQLWS))
+		assert.Nil(t, proto)
+	})
 }

--- a/v2/pkg/engine/datasource/graphql_datasource/subscriptionclient/transport/ws_transport_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/subscriptionclient/transport/ws_transport_test.go
@@ -1234,7 +1234,7 @@ func TestWSTransport_negotiateSubprotocol(t *testing.T) {
 	cases := []struct {
 		name      string
 		requested common.WSSubprotocol
-		accepted  string
+		accepted  common.WSSubprotocol
 		wantErr   bool
 		// wantSameTypeAs is the reference instance whose dynamic type the
 		// returned protocol must match.
@@ -1249,13 +1249,13 @@ func TestWSTransport_negotiateSubprotocol(t *testing.T) {
 		{
 			name:           "auto + graphql-transport-ws accepted picks transport-ws",
 			requested:      common.SubprotocolAuto,
-			accepted:       string(common.SubprotocolGraphQLTransportWS),
+			accepted:       common.SubprotocolGraphQLTransportWS,
 			wantSameTypeAs: graphQLTransportWSProto,
 		},
 		{
 			name:           "auto + graphql-ws accepted picks graphql-ws",
 			requested:      common.SubprotocolAuto,
-			accepted:       string(common.SubprotocolGraphQLWS),
+			accepted:       common.SubprotocolGraphQLWS,
 			wantSameTypeAs: graphQLWSProto,
 		},
 		{
@@ -1267,7 +1267,7 @@ func TestWSTransport_negotiateSubprotocol(t *testing.T) {
 		{
 			name:      "explicit graphql-transport-ws but server echoes graphql-ws fails",
 			requested: common.SubprotocolGraphQLTransportWS,
-			accepted:  string(common.SubprotocolGraphQLWS),
+			accepted:  common.SubprotocolGraphQLWS,
 			wantErr:   true,
 		},
 	}

--- a/v2/pkg/engine/datasource/graphql_datasource/subscriptionclient/transport/ws_transport_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/subscriptionclient/transport/ws_transport_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/datasource/graphql_datasource/subscriptionclient/common"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/datasource/graphql_datasource/subscriptionclient/protocol"
 )
 
 func TestWSTransport_Subscribe(t *testing.T) {
@@ -1220,4 +1221,69 @@ func newLegacyGraphQLWSServer(t *testing.T, handler func(ctx context.Context, co
 
 	t.Cleanup(server.Close)
 	return server
+}
+
+func TestWSTransport_negotiateSubprotocol(t *testing.T) {
+	t.Parallel()
+
+	tr := &WSTransport{}
+
+	graphQLWSProto := protocol.NewGraphQLWS()
+	graphQLTransportWSProto := protocol.NewGraphQLTransportWS()
+
+	cases := []struct {
+		name      string
+		requested common.WSSubprotocol
+		accepted  string
+		wantErr   bool
+		// wantSameTypeAs is the reference instance whose dynamic type the
+		// returned protocol must match.
+		wantSameTypeAs protocol.Protocol
+	}{
+		{
+			name:      "auto + empty accepted fails",
+			requested: common.SubprotocolAuto,
+			accepted:  "",
+			wantErr:   true,
+		},
+		{
+			name:           "auto + graphql-transport-ws accepted picks transport-ws",
+			requested:      common.SubprotocolAuto,
+			accepted:       string(common.SubprotocolGraphQLTransportWS),
+			wantSameTypeAs: graphQLTransportWSProto,
+		},
+		{
+			name:           "auto + graphql-ws accepted picks graphql-ws",
+			requested:      common.SubprotocolAuto,
+			accepted:       string(common.SubprotocolGraphQLWS),
+			wantSameTypeAs: graphQLWSProto,
+		},
+		{
+			name:      "explicit graphql-ws but server echoes nothing fails",
+			requested: common.SubprotocolGraphQLWS,
+			accepted:  "",
+			wantErr:   true,
+		},
+		{
+			name:      "explicit graphql-transport-ws but server echoes graphql-ws fails",
+			requested: common.SubprotocolGraphQLTransportWS,
+			accepted:  string(common.SubprotocolGraphQLWS),
+			wantErr:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			proto, err := tr.negotiateSubprotocol(tc.requested, tc.accepted)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, proto)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, proto)
+			assert.IsType(t, tc.wantSameTypeAs, proto)
+		})
+	}
 }


### PR DESCRIPTION
Upon receiving terminal messages, closed connections should be removed from the transport connection pool. This was only done when the transport was canceled. 

@coderabbitai summary

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->