### PR TITLE
fix(astnormalization): guard invalid type refs in variable default value extraction

### DIFF
--- a/v2/pkg/astnormalization/variables_default_value_extraction.go
+++ b/v2/pkg/astnormalization/variables_default_value_extraction.go
@@ -155,11 +155,23 @@ func (v *variablesDefaultValueExtractionVisitor) LeaveOperationDefinition(ref in
 	}
 }
 
+func (v *variablesDefaultValueExtractionVisitor) isValidTypeRef(ref int) bool {
+	return ref >= 0 && ref < len(v.definition.Types)
+}
+
 func (v *variablesDefaultValueExtractionVisitor) traverseValue(value ast.Value, defTypeRef int) {
+	if !v.isValidTypeRef(defTypeRef) {
+		return
+	}
+
 	switch value.Kind {
 	case ast.ValueKindVariable:
 		v.saveArgumentsWithTypeNotNull(value.Ref, defTypeRef)
 	case ast.ValueKindList:
+		if !v.definition.TypeIsList(defTypeRef) {
+			return
+		}
+
 		for _, ref := range v.operation.ListValues[value.Ref].Refs {
 			listValue := v.operation.Value(ref)
 			if !v.operation.ValueContainsVariable(listValue) {
@@ -172,7 +184,15 @@ func (v *variablesDefaultValueExtractionVisitor) traverseValue(value ast.Value, 
 				listTypeRef = v.definition.Types[listTypeRef].OfType
 			}
 
+			if !v.isValidTypeRef(listTypeRef) || !v.definition.TypeIsList(listTypeRef) {
+				continue
+			}
+
 			listItemType := v.definition.Types[listTypeRef].OfType
+			if !v.isValidTypeRef(listItemType) {
+				continue
+			}
+
 			v.traverseValue(listValue, listItemType)
 		}
 	case ast.ValueKindObject:
@@ -198,6 +218,10 @@ func (v *variablesDefaultValueExtractionVisitor) traverseValue(value ast.Value, 
 }
 
 func (v *variablesDefaultValueExtractionVisitor) saveArgumentsWithTypeNotNull(operationVariableValueRef, defTypeRef int) {
+	if !v.isValidTypeRef(defTypeRef) {
+		return
+	}
+
 	if v.definition.Types[defTypeRef].TypeKind != ast.TypeKindNonNull {
 		return
 	}

--- a/v2/pkg/astnormalization/variables_default_value_extraction_test.go
+++ b/v2/pkg/astnormalization/variables_default_value_extraction_test.go
@@ -352,6 +352,61 @@ func TestVariablesDefaultValueExtraction(t *testing.T) {
 		})
 	})
 
+	t.Run("list value against non-list schema field does not panic", func(t *testing.T) {
+		const findItemByColumnValueSchema = `
+			schema { query: Query }
+			type Query {
+				boards(ids: [ID!], limit: Int): [Board]
+			}
+			type Board {
+				items_page(limit: Int, query_params: ItemsQuery): ItemsPage
+			}
+			type ItemsPage {
+				items: [Item]
+			}
+			type Item {
+				id: ID
+			}
+			input ItemsQuery {
+				rules: [ItemsQueryRule]
+			}
+			input ItemsQueryRule {
+				column_id: ID!
+				compare_value: CompareValue
+			}
+			scalar CompareValue
+		`
+
+		const findItemByColumnValueQuery = `
+			query FindItemByColumnValue($boardId: ID!, $columnId: String!, $value: String!) {
+				boards(ids: [$boardId], limit: 1) {
+					items_page(limit: 1, query_params: {rules:[{column_id:$columnId,compare_value:[$value]}]}) {
+						items {
+							id
+						}
+					}
+				}
+			}
+		`
+
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("unexpected panic: %v", r)
+			}
+		}()
+
+		runWithVariablesDefaultValues(
+			t,
+			extractVariablesDefaultValue,
+			findItemByColumnValueSchema,
+			findItemByColumnValueQuery,
+			"",
+			findItemByColumnValueQuery,
+			`{"boardId":"1609319205","columnId":"numeric_mm03yy2r","value":"51.00"}`,
+			`{"boardId":"1609319205","columnId":"numeric_mm03yy2r","value":"51.00"}`,
+		)
+	})
+
 	t.Run("variables used in directive argument expecting non null value", func(t *testing.T) {
 		t.Run("nullable boolean with default value and variable value exists", func(t *testing.T) {
 			runWithVariablesDefaultValues(t, extractVariablesDefaultValue, variablesDefaultValueExtractionDefinition, `


### PR DESCRIPTION
## Summary

Fixes a panic in `variablesDefaultValueExtractionVisitor` during `VariablesNormalizer.NormalizeOperation` when a query passes a **list value** for a schema field that is **not a list type**.

This was hit in production on the cosmo router: invalid client queries caused HTTP 500 panics during variable normalization instead of proceeding to GraphQL validation (where errors would be returned cleanly, as Apollo does).

## Production issue

**Operation:** `FindItemByColumnValue`

```graphql
query FindItemByColumnValue($boardId: ID!, $columnId: String!, $value: String!) {
  boards(ids: [$boardId], limit: 1) {
    items_page(
      limit: 1
      query_params: { rules: [{ column_id: $columnId, compare_value: [$value] }] }
    ) {
      items { id }
    }
  }
}
```

**Schema (simplified):**

```graphql
input ItemsQueryRule {
  column_id: ID!
  compare_value: CompareValue   # scalar / named type — NOT a list
}
```

The client query wraps `$value` in a list (`[$value]`) and declares it as `String!`, while the schema expects `CompareValue`. That is invalid GraphQL and should surface as validation errors.

**Observed behavior:**

| Router | Result |
|--------|--------|
| Apollo | HTTP 200 with validation errors (`String!` vs `ID!`, `String!` vs `CompareValue`) |
| Cosmo  | HTTP 500 — panic recovered: `runtime error: index out of range [-1]` |

**Stack trace (cosmo router):**

```
variablesDefaultValueExtractionVisitor.saveArgumentsWithTypeNotNull  (variables_default_value_extraction.go:201)
  ← traverseValue
  ← VariablesNormalizer.NormalizeOperation
  ← OperationKit.NormalizeVariables
  ← PreHandler.handleOperation
```

Cosmo never reached validation — it crashed in the normalization pipeline, causing shadow-traffic mismatches (Apollo returns structured errors; cosmo returns an empty/absent errors body with status 500).

## Root cause

In `traverseValue`, when visiting a `ValueKindList`, the visitor unwraps the schema type assuming it is a list:

```go
listItemType := v.definition.Types[listTypeRef].OfType
v.traverseValue(listValue, listItemType)
```

For a **named/scalar** type like `CompareValue`, `OfType` is `-1`. That invalid ref propagates into `saveArgumentsWithTypeNotNull`, which indexes `v.definition.Types[-1]` and panics.

This happens when the **operation AST** uses list syntax but the **schema type** at that position is not a list — a type mismatch that validation would reject, but normalization must not crash on.

## Fix

- Add `isValidTypeRef` guard used by `traverseValue` and `saveArgumentsWithTypeNotNull`
- Skip list traversal when the schema type at that position is not a list
- Skip traversal when derived list item type ref is invalid

After this fix, normalization completes and downstream validation can return proper GraphQL errors instead of a 500.

## Test plan

- [x] Added regression test mirroring the production query shape (`FindItemByColumnValue` with `compare_value: [$value]` against scalar `CompareValue`)
- [x] `go test ./pkg/astnormalization/ -run TestVariablesDefaultValueExtraction`

## Related

Once merged here, cosmo can bump `github.com/wundergraph/graphql-go-tools/v2` to pick up the fix.