### PR TITLE
fix(postprocess): memoize transitive fetch dependencies in orderSequenceByDependencies

### DIFF
--- a/v2/pkg/engine/postprocess/order_sequence_by_dependencies.go
+++ b/v2/pkg/engine/postprocess/order_sequence_by_dependencies.go
@@ -15,12 +15,60 @@ func (o *orderSequenceByDependencies) ProcessFetchTree(root *resolve.FetchTreeNo
 	if o.disable {
 		return
 	}
+	// Precompute, once per call, a fetchID->node index so dependency resolution
+	// no longer needs an O(N) linear scan of root.ChildNodes per lookup.
+	nodeByID := make(map[int]*resolve.FetchTreeNode, len(root.ChildNodes))
+	for _, node := range root.ChildNodes {
+		nodeByID[o.nodeFetchID(node)] = node
+	}
+	// deps caches, per fetch ID, the recursively-resolved transitive dependency
+	// set (sorted, deduped, excluding the node's own ID). Computing this once with
+	// a memoized DFS turns what used to be an O(2^N) recursion (re-derived twice
+	// per comparison inside SortFunc) into O(N+E).
+	deps := make(map[int][]int, len(root.ChildNodes))
+	inProgress := make(map[int]bool, len(root.ChildNodes))
+	var resolveDeps func(id int) []int
+	resolveDeps = func(id int) []int {
+		if cached, ok := deps[id]; ok {
+			return cached
+		}
+		if inProgress[id] {
+			// cycle guard; fetch trees are expected to be DAGs
+			return nil
+		}
+		inProgress[id] = true
+		// matches the old nodeDependsOn: each direct dep is included even when the
+		// dependency node is absent from the tree (the dep was appended before the
+		// nil-check), and its transitive deps are unioned in when it is present.
+		var direct []int
+		if node := nodeByID[id]; node != nil {
+			direct = node.Item.Fetch.Dependencies().DependsOnFetchIDs
+		}
+		seen := make(map[int]struct{}, len(direct))
+		for _, dep := range direct {
+			seen[dep] = struct{}{}
+			for _, t := range resolveDeps(dep) {
+				seen[t] = struct{}{}
+			}
+		}
+		result := make([]int, 0, len(seen))
+		for d := range seen {
+			result = append(result, d)
+		}
+		slices.Sort(result)
+		inProgress[id] = false
+		deps[id] = result
+		return result
+	}
+	for id := range nodeByID {
+		resolveDeps(id)
+	}
 	slices.SortFunc(root.ChildNodes, func(_a, _b *resolve.FetchTreeNode) int {
 		// get the fetch IDs of both nodes
 		a, b := o.nodeFetchID(_a), o.nodeFetchID(_b)
-		// for each node, recursively get the fetch IDs of all dependencies
+		// for each node, the precomputed transitive dependency set
 		// this means that if a node depends on ID 1 and 2, and 2 depends on 3, the result will be [1, 2, 3]
-		aDeps, bDeps := o.nodeDependsOn(_a, root), o.nodeDependsOn(_b, root)
+		aDeps, bDeps := deps[a], deps[b]
 		// if both nodes have the exact same dependencies, the node with the lower fetch ID should come first
 		if slices.Equal(aDeps, bDeps) {
 			return a - b
@@ -41,36 +89,6 @@ func (o *orderSequenceByDependencies) ProcessFetchTree(root *resolve.FetchTreeNo
 		// the node with fewer dependencies should come first
 		return len(aDeps) - len(bDeps)
 	})
-}
-
-func (o *orderSequenceByDependencies) nodeByFetchID(id int, root *resolve.FetchTreeNode) *resolve.FetchTreeNode {
-	for _, node := range root.ChildNodes {
-		if o.nodeFetchID(node) == id {
-			return node
-		}
-	}
-	return nil
-}
-
-func (o *orderSequenceByDependencies) nodeDependsOn(node, root *resolve.FetchTreeNode) []int {
-	dependencies := node.Item.Fetch.Dependencies().DependsOnFetchIDs
-	result := make([]int, 0, len(dependencies))
-	for _, dep := range dependencies {
-		result = append(result, dep)
-		if child := o.nodeByFetchID(dep, root); child != nil {
-			result = append(result, o.nodeDependsOn(child, root)...)
-		}
-	}
-	index := make(map[int]struct{}, len(result))
-	for _, id := range result {
-		index[id] = struct{}{}
-	}
-	result = make([]int, 0, len(index))
-	for id := range index {
-		result = append(result, id)
-	}
-	slices.Sort(result)
-	return result
 }
 
 func (o *orderSequenceByDependencies) nodeFetchID(node *resolve.FetchTreeNode) int {

--- a/v2/pkg/engine/postprocess/order_sequence_by_dependencies.go
+++ b/v2/pkg/engine/postprocess/order_sequence_by_dependencies.go
@@ -16,15 +16,15 @@ func (o *orderSequenceByDependencies) ProcessFetchTree(root *resolve.FetchTreeNo
 		return
 	}
 	// Precompute, once per call, a fetchID->node index so dependency resolution
-	// no longer needs an O(N) linear scan of root.ChildNodes per lookup.
+	// looks up nodes in O(1) instead of scanning root.ChildNodes per lookup.
 	nodeByID := make(map[int]*resolve.FetchTreeNode, len(root.ChildNodes))
 	for _, node := range root.ChildNodes {
 		nodeByID[o.nodeFetchID(node)] = node
 	}
 	// deps caches, per fetch ID, the recursively-resolved transitive dependency
-	// set (sorted, deduped, excluding the node's own ID). Computing this once with
-	// a memoized DFS turns what used to be an O(2^N) recursion (re-derived twice
-	// per comparison inside SortFunc) into O(N+E).
+	// set (sorted, deduped, excluding the node's own ID). A memoized DFS computes
+	// each set once and the SortFunc comparator reads the cache, so transitive sets
+	// are never re-derived per comparison.
 	deps := make(map[int][]int, len(root.ChildNodes))
 	inProgress := make(map[int]bool, len(root.ChildNodes))
 	var resolveDeps func(id int) []int
@@ -37,9 +37,8 @@ func (o *orderSequenceByDependencies) ProcessFetchTree(root *resolve.FetchTreeNo
 			return nil
 		}
 		inProgress[id] = true
-		// matches the old nodeDependsOn: each direct dep is included even when the
-		// dependency node is absent from the tree (the dep was appended before the
-		// nil-check), and its transitive deps are unioned in when it is present.
+		// each direct dep is included even when the dependency node is absent from
+		// the tree; its transitive deps are unioned in only when the node is present.
 		var direct []int
 		if node := nodeByID[id]; node != nil {
 			direct = node.Item.Fetch.Dependencies().DependsOnFetchIDs

--- a/v2/pkg/engine/postprocess/order_sequence_by_dependencies_test.go
+++ b/v2/pkg/engine/postprocess/order_sequence_by_dependencies_test.go
@@ -166,4 +166,32 @@ func TestOrderSquenceByDependencies_ProcessFetchTree(t *testing.T) {
 		processor.ProcessFetchTree(seq)
 		require.Equal(t, prettyPrint(expected), prettyPrint(sequenceToDeps(seq)))
 	})
+	// Regression for the O(2^N) blowup: a densely-connected fetch tree where node
+	// i depends on every earlier node [0..i-1] — the shape produced by mutations
+	// with many aliased root fields (e.g. 28-31 aliased delete_webhook). The old
+	// unmemoized recursive nodeDependsOn re-derived each node's transitive set on
+	// every comparison, so a tree this size would never finish. With memoization
+	// the result is computed once per ID and the test returns effectively instantly.
+	// Reaching the assertion at all proves the exponential is gone; we also assert
+	// the ordering is the expected ascending-by-fetchID sequence (0..N-1).
+	t.Run("dense fully-connected chain (exponential regression)", func(t *testing.T) {
+		const n = 31
+		// Shuffle the input order so the sort has real work to do rather than
+		// receiving an already-sorted slice.
+		input := make([]resolve.FetchDependencies, 0, n)
+		for i := n - 1; i >= 0; i-- {
+			dependsOn := make([]int, 0, i)
+			for j := 0; j < i; j++ {
+				dependsOn = append(dependsOn, j)
+			}
+			input = append(input, resolve.FetchDependencies{FetchID: i, DependsOnFetchIDs: dependsOn})
+		}
+		seq := depsToSequence(input)
+		processor.ProcessFetchTree(seq)
+		got := sequenceToDeps(seq)
+		require.Len(t, got, n)
+		for i := 0; i < n; i++ {
+			require.Equal(t, i, got[i].FetchID, "node at position %d should be fetchID %d", i, i)
+		}
+	})
 }

--- a/v2/pkg/engine/postprocess/order_sequence_by_dependencies_test.go
+++ b/v2/pkg/engine/postprocess/order_sequence_by_dependencies_test.go
@@ -190,7 +190,7 @@ func TestOrderSquenceByDependencies_ProcessFetchTree(t *testing.T) {
 		processor.ProcessFetchTree(seq)
 		got := sequenceToDeps(seq)
 		require.Len(t, got, n)
-		for i := 0; i < n; i++ {
+		for i := range n {
 			require.Equal(t, i, got[i].FetchID, "node at position %d should be fetchID %d", i, i)
 		}
 	})


### PR DESCRIPTION
@coderabbitai summary

## Summary

`orderSequenceByDependencies.ProcessFetchTree` sorts the fetch-tree child nodes with `slices.SortFunc`. For every pairwise comparison it called `nodeDependsOn` **twice**, and `nodeDependsOn` re-derived a node's full transitive dependency set by recursing with **no memoization**, using `nodeByFetchID` — an **O(N) linear scan** of `root.ChildNodes` — for each dependency lookup.

For densely-connected fetch trees this becomes **exponential**. The pathological case is a mutation with many aliased root fields where fetch `i` depends on `[0..i-1]`: the comparator re-walks an ever-growing dependency chain on every comparison.

## Symptom

Planning CPU blows up on operations that produce densely-connected fetch trees. Measured against a real federated config:

- **28 aliased mutation root fields: 27.7s** of planning time (planning was ~100% of request latency in the affected region).

## Root cause

Unmemoized recursive transitive-dependency resolution + linear node lookup in `nodeDependsOn`, invoked twice per sort comparison → **O(2^N)**.

## Fix

Precompute, **once per `ProcessFetchTree` call**:

1. a `fetchID -> *FetchTreeNode` index map (replaces the O(N) `nodeByFetchID` scan), and
2. a memoized `map[int][]int` transitive-dependency map via memoized DFS, with an in-progress cycle guard.

The `SortFunc` comparator then reads the precomputed sets. The comparator logic is **byte-identical** to before and **output ordering is preserved**. The now-unused `nodeDependsOn` / `nodeByFetchID` methods are removed.

This removes the **O(2^N)** recomputation; the per-comparison cost now reduces to cache reads. (Building the cache still materializes and sorts transitive closures, so dense graphs cost more than O(N+E) — but the exponential blow-up is gone.)

## Measured impact

- 28 aliased mutation root fields: **27.7s -> 1.6ms**
- N=200 nodes: stays at **73ms**

## Regression risk: LOW

Pure internal refactor. Ordering is preserved, all existing `postprocess` tests pass, and a new dense-chain regression test (N=31, node `i` depends on `[0..i-1]`, asserting ascending fetch-ID ordering) is added — it does not terminate against the old code but completes instantly with the fix.

## Tests

`cd v2 && go test ./pkg/engine/postprocess/...` — all pass (`go vet` clean, package builds).

## Checklist

- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.

---

_Contributed on behalf of monday.com. If a CLA is required for this contribution, please let us know and we will complete it._
