### PR TITLE
fix(resolve): attach SUBREQUEST_HTTP_ERROR on status-fallback path

### DIFF
--- a/v2/pkg/engine/resolve/loader.go
+++ b/v2/pkg/engine/resolve/loader.go
@@ -1111,6 +1111,15 @@ func (l *Loader) renderErrorsStatusFallback(fetchItem *FetchItem, res *result, s
 
 	l.ctx.appendSubgraphErrors(res.ds, res.err, NewSubgraphError(res.ds, fetchItem.ResponsePath, reason, res.statusCode))
 
+	// A non-2XX response with no GraphQL errors body bypasses mergeErrors, which is where
+	// the Apollo Router compatibility error (SUBREQUEST_HTTP_ERROR) is normally attached.
+	// When that compatibility mode is enabled for a server/client error, emit the same
+	// coded error here instead of a bare status message so status-only failures are shaped
+	// identically to the errors-body path and downstream consumers can normalize them.
+	if l.apolloRouterCompatibilitySubrequestHTTPError && statusCode >= 400 {
+		return l.addApolloRouterCompatibilityError(res)
+	}
+
 	errorObject, err := astjson.ParseWithArena(l.jsonArena, fmt.Sprintf(`{"message":"%s"}`, reason))
 	if err != nil {
 		return err

--- a/v2/pkg/engine/resolve/resolve_arena_gc_test.go
+++ b/v2/pkg/engine/resolve/resolve_arena_gc_test.go
@@ -795,6 +795,28 @@ func TestArenaGCSafety_ApolloRouterCompatError(t *testing.T) {
 	assert.Equal(t, `{"errors":[{"message":"HTTP fetch failed from 'testService': 500: Internal Server Error","path":[],"extensions":{"code":"SUBREQUEST_HTTP_ERROR","service":"testService","reason":"500: Internal Server Error","http":{"status":500}}},{"message":"bad","extensions":{"statusCode":500}}],"data":{"field":null}}`, output)
 }
 
+func TestArenaGCSafety_ApolloRouterCompatError_StatusFallback(t *testing.T) {
+	// Covers: renderErrorsStatusFallback attaching addApolloRouterCompatibilityError.
+	// A non-2XX response with no GraphQL errors body must still carry the
+	// SUBREQUEST_HTTP_ERROR code when Apollo Router compatibility is enabled, so that
+	// status-only failures (e.g. a proxy 504 with an empty/non-GraphQL body) are shaped
+	// like the errors-body path instead of a bare status message.
+	opts := baseResolverOpts()
+	opts.ApolloRouterCompatibilitySubrequestHTTPError = true
+	resolver := newTestResolver(t, opts)
+	output := resolveWithGCPressure(t, resolver,
+		func() *Context { return NewContext(context.Background()) },
+		func() *GraphQLResponse {
+			resp, _ := gcTestResponse(&_statusCodeDataSource{
+				data:       `{"data":null}`,
+				statusCode: 504,
+			})
+			return resp
+		},
+	)
+	assert.Equal(t, `{"errors":[{"message":"HTTP fetch failed from 'testService': 504: Gateway Timeout","path":[],"extensions":{"code":"SUBREQUEST_HTTP_ERROR","service":"testService","reason":"504: Gateway Timeout","http":{"status":504}}}],"data":{"field":null}}`, output)
+}
+
 func TestArenaGCSafety_SubgraphStatusCodeInExtensions(t *testing.T) {
 	// Covers: setSubgraphStatusCode (adds statusCode to existing and new extensions)
 	opts := baseResolverOpts()


### PR DESCRIPTION
## Problem

With `ApolloRouterCompatibilitySubrequestHTTPError` enabled, every non-2XX subgraph response is expected to carry a `SUBREQUEST_HTTP_ERROR`-coded error (via `addApolloRouterCompatibilityError`).

However, that error is attached **only** on the errors-body path (`mergeErrors`, `loader.go:741/788`). When a subgraph returns a non-2XX with **no GraphQL errors body** — an empty/non-GraphQL body, or a null `data._entities` (typical of an LB/ingress `504 Gateway Timeout`) — the loader takes `renderErrorsStatusFallback` (`loader.go:502/565`), which emits a bare `{"message":"<status>: <statusText>"}` with **no `extensions.code`** and never invokes `addApolloRouterCompatibilityError`.

### Impact

The two non-2XX paths produce inconsistent error shapes: consumers relying on `SUBREQUEST_HTTP_ERROR` to normalize subgraph HTTP failures can normalize the errors-body case but not the status-only case (e.g. a bare `504 Gateway Timeout` from an ingress/proxy in front of a subgraph).

## Fix

In `renderErrorsStatusFallback`, when `apolloRouterCompatibilitySubrequestHTTPError` is enabled and `statusCode >= 400`, delegate to `addApolloRouterCompatibilityError` so status-only failures carry the same coded error as the errors-body path.

## Test

Adds `TestArenaGCSafety_ApolloRouterCompatError_StatusFallback` (504 + flag on + empty body → coded `SUBREQUEST_HTTP_ERROR`). New test and the full `pkg/engine/resolve` suite pass, no regressions.

## Notes

Reported by the monday.com platform API team while migrating from Apollo Router to Cosmo: an `_entities` fetch hitting a `504 Gateway Timeout` reached clients as a raw, uncoded error instead of a normalized one, diverging from the Apollo Router path.