### PR TITLE
feat: l1/l2 entity and root-field caching on the defer engine

### DIFF
--- a/docs/caching/CODING_GUIDELINES.md
+++ b/docs/caching/CODING_GUIDELINES.md
@@ -1,0 +1,199 @@
+# Caching Implementation — Coding Guidelines
+
+These are the rules every implementation session for the caching port MUST follow.
+This file is the STANDING CONTRACT for Fable (Claude), who executes the plan end to end — re-read it at the start of every session and obey it verbatim.
+The maintainer-feedback revision is FOLDED IN throughout (there is no override section to apply).
+Ground truth, in priority order:
+
+- `docs/caching/PLAN.md` + the task file you were handed (`docs/caching/tasks/NN-*.md`) — the contract for your session.
+- This file.
+- The RFC specs in `docs/caching/specs/` — background and rationale only; the task files record every deliberate deviation.
+- The actual source: this branch, the base branch worktree (first-pass implementation, reference only), the `caching-base` worktree (OLD implementation).
+
+Target: Go 1.25; code under `v2/` and `execution/`.
+
+---
+
+## 0. Workflow (single agent)
+
+- Fable (Claude) does the orchestration, the coding, the tests, the self-review, and the progress tracking; there is no separate coding agent.
+- Every task comes from `docs/caching/tasks/NN-*.md` with predefined, verifiable success goals (its ACCEPTANCE CRITERIA).
+- Follow the execution protocol in PLAN §2: orient → implement → verify with real command output → self-review against the task's reviewer guidance → record in `PROGRESS.md` → commit gate.
+- Update `PROGRESS.md` BEFORE ending any session; it and git history are the only durable state across sessions.
+- Commit only under the approval granted in the kickoff prompt; absent a standing grant, finished code + passing tests means "ask for review", not "commit".
+
+---
+
+## 1. Modern Go (target 1.25) — do NOT reinvent the stdlib
+
+Use modern idioms; legacy patterns are review-rejections.
+
+- `any` (never `interface{}`).
+- `slices`, `maps`, `cmp` for collection work (`slices.SortFunc`, `slices.EqualFunc`, `maps.Clone`, `cmp.Or`) — already used across the engine.
+- `min`, `max`, `clear` builtins; `for i := range n`; range-over-func where it reads cleanly.
+- `time.Since` / `time.Until` for elapsed/remaining math (TTLs, freshness).
+- `errors.Is` / `errors.As` / `errors.Join`.
+- `strings.Cut` instead of `Index`+slice.
+- Typed `atomic.Bool` / `atomic.Int64` / `atomic.Pointer[T]`.
+- `wg.Go(fn)` instead of manual `Add`/`Done`.
+- Before writing ANY helper, assume the stdlib already has it — search, then reuse.
+- When in doubt about an API signature, look it up; do not guess.
+
+---
+
+## 2. Search before you write — the mapped homes
+
+Reuse these; do NOT hand-roll equivalents:
+
+- Hashing (cache keys): `github.com/cespare/xxhash/v2` via `pkg/pool/hash64.go` (`pool.Hash64.Get()`/`.Put()`); follow the loader's existing batch-key hashing pattern.
+- JSON: `github.com/wundergraph/astjson` (`MarshalTo`, `ParseBytesWithArena`, `MergeValuesWithPath`, `SetValue`, the `Type*` constants). astjson has NO built-in Hash/Equal — key hash = `MarshalTo` + xxhash.
+- Arena: `github.com/wundergraph/go-arena`; build the `CacheTransaction` on top of it; do NOT introduce a new allocator.
+- Buffers: `pkg/pool/bytesbuffer.go` / `pkg/pool/fastbuffer.go`.
+- Sets: plain `map[string]struct{}` (repo convention; no generic Set type).
+- Representation-variable building: the shared `plan/representationvariable` package (task 01) — never a copy.
+- Test-side astjson building: `pkg/fastjsonext`; JSON normalization in tests: `compactJSONForAssert`.
+- Clock: there is NO clock abstraction and we do NOT add one.
+  Production code calls real `time.Now`/`time.Since`/`time.Until` directly — no injectable `now`, no clock seam.
+  Time-dependent tests use the Go 1.25 stdlib `testing/synctest` (§4.5).
+- DRY WITHIN the caching code too: before adding a helper, grep the caching packages for one an earlier task already added; when two tasks need the same predicate, keep ONE.
+
+If you believe nothing exists, say so explicitly in the commit notes so the reviewer can double-check.
+
+---
+
+## 3. Architecture rules (folded-in maintainer feedback)
+
+- ONE COMMON caching package: all cache logic lives in `v2/pkg/engine/cache` (controller with modular L1/L2/partial, key templates, transforms, pass logic, observer) + `cachetesting`.
+  Contract types stay in `resolve`; `plan/cacheconfig` is the leaf policy package; `plan`/`postprocess` hold thin shims only.
+- EXTENDING EXISTING PLANNERS/VISITORS IS ALLOWED — there are no forbidden files.
+  Prefer NEW single-responsibility caching visitors/passes; extend an existing one when that is the simpler, clearer path.
+- NO `switch` over concrete fetch types (`*SingleFetch`/`*EntityFetch`/`*BatchEntityFetch`): use the `Fetch` interface methods (`CacheConfig()`, `SetCacheConfig`, entity/batch predicates).
+  Improve OTHER fetch-type-switch sites you encounter in code you touch.
+- All astjson mutation happens inside a held `CacheTransaction` (`Begin()` … ops … `Commit()`); one transaction per hook = one `DataBuffer.Lock` acquisition; never from the off-lock load phase.
+- L1 stores `*astjson.Value` (never `[]byte`); only L2 marshals; parse each response ONCE; L1 and L2 SHARE the same keys (derive once).
+- Normalize to schema field names (+ argument-suffix keys) on WRITE; denormalize to the query's aliases on READ.
+- NAMES: plain, immediately understandable — `cacheKeyBuilder`, `fetchCacheConfigurator`, `ConfigureCaching`, `CacheTransaction`.
+  No "freezer"/"stamper" vocabulary anywhere.
+- REFACTOR IN PLACE — never copy-paste to modify; when extracting code into a reusable package, MOVE THE TESTS too.
+- Surgical-change discipline: touch only what the task requires; match existing style; do not "improve" adjacent code beyond the sanctioned fetch-switch cleanups.
+- Dead-code hygiene across the task chain: a task that supersedes an earlier helper DELETES it in the same commit.
+
+---
+
+## 4. Tests
+
+### 4.1 Package placement
+
+- NEVER append tests to an existing `*_test.go` file; group tests in dedicated files/packages per logical unit.
+- Controller/transform/pass unit tests live in `v2/pkg/engine/cache` (in-package where unexported access is needed — the engine convention — noted in the commit).
+- Plan-driven / e2e tests live in the EXECUTION module (built on `execution` + the `federationtesting` approach; `wgc`/cosmo-proto assets live there and `v2` must NOT take that dependency).
+- Drive the loader through the PUBLIC `resolve` entry points; assert seams OBSERVABLY (recording fakes, store-op logs, `-race`) — no `export_test.go` bridge.
+
+### 4.2 Structure to adopt
+
+- testify: `require.*` for aborting preconditions, `assert.*` for checks; look the API up before writing assertions.
+- Table tests + descriptive `t.Run`; scenario-matrix IDs in subtest names (e.g. `"[E3] backfill all after response"`).
+- `t.Context()` (never `context.Background()` in tests); `t.Helper()` in harness functions.
+- gomock for interface fakes where the repo already does; reuse the existing `MockDataSource`/`mockedDS` helpers.
+
+### 4.3 Assertions
+
+- Assert the FULL value with `assert.Equal` — the entire response string, struct, map, slice, key, call log, store-op log — inline, even when long.
+- NEVER `assert.Contains`, `assert.JSONEq`, or fuzzy comparisons (`GreaterOrEqual` etc.).
+- NO `.golden` snapshot files.
+- Non-deterministic bits are NORMALIZED first (synctest's fixed clock, `compactJSONForAssert`, sorting free-ordered records with `slices.SortFunc`), then asserted structurally.
+- NO placeholder tests; every test asserts real, worked-out expected values.
+
+### 4.4 Standing test gates
+
+- NO-OP gates: with no caching configured, plans AND runtime behavior are byte-identical to the baseline — every task keeps both green.
+- `ProvidesData` fidelity gate: P1 trees match the OLD branch's trees (task 05).
+- Key-builder aliasing gate: mutate the source `FederationMetaData` after building and re-assert equality.
+- Determinism: plan twice, byte-identical.
+- Ports are tested ADVERSARIALLY: a verbatim port carries the OLD bugs; add rows beyond the OLD test set (partial overlap, irrelevant providers, empty unions).
+
+### 4.5 Time — `testing/synctest`, never a custom clock
+
+- Wrap time-dependent bodies in `synctest.Test(t, func(t *testing.T) { … })`; production keeps calling real `time` functions, which the bubble fakes.
+- Test TTL expiry by sleeping PAST the TTL inside the bubble (instant in fake time).
+- Order concurrent/defer fetches with GATE CHANNELS + `synctest.Wait()` — NEVER latency sleeps; sleeps exist only to advance fake time.
+- Bubble constraints: start ALL goroutines inside the test body; ONLY in-process fakes (no sockets).
+
+### 4.6 Federation fixtures — real wgc composition, no hand-written plans
+
+- Subgraphs are SDL files + `graph.yaml`, composed by real `wgc` via `compose.sh`, with the composed `config.json` COMMITTED; re-running `compose.sh` is the composability guard (cross-validate with rover where available).
+- Never hand-write `plan.Configuration` or fetch-tree literals; obtain plans from the committed config through the config factory + the real planner (the task 04 harness).
+- Composition is the ONE network step: run `compose.sh` explicitly (it needs `npx wgc`, so expect a permission prompt) only when fixtures change, commit the resulting `config.json`, and build/test against the committed artifact.
+
+---
+
+## 5. Markdown
+
+- One sentence per line in all `.md` files; break long sentences at commas.
+- Applies to prose, bullets, and plan docs — not code blocks or inline code.
+
+---
+
+## 6. Scope guardrails (do NOT build these)
+
+- The `@requestScoped` DIRECTIVE FEATURE is REMOVED entirely — not a pass, not a provider method, not a config field.
+  (The request-LIFETIME shared L1 store is retained and is NOT that feature.)
+- Subscription/mutation caching, root-field→entity L1 promotion, and the cosmo `FromFederation` shim are out-of-core follow-ups.
+- Caching config is SELF-CONTAINED: no federation types or pointers at runtime; `@key` is a plan-time input frozen by value once, in `cacheKeyBuilder` only.
+- `CacheKeySpec` is MULTI-KEY, best-effort: none required; render what you can at lookup, backfill the rest at write.
+
+---
+
+## 7. Implementation order (mandated)
+
+Follow `PLAN.md` §5: Structure (01–04) → L2 entities (05–12) → L2 root fields incl. isolation (13–14) → entity-cache reuse (15) → L1 (16–18) → partial + ART (19–20).
+Each task is a reviewable increment with its own tests; cross-reference your task file for the acceptance goals.
+
+---
+
+## 8. Definition of done (per commit)
+
+- PROBLEM stated: the commit notes name the problem and the task-file goal it satisfies (link the task file and relevant spec sections).
+- TESTS: new tests in a dedicated, logically-grouped file; full-value `assert.Equal`; deterministic; the existing suite still passes.
+- IMPLEMENTATION: minimal, surgical, modern-Go, reuse-first; every changed line traces to the task.
+- QUALITY: every new type and every important function carries a responsibility doc comment; no very large functions — decompose; complex logic carries explanatory inline comments; every intentional error-swallow/best-effort skip and every externally-lock-guarded field carries a WHY comment.
+- NOTES: any design decision or deviation written down (one sentence per line) with short reviewer guidance on what to scrutinize.
+- No commit without explicit human approval.
+
+---
+
+## 9. CI / lint (match CI exactly, for every module you touch)
+
+CI runs `golangci-lint` (v2) SEPARATELY on `v2/` and `execution/`; a commit touching both must be clean in BOTH.
+Enabled: `errcheck`, `govet`, `ineffassign`, `staticcheck`, `bodyclose`, `embeddedstructfieldcheck`, `tparallel`, `modernize`, plus `gci` and `gofmt` (`unused` disabled).
+Known recurring failures — avoid up front:
+
+- `gci` import grouping: `standard` → `default` (third-party) → `prefix(github.com/wundergraph)` → `prefix(github.com/wundergraph/graphql-go-tools)`, blank-line-separated (`astjson` and `graphql-go-tools` are DIFFERENT groups).
+  Run `gci write -s standard -s default -s "prefix(github.com/wundergraph)" -s "prefix(github.com/wundergraph/graphql-go-tools)" <files>` before finishing.
+- `embeddedstructfieldcheck`: blank line between an embedded field and regular fields.
+- `staticcheck QF1012`: `fmt.Fprintf(&b, …)`, never `b.WriteString(fmt.Sprintf(…))`.
+- CI caps duplicate reports (`max-same-issues: 3`) — fix EVERY occurrence in your diff, not just the printed ones.
+- Emulate locally: `golangci-lint run` from each touched module's directory (if your local version lacks `modernize`, strip that line from a copy of the config and run the rest).
+
+Environment realities:
+
+- `compose.sh` needs network (`npx -y wgc@latest`); run it as an explicit step when fixtures change and commit `config.json` — never regenerate it implicitly inside a test run.
+- The `execution` module resolves local `v2` via `go.work`; run its tests with `cd execution && go test ./...`.
+- Long test runs (`-race`, both modules) belong in background shells; verify output, do not assume success.
+
+---
+
+## 10. Quick checklist (run before handing back)
+
+- [ ] Modern Go idioms; no reinvented stdlib; reused the cited packages.
+- [ ] No `switch` over concrete fetch types; no "freezer"/"stamper" names; all logic in `engine/cache` per the packaging rules.
+- [ ] All astjson mutation inside a held `CacheTransaction`; one per hook.
+- [ ] Tests in dedicated files; full-value `assert.Equal` only; no `.golden`, no `Contains`/`JSONEq`/fuzzy; no placeholders.
+- [ ] Time via `testing/synctest`; ordering via gates, never latency.
+- [ ] Fixtures wgc-composed and committed; no hand-written plans.
+- [ ] Both NO-OP gates still green.
+- [ ] Doc comments on every new type and important function; WHY comments on intentional skips and externally-locked fields.
+- [ ] No helper duplicated across caching files; no dead code left behind.
+- [ ] Stayed in scope (no `@requestScoped`, no subscription/mutation caching).
+- [ ] Lint-clean per §9 in EVERY touched module.
+- [ ] Markdown one sentence per line.

--- a/docs/caching/PLAN.md
+++ b/docs/caching/PLAN.md
@@ -1,0 +1,180 @@
+# Caching port — unified implementation plan
+
+Status: authoritative execution plan for the clean re-implementation.
+Branch under change: `caching-fable-on-defer` (branched from the defer branch BEFORE the first-pass caching commits), all code under `v2/` (Go 1.25) plus the `execution/` module for integration tests.
+
+This plan supersedes the first-pass PLAN.md on the base branch.
+The maintainer feedback (formerly the "R2" overlay) is FOLDED IN here — there is no override layer to mentally apply.
+Where this plan conflicts with the RFC specs in `specs/`, THIS PLAN WINS; the specs are background reference and design rationale, not the contract.
+
+## 1. Ground truth, in priority order
+
+1. This `PLAN.md` and the task files in `tasks/` (one file per subtask; each is a self-contained work order), plus `PROGRESS.md` (the live execution state — where any session resumes from).
+2. `CODING_GUIDELINES.md` (re-read at the start of EVERY implementation session).
+3. The RFC specs in `specs/` (RFC-1 loader abstraction, RFC-2 caching planner, RFC-3 root-field isolation, RFC-1 testing appendix) — background and rationale; superseded by the task files where they differ (the task files record every deliberate deviation).
+4. The actual source: this branch (`v2/`, `execution/`), the base branch worktree (`feat/eng-7770-add-defer-support-part-4`, which carries the FIRST-PASS implementation — consult it as a reference, do not cherry-pick blindly), and the OLD implementation (`caching-base` worktree).
+
+The scratchpad DOSSIER the RFCs cite (`scratchpad/caching-rfc/DOSSIER.md`) is NOT committed and is NOT required to execute this plan; every load-bearing fact from it has been folded into the task files.
+
+## 2. Workflow and execution protocol (single agent: Fable)
+
+Fable (Claude) executes this plan END TO END — implementation, tests, verification, self-review, and progress tracking.
+There is no separate coding agent.
+
+Per task, in order:
+
+1. ORIENT: read `PLAN.md`, `PROGRESS.md`, `CODING_GUIDELINES.md`, and the task file; open the referenced spec sections only where the task file points at them.
+2. IMPLEMENT the task exactly as scoped; stay surgical; test-first where the task defines behavior (write the failing test, then make it pass).
+3. VERIFY: run the task's tests, the full affected suites, and `golangci-lint` for EVERY touched module (v2 AND execution); every ACCEPTANCE CRITERIA checkbox must be proven with real command output, never assumed.
+4. SELF-REVIEW against the task's "Reviewer guidance" section and both no-op gates before declaring the task done.
+5. RECORD: update `PROGRESS.md` (status, commit hash, deviations, anything the next task must know) BEFORE moving on or ending the session.
+6. COMMIT: one reviewable commit per task (or per commit split the task file defines), linking the task file, with notes per CODING_GUIDELINES §8.
+   Commit only under the approval granted in the kickoff prompt; absent a standing grant, stop at each task boundary and ask for review.
+
+Continuity rules (what makes follow-through survive session and context boundaries):
+
+- `PROGRESS.md` plus git history are the ONLY durable state; never rely on conversation memory across sessions.
+- Never end a session mid-task without writing the exact stopping point and the next concrete step into `PROGRESS.md`.
+- A task's status is what `PROGRESS.md` says; if git reality and `PROGRESS.md` disagree, reconcile `PROGRESS.md` against git FIRST, then continue.
+- Execute tasks in the §5 dependency order unless `PROGRESS.md` records an approved re-ordering.
+- Never skip a failing acceptance criterion to move on: fix it, or record a precise blocker in `PROGRESS.md` and stop for input.
+- The kickoff prompt is idempotent by design: "read PROGRESS.md, resume the next incomplete step" always lands in a well-defined state.
+
+## 3. Architecture overview (the abstractions, post-feedback)
+
+Runtime (loader side):
+
+- The loader talks to ONE mode-blind working surface, `RequestCache` (`PrepareFetch` / `OnFetchSkipped` / `OnFetchResult` / `EndRequest`), obtained lazily from a `CacheController` set on `Context` (mirroring `SetAuthorizer`).
+- The loader branches on NOTHING but the returned `Decision` (`Fetch`, `SkipFullHit`, `FetchPartial`, `FetchShadow`) and a nil-check on the opaque two-level `*FetchCacheHandle`.
+- All astjson reads/merges/writes by the cache happen inside an explicit `CacheTransaction`: `tx := arena.Begin()` … ops on `tx` … `tx.Commit()`.
+  One transaction per hook == one `DataBuffer.Lock` acquisition (this replaces the RFC-1 `MergeArena`/`MergeSession` naming with the same locking semantics).
+- Per-fetch config is a self-contained, federation-free `*FetchCacheConfig` on the fetch; nil means "not cached".
+  Fetches expose it polymorphically via methods on the `Fetch` interface (`CacheConfig()`, `SetCacheConfig(...)`, entity/batch predicates) — NO `switch` over concrete fetch types.
+- L1 stores `*astjson.Value` in memory (never marshals); only L2 marshals/unmarshals; each response is parsed ONCE; L1 and L2 SHARE the same derived keys (derive once, use for both layers).
+- Values are NORMALIZED to schema field names (with argument-suffix keys) on write and DENORMALIZED back to the query's aliases on read, so a value cached by one fetch is reusable by another with different aliases/args.
+- Partial fetching is IN CORE: resolve layer by layer — serve what L1 has, look up the still-missing keys in L2, fetch only the keys still missing from the subgraph, then splice + realign (batch: refetch only the missing representations).
+- A `CacheObserver` port quarantines analytics/trace/shadow-compare off the lookup/write surface; verbose caching behavior (L1/L2, hits/misses, shadow compares, backfills, key derivations, remaining TTLs) is exposed through ART.
+
+Plan side (producer):
+
+- A leaf policy package `plan/cacheconfig` (`CachingConfiguration`, the `*CachePolicy` structs, `CacheConfigProvider`), reached via `dataSourceConfiguration[T].Caching()`.
+- One plan-time visitor, `cacheProvidesDataVisitor` (P1), run as a gated SECOND, filter-free walk on the `planningWalker` after the main walk, building the per-fetch `ProvidesData` tree (alias→`OriginalName`, `CacheArgs`, entity boundaries).
+- Postprocess passes over the finished fetch tree: `cacheKeyBuilder` (the SOLE federation reader; freezes every resolvable `@key` set into multi-key `CacheKeySpec.Candidates` by value) and `fetchCacheConfigurator` (assembles + sets `*FetchCacheConfig` on the concrete fetch types after `createConcreteSingleFetchTypes`), orchestrated by a thin `ConfigureCaching` facade holding the single no-op gate; then `optimizeL1Cache` narrows `cfg.L1` cross-tree.
+  (These are the RFC-2 "freezer"/"stamper" under plain names.)
+- Per-root-field cache isolation is IN CORE: sibling query root fields on the same datasource with different cache configs are split into separate fetches during path building (`path_builder_visitor.go` MAY be edited; there are no forbidden files).
+- Public entry point: the engine `Configuration` gains `SetCaching(...)` alongside `SetDataSources`/`SetFieldConfigurations`; `postprocess.EnableCaching(...)` stays an internal detail.
+
+Packaging:
+
+- Contract types (`FetchCacheConfig`, `CacheKeySpec`, `Decision`, the handle, the hook inputs, `CacheTransaction`) live in `resolve` (the loader references them; `resolve` imports no cache logic).
+- ALL cache logic — controller (L1/L2/partial as clean, separable modules), key templates and rendering, normalization transforms, the postprocess pass logic, observer/ART glue — consolidates into ONE common package `v2/pkg/engine/cache` (plus its `cachetesting` support subpackage).
+- `plan` keeps only the P1 visitor and the isolation seam (they need walk-time planner context); `postprocess` keeps only thin facade calls into `engine/cache`.
+
+## 4. Invariants every task must protect
+
+- RUNTIME NO-OP: with no `SetCacheController`, the loader path is byte-identical to today.
+- PLANNER NO-OP: with no caching configuration supplied, postprocessed plans are byte-identical to today.
+  Phase 0 as a whole is a pure no-op end to end; every later phase keeps both gates intact for integrators who do not opt in.
+- WRITE GATE: a fetched value is persisted only when `!FetchFailed && !HasErrors && ResponseData != nil && Type() != Null`; `EmptyEntity` is the one non-failure that still writes (the negative sentinel). The gate can never reduce to `!HasErrors`.
+- KEY FIDELITY: cache keys derive from the canonical pre-injection input + header hash; read key == write key, byte-identical; one `CacheKeyTemplate` per candidate is the sole source of read/write/invalidate keys.
+- LOCK DISCIPLINE: one `CacheTransaction` (one `DataBuffer.Lock` acquisition) per hook; the arena is never touched outside a held transaction; never from the off-lock load phase.
+- PLAN CACHE SAFETY: only static, request-independent config is written at plan time; per-request key material derives at runtime.
+
+## 5. Dependency order at a glance
+
+```
+Phase 0 — STRUCTURE (pure no-op end to end)
+  01 representationvariable extraction                  (no deps)
+  02 runtime contract + loader seam + transaction       (no deps; independent of 01)
+  03 planner wiring + cacheconfig + engine SetCaching   (deps: 01, 02)
+  04 test infrastructure: caching subgraphs + harness   (deps: 02, 03)
+
+Phase A — L2 ENTITIES
+  05 ProvidesData visitor (P1)                          (deps: 03, 04)
+  06 entity cache config: key builder + configurator    (deps: 01, 03, 05)
+  07 entity L2 controller core (single candidate)       (deps: 02, 04, 06)
+  08 multi-key: freshness, reorder, backfill            (deps: 07)
+  09 store-time normalization + argument-suffix keys    (deps: 07)
+  10 batch entity caching                               (deps: 08)
+  11 negative caching                                   (deps: 07)
+  12 shadow mode                                        (deps: 07)
+
+Phase B — L2 ROOT FIELDS
+  13 root-field L2 (plan + runtime)                     (deps: Phase A core: 07, 09)
+  14 per-root-field isolation (RFC-3, in core)          (deps: 13)
+
+Phase C — ROOT FIELDS RE-USING THE ENTITY CACHE
+  15 entity-cache reuse via EntityKeyMappings           (deps: 08, 13)
+
+Phase D — L1 CACHING
+  16 optimizeL1Cache cross-tree narrowing               (deps: 06)
+  17 request-lifetime shared L1 store (astjson values)  (deps: 09, 16)
+  18 defer + concurrency scenario coverage              (deps: 17; needs the 04 fixtures)
+
+Phase E — PARTIAL + OBSERVABILITY (in core per maintainer feedback)
+  19 partial fetching (partial cache load + batch realign)  (deps: 10, 17)
+  20 ART observability (verbose caching trace)              (deps: 12, 17)
+```
+
+Each task is a reviewable increment with its own tests; no task may regress the no-op gates.
+
+## 6. Task index
+
+| # | File | Phase | Deliverable |
+|---|---|---|---|
+| 01 | [tasks/01-representation-variable-extraction.md](tasks/01-representation-variable-extraction.md) | 0 | Shared exported `representationvariable` package; `graphql_datasource` refactored in place |
+| 02 | [tasks/02-runtime-contract-and-loader-seam.md](tasks/02-runtime-contract-and-loader-seam.md) | 0 | Contract types, `CacheTransaction`, `Fetch` interface methods, no-op loader seam |
+| 03 | [tasks/03-planner-wiring-and-engine-config.md](tasks/03-planner-wiring-and-engine-config.md) | 0 | `plan/cacheconfig`, postprocess pass skeletons, `Configuration.SetCaching(...)` |
+| 04 | [tasks/04-test-infrastructure.md](tasks/04-test-infrastructure.md) | 0 | Dedicated caching subgraphs, execution-module e2e framework, `cachetesting` fakes |
+| 05 | [tasks/05-provides-data-visitor.md](tasks/05-provides-data-visitor.md) | A | P1 visitor (second filter-free walk) + `*FetchInfo`-keyed side-table |
+| 06 | [tasks/06-entity-cache-configuration.md](tasks/06-entity-cache-configuration.md) | A | `cacheKeyBuilder` (multi-key freeze) + `fetchCacheConfigurator` entity arm |
+| 07 | [tasks/07-entity-l2-controller-core.md](tasks/07-entity-l2-controller-core.md) | A | Entity L2 controller: lookup → coverage → decision → gated write → flush |
+| 08 | [tasks/08-multi-key-freshness-reorder.md](tasks/08-multi-key-freshness-reorder.md) | A | Multi-candidate render/lookup, freshness selection, reorder, backfill |
+| 09 | [tasks/09-store-normalization.md](tasks/09-store-normalization.md) | A | Normalize-on-write / denormalize-on-read + argument-suffix keys |
+| 10 | [tasks/10-batch-entity-caching.md](tasks/10-batch-entity-caching.md) | A | Batch entity shapes, per-item state, end-to-end L2 hit |
+| 11 | [tasks/11-negative-caching.md](tasks/11-negative-caching.md) | A | Empty-entity null sentinel write + hit, TTL expiry |
+| 12 | [tasks/12-shadow-mode.md](tasks/12-shadow-mode.md) | A | `DecisionFetchShadow`: read-never-serve, compare-before-write |
+| 13 | [tasks/13-root-field-l2.md](tasks/13-root-field-l2.md) | B | Root-field policies, all-or-nothing safety net, root-field L2 runtime + shadow asymmetry |
+| 14 | [tasks/14-root-field-isolation.md](tasks/14-root-field-isolation.md) | B | Per-root-field fetch isolation in the path builder |
+| 15 | [tasks/15-entity-cache-reuse.md](tasks/15-entity-cache-reuse.md) | C | `EntityKeyMappings` derivation + by-key root fields served from the entity cache |
+| 16 | [tasks/16-optimize-l1-pass.md](tasks/16-optimize-l1-pass.md) | D | Cross-tree L1 narrowing pass |
+| 17 | [tasks/17-l1-runtime-store.md](tasks/17-l1-runtime-store.md) | D | Request-lifetime shared L1 (`*astjson.Value`, shared keys) across defer groups |
+| 18 | [tasks/18-defer-concurrency-coverage.md](tasks/18-defer-concurrency-coverage.md) | D | Defer + concurrency scenario rows (N/M), incl. the cross-group L1 fixture |
+| 19 | [tasks/19-partial-fetching.md](tasks/19-partial-fetching.md) | E | Partial cache load + partial batch realign (`DecisionFetchPartial`) |
+| 20 | [tasks/20-art-observability.md](tasks/20-art-observability.md) | E | Verbose caching behavior through ART via `CacheObserver` |
+
+## 7. Resolved decisions (deviations from the RFCs, recorded once)
+
+- D1. The maintainer-feedback revision is folded in; the RFCs are background.
+  Every task file states its own deviations inline, so no reader needs to diff spec against plan.
+- D2. `MergeArena`/`MergeSession` is renamed and reshaped into `CacheTransaction` (`Begin()` … ops … `Commit()`), identical locking semantics: one transaction per hook, one `DataBuffer.Lock` acquisition, arena untouchable outside a held transaction.
+- D3. L2 enablement stays DERIVED from policy TTLs (`TTL > 0 || NegativeCacheTTL > 0` for entities, `TTL > 0` for root fields); no explicit L2 bool is added to the policy structs (closes RFC-2 open question R3).
+- D4. `EntityMergePath` is a FIX, not a gap: the loader surfaces the fetch's post-processing merge path into the hook inputs so entity/batch values splice at the correct target (task 07/10); values are never silently spliced at the item root for non-root merge paths.
+- D5. Packaging: contract types in `resolve`; ALL logic in the common `v2/pkg/engine/cache` package; `plan/cacheconfig` stays a leaf policy package (avoids the plan↔cache import cycle); `plan`/`postprocess` hold only thin shims.
+- D6. Names: `cacheProvidesDataVisitor` (kept), `cacheKeyBuilder` (was "freezer"), `fetchCacheConfigurator` (was "stamper"), `ConfigureCaching` facade, `optimizeL1Cache` (kept). No "freeze"/"stamp" vocabulary in code or docs.
+- D7. Testing: NO `.golden` snapshot files; assert COMPLETE responses/plans with full-value `assert.Equal`; the appendix scenario catalog (A–P, M, N rows) is retained as the coverage checklist, re-based onto the new harness; dedicated caching subgraphs (not `commerce` alone) with nesting and TTL/config variance, built on `execution` + the `federationtesting` approach.
+- D8. `Fetch` interface methods (`CacheConfig()`, `SetCacheConfig(...)`, entity/batch predicates) replace all `switch`-over-concrete-fetch-type sites in caching code; other fetch-type switches encountered along the way are improved in the same spirit.
+- D9. P1 runs as a gated SECOND, filter-free walk on the `planningWalker` after the main walk (the first-pass correction to RFC-2 §9.2); it never re-runs the planning visitor and never rebuilds the plan.
+- D10. `EntityKeyMappings` are STRUCTURALLY DERIVED (root-field return type + args matched against the entity `@key` via definition + federation); this branch carries no external mapping config. By-key root-field reuse requires the root-field policy to share `CacheName` with the entity policy (read key == write key).
+- D11. The `@requestScoped` directive feature is EXCLUDED entirely (no pass, no provider method, no config field). The request-LIFETIME shared L1 store is retained and is not that feature.
+- D12. Subscription/mutation caching and the cosmo `FromFederation` migration shim remain out-of-core follow-ups; ART observability and partial fetching are IN core (Phase E).
+
+## 8. Out-of-core follow-ups (sequenced after Phase E)
+
+- Subscription/mutation caching (`cacheSubscriptionAnnotator`, trigger lifecycle, invalidation).
+- Root-field → entity L1 promotion.
+- cosmo migration shim (`cacheconfig.FromFederation(...)`).
+- Per-defer-group early L2 flush (correctness-neutral latency optimization).
+
+## 9. Completion checklist
+
+- [ ] All 20 tasks merged, each meeting its own ACCEPTANCE CRITERIA.
+- [ ] Both no-op gates hold at every commit (runtime byte-identical without a controller; plans byte-identical without caching config).
+- [ ] All caching code consolidated per D5; no `switch` over concrete fetch types in caching code (D8).
+- [ ] L1 stores `*astjson.Value`; single parse per response; L1/L2 share keys; normalization on write, denormalization on read (tasks 09, 17).
+- [ ] Partial fetching works end to end for single and batch fetches (task 19).
+- [ ] ART exposes verbose caching behavior (task 20).
+- [ ] The full scenario matrix passes: coverage/freshness/reorder, multi-key, negative, shadow, root-field split, entity reuse, partial expiry, alias/argument reuse, defer + concurrency under `-race`.
+- [ ] Every function of the modular cache interfaces has a meaningful unit test; every caching use case has a fully-implemented integration test; NO placeholder tests; NO dead code; HIGH coverage.
+- [ ] All caching tests assert FULL values with `assert.Equal`; no `Contains`/`JSONEq`/fuzzy anywhere.
+- [ ] Every new type and every important function carries a responsibility doc comment; complex logic carries explanatory inline comments.

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -22,7 +22,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 10 | batch entity caching | done | def25586 | Full-batch semantics per unique representation; prepareItemState reused per bucket; splice copies per target; reviews/10-*.md. |
 | 11 | negative caching | done | d8888bff | DEVIATION from first pass: negative hits splice NOTHING so cached and uncached responses are byte-identical (incl. the null-bubble error); reviews/11-*.md. |
 | 12 | shadow mode | done | 09d5775b | Stash-after-selection clears serving fields; ShadowCacheEntry gained CacheTTL (reserved in task-02 log); RecordingObserver materializes compares; H4 re-runs at task 17; reviews/12-*.md. |
-| 13 | root-field L2 | in-progress | (commit 1 below) | Commit 1 (plan side) landed; commit 2 (runtime) next. |
+| 13 | root-field L2 | done | be3295de + (commit 2 below) | Key excludes the query text (coordinate + canonical variables) for alias reuse; shadow hit = plain Fetch (compare structurally impossible); reviews/13-*.md. |
 | 14 | per-root-field isolation | todo | — | — |
 | 15 | entity-cache reuse | todo | — | — |
 | 16 | optimizeL1Cache pass | todo | — | — |
@@ -33,8 +33,8 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 
 ## Current focus
 
-- Next step: task 13 commit 2 (the runtime root-field branch in the controller).
-- Mid-task state: task 13 commit 1 (configurator root-field arm) is committed; the controller still declines root-field scope.
+- Next step: task 14 (per-root-field isolation; dep 13 is done).
+- Mid-task state: none.
 
 ## Blockers awaiting human input
 
@@ -85,3 +85,5 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 - Task 11: `EmptyEntity` from the loader means "entities-shaped response", not "empty" — the negative branch's `ResponseData TypeNull` conjunct is load-bearing.
 - Task 12: `ShadowCacheEntry.CacheTTL` added (the task-02 log reserved it); the observer derives age without re-deriving config.
 - Task 12: shadow stashes AFTER the selection ladder and clears the serving fields (incl. NeedsWriteback — OnFetchResult refreshes from fresh anyway); H4 (L1-hit-wins) re-runs at task 17.
+- Task 13: the root-field key preimage is coordinate + name-sorted variables, EXCLUDING the query text (alias reuse requires it); safe under the engine's always-on variable extraction (documented precondition at rootFieldCacheKey).
+- Task 13: merged-fetch policy equality compares VALUES excluding coordinates; a root-field shadow hit is a plain DecisionFetch (no stash → compare structurally impossible).

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -14,7 +14,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 02 | runtime contract + loader seam | done | e79ebbe8 | D2/D4/D8 applied; ShadowCacheEntry/ItemCacheState kept to RFC shape (first-pass extras not ported); reviewer notes in reviews/02-*.md. |
 | 03 | planner wiring + engine SetCaching | done | 4653a8e1 | SetCaching keyed by datasource ID; provider drops first-pass KeySpecs (D10); P1 registers on the second walk only; reviewer notes in reviews/03-*.md. |
 | 04 | test infrastructure | done | b0a6b045 | Fixtures in execution/cachingtesting (wgc+rover clean); fakes in v2 cache/cachetesting; first-pass RealishCache/Mode/Stage NOT ported (dead until task 07); Fetch.SetDataSource added (D8 swap); reviews/04-*.md. |
-| 05 | ProvidesData visitor (P1) | todo | — | — |
+| 05 | ProvidesData visitor (P1) | done | (see git log) | Full port + adversarial rows; ComputeHasAliases deferred to task 06 (first caller); empty-boundary tree pinned as zero coverage; reviews/05-*.md. |
 | 06 | entity cache configuration | todo | — | — |
 | 07 | entity L2 controller core | todo | — | — |
 | 08 | multi-key / freshness / reorder | todo | — | — |
@@ -33,7 +33,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 
 ## Current focus
 
-- Next step: task 05 (ProvidesData visitor; deps 03 + 04 are done). Phase 0 is complete.
+- Next step: task 06 (entity cache configuration; deps 01 + 03 + 05 are done).
 - Mid-task state: none.
 
 ## Blockers awaiting human input
@@ -60,3 +60,6 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 - Task 04: `Fetch.SetDataSource` added to the interface so datasource swapping needs no concrete-type switch (D8 spirit).
 - Task 04: first-pass `RealishCache`/`Mode`/`CacheStage`/`storeAdapter` NOT ported — they need the task-07 controller and would be dead code now; task 07 introduces the controller-backed test cache.
 - Task 04: the harness always plans with `IncludeQueryPlanInResponse` so plan-shape tests assert rendered trees inline (no goldens).
+- Task 05: `ComputeHasAliases` deferred to task 06 (its first caller, per the task file's "folded into the configurator" note).
+- Task 05: a boundary-only entity planner yields an EMPTY ProvidesData tree — the task-07 controller must treat an empty tree as ZERO coverage (never a vacuous full hit).
+- Task 05: `dataSourceConfiguration.Caching()` still unconsumed (the visitor reads nothing datasource-scoped); tasks 06+ read providers from the postprocess options instead.

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -27,13 +27,13 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 15 | entity-cache reuse | done | 44011a84 | Spec carries the FULL entity candidate set (first pass had mapping-only — E3 backfill impossible there); EntityMergePath finally populated; v1 variable-name constraint documented; reviews/15-*.md. |
 | 16 | optimizeL1Cache pass | done | abe90ce7 | Ordering = dependency edges + TREE order (deviation, argued in reviews/16); schema-name+args field matching; first-pass union aliasing bug fixed and pinned; reviews/16-*.md. |
 | 17 | L1 runtime store | done | 36ac68c5 | Pointer store, shared keys, L1-first ladder; fixed heap-mode StructuralCopy passthrough + optimize-pass chain break; H4 resolved (shadow stashes L1 selections); reviews/17-*.md. |
-| 18 | defer + concurrency coverage | todo | — | — |
+| 18 | defer + concurrency coverage | done | (see git log) | First-pass gap CLOSED (N1/N2/M3 proven e2e); flushed-out fix: defer-group ANCESTRY ordering (treeParents via DeferDescriptors.ParentID); N4 via Flushed gate channel (synctest incompatible with engine goroutines); reviews/18-*.md. |
 | 19 | partial fetching | todo | — | — |
 | 20 | ART observability | todo | — | — |
 
 ## Current focus
 
-- Next step: task 18 (defer + concurrency coverage; deps 10 + 17 are done).
+- Next step: task 19 (partial fetching; deps 10 + 17 are done).
 - Mid-task state: none.
 
 ## Blockers awaiting human input
@@ -96,3 +96,6 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 - Task 17: `CacheTransaction.StructuralCopy` was an identity passthrough in heap mode (DeepCopy(nil) returns v; resolve.go:361 runs a nil-arena loader) — heap mode now forces a real copy via marshal round-trip.
 - Task 17: the optimize-pass ordering walk now indexes EVERY fetch (chains pass through unconfigured hops: products→reviews→products); the l1_e2e chain fixture is the live proof.
 - Task 17: H4 = shadow stashes L1-selected values too (read-never-serve absolute); the L1 negative sentinel ignores the NegativeCacheTTL knob (in-request facts).
+- Task 18: executesBefore now uses defer-group ANCESTRY (treeEncloses over treeParents; postprocess derives them from DeferDescriptors.ParentID) — nested groups order after their parents; siblings stay unordered.
+- Task 18: a nested @defer with a SUBSET selection is normalized away — nested-group fixtures must select via a different path (the reviews hop back to the same entity).
+- Task 18: synctest bubbles deadlock on engine-lifetime goroutines (WS ping loops, resolver heartbeat) — defer-frame ordering tests gate on the writer's Flushed channel instead.

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -17,7 +17,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 05 | ProvidesData visitor (P1) | done | 648a768b | Full port + adversarial rows; ComputeHasAliases deferred to task 06 (first caller); empty-boundary tree pinned as zero coverage; reviews/05-*.md. |
 | 06 | entity cache configuration | done | 3f7e3ca5 | Entity arm only (root fields task 13, mappings task 15); NEW hardening: __typename-only candidates rejected as malformed; ComputeHasAliases landed with its first caller; reviews/06-*.md. |
 | 07 | entity L2 controller core | done | 29606414 | L2-only single-candidate core; deferral gates fail closed (shadow/batch/root/negative/L1/multi-key → plain fetch); no Mode enum; resolve.NewTransactionBeginner exported for controller tests; reviews/07-*.md. |
-| 08 | multi-key / freshness / reorder | todo | — | — |
+| 08 | multi-key / freshness / reorder | done | (see git log) | Full ladder + backfill; malformed cached bytes now refresh (first pass left poison entries); fixtures grew deals subgraph + featuredReview for the plan-driven cross-key row (wgc+rover clean, IDs stable); reviews/08-*.md. |
 | 09 | store normalization + arg keys | todo | — | — |
 | 10 | batch entity caching | todo | — | — |
 | 11 | negative caching | todo | — | — |
@@ -33,7 +33,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 
 ## Current focus
 
-- Next step: task 08 (multi-key: freshness, reorder, backfill; dep 07 is done). Tasks 09/11/12 are also unblocked.
+- Next step: task 09 (store normalization + arg keys; dep 07 is done). Tasks 10/11/12 are also unblocked.
 - Mid-task state: none.
 
 ## Blockers awaiting human input
@@ -71,3 +71,8 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 - Task 07: merge hooks read `MergeInput.MergePath` (D4); `ItemCacheState.EntityMergePath` stays unset (prepare has no path input).
 - Task 07: `resolve.NewTransactionBeginner` is new exported API for controller unit tests; the loader wires its own beginner internally.
 - Task 07: `ttlForConfig`/MutationTTLOverride not ported (mutation caching is out-of-core, D12); writes use `cfg.TTL`.
+- Task 08: served values are reordered to selection order with cached-only extras appended (task-07 splice pins updated accordingly).
+- Task 08: malformed cached bytes count as a MISS for that key and get refreshed by the write path (the first pass left poison entries in place).
+- Task 08: `WriteReasonRecorder` is an optional Store extension for refresh/backfill visibility; reasons never gate writes.
+- Task 08: fixtures grew the `deals` subgraph (sku-keyed Product reference) + `featuredReview` (single-object upc path) to make the cross-key plan expressible; datasource IDs 0–3 unchanged, deals is "4".
+- Task 08: pending candidates re-render on skip from the SERVED value only (the first pass also tried the request item).

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -18,7 +18,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 06 | entity cache configuration | done | 3f7e3ca5 | Entity arm only (root fields task 13, mappings task 15); NEW hardening: __typename-only candidates rejected as malformed; ComputeHasAliases landed with its first caller; reviews/06-*.md. |
 | 07 | entity L2 controller core | done | 29606414 | L2-only single-candidate core; deferral gates fail closed (shadow/batch/root/negative/L1/multi-key → plain fetch); no Mode enum; resolve.NewTransactionBeginner exported for controller tests; reviews/07-*.md. |
 | 08 | multi-key / freshness / reorder | done | 3372187b | Full ladder + backfill; malformed cached bytes now refresh (first pass left poison entries); fixtures grew deals subgraph + featuredReview for the plan-driven cross-key row (wgc+rover clean, IDs stable); reviews/08-*.md. |
-| 09 | store normalization + arg keys | todo | — | — |
+| 09 | store normalization + arg keys | done | (see git log) | FromCache stays NORMALIZED; denormalize-at-splice subsumes the task-08 reorder (deleted); pending renders now use the normalized value (first-pass alias bug fixed); inventory grew stockHistory(days) for the arg e2e; reviews/09-*.md. |
 | 10 | batch entity caching | todo | — | — |
 | 11 | negative caching | todo | — | — |
 | 12 | shadow mode | todo | — | — |
@@ -33,7 +33,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 
 ## Current focus
 
-- Next step: task 09 (store normalization + arg keys; dep 07 is done). Tasks 10/11/12 are also unblocked.
+- Next step: task 10 (batch entity caching; dep 08 is done). Tasks 11/12 are also unblocked.
 - Mid-task state: none.
 
 ## Blockers awaiting human input
@@ -76,3 +76,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 - Task 08: `WriteReasonRecorder` is an optional Store extension for refresh/backfill visibility; reasons never gate writes.
 - Task 08: fixtures grew the `deals` subgraph (sku-keyed Product reference) + `featuredReview` (single-object upc path) to make the cross-key plan expressible; datasource IDs 0–3 unchanged, deals is "4".
 - Task 08: pending candidates re-render on skip from the SERVED value only (the first pass also tried the request item).
+- Task 09: `FromCache` stays NORMALIZED on the handle; denormalization to the requesting aliases happens at splice time and subsumes the task-08 reorder (`reorderToSelectionOrder` deleted).
+- Task 09: the `HasAliases` fast path gates only write-side normalization; the read side always walks (it is also the selection-order pass).
+- Task 09: pending-candidate re-render uses the NORMALIZED value (representation fields carry schema names — a latent first-pass bug for aliased key fields).
+- Task 09: fixtures grew `Product.stockHistory(days: Int!)` on inventory for the entity-level argument e2e row (wgc + rover clean).

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -16,7 +16,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 04 | test infrastructure | done | b0a6b045 | Fixtures in execution/cachingtesting (wgc+rover clean); fakes in v2 cache/cachetesting; first-pass RealishCache/Mode/Stage NOT ported (dead until task 07); Fetch.SetDataSource added (D8 swap); reviews/04-*.md. |
 | 05 | ProvidesData visitor (P1) | done | 648a768b | Full port + adversarial rows; ComputeHasAliases deferred to task 06 (first caller); empty-boundary tree pinned as zero coverage; reviews/05-*.md. |
 | 06 | entity cache configuration | done | 3f7e3ca5 | Entity arm only (root fields task 13, mappings task 15); NEW hardening: __typename-only candidates rejected as malformed; ComputeHasAliases landed with its first caller; reviews/06-*.md. |
-| 07 | entity L2 controller core | todo | — | — |
+| 07 | entity L2 controller core | done | (see git log) | L2-only single-candidate core; deferral gates fail closed (shadow/batch/root/negative/L1/multi-key → plain fetch); no Mode enum; resolve.NewTransactionBeginner exported for controller tests; reviews/07-*.md. |
 | 08 | multi-key / freshness / reorder | todo | — | — |
 | 09 | store normalization + arg keys | todo | — | — |
 | 10 | batch entity caching | todo | — | — |
@@ -33,7 +33,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 
 ## Current focus
 
-- Next step: task 07 (entity L2 controller core; deps 02 + 04 + 06 are done).
+- Next step: task 08 (multi-key: freshness, reorder, backfill; dep 07 is done). Tasks 09/11/12 are also unblocked.
 - Mid-task state: none.
 
 ## Blockers awaiting human input
@@ -66,3 +66,8 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 - Task 06: `buildEntitySpec` rejects candidates whose representation carries no field beyond `__typename`
   (unknown-field @keys silently degrade to __typename-only nodes in the representation walker — a cross-entity key-collision hazard the first pass missed).
 - Task 06: the all-flags-false nil gate in `buildConfig` is unreachable for entities (found policy ⇒ L1); it serves the task-13 root-field arm.
+- Task 07: the controller has NO Mode enum (first pass had one); L2 enablement is `cfg.L2 && store != nil`, L1 composes in task 17.
+- Task 07: every not-yet-implemented feature fails CLOSED in PrepareFetch (shadow/root-field/batch → plain fetch, no reads served); tasks 08–13 replace those gates.
+- Task 07: merge hooks read `MergeInput.MergePath` (D4); `ItemCacheState.EntityMergePath` stays unset (prepare has no path input).
+- Task 07: `resolve.NewTransactionBeginner` is new exported API for controller unit tests; the loader wires its own beginner internally.
+- Task 07: `ttlForConfig`/MutationTTLOverride not ported (mutation caching is out-of-core, D12); writes use `cfg.TTL`.

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -10,7 +10,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 
 | # | Task | Status | Commit(s) | Notes / deviations |
 |---|---|---|---|---|
-| 01 | representationvariable extraction | todo | — | — |
+| 01 | representationvariable extraction | done | (see git log) | Pure move; tests moved and extended with an entity-interface case per the task file. |
 | 02 | runtime contract + loader seam | todo | — | — |
 | 03 | planner wiring + engine SetCaching | todo | — | — |
 | 04 | test infrastructure | todo | — | — |
@@ -33,7 +33,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 
 ## Current focus
 
-- Next step: task 01 (no dependencies; task 02 is also unblocked and may be taken first if preferred — record the choice here).
+- Next step: task 02 (runtime contract + loader seam; no dependencies).
 - Mid-task state: none.
 
 ## Blockers awaiting human input

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -27,7 +27,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 15 | entity-cache reuse | done | 44011a84 | Spec carries the FULL entity candidate set (first pass had mapping-only — E3 backfill impossible there); EntityMergePath finally populated; v1 variable-name constraint documented; reviews/15-*.md. |
 | 16 | optimizeL1Cache pass | done | abe90ce7 | Ordering = dependency edges + TREE order (deviation, argued in reviews/16); schema-name+args field matching; first-pass union aliasing bug fixed and pinned; reviews/16-*.md. |
 | 17 | L1 runtime store | done | 36ac68c5 | Pointer store, shared keys, L1-first ladder; fixed heap-mode StructuralCopy passthrough + optimize-pass chain break; H4 resolved (shadow stashes L1 selections); reviews/17-*.md. |
-| 18 | defer + concurrency coverage | done | (see git log) | First-pass gap CLOSED (N1/N2/M3 proven e2e); flushed-out fix: defer-group ANCESTRY ordering (treeParents via DeferDescriptors.ParentID); N4 via Flushed gate channel (synctest incompatible with engine goroutines); reviews/18-*.md. |
+| 18 | defer + concurrency coverage | done | a0ce527a | First-pass gap CLOSED (N1/N2/M3 proven e2e); flushed-out fix: defer-group ANCESTRY ordering (treeParents via DeferDescriptors.ParentID); N4 via Flushed gate channel (synctest incompatible with engine goroutines); reviews/18-*.md. |
 | 19 | partial fetching | todo | — | — |
 | 20 | ART observability | todo | — | — |
 

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -23,7 +23,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 11 | negative caching | done | d8888bff | DEVIATION from first pass: negative hits splice NOTHING so cached and uncached responses are byte-identical (incl. the null-bubble error); reviews/11-*.md. |
 | 12 | shadow mode | done | 09d5775b | Stash-after-selection clears serving fields; ShadowCacheEntry gained CacheTTL (reserved in task-02 log); RecordingObserver materializes compares; H4 re-runs at task 17; reviews/12-*.md. |
 | 13 | root-field L2 | done | be3295de + 29443089 | Key excludes the query text (coordinate + canonical variables) for alias reuse; shadow hit = plain Fetch (compare structurally impossible); reviews/13-*.md. |
-| 14 | per-root-field isolation | todo | — | — |
+| 14 | per-root-field isolation | done | (see git log) | Fresh RFC-3 implementation (no first-pass reference); exactly three path-builder touches; gate on parentPath=="query" + provider policy; reviews/14-*.md. |
 | 15 | entity-cache reuse | todo | — | — |
 | 16 | optimizeL1Cache pass | todo | — | — |
 | 17 | L1 runtime store | todo | — | — |
@@ -33,7 +33,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 
 ## Current focus
 
-- Next step: task 14 (per-root-field isolation; dep 13 is done).
+- Next step: task 15 (entity-cache reuse; deps 08 + 13 are done). Phase B is complete.
 - Mid-task state: none.
 
 ## Blockers awaiting human input
@@ -87,3 +87,4 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 - Task 12: shadow stashes AFTER the selection ladder and clears the serving fields (incl. NeedsWriteback — OnFetchResult refreshes from fresh anyway); H4 (L1-hit-wins) re-runs at task 17.
 - Task 13: the root-field key preimage is coordinate + name-sorted variables, EXCLUDING the query text (alias reuse requires it); safe under the engine's always-on variable extraction (documented precondition at rootFieldCacheKey).
 - Task 13: merged-fetch policy equality compares VALUES excluding coordinates; a root-field shadow hit is a plain DecisionFetch (no stash → compare structurally impossible).
+- Task 14: no first-pass reference existed (RFC-3 was a follow-up there); implemented fresh: `shouldIsolateRootField` gate + exactly three path-builder touches; the fold-refusal keys off parentPath (the entity-root-node trap row pins why).

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -20,7 +20,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 08 | multi-key / freshness / reorder | done | 3372187b | Full ladder + backfill; malformed cached bytes now refresh (first pass left poison entries); fixtures grew deals subgraph + featuredReview for the plan-driven cross-key row (wgc+rover clean, IDs stable); reviews/08-*.md. |
 | 09 | store normalization + arg keys | done | 5cbd5244 | FromCache stays NORMALIZED; denormalize-at-splice subsumes the task-08 reorder (deleted); pending renders now use the normalized value (first-pass alias bug fixed); inventory grew stockHistory(days) for the arg e2e; reviews/09-*.md. |
 | 10 | batch entity caching | done | def25586 | Full-batch semantics per unique representation; prepareItemState reused per bucket; splice copies per target; reviews/10-*.md. |
-| 11 | negative caching | done | (see git log) | DEVIATION from first pass: negative hits splice NOTHING so cached and uncached responses are byte-identical (incl. the null-bubble error); reviews/11-*.md. |
+| 11 | negative caching | done | d8888bff | DEVIATION from first pass: negative hits splice NOTHING so cached and uncached responses are byte-identical (incl. the null-bubble error); reviews/11-*.md. |
 | 12 | shadow mode | todo | — | — |
 | 13 | root-field L2 | todo | — | — |
 | 14 | per-root-field isolation | todo | — | — |

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -29,7 +29,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 17 | L1 runtime store | done | 36ac68c5 | Pointer store, shared keys, L1-first ladder; fixed heap-mode StructuralCopy passthrough + optimize-pass chain break; H4 resolved (shadow stashes L1 selections); reviews/17-*.md. |
 | 18 | defer + concurrency coverage | done | a0ce527a | First-pass gap CLOSED (N1/N2/M3 proven e2e); flushed-out fix: defer-group ANCESTRY ordering (treeParents via DeferDescriptors.ParentID); N4 via Flushed gate channel (synctest incompatible with engine goroutines); reviews/18-*.md. |
 | 19 | partial fetching | done | f7cf360a | Batch partial (filter+realign) in cache/partial.go; four explained loader touches; per-field expiry = mixed-TTL-across-fetches (interpretation documented); reviews/19-*.md. |
-| 20 | ART observability | done | (see git log) | Production TraceObserver; zero observer calls outside the controller; DataSourceLoadTrace.CacheTrace additive section; reviews/20-*.md. ALL 20 TASKS DONE. |
+| 20 | ART observability | done | 7bd1f3c6 | Production TraceObserver; zero observer calls outside the controller; DataSourceLoadTrace.CacheTrace additive section; reviews/20-*.md. ALL 20 TASKS DONE. |
 
 ## Current focus
 

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -28,12 +28,12 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 16 | optimizeL1Cache pass | done | abe90ce7 | Ordering = dependency edges + TREE order (deviation, argued in reviews/16); schema-name+args field matching; first-pass union aliasing bug fixed and pinned; reviews/16-*.md. |
 | 17 | L1 runtime store | done | 36ac68c5 | Pointer store, shared keys, L1-first ladder; fixed heap-mode StructuralCopy passthrough + optimize-pass chain break; H4 resolved (shadow stashes L1 selections); reviews/17-*.md. |
 | 18 | defer + concurrency coverage | done | a0ce527a | First-pass gap CLOSED (N1/N2/M3 proven e2e); flushed-out fix: defer-group ANCESTRY ordering (treeParents via DeferDescriptors.ParentID); N4 via Flushed gate channel (synctest incompatible with engine goroutines); reviews/18-*.md. |
-| 19 | partial fetching | todo | — | — |
+| 19 | partial fetching | done | (see git log) | Batch partial (filter+realign) in cache/partial.go; four explained loader touches; per-field expiry = mixed-TTL-across-fetches (interpretation documented); reviews/19-*.md. |
 | 20 | ART observability | todo | — | — |
 
 ## Current focus
 
-- Next step: task 19 (partial fetching; deps 10 + 17 are done).
+- Next step: task 20 (ART observability; final task).
 - Mid-task state: none.
 
 ## Blockers awaiting human input
@@ -99,3 +99,5 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 - Task 18: executesBefore now uses defer-group ANCESTRY (treeEncloses over treeParents; postprocess derives them from DeferDescriptors.ParentID) — nested groups order after their parents; siblings stay unordered.
 - Task 18: a nested @defer with a SUBSET selection is normalized away — nested-group fixtures must select via a different path (the reviews hop back to the same entity).
 - Task 18: synctest bubbles deadlock on engine-lifetime goroutines (WS ping loops, resolver heartbeat) — defer-frame ordering tests gate on the writer's Flushed channel instead.
+- Task 19: FetchPartial dispatches in OnFetchResult BEFORE the failure gate (covered splice must survive a failed fetch); mergeResult returns after response/error processing for partial fetches (res.cachePartial).
+- Task 19: per-field partial expiry = mixed-TTL semantics ACROSS fetches (per-request query rewriting is out of scope; documented in reviews/19); entity policies gate batch partial via EnablePartialCacheLoad, root-field policies via PartialBatchLoad.

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -1,0 +1,45 @@
+# Caching port — execution progress
+
+This file is the LIVE EXECUTION STATE of `PLAN.md`.
+Any session (fresh or resumed) starts here: reconcile against `git log`, then execute the next incomplete step per PLAN §2.
+Update this file BEFORE ending any session and after every task-state change.
+
+Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting human approval) | `done` (committed).
+
+## Task board
+
+| # | Task | Status | Commit(s) | Notes / deviations |
+|---|---|---|---|---|
+| 01 | representationvariable extraction | todo | — | — |
+| 02 | runtime contract + loader seam | todo | — | — |
+| 03 | planner wiring + engine SetCaching | todo | — | — |
+| 04 | test infrastructure | todo | — | — |
+| 05 | ProvidesData visitor (P1) | todo | — | — |
+| 06 | entity cache configuration | todo | — | — |
+| 07 | entity L2 controller core | todo | — | — |
+| 08 | multi-key / freshness / reorder | todo | — | — |
+| 09 | store normalization + arg keys | todo | — | — |
+| 10 | batch entity caching | todo | — | — |
+| 11 | negative caching | todo | — | — |
+| 12 | shadow mode | todo | — | — |
+| 13 | root-field L2 | todo | — | — |
+| 14 | per-root-field isolation | todo | — | — |
+| 15 | entity-cache reuse | todo | — | — |
+| 16 | optimizeL1Cache pass | todo | — | — |
+| 17 | L1 runtime store | todo | — | — |
+| 18 | defer + concurrency coverage | todo | — | — |
+| 19 | partial fetching | todo | — | — |
+| 20 | ART observability | todo | — | — |
+
+## Current focus
+
+- Next step: task 01 (no dependencies; task 02 is also unblocked and may be taken first if preferred — record the choice here).
+- Mid-task state: none.
+
+## Blockers awaiting human input
+
+- none
+
+## Decision log (execution-time decisions not already in PLAN §7)
+
+- none yet

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -25,7 +25,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 13 | root-field L2 | done | be3295de + 29443089 | Key excludes the query text (coordinate + canonical variables) for alias reuse; shadow hit = plain Fetch (compare structurally impossible); reviews/13-*.md. |
 | 14 | per-root-field isolation | done | 1b23ea0c | Fresh RFC-3 implementation (no first-pass reference); exactly three path-builder touches; gate on parentPath=="query" + provider policy; reviews/14-*.md. |
 | 15 | entity-cache reuse | done | 44011a84 | Spec carries the FULL entity candidate set (first pass had mapping-only — E3 backfill impossible there); EntityMergePath finally populated; v1 variable-name constraint documented; reviews/15-*.md. |
-| 16 | optimizeL1Cache pass | todo | — | — |
+| 16 | optimizeL1Cache pass | done | (see git log) | Ordering = dependency edges + TREE order (deviation, argued in reviews/16); schema-name+args field matching; first-pass union aliasing bug fixed and pinned; reviews/16-*.md. |
 | 17 | L1 runtime store | todo | — | — |
 | 18 | defer + concurrency coverage | todo | — | — |
 | 19 | partial fetching | todo | — | — |
@@ -33,7 +33,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 
 ## Current focus
 
-- Next step: task 16 (optimizeL1Cache pass; dep 06 is done). Phase C is complete.
+- Next step: task 17 (request-lifetime shared L1 store; deps 07 + 16 are done).
 - Mid-task state: none.
 
 ## Blockers awaiting human input
@@ -91,3 +91,5 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 - Task 15: by-key root-field specs carry the entity's FULL candidate set (arg-coverable render at lookup, the rest backfill) — the first pass froze mapping-only candidates, making the E3 data-derived backfill impossible.
 - Task 15: v1 argument binding reads the request variable NAMED like the key field (documented at deriveEntityKeyMappings); other bindings degrade to plain fetch + backfill, never wrong data.
 - Task 15: `ItemCacheState.EntityMergePath` is now populated (reserved since task 02/D4) — the reuse splice/extract path.
+- Task 16: executesBefore has TWO sources — dependency edges AND tree order (initial tree precedes every defer group); DependsOnFetchIDs alone cannot see cross-branch defer pairs, which the task's own defer row requires.
+- Task 16: the OLD unionObjects mutated live ProvidesData trees (existing.Value overwrite) — fixed with field copies and pinned by a regression row.

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -24,7 +24,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 12 | shadow mode | done | 09d5775b | Stash-after-selection clears serving fields; ShadowCacheEntry gained CacheTTL (reserved in task-02 log); RecordingObserver materializes compares; H4 re-runs at task 17; reviews/12-*.md. |
 | 13 | root-field L2 | done | be3295de + 29443089 | Key excludes the query text (coordinate + canonical variables) for alias reuse; shadow hit = plain Fetch (compare structurally impossible); reviews/13-*.md. |
 | 14 | per-root-field isolation | done | 1b23ea0c | Fresh RFC-3 implementation (no first-pass reference); exactly three path-builder touches; gate on parentPath=="query" + provider policy; reviews/14-*.md. |
-| 15 | entity-cache reuse | todo | — | — |
+| 15 | entity-cache reuse | done | (see git log) | Spec carries the FULL entity candidate set (first pass had mapping-only — E3 backfill impossible there); EntityMergePath finally populated; v1 variable-name constraint documented; reviews/15-*.md. |
 | 16 | optimizeL1Cache pass | todo | — | — |
 | 17 | L1 runtime store | todo | — | — |
 | 18 | defer + concurrency coverage | todo | — | — |
@@ -33,7 +33,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 
 ## Current focus
 
-- Next step: task 15 (entity-cache reuse; deps 08 + 13 are done). Phase B is complete.
+- Next step: task 16 (optimizeL1Cache pass; dep 06 is done). Phase C is complete.
 - Mid-task state: none.
 
 ## Blockers awaiting human input
@@ -88,3 +88,6 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 - Task 13: the root-field key preimage is coordinate + name-sorted variables, EXCLUDING the query text (alias reuse requires it); safe under the engine's always-on variable extraction (documented precondition at rootFieldCacheKey).
 - Task 13: merged-fetch policy equality compares VALUES excluding coordinates; a root-field shadow hit is a plain DecisionFetch (no stash → compare structurally impossible).
 - Task 14: no first-pass reference existed (RFC-3 was a follow-up there); implemented fresh: `shouldIsolateRootField` gate + exactly three path-builder touches; the fold-refusal keys off parentPath (the entity-root-node trap row pins why).
+- Task 15: by-key root-field specs carry the entity's FULL candidate set (arg-coverable render at lookup, the rest backfill) — the first pass froze mapping-only candidates, making the E3 data-derived backfill impossible.
+- Task 15: v1 argument binding reads the request variable NAMED like the key field (documented at deriveEntityKeyMappings); other bindings degrade to plain fetch + backfill, never wrong data.
+- Task 15: `ItemCacheState.EntityMergePath` is now populated (reserved since task 02/D4) — the reuse splice/extract path.

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -11,7 +11,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | # | Task | Status | Commit(s) | Notes / deviations |
 |---|---|---|---|---|
 | 01 | representationvariable extraction | done | ca0ec6fb | Pure move; tests moved and extended with an entity-interface case per the task file. |
-| 02 | runtime contract + loader seam | done | (see git log) | D2/D4/D8 applied; ShadowCacheEntry/ItemCacheState kept to RFC shape (first-pass extras not ported); reviewer notes in reviews/02-*.md. |
+| 02 | runtime contract + loader seam | done | e79ebbe8 | D2/D4/D8 applied; ShadowCacheEntry/ItemCacheState kept to RFC shape (first-pass extras not ported); reviewer notes in reviews/02-*.md. |
 | 03 | planner wiring + engine SetCaching | todo | — | — |
 | 04 | test infrastructure | todo | — | — |
 | 05 | ProvidesData visitor (P1) | todo | — | — |

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -21,7 +21,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 09 | store normalization + arg keys | done | 5cbd5244 | FromCache stays NORMALIZED; denormalize-at-splice subsumes the task-08 reorder (deleted); pending renders now use the normalized value (first-pass alias bug fixed); inventory grew stockHistory(days) for the arg e2e; reviews/09-*.md. |
 | 10 | batch entity caching | done | def25586 | Full-batch semantics per unique representation; prepareItemState reused per bucket; splice copies per target; reviews/10-*.md. |
 | 11 | negative caching | done | d8888bff | DEVIATION from first pass: negative hits splice NOTHING so cached and uncached responses are byte-identical (incl. the null-bubble error); reviews/11-*.md. |
-| 12 | shadow mode | todo | — | — |
+| 12 | shadow mode | done | (see git log) | Stash-after-selection clears serving fields; ShadowCacheEntry gained CacheTTL (reserved in task-02 log); RecordingObserver materializes compares; H4 re-runs at task 17; reviews/12-*.md. |
 | 13 | root-field L2 | todo | — | — |
 | 14 | per-root-field isolation | todo | — | — |
 | 15 | entity-cache reuse | todo | — | — |
@@ -33,7 +33,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 
 ## Current focus
 
-- Next step: task 12 (shadow mode; dep 07 is done).
+- Next step: task 13 (root-field L2; deps 07 + 09 are done). Phase A is complete.
 - Mid-task state: none.
 
 ## Blockers awaiting human input
@@ -83,3 +83,5 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 - Task 10: batch buckets use `bucket[0]` as the representative (loader dedup guarantees homogeneous buckets); non-array batch responses write nothing; the loader's batch dedup loop is untouched (task 19).
 - Task 11: negative hits splice NOTHING (first pass replaced the target with null) — the uncached empty fetch leaves targets unmerged and renders a null bubble WITH a non-null error; the cached path must be byte-identical.
 - Task 11: `EmptyEntity` from the loader means "entities-shaped response", not "empty" — the negative branch's `ResponseData TypeNull` conjunct is load-bearing.
+- Task 12: `ShadowCacheEntry.CacheTTL` added (the task-02 log reserved it); the observer derives age without re-deriving config.
+- Task 12: shadow stashes AFTER the selection ladder and clears the serving fields (incl. NeedsWriteback — OnFetchResult refreshes from fresh anyway); H4 (L1-hit-wins) re-runs at task 17.

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -12,7 +12,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 |---|---|---|---|---|
 | 01 | representationvariable extraction | done | ca0ec6fb | Pure move; tests moved and extended with an entity-interface case per the task file. |
 | 02 | runtime contract + loader seam | done | e79ebbe8 | D2/D4/D8 applied; ShadowCacheEntry/ItemCacheState kept to RFC shape (first-pass extras not ported); reviewer notes in reviews/02-*.md. |
-| 03 | planner wiring + engine SetCaching | done | (see git log) | SetCaching keyed by datasource ID; provider drops first-pass KeySpecs (D10); P1 registers on the second walk only; reviewer notes in reviews/03-*.md. |
+| 03 | planner wiring + engine SetCaching | done | 4653a8e1 | SetCaching keyed by datasource ID; provider drops first-pass KeySpecs (D10); P1 registers on the second walk only; reviewer notes in reviews/03-*.md. |
 | 04 | test infrastructure | todo | — | — |
 | 05 | ProvidesData visitor (P1) | todo | — | — |
 | 06 | entity cache configuration | todo | — | — |

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -26,14 +26,14 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 14 | per-root-field isolation | done | 1b23ea0c | Fresh RFC-3 implementation (no first-pass reference); exactly three path-builder touches; gate on parentPath=="query" + provider policy; reviews/14-*.md. |
 | 15 | entity-cache reuse | done | 44011a84 | Spec carries the FULL entity candidate set (first pass had mapping-only — E3 backfill impossible there); EntityMergePath finally populated; v1 variable-name constraint documented; reviews/15-*.md. |
 | 16 | optimizeL1Cache pass | done | abe90ce7 | Ordering = dependency edges + TREE order (deviation, argued in reviews/16); schema-name+args field matching; first-pass union aliasing bug fixed and pinned; reviews/16-*.md. |
-| 17 | L1 runtime store | todo | — | — |
+| 17 | L1 runtime store | done | (see git log) | Pointer store, shared keys, L1-first ladder; fixed heap-mode StructuralCopy passthrough + optimize-pass chain break; H4 resolved (shadow stashes L1 selections); reviews/17-*.md. |
 | 18 | defer + concurrency coverage | todo | — | — |
 | 19 | partial fetching | todo | — | — |
 | 20 | ART observability | todo | — | — |
 
 ## Current focus
 
-- Next step: task 17 (request-lifetime shared L1 store; deps 07 + 16 are done).
+- Next step: task 18 (defer + concurrency coverage; deps 10 + 17 are done).
 - Mid-task state: none.
 
 ## Blockers awaiting human input
@@ -93,3 +93,6 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 - Task 15: `ItemCacheState.EntityMergePath` is now populated (reserved since task 02/D4) — the reuse splice/extract path.
 - Task 16: executesBefore has TWO sources — dependency edges AND tree order (initial tree precedes every defer group); DependsOnFetchIDs alone cannot see cross-branch defer pairs, which the task's own defer row requires.
 - Task 16: the OLD unionObjects mutated live ProvidesData trees (existing.Value overwrite) — fixed with field copies and pinned by a regression row.
+- Task 17: `CacheTransaction.StructuralCopy` was an identity passthrough in heap mode (DeepCopy(nil) returns v; resolve.go:361 runs a nil-arena loader) — heap mode now forces a real copy via marshal round-trip.
+- Task 17: the optimize-pass ordering walk now indexes EVERY fetch (chains pass through unconfigured hops: products→reviews→products); the l1_e2e chain fixture is the live proof.
+- Task 17: H4 = shadow stashes L1-selected values too (read-never-serve absolute); the L1 negative sentinel ignores the NegativeCacheTTL knob (in-request facts).

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -29,11 +29,11 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 17 | L1 runtime store | done | 36ac68c5 | Pointer store, shared keys, L1-first ladder; fixed heap-mode StructuralCopy passthrough + optimize-pass chain break; H4 resolved (shadow stashes L1 selections); reviews/17-*.md. |
 | 18 | defer + concurrency coverage | done | a0ce527a | First-pass gap CLOSED (N1/N2/M3 proven e2e); flushed-out fix: defer-group ANCESTRY ordering (treeParents via DeferDescriptors.ParentID); N4 via Flushed gate channel (synctest incompatible with engine goroutines); reviews/18-*.md. |
 | 19 | partial fetching | done | f7cf360a | Batch partial (filter+realign) in cache/partial.go; four explained loader touches; per-field expiry = mixed-TTL-across-fetches (interpretation documented); reviews/19-*.md. |
-| 20 | ART observability | todo | — | — |
+| 20 | ART observability | done | (see git log) | Production TraceObserver; zero observer calls outside the controller; DataSourceLoadTrace.CacheTrace additive section; reviews/20-*.md. ALL 20 TASKS DONE. |
 
 ## Current focus
 
-- Next step: task 20 (ART observability; final task).
+- Next step: NONE — all 20 tasks are done. The plan is complete.
 - Mid-task state: none.
 
 ## Blockers awaiting human input
@@ -101,3 +101,4 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 - Task 18: synctest bubbles deadlock on engine-lifetime goroutines (WS ping loops, resolver heartbeat) — defer-frame ordering tests gate on the writer's Flushed channel instead.
 - Task 19: FetchPartial dispatches in OnFetchResult BEFORE the failure gate (covered splice must survive a failed fetch); mergeResult returns after response/error processing for partial fetches (res.cachePartial).
 - Task 19: per-field partial expiry = mixed-TTL semantics ACROSS fetches (per-request query rewriting is out of scope; documented in reviews/19); entity policies gate batch partial via EnablePartialCacheLoad, root-field policies via PartialBatchLoad.
+- Task 20: the handle carries the observability contract (Trace destination + HashAnalyticsKeys); trace assembly at EndRequest works because endCacheRequest defers before ResolveGraphQLResponse returns; the shadow stash clears ServedFromLayer (nothing was served).

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -14,7 +14,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 02 | runtime contract + loader seam | done | e79ebbe8 | D2/D4/D8 applied; ShadowCacheEntry/ItemCacheState kept to RFC shape (first-pass extras not ported); reviewer notes in reviews/02-*.md. |
 | 03 | planner wiring + engine SetCaching | done | 4653a8e1 | SetCaching keyed by datasource ID; provider drops first-pass KeySpecs (D10); P1 registers on the second walk only; reviewer notes in reviews/03-*.md. |
 | 04 | test infrastructure | done | b0a6b045 | Fixtures in execution/cachingtesting (wgc+rover clean); fakes in v2 cache/cachetesting; first-pass RealishCache/Mode/Stage NOT ported (dead until task 07); Fetch.SetDataSource added (D8 swap); reviews/04-*.md. |
-| 05 | ProvidesData visitor (P1) | done | (see git log) | Full port + adversarial rows; ComputeHasAliases deferred to task 06 (first caller); empty-boundary tree pinned as zero coverage; reviews/05-*.md. |
+| 05 | ProvidesData visitor (P1) | done | 648a768b | Full port + adversarial rows; ComputeHasAliases deferred to task 06 (first caller); empty-boundary tree pinned as zero coverage; reviews/05-*.md. |
 | 06 | entity cache configuration | todo | — | — |
 | 07 | entity L2 controller core | todo | — | — |
 | 08 | multi-key / freshness / reorder | todo | — | — |

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -24,7 +24,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 12 | shadow mode | done | 09d5775b | Stash-after-selection clears serving fields; ShadowCacheEntry gained CacheTTL (reserved in task-02 log); RecordingObserver materializes compares; H4 re-runs at task 17; reviews/12-*.md. |
 | 13 | root-field L2 | done | be3295de + 29443089 | Key excludes the query text (coordinate + canonical variables) for alias reuse; shadow hit = plain Fetch (compare structurally impossible); reviews/13-*.md. |
 | 14 | per-root-field isolation | done | 1b23ea0c | Fresh RFC-3 implementation (no first-pass reference); exactly three path-builder touches; gate on parentPath=="query" + provider policy; reviews/14-*.md. |
-| 15 | entity-cache reuse | done | (see git log) | Spec carries the FULL entity candidate set (first pass had mapping-only — E3 backfill impossible there); EntityMergePath finally populated; v1 variable-name constraint documented; reviews/15-*.md. |
+| 15 | entity-cache reuse | done | 44011a84 | Spec carries the FULL entity candidate set (first pass had mapping-only — E3 backfill impossible there); EntityMergePath finally populated; v1 variable-name constraint documented; reviews/15-*.md. |
 | 16 | optimizeL1Cache pass | todo | — | — |
 | 17 | L1 runtime store | todo | — | — |
 | 18 | defer + concurrency coverage | todo | — | — |

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -20,7 +20,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 08 | multi-key / freshness / reorder | done | 3372187b | Full ladder + backfill; malformed cached bytes now refresh (first pass left poison entries); fixtures grew deals subgraph + featuredReview for the plan-driven cross-key row (wgc+rover clean, IDs stable); reviews/08-*.md. |
 | 09 | store normalization + arg keys | done | 5cbd5244 | FromCache stays NORMALIZED; denormalize-at-splice subsumes the task-08 reorder (deleted); pending renders now use the normalized value (first-pass alias bug fixed); inventory grew stockHistory(days) for the arg e2e; reviews/09-*.md. |
 | 10 | batch entity caching | done | def25586 | Full-batch semantics per unique representation; prepareItemState reused per bucket; splice copies per target; reviews/10-*.md. |
-| 11 | negative caching | todo | — | — |
+| 11 | negative caching | done | (see git log) | DEVIATION from first pass: negative hits splice NOTHING so cached and uncached responses are byte-identical (incl. the null-bubble error); reviews/11-*.md. |
 | 12 | shadow mode | todo | — | — |
 | 13 | root-field L2 | todo | — | — |
 | 14 | per-root-field isolation | todo | — | — |
@@ -33,7 +33,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 
 ## Current focus
 
-- Next step: task 11 (negative caching; dep 07 is done). Task 12 is also unblocked.
+- Next step: task 12 (shadow mode; dep 07 is done).
 - Mid-task state: none.
 
 ## Blockers awaiting human input
@@ -81,3 +81,5 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 - Task 09: pending-candidate re-render uses the NORMALIZED value (representation fields carry schema names — a latent first-pass bug for aliased key fields).
 - Task 09: fixtures grew `Product.stockHistory(days: Int!)` on inventory for the entity-level argument e2e row (wgc + rover clean).
 - Task 10: batch buckets use `bucket[0]` as the representative (loader dedup guarantees homogeneous buckets); non-array batch responses write nothing; the loader's batch dedup loop is untouched (task 19).
+- Task 11: negative hits splice NOTHING (first pass replaced the target with null) — the uncached empty fetch leaves targets unmerged and renders a null bubble WITH a non-null error; the cached path must be byte-identical.
+- Task 11: `EmptyEntity` from the loader means "entities-shaped response", not "empty" — the negative branch's `ResponseData TypeNull` conjunct is load-bearing.

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -19,7 +19,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 07 | entity L2 controller core | done | 29606414 | L2-only single-candidate core; deferral gates fail closed (shadow/batch/root/negative/L1/multi-key → plain fetch); no Mode enum; resolve.NewTransactionBeginner exported for controller tests; reviews/07-*.md. |
 | 08 | multi-key / freshness / reorder | done | 3372187b | Full ladder + backfill; malformed cached bytes now refresh (first pass left poison entries); fixtures grew deals subgraph + featuredReview for the plan-driven cross-key row (wgc+rover clean, IDs stable); reviews/08-*.md. |
 | 09 | store normalization + arg keys | done | 5cbd5244 | FromCache stays NORMALIZED; denormalize-at-splice subsumes the task-08 reorder (deleted); pending renders now use the normalized value (first-pass alias bug fixed); inventory grew stockHistory(days) for the arg e2e; reviews/09-*.md. |
-| 10 | batch entity caching | todo | — | — |
+| 10 | batch entity caching | done | (see git log) | Full-batch semantics per unique representation; prepareItemState reused per bucket; splice copies per target; reviews/10-*.md. |
 | 11 | negative caching | todo | — | — |
 | 12 | shadow mode | todo | — | — |
 | 13 | root-field L2 | todo | — | — |
@@ -33,7 +33,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 
 ## Current focus
 
-- Next step: task 10 (batch entity caching; dep 08 is done). Tasks 11/12 are also unblocked.
+- Next step: task 11 (negative caching; dep 07 is done). Task 12 is also unblocked.
 - Mid-task state: none.
 
 ## Blockers awaiting human input
@@ -80,3 +80,4 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 - Task 09: the `HasAliases` fast path gates only write-side normalization; the read side always walks (it is also the selection-order pass).
 - Task 09: pending-candidate re-render uses the NORMALIZED value (representation fields carry schema names — a latent first-pass bug for aliased key fields).
 - Task 09: fixtures grew `Product.stockHistory(days: Int!)` on inventory for the entity-level argument e2e row (wgc + rover clean).
+- Task 10: batch buckets use `bucket[0]` as the representative (loader dedup guarantees homogeneous buckets); non-array batch responses write nothing; the loader's batch dedup loop is untouched (task 19).

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -15,7 +15,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 03 | planner wiring + engine SetCaching | done | 4653a8e1 | SetCaching keyed by datasource ID; provider drops first-pass KeySpecs (D10); P1 registers on the second walk only; reviewer notes in reviews/03-*.md. |
 | 04 | test infrastructure | done | b0a6b045 | Fixtures in execution/cachingtesting (wgc+rover clean); fakes in v2 cache/cachetesting; first-pass RealishCache/Mode/Stage NOT ported (dead until task 07); Fetch.SetDataSource added (D8 swap); reviews/04-*.md. |
 | 05 | ProvidesData visitor (P1) | done | 648a768b | Full port + adversarial rows; ComputeHasAliases deferred to task 06 (first caller); empty-boundary tree pinned as zero coverage; reviews/05-*.md. |
-| 06 | entity cache configuration | done | (see git log) | Entity arm only (root fields task 13, mappings task 15); NEW hardening: __typename-only candidates rejected as malformed; ComputeHasAliases landed with its first caller; reviews/06-*.md. |
+| 06 | entity cache configuration | done | 3f7e3ca5 | Entity arm only (root fields task 13, mappings task 15); NEW hardening: __typename-only candidates rejected as malformed; ComputeHasAliases landed with its first caller; reviews/06-*.md. |
 | 07 | entity L2 controller core | todo | — | — |
 | 08 | multi-key / freshness / reorder | todo | — | — |
 | 09 | store normalization + arg keys | todo | — | — |

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -28,7 +28,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 16 | optimizeL1Cache pass | done | abe90ce7 | Ordering = dependency edges + TREE order (deviation, argued in reviews/16); schema-name+args field matching; first-pass union aliasing bug fixed and pinned; reviews/16-*.md. |
 | 17 | L1 runtime store | done | 36ac68c5 | Pointer store, shared keys, L1-first ladder; fixed heap-mode StructuralCopy passthrough + optimize-pass chain break; H4 resolved (shadow stashes L1 selections); reviews/17-*.md. |
 | 18 | defer + concurrency coverage | done | a0ce527a | First-pass gap CLOSED (N1/N2/M3 proven e2e); flushed-out fix: defer-group ANCESTRY ordering (treeParents via DeferDescriptors.ParentID); N4 via Flushed gate channel (synctest incompatible with engine goroutines); reviews/18-*.md. |
-| 19 | partial fetching | done | (see git log) | Batch partial (filter+realign) in cache/partial.go; four explained loader touches; per-field expiry = mixed-TTL-across-fetches (interpretation documented); reviews/19-*.md. |
+| 19 | partial fetching | done | f7cf360a | Batch partial (filter+realign) in cache/partial.go; four explained loader touches; per-field expiry = mixed-TTL-across-fetches (interpretation documented); reviews/19-*.md. |
 | 20 | ART observability | todo | — | — |
 
 ## Current focus

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -21,7 +21,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 09 | store normalization + arg keys | done | 5cbd5244 | FromCache stays NORMALIZED; denormalize-at-splice subsumes the task-08 reorder (deleted); pending renders now use the normalized value (first-pass alias bug fixed); inventory grew stockHistory(days) for the arg e2e; reviews/09-*.md. |
 | 10 | batch entity caching | done | def25586 | Full-batch semantics per unique representation; prepareItemState reused per bucket; splice copies per target; reviews/10-*.md. |
 | 11 | negative caching | done | d8888bff | DEVIATION from first pass: negative hits splice NOTHING so cached and uncached responses are byte-identical (incl. the null-bubble error); reviews/11-*.md. |
-| 12 | shadow mode | done | (see git log) | Stash-after-selection clears serving fields; ShadowCacheEntry gained CacheTTL (reserved in task-02 log); RecordingObserver materializes compares; H4 re-runs at task 17; reviews/12-*.md. |
+| 12 | shadow mode | done | 09d5775b | Stash-after-selection clears serving fields; ShadowCacheEntry gained CacheTTL (reserved in task-02 log); RecordingObserver materializes compares; H4 re-runs at task 17; reviews/12-*.md. |
 | 13 | root-field L2 | todo | — | — |
 | 14 | per-root-field isolation | todo | — | — |
 | 15 | entity-cache reuse | todo | — | — |

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -13,7 +13,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 01 | representationvariable extraction | done | ca0ec6fb | Pure move; tests moved and extended with an entity-interface case per the task file. |
 | 02 | runtime contract + loader seam | done | e79ebbe8 | D2/D4/D8 applied; ShadowCacheEntry/ItemCacheState kept to RFC shape (first-pass extras not ported); reviewer notes in reviews/02-*.md. |
 | 03 | planner wiring + engine SetCaching | done | 4653a8e1 | SetCaching keyed by datasource ID; provider drops first-pass KeySpecs (D10); P1 registers on the second walk only; reviewer notes in reviews/03-*.md. |
-| 04 | test infrastructure | done | (see git log) | Fixtures in execution/cachingtesting (wgc+rover clean); fakes in v2 cache/cachetesting; first-pass RealishCache/Mode/Stage NOT ported (dead until task 07); Fetch.SetDataSource added (D8 swap); reviews/04-*.md. |
+| 04 | test infrastructure | done | b0a6b045 | Fixtures in execution/cachingtesting (wgc+rover clean); fakes in v2 cache/cachetesting; first-pass RealishCache/Mode/Stage NOT ported (dead until task 07); Fetch.SetDataSource added (D8 swap); reviews/04-*.md. |
 | 05 | ProvidesData visitor (P1) | todo | — | — |
 | 06 | entity cache configuration | todo | — | — |
 | 07 | entity L2 controller core | todo | — | — |

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -18,7 +18,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 06 | entity cache configuration | done | 3f7e3ca5 | Entity arm only (root fields task 13, mappings task 15); NEW hardening: __typename-only candidates rejected as malformed; ComputeHasAliases landed with its first caller; reviews/06-*.md. |
 | 07 | entity L2 controller core | done | 29606414 | L2-only single-candidate core; deferral gates fail closed (shadow/batch/root/negative/L1/multi-key → plain fetch); no Mode enum; resolve.NewTransactionBeginner exported for controller tests; reviews/07-*.md. |
 | 08 | multi-key / freshness / reorder | done | 3372187b | Full ladder + backfill; malformed cached bytes now refresh (first pass left poison entries); fixtures grew deals subgraph + featuredReview for the plan-driven cross-key row (wgc+rover clean, IDs stable); reviews/08-*.md. |
-| 09 | store normalization + arg keys | done | (see git log) | FromCache stays NORMALIZED; denormalize-at-splice subsumes the task-08 reorder (deleted); pending renders now use the normalized value (first-pass alias bug fixed); inventory grew stockHistory(days) for the arg e2e; reviews/09-*.md. |
+| 09 | store normalization + arg keys | done | 5cbd5244 | FromCache stays NORMALIZED; denormalize-at-splice subsumes the task-08 reorder (deleted); pending renders now use the normalized value (first-pass alias bug fixed); inventory grew stockHistory(days) for the arg e2e; reviews/09-*.md. |
 | 10 | batch entity caching | todo | — | — |
 | 11 | negative caching | todo | — | — |
 | 12 | shadow mode | todo | — | — |

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -19,7 +19,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 07 | entity L2 controller core | done | 29606414 | L2-only single-candidate core; deferral gates fail closed (shadow/batch/root/negative/L1/multi-key → plain fetch); no Mode enum; resolve.NewTransactionBeginner exported for controller tests; reviews/07-*.md. |
 | 08 | multi-key / freshness / reorder | done | 3372187b | Full ladder + backfill; malformed cached bytes now refresh (first pass left poison entries); fixtures grew deals subgraph + featuredReview for the plan-driven cross-key row (wgc+rover clean, IDs stable); reviews/08-*.md. |
 | 09 | store normalization + arg keys | done | 5cbd5244 | FromCache stays NORMALIZED; denormalize-at-splice subsumes the task-08 reorder (deleted); pending renders now use the normalized value (first-pass alias bug fixed); inventory grew stockHistory(days) for the arg e2e; reviews/09-*.md. |
-| 10 | batch entity caching | done | (see git log) | Full-batch semantics per unique representation; prepareItemState reused per bucket; splice copies per target; reviews/10-*.md. |
+| 10 | batch entity caching | done | def25586 | Full-batch semantics per unique representation; prepareItemState reused per bucket; splice copies per target; reviews/10-*.md. |
 | 11 | negative caching | todo | — | — |
 | 12 | shadow mode | todo | — | — |
 | 13 | root-field L2 | todo | — | — |

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -11,7 +11,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | # | Task | Status | Commit(s) | Notes / deviations |
 |---|---|---|---|---|
 | 01 | representationvariable extraction | done | ca0ec6fb | Pure move; tests moved and extended with an entity-interface case per the task file. |
-| 02 | runtime contract + loader seam | todo | — | — |
+| 02 | runtime contract + loader seam | done | (see git log) | D2/D4/D8 applied; ShadowCacheEntry/ItemCacheState kept to RFC shape (first-pass extras not ported); reviewer notes in reviews/02-*.md. |
 | 03 | planner wiring + engine SetCaching | todo | — | — |
 | 04 | test infrastructure | todo | — | — |
 | 05 | ProvidesData visitor (P1) | todo | — | — |
@@ -33,7 +33,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 
 ## Current focus
 
-- Next step: task 02 (runtime contract + loader seam; no dependencies).
+- Next step: task 03 (planner wiring + engine SetCaching; deps 01 + 02 are done).
 - Mid-task state: none.
 
 ## Blockers awaiting human input
@@ -42,4 +42,10 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 
 ## Decision log (execution-time decisions not already in PLAN §7)
 
-- none yet
+- 2026-07-01 (user directive): every task commit ships a reviewer document under `docs/caching/reviews/NN-<task>.md`,
+  explaining the decisions of that turn, what was implemented, and what the reviewer should look into.
+  Task 01's document was backfilled in the task 02 commit.
+- Task 02: `ShadowCacheEntry` and `ItemCacheState` follow the RFC-1 §3.7 field set;
+  the first-pass extras (`ShadowCacheEntry.CacheTTL`, per-item `BatchEntityKey`) were not ported — tasks 10/12 add them only if actually needed.
+- Task 02: no existing fetch-type-switch site qualified for the sanctioned predicate cleanup
+  (`preparePhase` needs the concrete types; `isEmptyEntityFetch` already dispatches via `FetchKind()`).

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -17,7 +17,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 05 | ProvidesData visitor (P1) | done | 648a768b | Full port + adversarial rows; ComputeHasAliases deferred to task 06 (first caller); empty-boundary tree pinned as zero coverage; reviews/05-*.md. |
 | 06 | entity cache configuration | done | 3f7e3ca5 | Entity arm only (root fields task 13, mappings task 15); NEW hardening: __typename-only candidates rejected as malformed; ComputeHasAliases landed with its first caller; reviews/06-*.md. |
 | 07 | entity L2 controller core | done | 29606414 | L2-only single-candidate core; deferral gates fail closed (shadow/batch/root/negative/L1/multi-key → plain fetch); no Mode enum; resolve.NewTransactionBeginner exported for controller tests; reviews/07-*.md. |
-| 08 | multi-key / freshness / reorder | done | (see git log) | Full ladder + backfill; malformed cached bytes now refresh (first pass left poison entries); fixtures grew deals subgraph + featuredReview for the plan-driven cross-key row (wgc+rover clean, IDs stable); reviews/08-*.md. |
+| 08 | multi-key / freshness / reorder | done | 3372187b | Full ladder + backfill; malformed cached bytes now refresh (first pass left poison entries); fixtures grew deals subgraph + featuredReview for the plan-driven cross-key row (wgc+rover clean, IDs stable); reviews/08-*.md. |
 | 09 | store normalization + arg keys | todo | — | — |
 | 10 | batch entity caching | todo | — | — |
 | 11 | negative caching | todo | — | — |

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -16,7 +16,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 04 | test infrastructure | done | b0a6b045 | Fixtures in execution/cachingtesting (wgc+rover clean); fakes in v2 cache/cachetesting; first-pass RealishCache/Mode/Stage NOT ported (dead until task 07); Fetch.SetDataSource added (D8 swap); reviews/04-*.md. |
 | 05 | ProvidesData visitor (P1) | done | 648a768b | Full port + adversarial rows; ComputeHasAliases deferred to task 06 (first caller); empty-boundary tree pinned as zero coverage; reviews/05-*.md. |
 | 06 | entity cache configuration | done | 3f7e3ca5 | Entity arm only (root fields task 13, mappings task 15); NEW hardening: __typename-only candidates rejected as malformed; ComputeHasAliases landed with its first caller; reviews/06-*.md. |
-| 07 | entity L2 controller core | done | (see git log) | L2-only single-candidate core; deferral gates fail closed (shadow/batch/root/negative/L1/multi-key → plain fetch); no Mode enum; resolve.NewTransactionBeginner exported for controller tests; reviews/07-*.md. |
+| 07 | entity L2 controller core | done | 29606414 | L2-only single-candidate core; deferral gates fail closed (shadow/batch/root/negative/L1/multi-key → plain fetch); no Mode enum; resolve.NewTransactionBeginner exported for controller tests; reviews/07-*.md. |
 | 08 | multi-key / freshness / reorder | todo | — | — |
 | 09 | store normalization + arg keys | todo | — | — |
 | 10 | batch entity caching | todo | — | — |

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -26,7 +26,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 14 | per-root-field isolation | done | 1b23ea0c | Fresh RFC-3 implementation (no first-pass reference); exactly three path-builder touches; gate on parentPath=="query" + provider policy; reviews/14-*.md. |
 | 15 | entity-cache reuse | done | 44011a84 | Spec carries the FULL entity candidate set (first pass had mapping-only — E3 backfill impossible there); EntityMergePath finally populated; v1 variable-name constraint documented; reviews/15-*.md. |
 | 16 | optimizeL1Cache pass | done | abe90ce7 | Ordering = dependency edges + TREE order (deviation, argued in reviews/16); schema-name+args field matching; first-pass union aliasing bug fixed and pinned; reviews/16-*.md. |
-| 17 | L1 runtime store | done | (see git log) | Pointer store, shared keys, L1-first ladder; fixed heap-mode StructuralCopy passthrough + optimize-pass chain break; H4 resolved (shadow stashes L1 selections); reviews/17-*.md. |
+| 17 | L1 runtime store | done | 36ac68c5 | Pointer store, shared keys, L1-first ladder; fixed heap-mode StructuralCopy passthrough + optimize-pass chain break; H4 resolved (shadow stashes L1 selections); reviews/17-*.md. |
 | 18 | defer + concurrency coverage | todo | — | — |
 | 19 | partial fetching | todo | — | — |
 | 20 | ART observability | todo | — | — |

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -15,7 +15,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 03 | planner wiring + engine SetCaching | done | 4653a8e1 | SetCaching keyed by datasource ID; provider drops first-pass KeySpecs (D10); P1 registers on the second walk only; reviewer notes in reviews/03-*.md. |
 | 04 | test infrastructure | done | b0a6b045 | Fixtures in execution/cachingtesting (wgc+rover clean); fakes in v2 cache/cachetesting; first-pass RealishCache/Mode/Stage NOT ported (dead until task 07); Fetch.SetDataSource added (D8 swap); reviews/04-*.md. |
 | 05 | ProvidesData visitor (P1) | done | 648a768b | Full port + adversarial rows; ComputeHasAliases deferred to task 06 (first caller); empty-boundary tree pinned as zero coverage; reviews/05-*.md. |
-| 06 | entity cache configuration | todo | — | — |
+| 06 | entity cache configuration | done | (see git log) | Entity arm only (root fields task 13, mappings task 15); NEW hardening: __typename-only candidates rejected as malformed; ComputeHasAliases landed with its first caller; reviews/06-*.md. |
 | 07 | entity L2 controller core | todo | — | — |
 | 08 | multi-key / freshness / reorder | todo | — | — |
 | 09 | store normalization + arg keys | todo | — | — |
@@ -33,7 +33,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 
 ## Current focus
 
-- Next step: task 06 (entity cache configuration; deps 01 + 03 + 05 are done).
+- Next step: task 07 (entity L2 controller core; deps 02 + 04 + 06 are done).
 - Mid-task state: none.
 
 ## Blockers awaiting human input
@@ -63,3 +63,6 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 - Task 05: `ComputeHasAliases` deferred to task 06 (its first caller, per the task file's "folded into the configurator" note).
 - Task 05: a boundary-only entity planner yields an EMPTY ProvidesData tree — the task-07 controller must treat an empty tree as ZERO coverage (never a vacuous full hit).
 - Task 05: `dataSourceConfiguration.Caching()` still unconsumed (the visitor reads nothing datasource-scoped); tasks 06+ read providers from the postprocess options instead.
+- Task 06: `buildEntitySpec` rejects candidates whose representation carries no field beyond `__typename`
+  (unknown-field @keys silently degrade to __typename-only nodes in the representation walker — a cross-entity key-collision hazard the first pass missed).
+- Task 06: the all-flags-false nil gate in `buildConfig` is unreachable for entities (found policy ⇒ L1); it serves the task-13 root-field arm.

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -10,7 +10,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 
 | # | Task | Status | Commit(s) | Notes / deviations |
 |---|---|---|---|---|
-| 01 | representationvariable extraction | done | (see git log) | Pure move; tests moved and extended with an entity-interface case per the task file. |
+| 01 | representationvariable extraction | done | ca0ec6fb | Pure move; tests moved and extended with an entity-interface case per the task file. |
 | 02 | runtime contract + loader seam | todo | — | — |
 | 03 | planner wiring + engine SetCaching | todo | — | — |
 | 04 | test infrastructure | todo | — | — |

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -23,7 +23,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 11 | negative caching | done | d8888bff | DEVIATION from first pass: negative hits splice NOTHING so cached and uncached responses are byte-identical (incl. the null-bubble error); reviews/11-*.md. |
 | 12 | shadow mode | done | 09d5775b | Stash-after-selection clears serving fields; ShadowCacheEntry gained CacheTTL (reserved in task-02 log); RecordingObserver materializes compares; H4 re-runs at task 17; reviews/12-*.md. |
 | 13 | root-field L2 | done | be3295de + 29443089 | Key excludes the query text (coordinate + canonical variables) for alias reuse; shadow hit = plain Fetch (compare structurally impossible); reviews/13-*.md. |
-| 14 | per-root-field isolation | done | (see git log) | Fresh RFC-3 implementation (no first-pass reference); exactly three path-builder touches; gate on parentPath=="query" + provider policy; reviews/14-*.md. |
+| 14 | per-root-field isolation | done | 1b23ea0c | Fresh RFC-3 implementation (no first-pass reference); exactly three path-builder touches; gate on parentPath=="query" + provider policy; reviews/14-*.md. |
 | 15 | entity-cache reuse | todo | — | — |
 | 16 | optimizeL1Cache pass | todo | — | — |
 | 17 | L1 runtime store | todo | — | — |

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -13,7 +13,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 01 | representationvariable extraction | done | ca0ec6fb | Pure move; tests moved and extended with an entity-interface case per the task file. |
 | 02 | runtime contract + loader seam | done | e79ebbe8 | D2/D4/D8 applied; ShadowCacheEntry/ItemCacheState kept to RFC shape (first-pass extras not ported); reviewer notes in reviews/02-*.md. |
 | 03 | planner wiring + engine SetCaching | done | 4653a8e1 | SetCaching keyed by datasource ID; provider drops first-pass KeySpecs (D10); P1 registers on the second walk only; reviewer notes in reviews/03-*.md. |
-| 04 | test infrastructure | todo | — | — |
+| 04 | test infrastructure | done | (see git log) | Fixtures in execution/cachingtesting (wgc+rover clean); fakes in v2 cache/cachetesting; first-pass RealishCache/Mode/Stage NOT ported (dead until task 07); Fetch.SetDataSource added (D8 swap); reviews/04-*.md. |
 | 05 | ProvidesData visitor (P1) | todo | — | — |
 | 06 | entity cache configuration | todo | — | — |
 | 07 | entity L2 controller core | todo | — | — |
@@ -33,7 +33,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 
 ## Current focus
 
-- Next step: task 04 (test infrastructure; deps 02 + 03 are done).
+- Next step: task 05 (ProvidesData visitor; deps 03 + 04 are done). Phase 0 is complete.
 - Mid-task state: none.
 
 ## Blockers awaiting human input
@@ -56,3 +56,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 - Task 03: P1 registers ONLY on the gated second walk (the first pass also registered it on the main walk);
   task 05 may revisit if the ported visitor body genuinely needs main-walk state.
 - Task 03: `dataSourceConfiguration.caching` has no producer yet (accessor-only seam, same as the first pass); first consumer lands with task 05.
+- Task 04: harness caching/response keys use SUBGRAPH NAMES, translated to the ID-named datasources of factory-built configs.
+- Task 04: `Fetch.SetDataSource` added to the interface so datasource swapping needs no concrete-type switch (D8 spirit).
+- Task 04: first-pass `RealishCache`/`Mode`/`CacheStage`/`storeAdapter` NOT ported — they need the task-07 controller and would be dead code now; task 07 introduces the controller-backed test cache.
+- Task 04: the harness always plans with `IncludeQueryPlanInResponse` so plan-shape tests assert rendered trees inline (no goldens).

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -25,7 +25,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 13 | root-field L2 | done | be3295de + 29443089 | Key excludes the query text (coordinate + canonical variables) for alias reuse; shadow hit = plain Fetch (compare structurally impossible); reviews/13-*.md. |
 | 14 | per-root-field isolation | done | 1b23ea0c | Fresh RFC-3 implementation (no first-pass reference); exactly three path-builder touches; gate on parentPath=="query" + provider policy; reviews/14-*.md. |
 | 15 | entity-cache reuse | done | 44011a84 | Spec carries the FULL entity candidate set (first pass had mapping-only — E3 backfill impossible there); EntityMergePath finally populated; v1 variable-name constraint documented; reviews/15-*.md. |
-| 16 | optimizeL1Cache pass | done | (see git log) | Ordering = dependency edges + TREE order (deviation, argued in reviews/16); schema-name+args field matching; first-pass union aliasing bug fixed and pinned; reviews/16-*.md. |
+| 16 | optimizeL1Cache pass | done | abe90ce7 | Ordering = dependency edges + TREE order (deviation, argued in reviews/16); schema-name+args field matching; first-pass union aliasing bug fixed and pinned; reviews/16-*.md. |
 | 17 | L1 runtime store | todo | — | — |
 | 18 | defer + concurrency coverage | todo | — | — |
 | 19 | partial fetching | todo | — | — |

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -22,7 +22,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 10 | batch entity caching | done | def25586 | Full-batch semantics per unique representation; prepareItemState reused per bucket; splice copies per target; reviews/10-*.md. |
 | 11 | negative caching | done | d8888bff | DEVIATION from first pass: negative hits splice NOTHING so cached and uncached responses are byte-identical (incl. the null-bubble error); reviews/11-*.md. |
 | 12 | shadow mode | done | 09d5775b | Stash-after-selection clears serving fields; ShadowCacheEntry gained CacheTTL (reserved in task-02 log); RecordingObserver materializes compares; H4 re-runs at task 17; reviews/12-*.md. |
-| 13 | root-field L2 | done | be3295de + (commit 2 below) | Key excludes the query text (coordinate + canonical variables) for alias reuse; shadow hit = plain Fetch (compare structurally impossible); reviews/13-*.md. |
+| 13 | root-field L2 | done | be3295de + 29443089 | Key excludes the query text (coordinate + canonical variables) for alias reuse; shadow hit = plain Fetch (compare structurally impossible); reviews/13-*.md. |
 | 14 | per-root-field isolation | todo | — | — |
 | 15 | entity-cache reuse | todo | — | — |
 | 16 | optimizeL1Cache pass | todo | — | — |

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -12,7 +12,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 |---|---|---|---|---|
 | 01 | representationvariable extraction | done | ca0ec6fb | Pure move; tests moved and extended with an entity-interface case per the task file. |
 | 02 | runtime contract + loader seam | done | e79ebbe8 | D2/D4/D8 applied; ShadowCacheEntry/ItemCacheState kept to RFC shape (first-pass extras not ported); reviewer notes in reviews/02-*.md. |
-| 03 | planner wiring + engine SetCaching | todo | — | — |
+| 03 | planner wiring + engine SetCaching | done | (see git log) | SetCaching keyed by datasource ID; provider drops first-pass KeySpecs (D10); P1 registers on the second walk only; reviewer notes in reviews/03-*.md. |
 | 04 | test infrastructure | todo | — | — |
 | 05 | ProvidesData visitor (P1) | todo | — | — |
 | 06 | entity cache configuration | todo | — | — |
@@ -33,7 +33,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 
 ## Current focus
 
-- Next step: task 03 (planner wiring + engine SetCaching; deps 01 + 02 are done).
+- Next step: task 04 (test infrastructure; deps 02 + 03 are done).
 - Mid-task state: none.
 
 ## Blockers awaiting human input
@@ -49,3 +49,10 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
   the first-pass extras (`ShadowCacheEntry.CacheTTL`, per-item `BatchEntityKey`) were not ported — tasks 10/12 add them only if actually needed.
 - Task 02: no existing fetch-type-switch site qualified for the sanctioned predicate cleanup
   (`preparePhase` needs the concrete types; `isEmptyEntityFetch` already dispatches via `FetchKind()`).
+- Task 03: `SetCaching(map[string]cacheconfig.CachingConfiguration)` is keyed by DATASOURCE ID
+  (matches `FetchInfo.DataSourceID`, the runtime provider key); unknown IDs fail `NewExecutionEngine`.
+- Task 03: the provider interface drops the first-pass `KeySpecs`/`KeySpec(...)` external key input (D10 — keys derive structurally in `cacheKeyBuilder`);
+  `cacheconfig` therefore imports only `time`.
+- Task 03: P1 registers ONLY on the gated second walk (the first pass also registered it on the main walk);
+  task 05 may revisit if the ported visitor body genuinely needs main-walk state.
+- Task 03: `dataSourceConfiguration.caching` has no producer yet (accessor-only seam, same as the first pass); first consumer lands with task 05.

--- a/docs/caching/PROGRESS.md
+++ b/docs/caching/PROGRESS.md
@@ -22,7 +22,7 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 | 10 | batch entity caching | done | def25586 | Full-batch semantics per unique representation; prepareItemState reused per bucket; splice copies per target; reviews/10-*.md. |
 | 11 | negative caching | done | d8888bff | DEVIATION from first pass: negative hits splice NOTHING so cached and uncached responses are byte-identical (incl. the null-bubble error); reviews/11-*.md. |
 | 12 | shadow mode | done | 09d5775b | Stash-after-selection clears serving fields; ShadowCacheEntry gained CacheTTL (reserved in task-02 log); RecordingObserver materializes compares; H4 re-runs at task 17; reviews/12-*.md. |
-| 13 | root-field L2 | todo | — | — |
+| 13 | root-field L2 | in-progress | (commit 1 below) | Commit 1 (plan side) landed; commit 2 (runtime) next. |
 | 14 | per-root-field isolation | todo | — | — |
 | 15 | entity-cache reuse | todo | — | — |
 | 16 | optimizeL1Cache pass | todo | — | — |
@@ -33,8 +33,8 @@ Status legend: `todo` | `in-progress` | `blocked` | `review` (done, awaiting hum
 
 ## Current focus
 
-- Next step: task 13 (root-field L2; deps 07 + 09 are done). Phase A is complete.
-- Mid-task state: none.
+- Next step: task 13 commit 2 (the runtime root-field branch in the controller).
+- Mid-task state: task 13 commit 1 (configurator root-field arm) is committed; the controller still declines root-field scope.
 
 ## Blockers awaiting human input
 

--- a/docs/caching/reviews/01-representation-variable-extraction.md
+++ b/docs/caching/reviews/01-representation-variable-extraction.md
@@ -1,0 +1,36 @@
+# Reviewer notes — task 01: representationvariable extraction
+
+Commit: `ca0ec6fb`.
+Task file: [tasks/01-representation-variable-extraction.md](../tasks/01-representation-variable-extraction.md).
+
+## What this commit adds
+
+A new exported package `v2/pkg/engine/plan/representationvariable` containing the `@key` → representation-node builder that was previously unexported in `graphql_datasource`.
+Cache-key construction (task 06) will reuse it, so there is exactly ONE `@key`→representation walker in the codebase and read/write cache keys can never skew against the datasource's own representations.
+
+## Decisions made
+
+- Pure move: the visitor, the merge helpers, and both entry functions moved verbatim; only the two entry points were renamed to exported form (`BuildRepresentationVariableNode`, `MergeRepresentationVariableNodes`).
+- The merge helpers (`mergeFields`, `mergeObjects`, `mergeArrays`, `fieldsHasField`, `isOnTypeEqual`) stay unexported inside the new package; nothing else in `graphql_datasource` used them (verified by grep).
+- Doc comments were added to the package and the two exported functions (required by CODING_GUIDELINES §8); no logic lines changed.
+- The pre-existing `// TODO: add support for remapping path` comment and the `unusedparams` hint on `resolveOnTypeNames(fieldRef …)` were left as-is — carrying them over unchanged keeps the diff a relocation.
+
+## What was implemented
+
+- `v2/pkg/engine/plan/representationvariable/representation_variable.go` — the moved code.
+- `v2/pkg/engine/datasource/graphql_datasource/graphql_datasource.go` — both call sites (`buildRepresentationsVariable`: build + merge) now call the exported names; import added.
+- Old `representation_variable.go` / `_test.go` deleted from `graphql_datasource`; tests moved with the code.
+- One NEW test case: `TestBuildRepresentationVariableNode/with entity interface` — the `entityInterfaceTypeName` → `OnTypeNames` remap branch was previously uncovered (only the interfaceObject branch had a test).
+
+## What to look into (review focus)
+
+- Confirm the diff reads as relocation + rename, not rewrite: git detected the renames at 89% (impl; the delta is doc comments) and 92% (tests; the delta is the new entity-interface case).
+- Confirm no import cycle: `representationvariable` imports `plan`; `plan` does NOT import `representationvariable` (only `graphql_datasource` does).
+- Confirm `MergeRepresentationVariableNodes` is exported for the datasource only; the task 06 `cacheKeyBuilder` must NOT call it (multi-key keeps candidates separate).
+
+## Verification evidence
+
+- `go test ./pkg/engine/plan/representationvariable/...` — ok.
+- `go test ./pkg/engine/datasource/graphql_datasource/...` and `./pkg/engine/plan/...` — ok (behavior-preservation guard).
+- Full `v2` suite: 40 packages ok, exit 0; `execution` module: 5 packages ok, exit 0.
+- `golangci-lint` (v2.5.0, repo config minus `modernize`, which the local binary lacks): 0 issues; `gci`/`gofmt` clean.

--- a/docs/caching/reviews/02-runtime-contract-and-loader-seam.md
+++ b/docs/caching/reviews/02-runtime-contract-and-loader-seam.md
@@ -1,0 +1,64 @@
+# Reviewer notes — task 02: runtime contract + loader seam + CacheTransaction
+
+Commit: (hash recorded in PROGRESS.md).
+Task file: [tasks/02-runtime-contract-and-loader-seam.md](../tasks/02-runtime-contract-and-loader-seam.md).
+Spec background: RFC-1 §3, §4, §6, §10; deviations D2, D4, D5, D8 (PLAN §7).
+
+## What this commit adds
+
+The complete runtime cache CONTRACT (types the loader and the future controller share) plus the loader SEAM, wired as a strict no-op.
+No cache implementation exists yet; with no `SetCacheController` the loader path is byte-identical to before this commit.
+Every later runtime task (07–12, 17–19) plugs into these seams without touching the loader again.
+
+Three new contract files in `resolve`:
+
+- `cache_controller.go` — `CacheController` (lifecycle port), `RequestCache` (the ONE mode-blind working surface: `PrepareFetch` / `OnFetchSkipped` / `OnFetchResult` / `EndRequest`), `Decision` enum, `PrepareFetchInput`, `MergeInput`, `CacheObserver`, `FetchCacheHandle` + `ItemCacheState` + `CacheCandidate` + `ShadowCacheEntry` (the opaque two-level handle).
+- `cache_transaction.go` — `TransactionBeginner` + concrete `CacheTransaction` (D2: the RFC's `MergeArena`/`MergeSession` renamed and reshaped; `Begin()` takes `DataBuffer.Lock` once, ops are methods on the transaction, `Commit()` releases).
+- `cache_config.go` — `FetchCacheConfig` (nil-safe `Equals`/`String`), `CacheKeySpec`, `CacheKeyCandidate`, `CacheScope`, `CacheWriteReason`, `EntityKeyMapping`/`EntityFieldMapping`.
+
+## Decisions made (and deviations applied)
+
+- D2 applied: `CacheTransaction` is a CONCRETE struct with unexported fields, so the arena is untouchable outside a held transaction by construction; `Commit()` (not `Close()`) releases the lock.
+- D8 applied: `cachePrepare` reads the config via the new `Fetch.CacheConfig()` interface method — NOT the RFC's `switch` over concrete fetch types.
+  The `Fetch` interface gains `CacheConfig()`, `SetCacheConfig(...)`, `IsEntityFetch()`, `IsBatchEntityFetch()`, implemented on all three concrete types.
+- D4 applied: `MergeInput.MergePath` carries `res.postProcessing.MergePath`, so entity/batch values can splice at the correct non-root target (consumed from task 07 on).
+- `FetchCacheConfig.Equals` is nil-safe ITSELF (`c == nil || other == nil` → pointer equality) in addition to the nil-safe clause at the `FetchConfiguration.Equals` call site; the task file asks for a nil-safe `Equals`, and belt-and-braces here avoids the nil-receiver footgun RFC-1 §3.8 flags.
+- `ShadowCacheEntry` carries the RFC's three fields only (the first pass had added a fourth, `CacheTTL`); task 12 adds fields if the shadow compare actually needs them.
+  Same for `ItemCacheState`: the first-pass extra `BatchEntityKey` per-item flag was NOT ported (it lives on the handle).
+- Full-hit modeling: `DecisionSkipFullHit` sets BOTH `prepared.skipLoad` (skips the network via the existing `loadPhase` guard) and `res.fetchSkipped` (reuses the existing `mergeResult` early-return so no spurious "failed to fetch" error is rendered for the empty `res.out`).
+- `cachePrepare` runs only when `!prepared.skipLoad` (render-skip sites win — a fetch the loader already decided to skip is not a cache decision) and only when `cfg != nil && (cfg.L1 || cfg.L2)`.
+- `cacheRequest` creates the request-lifetime surface lazily, ONCE, under `DataBuffer.Lock` (race-free across parallel fetches and per-defer-group Loaders because there is exactly one `DataBuffer` per request); it does NOT hold the lock across the hook.
+- The three `result` carrier fields (`response`, `responseData`, `responseHasErrors`) are assigned in `mergeResult` exactly where each value is already computed, per RFC-1 Appendix B; they are dead weight when caching is off.
+- `isEmptyEntityFetch` stays the single source of truth for empty-entity detection: `cacheMerge` calls it (guarded by `res.response != nil`) instead of re-deriving the rule cache-side.
+- Sanctioned fetch-switch cleanup survey: `preparePhase`'s switch dispatches to type-specific prepare functions that need the concrete types (not caching code, not simplifiable by the new predicates), and `isEmptyEntityFetch` already dispatches polymorphically via `FetchKind()`; no site qualified for a clear-simplification rewrite, so none was touched.
+
+## What was implemented
+
+- Contract files as above (pure additions).
+- `fetch.go`: `Cache *FetchCacheConfig` on `FetchConfiguration` / `EntityFetch` / `BatchEntityFetch`; the four new `Fetch` interface methods on all three concrete types; the nil-safe cache clause in `FetchConfiguration.Equals`.
+- `loader.go`: `preparedFetch.cacheHandle`; the two behavior call sites in `resolveSingle` (`cachePrepare` after the prepare phase, `cacheMerge` after the merge phase, both OUTSIDE the phase locks); helpers `cacheRequest` / `cachePrepare` / `cacheMerge` / `cacheTransactions`; the three `mergeResult` carrier assignments.
+- `context.go`: `cacheController`/`requestCache` fields, `SetCacheController` (mirrors `SetAuthorizer`), idempotent `endCacheRequest()`, `clone` resets `requestCache` (subscription-event isolation), `Free` calls `endCacheRequest` defensively and nils the controller.
+- `resolve.go`: `defer ctx.endCacheRequest()` at ALL FOUR entry functions (`ResolveGraphQLResponse`, `ArenaResolveGraphQLResponse`, `ResolveGraphQLDeferResponse`, `executeSubscriptionUpdate`), so the request-end flush covers sync, defer, and subscription paths.
+- Compile fixes: the three test-only `Fetch` stubs (`mockFetchWithInfo`, `stubFetch`, `nilInfoFetch`) got the four new methods.
+
+New tests (dedicated files, full-value `assert.Equal`):
+
+- `cache_config_test.go` — `FetchCacheConfig.Equals` nil-safety + a 24-row mutation table proving EVERY field participates; `FetchConfiguration.Equals` cache clause rows P1–P5; exact `String()` renders (nil / populated / zero value); `CacheScope.String`.
+- `cache_fetch_test.go` — cache accessor + predicate table across all three concrete fetch types; a pin that `SingleFetch` stores the config in the embedded `FetchConfiguration` (what plan dedup compares).
+- `cache_controller_test.go` — `Decision.String` exhaustive; `FetchCacheHandle.String` nil / zero / populated / shadow, exact strings.
+- `cache_noop_test.go` — the no-op gates asserted OBSERVABLY: a real loader run (mocked datasource) with no controller, and with a controller but no per-fetch config, both produce the exact expected response and never call `BeginRequest`; `endCacheRequest` idempotency; `clone` resets `requestCache` while keeping the controller port.
+
+## What to look into (review focus)
+
+- WRITE GATE plumbing (the RFC's blocking-bug class): `MergeInput.FetchFailed` is `res.err != nil || len(res.out) == 0 || res.response == nil` and `res.response` is assigned ONLY after a successful parse — confirm a controller following the documented gate can never cache a transport/empty/parse failure even though `HasErrors` is false on those paths.
+- Lock discipline: both hook call sites are in `resolveSingle` AFTER the phase functions return (locks released); `cacheRequest` takes the lock only for the once-create; `CacheTransaction.Begin/Commit` is the single acquisition per hook. Nothing cache-related runs inside `preparePhase`/`mergePhase`/`loadPhase`.
+- No-op strictness: with a nil controller the only new work on the hot path is one `CacheConfig()` interface call returning nil per fetch (plus three dead field writes in `mergeResult`); confirm that is acceptable as "zero behavior change" (it allocates nothing and branches identically).
+- `loader.go` references no `*Object` for caching (`ProvidesData` lives inside the config, consumed by the future controller) — grep guard per task reviewer guidance.
+- The nested-merge branch (`res.nestedMergeItems`) is intentionally NOT hooked: the field is never assigned anywhere in the repo (RFC-1 §4.7 proof); flag if that ever changes.
+
+## Verification evidence
+
+- New contract tests: all pass (see commit CI output); full `resolve` package suite: ok (8.9s).
+- Full `v2` suite: 40 packages ok, exit 0; `execution` module: 5 packages ok, exit 0 (no-op gate: entire existing behavior unchanged).
+- `go test -race ./pkg/engine/resolve/`: ok, exit 0.
+- `golangci-lint` (v2.5.0, repo config minus `modernize`, which the local binary lacks): 0 issues; `gci`/`gofmt` clean.

--- a/docs/caching/reviews/03-planner-wiring-and-engine-config.md
+++ b/docs/caching/reviews/03-planner-wiring-and-engine-config.md
@@ -1,0 +1,60 @@
+# Reviewer notes — task 03: planner wiring, cacheconfig package, engine SetCaching
+
+Commit: (hash recorded in PROGRESS.md).
+Task file: [tasks/03-planner-wiring-and-engine-config.md](../tasks/03-planner-wiring-and-engine-config.md).
+Spec background: RFC-2 §5, §7.2–7.3, §11; deviations D3, D5, D6, D9 (PLAN §7).
+
+## What this commit adds
+
+The complete PLAN-side caching wiring, all gated and inert: the policy model, the postprocess pass pipeline (skeletons), the P1 second-walk registration seam, the per-field metadata carriers, and the public engine entry point `Configuration.SetCaching`.
+With no `SetCaching`, plans are byte-identical to before (proven by a determinism test and the full existing suites).
+Tasks 05/06/13/16 fill the pass and visitor bodies without touching the wiring again.
+
+## Decisions made (and deviations applied)
+
+- D6 names throughout: `cacheKeyBuilder`, `fetchCacheConfigurator`, `optimizeL1Cache`, and the `ConfigureCaching` entry point.
+  The facade is a struct named `cache.Configurator` whose METHOD is `ConfigureCaching(response, trees...)` — a verb-named struct read awkwardly; the method carries the D6 name.
+- D5 packaging: the pass pipeline lives in the new common `v2/pkg/engine/cache` package; `postprocess` holds only the option plumbing and three one-line `ConfigureCaching` calls.
+- D3: the `cacheconfig` policy structs carry NO L1/L2 bools; L2 is derived from TTLs by later tasks.
+- Provider shape: the first pass carried `KeySpecs []resolve.CacheKeySpec` + a `KeySpec(...)` provider method as an external key input; both are DROPPED per D10 (keys are structurally derived by `cacheKeyBuilder` from federation `@key` at plan time, the provider supplies only policies).
+  This also makes `cacheconfig` a true leaf: it imports only `time`.
+- `CachingConfiguration` itself implements `CacheConfigProvider` (linear-scan lookups; policy sets are small and the lookup runs at plan time), so `SetCaching` needs no adapter type.
+- ENGINE ENTRY SHAPE (task file asked to settle and record): `SetCaching(map[string]cacheconfig.CachingConfiguration)` keyed by DATASOURCE ID — the same ID `NewDataSourceConfiguration` receives and the same key the runtime uses (`FetchInfo.DataSourceID`), where `SetFieldConfigurations` keys by type/field inside its slice.
+  `NewExecutionEngine` validates every configured ID against the registered datasources and fails fast on an unknown ID (a typo must not silently disable caching).
+- Hard wiring precondition applied: configuring caching force-sets `plannerConfig.DisableIncludeInfo = false` (providers are matched to fetches via `FetchInfo.DataSourceID`; without info, caching would silently no-op).
+- D9 seam: the P1 visitor registers ONLY on the second walk (`ResetVisitors` + `SetVisitorFilter(nil)` + register P1 + `Walk` + `attachTo`), after the cost-calculator step.
+  The first pass ALSO registered P1 on the main walk; that was not ported — the task file and D9 specify the second walk only, and task 05 can revisit if the port genuinely needs main-walk state.
+- `dataSourceConfiguration[T].Caching()` accessor added with its `caching` field; NOTHING sets the field yet (same as the first pass) — it is the declared seam for per-datasource provider plumbing, first consumed in task 05.
+- `postprocess.EnableCaching(providers, federation, definition)` stays internal-facing (exported for the execution module, but the engine `Configuration` is the only public entry point).
+- `deferTrees` collects the initial tree plus every defer-group tree so cross-tree passes (`optimizeL1Cache`, task 16) see the full set of one response's trees in one call.
+
+## What was implemented
+
+- NEW `v2/pkg/engine/plan/cacheconfig`: `CachingConfiguration` (+ provider methods), `EntityCachePolicy`, `RootFieldCachePolicy`, `MutationCachePolicy`, `SubscriptionCachePolicy`, `CacheConfigProvider`.
+- NEW `v2/pkg/engine/cache`: `Configurator`/`NewConfigurator`/`ConfigureCaching` (holding the single no-op gate `len(providers) == 0`), plus inert skeletons `cacheKeyBuilder` (task 06), `fetchCacheConfigurator.configureTree` (tasks 06/13), `optimizeL1Cache.optimize` (task 16).
+- `plan`: `Configuration.CacheConfigProviders`; `dataSourceConfiguration.caching` + `Caching()`; `cacheProvidesDataVisitor` skeleton (`reset`/`EnterField`/`LeaveField`/`attachTo`); the gated second-walk seam in `Planner.Plan`.
+- `postprocess`: `EnableCaching` option, `Processor.caching`, the three `ConfigureCaching` call sites (sync / defer incl. every defer group via `deferTrees` / subscription), each after `processFlatFetchTree`/`extractDeferFetches` and before `organizeFetchTree`/`buildDeferTree`.
+- `resolve`: `Object.HasAliases`, `Field.OriginalName`, `Field.CacheArgs` (+ `CacheFieldArg`), carried through `Object.Copy`/`Field.Copy` (CacheArgs cloned, not aliased); `GraphQLResponse.cacheProvidesData` side-table + `SetCacheProvidesData`/`CacheProvidesData`.
+- `execution/engine`: `Configuration.SetCaching`; `NewExecutionEngine` builds providers + federation maps, validates IDs, forces FetchInfo, and threads `postprocess.EnableCaching` into every per-execution processor (`newInternalExecutionContext` now takes processor options).
+
+Tests (dedicated files, full-value `assert.Equal`):
+
+- `cache/configure_caching_test.go` — no-providers and providers-but-inert rows both leave the fetch tree byte-identical (full-tree equality) with all `Cache` nil.
+- `cacheconfig/cacheconfig_test.go` — provider lookup hit/miss rows for all four policy kinds, full policy values asserted; empty-configuration misses everywhere.
+- `plan/cache_provides_data_visitor_test.go` — P1 constructed only with providers; the second-walk determinism proof: plan WITH inert caching configured == plan WITHOUT, compared via the package's pretty-print convention.
+- `resolve/cache_node_copy_test.go` — `Copy()` carries `HasAliases`/`OriginalName`/`CacheArgs` (full-object equality) and clones `CacheArgs`; response side-table accessors.
+- `execution/engine/engine_caching_config_test.go` — `SetCaching` reaches planner providers + forces `DisableIncludeInfo=false` + produces the postprocess option; without it nothing is constructed; unknown datasource ID errors.
+
+## What to look into (review focus)
+
+- Facade placement: `ConfigureCaching` runs after `createConcreteSingleFetchTypes` (last step of `processFlatFetchTree`) and before `organizeFetchTree`; for defer plans it runs after `extractDeferFetches` and before `organizeFetchTree`/`buildDeferTree` nils `Defers` — verify against `postprocess.go` `Process`.
+- The four config gates: empty providers (facade returns), per-datasource nil provider and per-coordinate `(_, false)` (provider contract, exercised by the cacheconfig tests), all-flags-false config → nil Cache (trivially true while the configurator is inert; re-review at task 06).
+- `cacheProvidesData` is a side-table on `GraphQLResponse`, not part of the response tree — defer's response-tree `Copy()` cannot reach it.
+- The P1 seam calls `ResetVisitors()` on the planningWalker AFTER the plan is fully built (including cost calculation); confirm nothing later in `Plan` relies on the planning visitors still being registered.
+- Import shape: `cacheconfig` imports only `time`; `engine/cache` imports `plan`/`cacheconfig`/`resolve`/`ast`; `plan` does not import `engine/cache` — no cycle.
+
+## Verification evidence
+
+- All new tests pass (`engine/cache`, `plan/cacheconfig`, `plan`, `resolve`, `execution/engine`).
+- Full `v2` and `execution` suites pass (see PROGRESS.md notes for the run).
+- `golangci-lint` (v2.5.0, repo config minus `modernize`): 0 issues in BOTH modules; `gci`/`gofmt` clean.

--- a/docs/caching/reviews/04-test-infrastructure.md
+++ b/docs/caching/reviews/04-test-infrastructure.md
@@ -1,0 +1,55 @@
+# Reviewer notes — task 04: caching subgraphs, e2e harness, cachetesting fakes
+
+Commit: (hash recorded in PROGRESS.md).
+Task file: [tasks/04-test-infrastructure.md](../tasks/04-test-infrastructure.md).
+Spec background: RFC-1 testing appendix, re-based per D7 (no goldens, full-value assertions).
+
+## What this commit adds
+
+The complete caching test infrastructure the later tasks build on: dedicated wgc-composed caching subgraphs (committed `config.json`), a real-planner harness in the execution module, and the cosmo-free `cachetesting` fake set in `v2`.
+It proves itself with the Phase 0 no-op e2e row, one smoke row per fixture shape, and fake self-tests.
+
+## Decisions made
+
+- Fixture home: NEW `execution/cachingtesting/` (parallel to `federationtesting`, whose compose approach it copies): `subgraphs/{products,inventory,reviews,users}.graphql` + `graph.yaml` + `compose.sh` + committed `config.json`.
+  Fed-v1 `extend type` syntax matches the proven existing fixtures; wgc's `@external`-on-extension-key notes are informational relics, and rover cross-validation also passes (exit 0).
+- Fixture shapes (each smoke-tested):
+  multi-key `Product @key(upc) @key(sku)`; cross-subgraph nested entities (`users → products → inventory` via `me.favoriteProduct.stock`); by-key root fields `product(upc:)`/`productBySku(sku:)`/`user(id:)`; sibling root fields `products`/`promotions` on one datasource; mixed-TTL sibling fields via Product base data (products DS policy) vs `Product.stock` (inventory DS policy); batch entities via `products { reviews }`.
+- The FIXTURE-GAP closure (load-bearing): `TestDeferSupersetShape` plans `me.favoriteProduct { upc stock warehouse { id location } }` + `products { upc ... @defer { stock } }` and pins (full-value) that the defer group holds exactly one inventory entity fetch selecting ONLY `stock` — a strict subset of the initial inventory fetch for the same entity type, making cross-defer-group L1 serving provable (task 18 rows N1/N2/M3).
+- Harness wiring: the factory-built datasources are ID-named (`"0"`–`"3"`), so the harness accepts caching config AND response keys by SUBGRAPH NAME and translates via the router config's subgraph list; it wires caching exactly as `NewExecutionEngine` does (providers + federation by datasource ID, `DisableIncludeInfo=false`, `postprocess.EnableCaching`) rather than building a full engine, using the NEW exported `Configuration.PlannerConfig()` accessor.
+  The small wiring duplication is deliberate: the engine wiring itself is covered by the task 03 wiring test, and the harness stays a plain planner driver.
+- Query plans are ALWAYS included by the harness (`plan.IncludeQueryPlanInResponse()`), so plan-shape assertions are inline full-value `assert.Equal` on rendered fetch trees instead of golden files.
+- `Fetch.SetDataSource(DataSource)` added to the `Fetch` interface (implemented on all three concrete types): the first pass swapped datasources with a `switch` over concrete fetch types inside its test util — exactly the D8 pattern this port removes, so the swap is now polymorphic.
+- Fakes live in `v2/pkg/engine/cache/cachetesting` (D5 packaging), adapted from the first pass with these deviations:
+  the first-pass `CacheStage`/`Mode`/`storeAdapter`/`NewRealishCache` are NOT ported — they depend on the controller (task 07) and would be dead code today (the task file caps RealishCache at "what task 02's contract allows", which is nothing runnable);
+  `RecordingObserver` records only lifecycle counts, observed handles, and shadow cache keys (deep shadow-compare recording is task 12 logic);
+  `Call` gains the `MergePath` carrier (task 02's D4 addition).
+- No custom clock anywhere: `FakeStore` calls real `time.Now`, and the self-tests fake time with `testing/synctest` (TTL via bubble sleeps; ordering via gates + `synctest.Wait()`).
+
+## What was implemented
+
+- Fixtures + composition: `execution/cachingtesting/{subgraphs/*.graphql,graph.yaml,compose.sh,config.json}`; composed with real wgc (`npx -y wgc@latest router compose`), cross-validated with rover.
+- Harness: `execution/cachingtesting/cachingtesting.go` — `Plan(tb, query, caching, responses)`, `ResolveResponse` (public sync entry point), `DeferGroups`; config loaded relative to the package file via `runtime.Caller`, so any execution-module package can use it.
+- `execution/engine/engine_config.go`: exported `PlannerConfig()` accessor (refactor in place).
+- `v2/pkg/engine/resolve/fetch.go`: `SetDataSource` on the `Fetch` interface + three concrete implementations (+ the three test-double stubs).
+- Fakes: `v2/pkg/engine/cache/cachetesting/fakes.go` — `FakeCacheController`, `FakeRequestCache` (normalized `Call` log, scripted decisions, error injection, result-handle identity), `RecordingController`, `FakeStore` (absolute `ExpiresAt`, ordered `StoreOp` log, non-logging `Seed`), `GatedDataSource`/`DataSourceGate`, `RecordingObserver`, `FakeRegistry` + `SwapDataSources` + `Compact`.
+
+Tests:
+
+- `execution/cachingtesting/cachingtesting_test.go` — `TestNoOpBaseline` (byte-identical response with a recording controller set and caching unconfigured; zero `BeginRequest`s, zero calls), `TestFixtureSmoke` (six shape rows, complete response bodies), `TestDeferSupersetShape` (full-value rendered defer-group plan).
+- `v2/pkg/engine/cache/cachetesting/fakes_test.go` — `FakeStore` TTL expiry + Seed-does-not-log (synctest bubbles, full op-log asserts), `GatedDataSource` gating (arrival observable, blocked until release, via `synctest.Wait`), `FakeRequestCache` full `Call`-log round-trip incl. `MergePath` and handle identity, `FakeRegistry` response-key fallback order + load counting.
+
+## What to look into (review focus)
+
+- Re-run `./compose.sh` in `execution/cachingtesting` (needs `npx`): it must reproduce the committed `config.json` (the composability guard).
+- The defer-superset pin: confirm the asserted defer-group plan really is a strict subset of the initial inventory fetch selection for the same entity (`upc stock warehouse{id location}` vs `stock`).
+- `SetDataSource` on the `Fetch` interface: confirm the production surface is acceptable for what is primarily a test seam (the alternative was a concrete-type switch in caching code, which D8 forbids).
+- `v2` cosmo-freedom: `cachetesting` imports only `resolve`, `astjson`, `httpclient`; the cosmo proto stays in the execution module.
+- Goroutine discipline: all goroutine-spawning fake tests run inside `synctest.Test` bodies with in-process fakes only.
+
+## Verification evidence
+
+- wgc composition clean (config.json written); rover composition exit 0.
+- All new tests pass: `execution/cachingtesting` (no-op baseline, 6 smoke rows, defer superset), `v2 cachetesting` (5 self-tests).
+- Full `v2` and `execution` suites pass (see PROGRESS.md notes for the run).
+- `golangci-lint` (v2.5.0, repo config minus `modernize`): 0 issues in BOTH modules; `gci`/`gofmt` clean.

--- a/docs/caching/reviews/05-provides-data-visitor.md
+++ b/docs/caching/reviews/05-provides-data-visitor.md
@@ -1,0 +1,46 @@
+# Reviewer notes — task 05: ProvidesData visitor (P1)
+
+Commit: (hash recorded in PROGRESS.md).
+Task file: [tasks/05-provides-data-visitor.md](../tasks/05-provides-data-visitor.md).
+Spec background: RFC-2 §9 with the §9.2 correction (D9); the OLD builder via the first-pass port.
+
+## What this commit adds
+
+The full `cacheProvidesDataVisitor` body: per fetch, the exact field tree the fetch returns — alias-aware (`OriginalName`), argument-aware (sorted `CacheArgs`), with inline-fragment `OnTypeNames`, `__typename` dedup, and the entity-boundary reset (a nested entity fetch's tree starts at the ENTITY, not at the query root).
+The task-03 registration seam is filled in: the second walk now receives `operation`/`definition`/`config`/`planners`/`fieldPlanners` before it runs.
+
+## Decisions made
+
+- The port source is the FIRST-PASS visitor (itself the OLD-builder port adapted to this planner); logic preserved verbatim except:
+  modern-idiom touch-ups (`slices.Sorted(maps.Keys(...))` in `attachTo`, `strings.CutPrefix` in the entity-root check), removal of a redundant `v.objects == nil` re-init inside `ensurePlanner` (the planner seam always calls `reset()` first), and `addInterfaceObjectNameToTypeNames` returning at the first match instead of tracking flags.
+- D9 holds: P1 registers ONLY on the second walk.
+  The first pass additionally registered P1 on the main walk, where `fieldPlanners` is still incomplete and `reset()` discards whatever that pass collected — porting that would have been wasted work per plan; nothing in the visitor body needs main-walk state.
+- `attachTo` keys the side-table by `*FetchInfo` — the identity-stable key across dedup, fetchID-append, and concrete-type conversion (all copy `Info` by reference) — and iterates planner IDs in sorted order for determinism.
+- Root-operation-field arguments are NOT captured as `CacheArgs` (they are part of the root-field key rendered from the fetch input); only variable-bound arguments are captured, sorted by name; inline literal arguments are part of the normalized operation and thus already in the fetch input.
+- `ComputeHasAliases` is NOT added yet: the task file notes it is "folded into the configurator in task 06", and nothing calls it before then — adding it now would be dead code.
+
+## What was implemented
+
+- `v2/pkg/engine/plan/cache_provides_data_visitor.go` — the full visitor (replacing the task-03 skeleton): `trackField` (boundary reset, `__typename` dedup, alias/args capture, frame management), `createFieldValue` (schema type → Scalar/Object/Array with nullability), `isEntityBoundaryField`/`isEntityRootField` (fragment-marker-normalized path comparison), `resolveEntityOnTypeNames`/`resolveOnTypeNames` (entity root type condition; inline-fragment expansion with union/interface/object grandparent narrowing), `addInterfaceObjectNameToTypeNames`, `attachTo`, `responseOf`.
+- `v2/pkg/engine/plan/planner.go` — the seam now assigns the visitor's inputs; a comment records that `fieldPlanners` is complete because the main walk has finished (the reviewer-guidance invariant).
+- Tests `cache_provides_data_visitor_port_test.go`:
+  - `TestCacheProvidesDataVisitor` — the fidelity rows ported 1:1 (single key, nested object, alias, args-except-root, `__typename` dedup) PLUS a new inline-fragment row (the ported set had none; adding it immediately exposed that synthetic test planners must carry datasource + paths configurations, now provided by `newTestProvidesDataPlanner`).
+  - `TestCacheProvidesDataVisitorAdversarial` — beyond the OLD set: irrelevant provider sharing the consumer query (no leakage between trees); partial overlap (two entity fetches share `username`, each gets its own tree); empty selections (a boundary-only entity planner yields an EMPTY tree — zero coverage — while a never-attributed planner is absent entirely).
+  - `TestCacheProvidesDataVisitorDeterminism` — same op twice, identical side-tables (re-keyed by datasource).
+- Execution-module fidelity over REAL plans (`execution/cachingtesting/provides_data_test.go`):
+  - `TestProvidesDataFidelity` — full side-table pinned for a root + batch-entity plan (real `fieldPlanners`, entity-boundary reset visible in the reviews tree starting at `Product`).
+  - `TestProvidesDataDeferredFetchOwnTree` — the DEFERRED inventory fetch has its own `{stock}` entry in the shared side-table, independent of the initial inventory fetch's larger tree (the defer-`Copy()` immunity criterion).
+
+## What to look into (review focus)
+
+- The port diff against the first-pass visitor (behavioral equivalence apart from the listed touch-ups); the fidelity rows pin the OLD tree shapes.
+- `fieldPlanners` is read only in the second walk, after the main walk populated it in `LeaveField` (planner.go comment + D9 seam).
+- The empty-tree semantics for a boundary-only entity planner: an empty ProvidesData tree means ZERO coverage — the controller (task 07) must treat it as "never a full hit", not "vacuously covered".
+- The side-table stays a side-table (`GraphQLResponse.cacheProvidesData`); no `FetchInfo.ProvidesData` field was re-added.
+
+## Verification evidence
+
+- All visitor tests pass (fidelity, adversarial, determinism, gating, plan-identity).
+- Execution-module fidelity tests pass against real plans on the committed fixture config.
+- Full `v2` and `execution` suites pass (see PROGRESS.md notes for the run).
+- `golangci-lint` (v2.5.0, repo config minus `modernize`): 0 issues; `gci`/`gofmt` clean.

--- a/docs/caching/reviews/06-entity-cache-configuration.md
+++ b/docs/caching/reviews/06-entity-cache-configuration.md
@@ -1,0 +1,47 @@
+# Reviewer notes — task 06: cacheKeyBuilder + fetchCacheConfigurator (entity arm)
+
+Commit: (hash recorded in PROGRESS.md).
+Task file: [tasks/06-entity-cache-configuration.md](../tasks/06-entity-cache-configuration.md).
+Spec background: RFC-2 §6–§7 (D6 names); deviations D3, D5, D6.
+
+## What this commit adds
+
+Entity fetches now carry runtime cache config: the `cacheKeyBuilder` turns every resolvable `@key` set into multi-key candidates BY VALUE (the sole federation reader), and the `fetchCacheConfigurator`'s entity arm assembles and sets `*resolve.FetchCacheConfig` on entity/batch-entity fetches through the `Fetch` interface.
+Root-field configuration remains for task 13; entity-key mappings for task 15.
+
+## Decisions made
+
+- Port source: the first-pass "freezer"/"stamper", renamed and reshaped per D6, with the entity arm only:
+  the root-field branch, `EntityKeyMappings` derivation, and the first pass's `fetchIsEntity` type-switch (replaced by the D8 `IsEntityFetch`/`IsBatchEntityFetch` predicates; the switch also special-cased pre-conversion `SingleFetch`, unnecessary because the configurator runs strictly after `createConcreteSingleFetchTypes`) were not ported.
+- HARDENING beyond the first pass: a `@key` whose fields do not exist in the schema is now rejected as malformed.
+  The representation walker silently drops unknown fields, so such a key degraded to a `__typename`-only candidate in the first pass — a key that would collide across ALL entities of the type.
+  `buildEntitySpec` skips any candidate whose representation has no field beyond `__typename` (WHY comment at the site); if every key is malformed the entity is simply not cached.
+- Candidates are deterministically ordered by selection-set string; value-copy out is guaranteed structurally (each candidate node is built fresh by the shared `representationvariable` builder) and pinned by the aliasing-gate test.
+- `L1 = true` marks ELIGIBILITY (task 16 narrows); `L2 = TTL > 0 || NegativeCacheTTL > 0` (D3).
+- `ComputeHasAliases` (task 05 leftover) lands here with its first caller: the configurator folds it over the fetch's `ProvidesData` tree (the side-table's tree itself, not a copy — pinned by a `assert.Same` row).
+- The all-flags-false safety net (`!L1 && !L2 && !ShadowMode → nil`) is unreachable for the entity arm today (a found policy implies `L1`); it exists for the task-13 root-field arm where all-off configs are possible.
+
+## What was implemented
+
+- `v2/pkg/engine/cache/cache_key_builder.go` — `buildEntitySpec` (entity index check, sorted key sets, per-candidate build via `representationvariable.BuildRepresentationVariableNode`, malformed-candidate skip, zero-candidate bail).
+- `v2/pkg/engine/cache/fetch_cache_configurator.go` — `configureTree` (recursive walk, `SetCacheConfig` via the interface) and `buildConfig` (provider lookup by `FetchInfo.DataSourceID`, entity policy by `RootFields[0].TypeName`, spec + scalar policy fields + `ProvidesData` + `ComputeHasAliases`).
+- `v2/pkg/engine/resolve/node_object.go` — `ComputeHasAliases`/`computeNodeHasAliases` (ported; sets the flag on every object along the way).
+
+Tests:
+
+- `cache_key_builder_test.go` — full `CacheKeySpec` literals for single and composite/nested keys; MULTIPLE key sets registered in reverse order come out sorted; no-`@key`/unknown-datasource/nil-info → `(zero, false)`; broken-candidate-skipped and all-broken rows; the ALIASING GATE (mutate the source `FederationMetaData` and the builder's map copy after building; spec unchanged); candidate node equals the datasource's representation node for the same `@key` (same shared builder).
+- `fetch_cache_configurator_test.go` — FULL `*FetchCacheConfig` on `EntityFetch` (incl. `HasAliases` folded and `assert.Same` on `ProvidesData`) and `BatchEntityFetch`; zero-TTL row keeps `L1` with `L2` off; five nil rows (SingleFetch-until-13, no provider, no policy, no key, nil info).
+- Plan-level via the task-04 harness (`execution/cachingtesting/entity_config_test.go`) — full rendered config per fetch for a sync plan (reviews batch entity configured, root fetch nil), a DEFER plan (initial `me.favoriteProduct` inventory fetch AND the deferred-group inventory fetch both configured), and determinism (plan twice, identical rendering).
+
+## What to look into (review focus)
+
+- The one-file federation boundary: `cache_key_builder.go` — confirm nothing retains a pointer into `FederationMetaData` (candidates are freshly built nodes; the spec carries strings and nodes only).
+- The `__typename`-only candidate rejection: confirm the `len(node.Fields) < 2` guard is the right malformed-key detector (the representation node always leads with `__typename`).
+- Configurator placement is unchanged from task 03 (after `createConcreteSingleFetchTypes`, before `organizeFetchTree`); the defer-plan test proves defer-group fetches are covered via `deferTrees`.
+- No "freeze"/"stamp" vocabulary anywhere (D6) — grep `freeze|stamp` over `v2/pkg/engine/cache` and the tests.
+
+## Verification evidence
+
+- All cache-package and harness tests pass (first run for the plan-level rows).
+- Full `v2` and `execution` suites pass (see PROGRESS.md notes for the run).
+- `golangci-lint` (v2.5.0, repo config minus `modernize`): 0 issues in BOTH modules; `gci`/`gofmt` clean.

--- a/docs/caching/reviews/07-entity-l2-controller-core.md
+++ b/docs/caching/reviews/07-entity-l2-controller-core.md
@@ -1,0 +1,56 @@
+# Reviewer notes — task 07: entity L2 controller core (single candidate)
+
+Commit: (hash recorded in PROGRESS.md).
+Task file: [tasks/07-entity-l2-controller-core.md](../tasks/07-entity-l2-controller-core.md).
+Spec background: RFC-1 §3, §4.4, §5, §6; appendix rows A/B/C/D-core/F/K/L/O; deviations D2, D4, D5.
+
+## What this commit adds
+
+The first working `RequestCache`: an L2-only entity controller for the single-candidate case — lookup → coverage → decision → gated write → request-end flush.
+An end-to-end L2 entity hit now works over real plans: request 1 misses and writes, request 2 serves from the cache with ZERO network for the cached fetch.
+
+## Decisions made
+
+- Port source is the first-pass controller, cut down to the task's scope with EXPLICIT deferral gates (each with a task-reference comment): shadow-configured fetches behave as plain misses until task 12 (read-never-serve holds trivially — no reads at all), root-field scope until 13, batch until 10, negative sentinels until 11, L1 until 17, multi-candidate selection/reorder/backfill until 08–09.
+  `PrepareFetch` uses `Candidates[0]` only (the single-candidate contract).
+- NO `Mode` enum (the first pass had NoOp/L1/L2/L1L2): the controller is the L2 module; enablement derives from `cfg.L2 && store != nil`.
+  Task 17 composes L1 without a mode switch.
+- `cacheKeyTemplate` is a named type (the task's "one CacheKeyTemplate per candidate — the sole source of read/write/invalidate keys"), wrapping (prefix, representation) with a best-effort `render`; keys are `<prefix>:<16-hex pooled-xxhash64>`; numbers canonicalize to their JSON string in the preimage so `1` and `1.0` cannot split the key space; a representation that renders zero key fields is unrenderable (defense in depth on top of the task-06 builder guard).
+- D4 applied structurally: the merge hooks read `MergeInput.MergePath` — the write extracts the entity BELOW the path before storing, the splice merges the cached value AT the path (`ItemCacheState.EntityMergePath` stays unset; the prepare phase has no path input).
+- `ttlForConfig` was not ported: it special-cased `MutationTTLOverride`, and mutation caching is out-of-core (D12); writes use `cfg.TTL` directly.
+- The first pass parsed cached bytes and recorded `FromCacheCandidates` even on parse failure paths; here a malformed cached value records NOTHING (miss, no candidate) and never panics (unit row).
+- `resolve.NewTransactionBeginner(arena, db)` is new EXPORTED API: controller unit tests (and any out-of-tree controller's tests) need to construct the transaction seam; the loader keeps wiring its own internally.
+- The lock-discipline invariant is documented at the `requestCache` struct: all mutable fields are guarded by the transaction's `DataBuffer.Lock` (external lock, no internal mutex); `EndRequest` is single-threaded and touches bytes only.
+
+## What was implemented
+
+- `v2/pkg/engine/cache/controller.go` — `Store`, `Controller`/`NewController`/`BeginRequest`, `requestCache` with the four hooks, `deferredSet` + `deferSet` + flush.
+- `v2/pkg/engine/cache/cache_key_template.go` — `cacheKeyTemplate`/`newCacheKeyTemplates`/`render`, `renderRepresentationValue`, `cacheKeyPrefix`, `renderCacheKey`, pooled hashing.
+- `v2/pkg/engine/cache/coverage.go` — `covers`/`coversNode` (response-name reads for now; task 09 extends the naming).
+- `v2/pkg/engine/resolve/cache_transaction.go` — `NewTransactionBeginner`.
+- `cachetesting/realish.go` — `StoreAdapter` (FakeStore → `cache.Store`) and `NewRealishCache` (the REAL controller over the in-memory store), completing the task-04 deferral.
+
+Tests (row IDs in subtest names):
+
+- `controller_test.go` (unit, constructed astjson + a local `testStore` — `cachetesting` cannot be imported by the package it imports):
+  D rows (full hit incl. read-key==write-key, miss, coverage-fail with the candidate recorded but NOT served, nullability both ways, `ProvidesData == nil`, partial-hit AND-reduction, malformed-bytes no-panic, TTL expiry in a synctest bubble);
+  F rows F1–F8 (clean write with exact op log and TTL; transport/empty/parse/status failures with `HasErrors == false` — the historical blocking bug — plus GraphQL errors, JSON-null, and empty-entity all producing ZERO Sets);
+  K rows K1–K4 (accumulate then one flush batch, byte-snapshot isolation from later value mutation, empty flush);
+  the D4 merge-path rows (store below the path, splice at the path, root splice) and the gate/nil-guard rows (O).
+- `execution/cachingtesting/entity_l2_test.go` (e2e over real plans, public entry points, also run under `-race`):
+  the end-to-end L2 hit (complete responses, per-datasource load counts via the new name-translating `PlanResult.LoadCount`, exact store-op log across both requests proving key fidelity, lazy single `BeginRequest`, observer begin/end counts, and C7 — LoaderHooks silent for the skipped fetch);
+  dispatch rows with the recording fake (decision → hook routing, C8 handle pointer identity, hook-error propagation to the caller).
+
+## What to look into (review focus)
+
+- The write gate order in `OnFetchResult`: `FetchFailed || HasErrors` first, then `ResponseData == nil || TypeNull` — confirm no path can write after any failure signal.
+- One transaction per hook: `PrepareFetch`/`OnFetchSkipped`/`OnFetchResult` each call `in.Arena.Begin()` exactly once with `defer tx.Commit()`; nothing arena-touching sits outside.
+- The full-hit path relies on the task-02 loader seam (`skipLoad` + `fetchSkipped`); the e2e hit asserting the COMPLETE response is the no-spurious-error proof (C3/C6).
+- The deferral gates: each unimplemented feature fails CLOSED (plain fetch, no serving, no write) — worth re-checking against tasks 08–13 scopes.
+- `cachetesting` grew `StoreAdapter`/`NewRealishCache`; the unit tests keep a minimal local store double because of the import direction — flag if you prefer moving the op-log store into a third shared package instead.
+
+## Verification evidence
+
+- All unit + e2e rows pass; `-race` clean over `engine/cache`, `cachetesting`, and the execution harness tests.
+- Full `v2` and `execution` suites pass (see PROGRESS.md notes for the run).
+- `golangci-lint` (v2.5.0, repo config minus `modernize`): 0 issues in BOTH modules; `gci`/`gofmt` clean.

--- a/docs/caching/reviews/08-multi-key-freshness-reorder.md
+++ b/docs/caching/reviews/08-multi-key-freshness-reorder.md
@@ -1,0 +1,48 @@
+# Reviewer notes — task 08: multi-key candidates: render, freshness, reorder, backfill
+
+Commit: (hash recorded in PROGRESS.md).
+Task file: [tasks/08-multi-key-freshness-reorder.md](../tasks/08-multi-key-freshness-reorder.md).
+Spec background: RFC-1 §3.6–3.7, §5.1; RFC-2 §6.3; appendix rows D7–D13, E1–E7.
+
+## What this commit adds
+
+The best-effort multi-key model inside the task-07 controller: every frozen candidate renders independently (renderable → `RenderedKeys`, not renderable → `PendingCandidates`), lookup runs under ALL rendered keys (a hit on ANY serves), candidates are collected freshest-first, the selection ladder picks or synthesizes a covering value, the chosen value is reordered to selection order, and the write side refreshes and backfills every renderable key.
+
+## Decisions made
+
+- Port source is the first pass's `prepareItemCacheState`/`applyHits`/`selectMultiCandidateCacheValue`/`reorderCacheValueToSelectionOrder`, reshaped: the per-item ladder is one function (`prepareItemState`), L1/shadow/negative arms are still gated out (their tasks), and the selection ladder takes the parsed values explicitly (each candidate parsed lazily, ONCE, via `tx.ParseBytes`).
+- Malformed cached bytes count as a MISS for that key (added to the item's missed set, so the write path refreshes it) — the first pass silently dropped such keys from both hit and backfill sets, leaving poison entries in place.
+- The freshness order is `compareCacheCandidateFreshness`: known remaining TTL beats unknown (non-positive), larger beats smaller, stable for ties.
+- The selection ladder (documented at `selectMultiCandidateCacheValue`): freshest-covers → serve; union-covers (merged OLDEST-first so the freshest wins conflicts) → serve + `NeedsWriteback`; older-single-covers → serve + `NeedsWriteback`; nothing → miss.
+  A merge failure voids the synthesis and falls through to the older-single rung (never a half-merged value).
+- Reorder keeps cached-only extras APPENDED after the selection-ordered fields, so a write-back never loses data another fetch needs (e.g. key fields).
+- `MustWriteBack` = full hit AND (missed keys ∥ pending candidates ∥ `NeedsWriteback`); `OnFetchSkipped` then: refresh ALL rendered keys after a synthesized/older selection, else backfill the missed keys, plus best-effort pending-candidate renders from the SERVED value (which can carry more fields than the request item).
+- `WriteReason` (refresh/backfill) is metadata carried on the deferred set and surfaced through the NEW optional `WriteReasonRecorder` store extension — reasons never gate writes; stores that don't implement it see plain Sets.
+- FIXTURE EXTENSION (composition re-validated with wgc AND rover): a `deals` subgraph referencing `Product` by the SKU key plus a single-object `featuredReview` root field on reviews.
+  Without a key-availability asymmetry (one path providing only upc, another only sku) a true plan-driven cross-key hit is not expressible; datasource IDs 0–3 are unchanged (deals is "4"), so all pinned plans stay valid.
+
+## What was implemented
+
+- `controller.go` — `prepareItemState` (render/lookup/collect per item), handle-side `MustWriteBack`, the `prefixes`/`missedKeys` per-handle side maps (same external-lock invariant), `OnFetchSkipped` write-back arms, `OnFetchResult` pending re-render + reasons, reason-aware flush.
+- `multikey.go` — `selectMultiCandidateCacheValue`, `compareCacheCandidateFreshness`, `reorderToSelectionOrder`.
+- `cachetesting` untouched; the unit `testStore` gained `seed`/`seedNoTTL` (unknown-TTL hits) and the `Reason` op column.
+
+Tests (row IDs in subtest names; every row asserts the EXACT ordered `[]testStoreOp`/`[]StoreOp` where writes occur):
+
+- `multikey_test.go` — E1 (both render, both refreshed), E3 (`[Get k_upc, Set k_upc refresh, Set k_sku backfill]` exact), E4 (none renderable: ZERO Gets, two backfills), E7 (single-key degenerate), E2 (hit on the non-primary key + missed-key backfill on skip), E5 (pending candidate renders from the SERVED value), D7 (freshest wins, exact `SelectedRemainingTTL` under synctest, candidates recorded freshest-first), D8 (known beats unknown via `seedNoTTL`), D9 (merge synthesis with conflict won by the fresher value, `NeedsWriteback` + canonical refresh of BOTH keys), D10 (older-single fallback), adversarial empty-union and all-stale rows, D12/D13 AND-reduction.
+- `multikey_e2e_test.go` (plan-driven) — prime through the upc-keyed reviews path (response carries sku → sku key BACKFILLED), serve through the sku-keyed deals path: complete responses, ZERO products loads on the serve request, and the full ordered store-op log across both requests.
+- Task-07 rows updated where behavior legitimately changed: served values are now reordered to selection order (D1 and the splice rows pin the new canonical order); F/K expected ops carry `Reason: refresh`.
+
+## What to look into (review focus)
+
+- The ladder ordering (reviewer-flagged subtlest logic): freshest-single before union before older-single; the union merges OLDEST-first — verify the conflict-winner direction against the D9 row.
+- `NeedsWriteback` refreshes ALL rendered keys (not only the stale one) — intentional: the synthesized value is the new canonical entry everywhere.
+- The pending-candidate render on `OnFetchSkipped` tries ONLY the served value (the first pass also fell back to the request item; the served value is a superset of what the item can render for entity data — flag if you see a case where the item renders and the value does not).
+- Fixture diff: `deals.graphql` + `featuredReview`; re-run `./compose.sh` as the composability guard.
+
+## Verification evidence
+
+- All multi-key unit rows and the cross-key e2e pass (first run); `-race` clean over `engine/cache` and the execution harness tests.
+- wgc + rover composition clean after the fixture extension; all pre-existing harness tests still pass (IDs stable).
+- Full `v2` and `execution` suites pass (see PROGRESS.md notes for the run).
+- `golangci-lint` (v2.5.0, repo config minus `modernize`): 0 issues in BOTH modules; `gci`/`gofmt` clean.

--- a/docs/caching/reviews/09-store-normalization.md
+++ b/docs/caching/reviews/09-store-normalization.md
@@ -1,0 +1,48 @@
+# Reviewer notes — task 09: store-time normalization + argument-suffix keys
+
+Commit: (hash recorded in PROGRESS.md).
+Task file: [tasks/09-store-normalization.md](../tasks/09-store-normalization.md).
+Spec background: maintainer feedback R2.5; OLD transform pipeline; appendix row D6.
+
+## What this commit adds
+
+The transform module: values are cached NORMALIZED — schema field names (aliases resolved via `Field.OriginalName`) with a deterministic argument suffix folded into object keys (from `Field.CacheArgs` + the request variables) — and DENORMALIZED back to the requesting operation's aliases at serve time.
+A value cached by one operation now serves another with different aliases; `friends(first:5)` can never serve `friends(first:20)`.
+
+## Decisions made
+
+- ONE name derivation: `normalizedFieldName` (schema name + arg suffix) is shared by the write path, the coverage walk, and the read path — the reviewer-flagged "one implementation, not two".
+- `FromCache` STAYS NORMALIZED on the handle; denormalization happens at SPLICE time in `OnFetchSkipped`.
+  This kills the write-back trap (a value denormalized at prepare would be written back alias-shaped, poisoning the store) and removes the need to stash a second copy per item.
+  `denormalizeToSelection` builds a fresh transaction-owned value, so it also replaces both the task-08 `reorderToSelectionOrder` (deleted — dead-code hygiene) and the splice's `StructuralCopy`.
+- The `HasAliases` fast path gates only the WRITE-side normalize (alias-free trees store the raw marshal, zero transform cost); the read side always walks (it is also the selection-order pass).
+- Pending-candidate re-rendering in `OnFetchResult` now renders from the NORMALIZED value — representation fields carry schema names, which an alias-shaped response would not match (a latent first-pass bug for aliased key fields).
+- `computeArgSuffix`: args sorted by name, values from `ctx.Variables` through `RemapVariables`, absent values hash as `null`, pooled xxhash — ported from the first pass unchanged in behavior.
+- Fixture extension (wgc + rover clean, IDs stable): `Product.stockHistory(days: Int!)` on inventory, the entity-level argument field the arg-mismatch e2e row needs.
+
+## What was implemented
+
+- NEW `v2/pkg/engine/cache/transform.go` — `normalizedFieldName`, `computeArgSuffix`, `normalizeToSchema` (write), `denormalizeToSelection` (read; selection order + extras appended), all arena-allocating through the transaction only.
+- `coverage.go` — the walk reads by `normalizedFieldName` (an arg-mismatched cached field is structurally a MISS).
+- `multikey.go` — selection ladder is ctx-aware; `reorderToSelectionOrder` deleted (superseded).
+- `controller.go` — write-side normalize behind the `HasAliases` gate; splice-side denormalize; pending renders from the normalized value.
+- Pins updated where semantics legitimately changed: `FromCache`/write-back bytes are now the STORED form (task-07/08 rows note this inline).
+
+Tests:
+
+- `transform_test.go` — `normalizedFieldName` rows (plain/alias/deterministic order-independent suffix/different-args-differ/remap/absent-as-null); the full round-trip (alias-shaped response → EXACT stored bytes with schema names + suffix → coverage under a DIFFERENT alias tree → EXACT denormalized response); D6 both ways (same-ctx covers, different-args ctx does not); the controller-level alias round-trip (stored bytes pinned, second operation spliced under ITS alias).
+- `normalization_e2e_test.go` (plan-driven, real fixtures) — alias-independent reuse end to end (op A caches `inStock: stock`, stored bytes pinned as `{"stock":5,...}`, op B `availability: stock` served with ZERO inventory loads, complete responses both); argument-suffix both ways (same `days` → HIT serving the CACHED history, different `days` → MISS that fetches).
+
+## What to look into (review focus)
+
+- The write-back correctness argument: `FromCache` normalized end-to-end — check `OnFetchSkipped`'s refresh/backfill writes marshal `item.FromCache` (stored form), never the denormalized splice value.
+- Extras handling in both walks (fields the tree does not select are preserved as-is, keyed by their stored/response name) — deliberate so key fields and `__typename` survive round-trips; flag if you want extras dropped instead.
+- Allocation: normalize runs once per cached entity, denormalize once per served item, both through `tx.NewObject`/`NewArray`; nothing marshals twice.
+- The e2e alias row pins the stored bytes (`{"stock":5,"__typename":"Product"}`) — the normalization contract at the wire level.
+
+## Verification evidence
+
+- All unit + e2e rows pass; `-race` clean over `engine/cache` and the execution harness tests.
+- wgc + rover composition clean after the `stockHistory` fixture addition; all pre-existing harness tests pass.
+- Full `v2` and `execution` suites pass (see PROGRESS.md notes for the run).
+- `golangci-lint` (v2.5.0, repo config minus `modernize`): 0 issues in BOTH modules; `gci`/`gofmt` clean.

--- a/docs/caching/reviews/10-batch-entity-caching.md
+++ b/docs/caching/reviews/10-batch-entity-caching.md
@@ -1,0 +1,42 @@
+# Reviewer notes — task 10: batch entity caching
+
+Commit: (hash recorded in PROGRESS.md).
+Task file: [tasks/10-batch-entity-caching.md](../tasks/10-batch-entity-caching.md).
+Spec background: RFC-1 §5.1(e); appendix rows I1–I8; deviation D4.
+
+## What this commit adds
+
+The batch arm of the controller: batch entity fetches are keyed, looked up, and written PER unique representation, with full-batch semantics — all covered serves, any uncovered refetches everything (partial refetch is task 19).
+The task-07 "batch fetches until task 10" deferral gate is replaced by real behavior.
+
+## Decisions made
+
+- `prepareBatchFetch` mirrors the item loop over `BatchStats` buckets, taking `bucket[0]` as the representative (all targets of a bucket share one representation by construction of the loader's dedup), reusing `prepareItemState` — no duplicated ladder.
+- `ItemCacheState.BatchIndex` records the ORIGINAL batch position and `FetchCacheHandle.BatchEntityKey` marks the mode; both are exactly what task 19's partial realign needs (per-item rendered/pending keys already exist from task 08).
+- Splice: a batch item denormalizes ONCE PER TARGET (each target gets its own transaction-owned copy) into every merge target of its bucket, at the surfaced merge path (D4).
+- Write: the batch response's `_entities` array indexes by `BatchIndex`; a NON-ARRAY batch response writes nothing (fail closed); the merge-path extraction applies per element, after batch indexing.
+- The loader's batch dedup loop is UNTOUCHED (cache awareness of that loop arrives with task 19, per the reviewer guidance).
+- The empty-batch short-circuit (`BatchStats != nil && len == 0`) returns no handle — the loader's own empty-batch skip normally prevents the call entirely.
+
+## What was implemented
+
+- `controller.go` — `prepareBatchFetch`; batch-aware splice targets in `OnFetchSkipped`; batch element extraction in `OnFetchResult`.
+- No new helpers: keying, selection, normalization, and backfill all reuse the task 07–09 modules per element.
+
+Tests:
+
+- `controller_batch_test.go` — I1 per-item keying (two entities → two distinct keys, exact ordered ops), I2 full-batch hit spliced into EVERY target of a deduplicated bucket at a NON-ROOT merge path (all three targets pinned), I3 mixed batch (covered item recorded but the batch refetches fully; the exact op log shows the lookups AND the post-refetch writes for ALL entities), I4 per-element multi-key backfill from the batch response, I5 non-array batch response writes nothing; the empty-batch short-circuit row replaced the superseded task-07 gate row.
+- `batch_e2e_test.go` (plan-driven, the real reviews `BatchEntityFetch`) — full-batch hit end to end (request 1 writes one entry per entity with the exact op log; request 2 serves with ZERO reviews loads and byte-identical response); the mixed run (one primed, one not → full refetch with the correct response, then a repeat proves BOTH entities were written — its reviews response is intentionally empty, so any accidental network use fails loudly).
+
+## What to look into (review focus)
+
+- Bucket-representative soundness: `bucket[0]` stands for the whole bucket — all targets of one `BatchStats` bucket share one unique representation by the loader's dedup construction; flag if any loader path can produce heterogeneous buckets.
+- The splice copies per TARGET (not per item) — one shared copy across targets would alias mutations between response branches.
+- Mixed batches must never partially serve here: I3/the e2e mixed run pin `DecisionFetch` with the covered item's `FromCache` populated but unused for serving.
+- `OnFetchResult` indexes strictly by `BatchIndex` against the response array and skips out-of-range items — the loader guarantees `len(batchStats) == len(batch)` for successful batch responses.
+
+## Verification evidence
+
+- All I rows and both e2e rows pass (first run); `-race` clean over `engine/cache`, `cachetesting`, and the execution harness tests.
+- Full `v2` and `execution` suites pass (see PROGRESS.md notes for the run).
+- `golangci-lint` (v2.5.0, repo config minus `modernize`): 0 issues in BOTH modules; `gci`/`gofmt` clean.

--- a/docs/caching/reviews/11-negative-caching.md
+++ b/docs/caching/reviews/11-negative-caching.md
@@ -1,0 +1,43 @@
+# Reviewer notes — task 11: negative caching
+
+Commit: (hash recorded in PROGRESS.md).
+Task file: [tasks/11-negative-caching.md](../tasks/11-negative-caching.md).
+Spec background: RFC-1 §3.3, §5.1(d); appendix rows G1–G6.
+
+## What this commit adds
+
+The negative-cache path: a SUCCESSFUL-but-empty entity fetch writes a null sentinel under the item's keys with `NegativeCacheTTL`, and a sentinel hit serves as a full hit with zero network — while every failure signal keeps blocking ALL writes, negative ones included.
+
+## Decisions made
+
+- Write condition (in `OnFetchResult`, after the failure gate): `EmptyEntity && ResponseData != nil && TypeNull && NegativeCacheTTL > 0`.
+  `FetchFailed`/`HasErrors` return BEFORE this branch, so a failure can never masquerade as nonexistence (G5, all combinations).
+  Note the task-02 loader computes `EmptyEntity` unconditionally from the parsed response shape (any `_entities` array), so the `ResponseData TypeNull` conjunct is load-bearing — `EmptyEntity` alone does NOT mean "empty".
+- Sentinel semantics at read time: a TOP-LEVEL `TypeNull` cached value routes as a negative hit (before, and instead of, the coverage walk — there is nothing to cover); a positive value with a null FIELD lives inside an object and can never be mistaken for it (G6 unit row).
+  The freshest sentinel wins among candidates.
+- SPLICE BEHAVIOR DELIBERATELY DIFFERS FROM THE FIRST PASS: a negative hit splices NOTHING.
+  The first pass replaced the merge target with null; the e2e row exposed that this makes the cached response DIFFER from the uncached one (the real empty fetch leaves the target unmerged, and the resolvable renders a null bubble WITH its non-null error; the null-replacement rendered a clean null WITHOUT the error).
+  Caching must never change the response, so the controller now reproduces the uncached shape byte-identically — the e2e row pins `firstBody == secondBody` including the error entry.
+- `NegativeCacheTTL == 0` disables the path entirely (G2); the sentinel TTL is its own knob, independent of `cfg.TTL`.
+- The sentinel write branch opens its own transaction — `deferSet` mutates request-shared state and must run under the lock like every other hook body.
+
+## What was implemented
+
+- `controller.go` — the `negativeCacheSentinel` const (with the distinguishability rationale), the sentinel-routing block in `prepareItemState`, the no-splice negative branch in `OnFetchSkipped`, and the negative-write branch in `OnFetchResult`.
+
+Tests:
+
+- `controller_negative_test.go` — G1 exact sentinel bytes + `NegativeCacheTTL` in the op log; G2 zero writes at TTL 0; G3 sentinel hit (SkipFullHit, `NegativeHit`, `FromCache` TypeNull, target UNTOUCHED by the splice); G4 expiry inside a synctest bubble (network runs again); G5 failure-signal matrix (FetchFailed / HasErrors / both) with zero writes; G6 positive-null-field row (normal hit, never the negative path).
+- `negative_e2e_test.go` — the nonexistent-entity row over real plans: request 1 fetches `_entities:[null]` and writes the sentinel (exact op log with the negative TTL); request 2 zero inventory loads and a BYTE-IDENTICAL response (null bubble + the same non-null error, pinned in full).
+
+## What to look into (review focus)
+
+- The splice-nothing decision (the deviation from the first pass): confirm you agree that reproducing the uncached response (including its error entry) beats the "cleaner" null replacement; the e2e pin makes the tradeoff explicit.
+- Gate ordering in `OnFetchResult`: failure gate → negative branch → null-data gate — verify no ordering lets a failed fetch write a sentinel.
+- The sentinel routing happens before candidate selection and skips the coverage walk — confirm a sentinel candidate cannot leak into merge synthesis.
+
+## Verification evidence
+
+- All G rows and the e2e row pass; `-race` clean over `engine/cache`, `cachetesting`, and the execution harness tests.
+- Full `v2` (43 pkgs) and `execution` (6 pkgs) suites pass, exit 0.
+- `golangci-lint` (v2.5.0, repo config minus `modernize`): 0 issues in BOTH modules; `gci`/`gofmt` clean.

--- a/docs/caching/reviews/12-shadow-mode.md
+++ b/docs/caching/reviews/12-shadow-mode.md
@@ -1,0 +1,44 @@
+# Reviewer notes — task 12: shadow mode (entity compare)
+
+Commit: (hash recorded in PROGRESS.md).
+Task file: [tasks/12-shadow-mode.md](../tasks/12-shadow-mode.md).
+Spec background: RFC-1 §3.2, §3.5, §5.1(b); appendix rows H1–H4, H6, H7.
+
+## What this commit adds
+
+Shadow mode: a shadow-configured fetch READS L2 but never serves it — the read is stashed on the handle, the loader force-fetches (`DecisionFetchShadow` is byte-identical to `DecisionFetch` on the loader side; no loader change in this commit), and `CacheObserver.CompareShadow` runs the staleness probe BEFORE the writes, inside the hook's already-open transaction.
+
+## Decisions made
+
+- The stash happens AFTER the normal lookup/selection ladder: `shadowStashEntry` moves the would-be-served value (the exact selection, including the negative sentinel case with its `NegativeCacheTTL`) into `ShadowStash[i]` and CLEARS the serving fields, so no code path downstream can serve it.
+  `NeedsWriteback` is cleared too — under shadow, `OnFetchResult` refreshes every rendered key from the FRESH value anyway.
+- `resolve.ShadowCacheEntry` gained `CacheTTL` (the task-02 decision log reserved this: "tasks 10/12 add them only if actually needed") — the observer derives the entry's age (`CacheTTL − RemainingTTL`) without re-deriving config.
+- Decision precedence: any stash → `DecisionFetchShadow`, else all-covered → `SkipFullHit`; `WasHit` stays false under shadow (nothing served); both the single and the batch arm stash identically.
+- No mode enum grew (reviewer guidance): shadow rides `cfg.ShadowMode` on the existing L2 path; L2-off shadow never reaches the controller (H7).
+- A shadow MISS is byte-identical to a plain miss (fetch + write), and `CompareShadow` fires only when `h.Shadow && obs != nil` — a nil observer force-fetches and records nothing (H6).
+- `cachetesting.RecordingObserver` now materializes compares (`ShadowCompare{CacheKey, IsFresh, CacheAge}`, byte-equality of stashed vs fresh, batch-aware via `BatchIndex`), replacing the never-consumed `ShadowKeys`; production observer wiring stays with ART (task 20).
+
+## What was implemented
+
+- `controller.go` — `shadowStashEntry`; stash collection + `DecisionFetchShadow` in both prepare arms; the `CompareShadow` call in `OnFetchResult` before any write.
+- `resolve/cache_controller.go` — `ShadowCacheEntry.CacheTTL`.
+- `cachetesting/fakes.go` — the compare-materializing `RecordingObserver` (+ `ShadowCompare`).
+
+Tests:
+
+- `controller_shadow_test.go` — H1 (stash carries the exact key + cached bytes; nothing servable; the store log shows the read; force-fetch implied by `DecisionFetchShadow`), H2 (synctest-aged entry: compare records the EXACT 20s age, runs before the flush, L2 overwritten after), H3 (mismatch: `IsFresh=false`, fresh value wins the store), H6 (nil observer), H7 (L2-off never shadows), and the shadow-miss row.
+  H4 (L1-hit-wins) is deferred to task 17 as the task file specifies — until L1 exists the row is L2-scoped and covered by H1.
+- `shadow_e2e_test.go` — three requests over real plans: miss (no compare), hit-with-changed-data (response shows the FRESH value, compare `IsFresh=false`, L2 overwritten — pinned bytes), hit-with-unchanged-data (`IsFresh=true`); inventory loads on EVERY request (never served from cache); real-clock `CacheAge` normalized to zero with the exact age pinned by the synctest H2 unit row.
+
+## What to look into (review focus)
+
+- The loader has NO new branch for `DecisionFetchShadow` (it falls into the `default:` dispatch to `OnFetchResult` from task 02) — grep `FetchShadow` in `loader.go` to confirm nothing grew.
+- The compare runs inside the hook's existing transaction (no second `Begin`); confirm `CompareShadow` sits after `tx := in.Arena.Begin()` and before the write loop.
+- The stash copies via `tx.StructuralCopy` — the stashed value must not alias the parse buffer the selection used.
+- The negative-sentinel-under-shadow path: a stashed sentinel carries `CacheTTL = NegativeCacheTTL`; nothing serves and nothing special-cases it downstream.
+
+## Verification evidence
+
+- All H rows and the e2e row pass; `-race` clean over `engine/cache`, `cachetesting`, `resolve`, and the execution harness tests.
+- Full `v2` and `execution` suites pass, exit 0.
+- `golangci-lint` (v2.5.0, repo config minus `modernize`): 0 issues in BOTH modules; `gci`/`gofmt` clean.

--- a/docs/caching/reviews/13-root-field-l2.md
+++ b/docs/caching/reviews/13-root-field-l2.md
@@ -1,0 +1,45 @@
+# Reviewer notes — task 13: root-field L2 caching (plan + runtime)
+
+Commits: two (plan side, then runtime; hashes in PROGRESS.md).
+Task file: [tasks/13-root-field-l2.md](../tasks/13-root-field-l2.md).
+Spec background: RFC-2 §7.2; RFC-1 §3.5, §5.1(b); appendix D/F/I/J root arms, H5.
+
+## What this adds
+
+Root-field fetches now cache: the configurator's root-field arm (commit 1) and the controller's root-field branch (commit 2) — whole-response-scoped entries per field coordinate, alias-independent reuse via the task-09 transforms, and the historical shadow ASYMMETRY (force-refetch, never compare).
+
+## Decisions made
+
+- Mixed-fetch safety net: `rootFieldPolicyForAllRootFields` compares policy VALUES excluding the coordinate (the first pass's `sameRootFieldCachePolicy` semantics) — a merged fetch whose fields all carry equal settings caches as ONE unit; any mix (different values, cached + uncached) leaves `Cache` nil.
+  My first cut compared whole structs (coordinate included), which silently declined EVERY merged fetch — caught by the "identical values" row and corrected.
+- THE KEY DESIGN (the load-bearing deviation from the RFC sketch): the root-field key preimage is the fetch's root-field COORDINATE plus the request variables in canonical (name-sorted) form — the QUERY TEXT and the rendered input are deliberately EXCLUDED.
+  Keying on the canonical input (as RFC-1 sketched) would make alias-variant operations miss (different query text → different input bytes), defeating the task-09 reuse the e2e row requires.
+  Safety: coverage guards sub-selection differences, normalization guards shapes, and inline argument literals cannot collide because the engine ALWAYS normalizes with variable extraction (precondition documented at `rootFieldCacheKey`).
+  Two fetch shapes sharing a first coordinate share an entry ON PURPOSE (bigger values serve smaller selections; smaller entries fail coverage for bigger ones).
+- Shadow asymmetry implementation: a root-field shadow hit yields a plain `DecisionFetch` — no stash, no `Shadow` flag — so a compare is STRUCTURALLY impossible (the first pass stashed and suppressed the compare with a scope check; this is simpler and cannot regress).
+  The read still happens (hit-rate visible in store ops); the normal write path overwrites L2.
+- Runtime reuse: the root branch reuses `covers`, `normalizeToSchema`/`denormalizeToSelection`, `deferSet`, and the generic `OnFetchSkipped` splice — the only new primitives are `rootFieldCacheKey`/`canonicalVariables`.
+- `L1 = false` (root fields are L2 providers only); config declines entirely when nothing is enabled (the task-06 safety net is now reachable).
+
+## What was implemented
+
+- Commit 1 (plan): `cacheKeyBuilder.buildRootFieldSpec`; the configurator's root-field arm + `rootFieldPolicyForAllRootFields`/`sameRootFieldCachePolicy`; rows for full config, identical-values merge, mixed/cached+uncached declines, all-flags-false.
+- Commit 2 (runtime): `prepareRootFieldFetch` (single key, single lookup, shared served value), the root-field write branch in `OnFetchResult` (whole response, normalized when aliased, written once), `rootFieldCacheKey` + `canonicalVariables`.
+
+Tests (commit 2):
+
+- `controller_rootfield_test.go` — D-root miss→hit with exact op log and read-key==write-key; coverage failure (smaller entry never serves a bigger selection); key rows (different variables → different keys; variable ORDER irrelevant); F-root write gate; H5 (shadow hit → plain Fetch, ZERO compares, L2 overwritten with the changed value); J (cache-served data byte-identical to network-merged data).
+- `rootfield_e2e_test.go` — L2 hit with zero network; the ALIAS-VARIANT operation (`items: products { code: upc title: name }`) served from the SAME entry with its own shape; different arguments miss and fetch; stored bytes pinned (`{"products":[...]}` under the schema names).
+
+## What to look into (review focus)
+
+- The key-design deviation: agree/disagree with excluding the query text (the alternative kills alias reuse; the documented extraction precondition is what makes it safe — if an integrator can reach the planner with UNEXTRACTED inline literals, two operations could collide; flag if that path exists).
+- The variables canonicalization is top-level-only (nested object key order inside a variable VALUE still distinguishes) — conservative misses only, never wrong data.
+- H5: grep confirms no `CompareShadow` call is reachable for root scope (no stash exists to iterate even if it were).
+- Duplication check: the runtime root branch adds no parallel implementations of coverage/normalization/write.
+
+## Verification evidence
+
+- All configurator + runtime rows and the e2e rows pass (e2e first run); `-race` clean.
+- Full `v2` and `execution` suites pass, exit 0.
+- `golangci-lint` (v2.5.0, repo config minus `modernize`): 0 issues in BOTH modules; `gci`/`gofmt` clean.

--- a/docs/caching/reviews/14-root-field-isolation.md
+++ b/docs/caching/reviews/14-root-field-isolation.md
@@ -1,0 +1,47 @@
+# Reviewer notes — task 14: per-root-field cache isolation
+
+Commit: (hash recorded in PROGRESS.md).
+Task file: [tasks/14-root-field-isolation.md](../tasks/14-root-field-isolation.md).
+Spec background: RFC-3 (in core per maintainer feedback R2.2); deviation D5.
+
+## What this commit adds
+
+Cached query root fields now get their OWN planner during path building: sibling root fields with different (or no) cache policies never merge into one fetch, so each cached field keeps its own L2 key and TTL and the task-13 all-or-nothing decline becomes a rare residual.
+There was NO first-pass implementation of this (RFC-3 was a follow-up there) — this is a fresh implementation from the RFC.
+
+## Decisions made
+
+- All decision logic lives in the new unit `plan/root_field_isolation.go` (`shouldIsolateRootField`); `path_builder_visitor.go` carries EXACTLY the three sanctioned touches:
+  1. the additive `objectFetchConfiguration.isolatedRootField` flag;
+  2. the isolation disjunct beside the mutation-root branch in `handlePlanningField` (isolated planners are created via the existing `addNewPlanner`, then flagged);
+  3. the fold-refusal at the top of `planWithExistingPlanners`, keyed off `isParentPathIsRootOperationPath(field.parentPath)` — NEVER off `IsRootNode` (entity types are root nodes too; an `IsRootNode` guard would tear the isolated field's own nested entity subtree apart — the entity-root-node trap, pinned by its own test row).
+- Gate condition: non-empty `CacheConfigProviders` (with caching off the branches are provably dead — plans byte-identical), `field.parentPath == "query"` (covers both "query operation only" and "direct child of the operation root" in one comparison), and the exact coordinate having a `RootFieldPolicy` from the datasource's provider — read from the provider ONLY, never `FederationMetaData`.
+- Per-field isolation with no amplification cap (matching OLD; opt-in and bounded by configured fields; per-policy-group batching is the recorded future mitigation).
+- Secondary-run safety: revisits of an already-planned fieldRef return early via the existing `fieldsPlannedOn` guard at the top of `handlePlanningField`, so the isolation branch cannot double-create planners.
+- Downstream passes needed ZERO changes: P1, the configurator (single-root-field fetches trivially pass the all-or-nothing rule), and the defer machinery all see the isolated planners naturally — pinned by the defer-composition row.
+
+## What was implemented
+
+- `plan/root_field_isolation.go` — the gate predicate with the full rationale doc comment.
+- `plan/path_builder_visitor.go` — the three touches (diff-checkable).
+
+Tests (plan-level rows drive REAL plans through the harness; assertions render path + cache name/TTL + dependency edges per fetch):
+
+- Two cached siblings with different policies → TWO fetches, each with its OWN cache name and TTL, no dependency edges (parallel).
+- Cached + uncached sibling → the cached one isolated with config, the uncached one separate without.
+- Caching off → ONE merged fetch (plus the pre-existing task-04 smoke row and the full plan suite as the byte-identical proof).
+- ENTITY-ROOT-NODE TRAP row: `{ products { upc stock } }` under isolation yields exactly the isolated products fetch + the dependent inventory entity fetch — the isolated subtree stays intact — and resolves correctly end to end.
+- Defer composition row: an isolated root with a deferred fragment keeps its deferred sub-fetch in the correct defer group.
+- e2e independent serving: both siblings cached under DISTINCT keys; force-expiring ONE entry (store-double aging; TTL semantics are pinned by the synctest unit rows) makes only that fetch refetch while the sibling still hits.
+
+## What to look into (review focus)
+
+- The `path_builder_visitor.go` diff — confirm it is exactly the three touches and nothing else.
+- The fold-refusal guard placement: after the datasource-hash check, before every other merge consideration — confirm no earlier `return plannerIdx, true` path (e.g. the secondary-run `HasPath` shortcut) can fold a top-level field into an isolated planner: the secondary-run shortcut only fires for paths the planner ALREADY has, which for an isolated planner is only its own field's subtree.
+- The gate's `parentPath == "query"` literal: confirm the walker renders operation roots as bare `query` (the existing `isParentPathIsRootOperationPath` relies on the same convention).
+
+## Verification evidence
+
+- All isolation rows pass; the full `plan` package suite passes untouched (no-op proof); `-race` clean on the harness tests.
+- Full `v2` and `execution` suites pass, exit 0.
+- `golangci-lint` (v2.5.0, repo config minus `modernize`): 0 issues in BOTH modules; `gci`/`gofmt` clean.

--- a/docs/caching/reviews/15-entity-cache-reuse.md
+++ b/docs/caching/reviews/15-entity-cache-reuse.md
@@ -1,0 +1,47 @@
+# Reviewer notes — task 15: root fields re-using the entity cache
+
+Commit: (hash recorded in PROGRESS.md).
+Task file: [tasks/15-entity-cache-reuse.md](../tasks/15-entity-cache-reuse.md).
+Spec background: RFC-2 §6 derivation note; RFC-1 §3.6; appendix E3/E5; deviation D10.
+
+## What this commit adds
+
+By-key root fields (`product(upc:)`, `user(id:)`) now hit entity entries: the builder derives `EntityKeyMappings` STRUCTURALLY (D10 — definition + federation only, no external mapping config) and freezes the entity's FULL candidate set onto the root-field spec; the runtime renders the arg-derived candidate at lookup, serves the entity value at the field's response key, and backfills the data-derived keys after a fetch or read-hit — all through the SAME best-effort multi-key machinery.
+
+## Decisions made
+
+- KEY STRUCTURAL DIFFERENCE from the first pass: the spec carries the entity's WHOLE candidate set (arg-coverable keys render at lookup; the rest become `PendingCandidates`), not just mapping-derived candidates.
+  The first pass built candidates only from the mappings, which made the E3 data-derived backfill (`sku` written after the response) impossible for root reuse.
+  This is also what routes everything through `prepareItemState` unchanged — the reviewer-guidance requirement of "no separate lookup path".
+- Candidate representations get `TypeName` set at freeze time: the arg-derived lookup item has no `__typename`, and the task-07 template already falls back to `representation.TypeName` (the seam was reserved for exactly this).
+- Serving shape: the item state carries `EntityMergePath = [field's RESPONSE key]` — the splice lands the denormalized ENTITY at `data.<alias>`, and the write side extracts the entity below that key before normalizing; coverage/transforms run against the FIELD SUBTREE (`reuseProvides` per-handle override), because the cached value is the entity, not the whole response.
+  This finally populates `ItemCacheState.EntityMergePath` (reserved since task 02/D4).
+- The `CacheName` constraint is enforced BY CONSTRUCTION: the key prefix is the policy's cache name, so a mismatched name renders a different key and simply misses (pinned both ways in the e2e).
+- v1 argument-binding constraint (documented at `deriveEntityKeyMappings`): the runtime reads the argument value from a request variable NAMED LIKE THE KEY FIELD (`query($upc:...){ product(upc:$upc) }`).
+  Inline literals (extracted to synthetic variable names) and differently-named variables leave the candidate unrenderable — a plain fetch with post-response backfill, never wrong data.
+  Operator-declared bindings are the recorded follow-up.
+- Fallbacks fail open to the PLAIN root-field path: a non-object subtree (list-returning fields), a missing subtree, or zero templates.
+- The root-field shadow asymmetry (task 13) applies to reuse too: shadow clears the served value; plain `DecisionFetch`, no compare possible.
+
+## What was implemented
+
+- `cache_key_builder.go` — `buildRootFieldSpec` extension, `deriveEntityKeyMappings`, `keySelectionSetFieldNames` (ported from the first pass's derivation with the candidate-set change above).
+- `controller.go` — `prepareRootFieldEntityReuse` (+ `rootFieldSubtree`, `entityLookupItem`), the `reuseProvides` per-handle override, the per-item `EntityMergePath` splice/extract arms in both merge hooks.
+
+Tests:
+
+- `entity_reuse_test.go` — builder rows (full mappings + both candidates with `TypeName`, arg-mismatch/no-entity/multi-root-field declines); E3 with the EXACT ordered ops (`[Get upcKey, Set upcKey refresh, Set skuKey backfill]` in the ENTITY key space, cross-derived from a real entity fetch so read key == write key is proven by construction); the hit row (entity value spliced at `data.product`); E5 read-hit backfill; the missing-variable fallback (zero lookups, both candidates pending).
+- `entity_reuse_e2e_test.go` — the full loop: `featuredReview.product` primes the entity (upc + sku keys), `product(upc:$upc)` is served from that entry with ZERO products loads (canned network response deliberately different, so accidental network use fails loudly), and the mismatched-`CacheName` variant fetches from the network.
+
+## What to look into (review focus)
+
+- The whole-candidate-set decision (vs the first pass's mapping-only candidates) — it is what makes E3 satisfiable; confirm no downside for lookup cost (one extra unrenderable candidate per non-arg key).
+- `entityWriteKeys` in the unit tests derives expected keys from a REAL entity fetch through the controller — the strongest read==write proof available without duplicating key derivation in tests.
+- The v1 variable-name constraint: confirm the documented behavior (miss, fetch, backfill — never wrong data) is acceptable until operator bindings land.
+- `reuseProvides` joins the per-handle side maps under the same external-lock invariant.
+
+## Verification evidence
+
+- All builder/runtime/e2e rows pass (e2e first run); `-race` clean.
+- Full `v2` and `execution` suites pass, exit 0.
+- `golangci-lint` (v2.5.0, repo config minus `modernize`): 0 issues in BOTH modules; `gci`/`gofmt` clean.

--- a/docs/caching/reviews/16-optimize-l1-pass.md
+++ b/docs/caching/reviews/16-optimize-l1-pass.md
@@ -1,0 +1,45 @@
+# Reviewer notes — task 16: optimizeL1Cache cross-tree narrowing
+
+Commit: (hash recorded in PROGRESS.md).
+Task file: [tasks/16-optimize-l1-pass.md](../tasks/16-optimize-l1-pass.md).
+Spec background: RFC-2 §10; OLD `postprocess/optimize_l1_cache.go`; CODING_GUIDELINES §10.5.
+
+## What this commit adds
+
+The `optimizeL1Cache` skeleton (inert since task 06) is now the real pass: after the configurator marks every entity fetch L1-eligible, the pass keeps `cfg.L1` only where a request-lifetime provider/consumer pair exists — `canRead` (a prior same-type fetch or union of priors provides a superset) or `canWrite` (a later same-type fetch needs a subset this fetch contributes to).
+Narrowing only; the pass NEVER turns L1 on.
+
+## Decisions made
+
+- ORDERING HAS TWO SOURCES, not one: dependency edges (direct + transitive) AND tree order — the initial response tree always completes before any defer group starts, so an initial-tree fetch executes before every defer-group fetch even across branches with NO dependency edge.
+  The task text said "purely from DependsOnFetchIDs", but that alone cannot see the initial-inventory → deferred-inventory pair in the defer fixture (different branches, no edge) and would defeat the cross-tree requirement the same task demands; tree order is the missing, still-conservative source.
+  Defer groups among themselves stay UNORDERED (they may run in parallel) — pinned by its own row.
+- Field matching uses `fieldNarrowingName` — SCHEMA name (`OriginalName` when aliased) plus the CacheArgs bindings — instead of the OLD raw-`Name` comparison: the L1 store will hold normalized values, and fields selected with different arguments are different cache fields.
+  Mismatches only ever produce false NEGATIVES (over-narrowing → missed hits), never false positives.
+- The union-fallback contribution gate (`objectSharesAnyField`) is ported as specified — a provider is kept via the union only when it contributes at least one field the shared consumer needs; the irrelevant-provider row pins the flaw both ways.
+- FIXED A FIRST-PASS ALIASING BUG the task did not list: the OLD `unionObjects` wrote the recursive merge into `existing.Value`, where `existing` is a field of a LIVE `ProvidesData` tree on a fetch config — the union computation silently mutated fetch configs.
+  The port copies the field struct before overriding; the "union never mutates provider trees" row pins it.
+- Re-nil of fully-inert configs (`!L1 && !L2 && !ShadowMode`) implemented as the last step per the task's option.
+- The unused OLD helpers (`treeContainsAllFields`/`nodeContainsAllFields`) were dead code and were NOT ported.
+
+## What was implemented
+
+- `optimize_l1_cache.go` — the full pass (collection across all trees with `treeIndex`, eligibility filter, provider/consumer/union predicates, dependency-chain ordering, coverage primitives, safe union).
+- The facade wiring from task 06 (`ConfigureCaching` → `l1.optimize(trees)`) was already in place; no facade change.
+- Existing plan-level pins updated: the SYNC fixture's lone entity fetch now renders `l1:false` (correct narrowing); the DEFER fixture keeps `l1:true` on BOTH inventory fetches (the cross-tree pair — this is the live proof the tree-order source works over real plans).
+
+Tests (`optimize_l1_cache_test.go`, 13 rows):
+
+- Pair kept; lone fetch off; inert re-nil; NEVER-turns-on (ineligible provider also strands its consumer); union coverage keeps all three; the FLAW PIN (irrelevant provider off, relevant kept); partial overlap (both off); empty union; transitive chain ordering; CROSS-TREE (root provider kept by a deferred consumer; per-tree-only behavior explicitly rejected by re-running with the root tree alone); defer↔defer unordered; determinism (second run identical); union-mutation regression row.
+
+## What to look into (review focus)
+
+- The tree-order ordering source — the one deviation from the task's letter, argued above; reject it and the task's own defer row becomes unsatisfiable.
+- The narrowing-name choice (schema name + args): confirm over-narrowing-only is the correct failure direction for every row.
+- The union-mutation fix: compare against the OLD `unionObjects` if in doubt (`existing.Value = unionObjects(...)` on a live tree).
+
+## Verification evidence
+
+- All 13 rows pass; the full plan suite and harness suite pass with the two updated pins; `-race` clean in both modules.
+- Full `v2` and `execution` suites pass, exit 0.
+- `golangci-lint` (v2.5.0, repo config minus `modernize`): 0 issues in BOTH modules; `gci`/`gofmt` clean.

--- a/docs/caching/reviews/17-l1-runtime-store.md
+++ b/docs/caching/reviews/17-l1-runtime-store.md
@@ -1,0 +1,47 @@
+# Reviewer notes — task 17: request-lifetime shared L1 store
+
+Commit: (hash recorded in PROGRESS.md).
+Task file: [tasks/17-l1-runtime-store.md](../tasks/17-l1-runtime-store.md).
+Spec background: RFC-1 §6; maintainer feedback R2.4; appendix J1–J7, M1–M2 (M3/N complete in task 18).
+
+## What this commit adds
+
+The request-lifetime L1 entity store: a `map[string]*astjson.Value` on `requestCache` (POINTERS, never bytes, never marshaled — R2.4), keyed by the SAME derived keys as L2 (one derivation per fetch feeds both layers), read L1 → L2 → subgraph with coverage at each layer, written normalized once per response (only the L2 write marshals), guarded by the hook's transaction under the external-lock invariant (no internal mutex).
+
+## Decisions made
+
+- L1 lookup runs over the already-rendered keys BEFORE any L2 `Get`; a covering (or negative-sentinel) L1 hit early-returns with NO missed keys and NO write-back duties — an L1 hit can never emit L2 traffic (the reviewer-guidance ordering hazard, pinned by the exact op logs).
+- An L2-served value populates L1 under ALL of the item's rendered keys (`populateL1`); the fetch write path stores one structural copy under rendered + pending-backfilled keys, so multi-key aliases hit L1 too (pinned by the sku→upc row).
+- The `PrepareFetch` gate widened from `useL2` to `L1 || useL2` — with the L2 loop and every `deferSet` now individually gated, an L1-only config produces ZERO store ops end to end.
+- Negative L1 sentinel: an `EmptyEntity` result writes `tx.Null()` into L1 unconditionally under `cfg.L1` (within one request nonexistence is a fact; the `NegativeCacheTTL` knob gates only the L2 sentinel).
+- H4 resolution (deferred from task 12): shadow stashes an L1-SELECTED value exactly like an L2 one — read-never-serve stays absolute (the stash ladder runs after selection, so this fell out of the task-12 structure; pinned).
+- FIXED A LATENT ISOLATION BUG in `resolve.CacheTransaction.StructuralCopy`: `astjson.DeepCopy(nil, v)` is an identity PASSTHROUGH in heap mode (nil arena), and one production resolve entry (`resolve.go:361`) runs the loader with a nil arena — stored L1 values would have aliased live response values there.
+  Heap mode now forces a real copy via a marshal round-trip; the arena path (the main production paths) is unchanged and keeps the zero-marshal guarantee.
+- OPTIMIZE-PASS FIX surfaced by the e2e: the transitive-order walk consulted only cache-configured entity fetches, so a chain passing THROUGH an unconfigured fetch (products → reviews → products) broke at the middle hop and the pair was narrowed off.
+  The pass now builds a dependency index over EVERY fetch in the trees (`collectFetchDependencies`).
+- Superseded pins updated: the task-07 "L1-only untouched" gate row (now participates, zero store ops), G2 (isolates the L2 TTL rule with `L1=false`), H7 (split into NO-OP and L1-only-shadow rows).
+- N6 (subscription event isolation): VERIFIED, not re-implemented — `clone` resets `requestCache` (pinned since task 02 in `cache_noop_test.go`), and the "no bleed across requests" unit row pins fresh-L1-per-BeginRequest at the controller level.
+
+## What was implemented
+
+- `controller.go` — the `l1` map + `l1Put`/`populateL1`; the L1-first read in `prepareItemState`; the L1/L2-split write paths in `OnFetchResult` (positive and negative); the widened gate.
+- `resolve/cache_transaction.go` — the heap-mode `StructuralCopy` fix.
+- `optimize_l1_cache.go` — the full-tree dependency index.
+
+Tests:
+
+- `controller_l1_test.go` (9 rows) — in-request reuse with EXACT op log (miss Get + flush Set only; shared-key equality asserted); L1-only zero-store round-trip; write and read isolation (mutate source / mutate served value → stored value pinned unaffected); L2-hit-populates-L1 (no second Get); multi-key backfill reaching L1; negative L1; H4; per-request isolation.
+- `l1_e2e_test.go` — the chain fixture (`deal → product(sku) → reviews(upc) → product(upc)`: a genuinely dependency-ordered same-type pair, the only sync shape the narrowing correctly keeps); in-request reuse with a TAMPERED canned response for fetch B (accidental network use fails loudly) and zero store ops; the J mode matrix (NO-OP / L1-only / L1+L2 byte-identical, second request L2+L1); M1 (exactly one `BeginRequest` across parallel eligible fetches) + M2 (parallel single+batch writes, uncorrupted response) under `-race`.
+
+## What to look into (review focus)
+
+- The heap-mode `StructuralCopy` fix — confirm `resolve.go:361` (nil-arena loader) is a real production path; if it is ever removed, the marshal fallback can go with it.
+- The GC/arena hazard (reviewer guidance): every value entering `l1` flows through `tx.StructuralCopy`/`tx.Null` — grep `l1Put` call sites.
+- The optimize-pass dependency-index fix changes narrowing results for chain shapes — the task-16 rows still pass unchanged; the e2e chain is the new coverage.
+- L1 population under ALL rendered keys (not just the selected hit's key) — safe because every rendered key identifies the same item, and readers re-run coverage.
+
+## Verification evidence
+
+- All unit + e2e rows pass; `-race` clean over `engine/cache`, `cachetesting`, `resolve`, and the execution harness.
+- Full `v2` and `execution` suites pass, exit 0.
+- `golangci-lint` (v2.5.0, repo config minus `modernize`): 0 issues in BOTH modules; `gci`/`gofmt` clean.

--- a/docs/caching/reviews/18-defer-concurrency-coverage.md
+++ b/docs/caching/reviews/18-defer-concurrency-coverage.md
@@ -1,0 +1,45 @@
+# Reviewer notes — task 18: defer + concurrency scenario coverage
+
+Commit: (hash recorded in PROGRESS.md).
+Task file: [tasks/18-defer-concurrency-coverage.md](../tasks/18-defer-concurrency-coverage.md).
+Spec background: appendix §6–§7 (M3–M5, N1–N5); CODING_GUIDELINES §4.5.
+
+## What this commit adds
+
+The defer × caching proofs the first pass could not complete: cross-defer-group L1 SERVING is now proven end to end through `ResolveGraphQLDeferResponse`, with complete-frame assertions, gated datasources, and `-race`.
+One small runtime fix flushed out (as the task anticipated): the narrowing pass learned the DEFER-GROUP ANCESTRY as an ordering source.
+
+## Decisions made
+
+- THE FLUSHED-OUT FIX: `executesBefore`'s "tree 0 before all" rule could not order a deferred provider before a NESTED (child-group) consumer — N2's shape has NO dependency edge between the two inventory fetches, only group ancestry.
+  `ConfigureCaching` now takes `treeParents` (derived in postprocess from `DeferDescriptors.ParentID`, mirroring `deferTrees`), and `treeEncloses` generalizes the rule: an ANCESTOR tree's fetches execute before every DESCENDANT tree's (the resolver resolves a parent group fully before its children — `resolveDeferTree`'s Sequence arm); SIBLING groups stay unordered (they run in parallel).
+  Pinned by a new narrowing unit row plus N2's plan inspection.
+- N2's fixture shape: a nested `@defer` whose selection is a SUBSET of the enclosing fragment gets normalized away (discovered by probing), so the nested group routes through the reviews hop back to the same Product (`... @defer { stock warehouse {...} ... @defer { reviews { product { stock } } } }`) — distinct path, same entity, ancestry-only ordering.
+- N4 uses PURE channel synchronization, not synctest: `Plan` and `resolve.New` spawn request-lifetime goroutines (WS ping loops, the resolver heartbeat) that deadlock a synctest bubble at exit.
+  The harness `deferFrameWriter` gained an optional `Flushed` signal channel — the test consumes exactly two flush signals while the gated sibling is provably blocked (its `Arrived` signal received, its `Release` still closed-off), so ordering is gate-based with zero latency dependence.
+- M5's empirical behavior, now pinned: a cache-hook error surfaces in THAT group's `completed` entry as a frame error (`"errors":[{"message":"cache hook failed"}]`) while the sibling group's frame carries its complete data — sibling isolation holds.
+- N5/M4 (per-group transactions, single lock per hook, no cross-group arena race) are covered by `-race` across N1–N4 plus the task-02 loader seam rows; no separate row can observe lock acquisition counts from outside without instrumenting production code.
+
+## What was implemented
+
+- `cache/configure_caching.go` + `optimize_l1_cache.go` — the `treeParents` ancestry ordering (+ unit row).
+- `postprocess/postprocess.go` — `deferTreeParents` (ParentID chain → parent tree indices) threaded into the defer arm; other arms pass nil.
+- Harness (`cachingtesting.go`) — `ResolveDeferResponse`/`ResolveDeferResponseWith` over a frame-capturing `DeferResponseWriter` (with the `Flushed` gate channel), and `PlanResult.Gate` (name-translated `SetGate` + re-swap).
+- `defer_l1_e2e_test.go` — the rows:
+  - N1 + M3: initial-fetch entity serves the deferred group — plan INSPECTED (the reviewer-guidance point: the defer group really carries a configured same-entity fetch), both frames pinned as complete strings, the deferred subgraph never hit (tampered canned response), zero store ops (L1-only), exactly ONE `BeginRequest` across all groups.
+  - N2: a deferred fetch populates L1 served to the NESTED later group (ancestry-only ordering); all three frames pinned; tampered response; zero store ops.
+  - N3: exactly one `EndRequest`; the single request-end flush carries the initial fetch's L2 write AND the deferred group's (all Gets before all Sets, both values asserted).
+  - N4: a `SkipFullHit` sibling flushes its frame while the other sibling is still gated mid-`Load` — the skip neither waits nor reorders.
+  - M5: the hook-error isolation row above.
+
+## What to look into (review focus)
+
+- The ancestry fix is the one production change — verify `deferTreeParents` against `buildDeferTree`'s actual execution semantics (Sequence = parent-then-children; Parallel = unordered), and that passing nil elsewhere degrades to the old root-before-defers rule.
+- N4's synchronization: confirm the `Flushed` channel consumption can neither deadlock (buffered, exact counts) nor pass vacuously (the gated fetch's `Arrived` is received BEFORE the flush waits).
+- Frame strings are pinned byte-exact except N4/M5's parallel-sibling frames (matched by content, order-independent) — the one place full-value ordering would be racy by construction.
+
+## Verification evidence
+
+- All defer rows pass; the FULL execution harness suite is `-race` clean; `v2` cache/postprocess suites `-race` clean.
+- Full `v2` and `execution` suites pass, exit 0.
+- `golangci-lint` (v2.5.0, repo config minus `modernize`): 0 issues in BOTH modules; `gci`/`gofmt` clean.

--- a/docs/caching/reviews/19-partial-fetching.md
+++ b/docs/caching/reviews/19-partial-fetching.md
@@ -1,0 +1,56 @@
+# Reviewer notes — task 19: partial fetching
+
+Commit: (hash recorded in PROGRESS.md).
+Task file: [tasks/19-partial-fetching.md](../tasks/19-partial-fetching.md).
+Spec background: maintainer feedback R2.3; OLD partial-batch machinery on `caching-base`.
+
+## What this commit adds
+
+`DecisionFetchPartial` graduates from seam to implemented for BATCH entity fetches: a batch with SOME buckets covered serves those from cache, sends the subgraph a REDUCED representations list, and realigns the response to the original bucket positions via `ItemCacheState.BatchIndex`.
+All partial semantics live in the new `engine/cache/partial.go` (the separable-module requirement); the loader diff is four small, explained touches.
+
+## The loader touches (the sanctioned beyond-seam changes)
+
+1. `cachePrepare`: on `DecisionFetchPartial`, swap `prepared.input` for `handle.PartialInput` (so single-flight dedups on the REDUCED input) and set `res.cachePartial`.
+2. `result.cachePartial` field (one bool).
+3. `mergeResult`: after response/error processing (error rendering, response parse, `responseData` extraction, subgraph-error merging — all UNCHANGED), return before the positional data merge — the reduced response is misaligned with `batchStats`, and the cache hook owns the merge.
+4. `cacheMerge` dispatch: `FetchPartial` now routes to `OnFetchResult` (the task-02 seam sent it to `OnFetchSkipped`, which could splice but never write the fetched values).
+
+## Decisions made
+
+- Splice + realign + write happen in ONE hook (`onPartialBatchResult`) inside one transaction — the single-lock-per-hook invariant holds for partial too.
+  The arm dispatches BEFORE the failure gate: on a failed partial fetch the covered splice still happens (the cached data is valid; the loader has already rendered the fetch errors) and only the fetched subset's merge/writes are skipped — pinned by the failure row.
+- `filterBatchInput` is best-effort: any unexpected input shape (no `body.variables.representations`, length mismatch, degenerate all/none) falls back to a plain FULL fetch — never a wrong request.
+  `keep[i]` mirrors the BatchStats bucket order, which IS the representations order (the dedup loop builds both), so the realign consumes the reduced `_entities` in fetched-bucket order.
+- Config gates: entity policies expose the knob as `EnablePartialCacheLoad`, root-field policies as `PartialBatchLoad` — either enables the batch path; SHADOW WINS over partial (read-never-serve is absolute).
+  With the knob off, behavior is byte-for-byte the old all-or-nothing (every earlier task's row passes unchanged).
+- Shared helpers factored, not duplicated: `spliceCachedItem` (extracted from `OnFetchSkipped` — including the negative-sentinel splice-NOTHING-write-NOTHING rule) and `writeFetchedValue` (extracted from `OnFetchResult`) serve both the normal and the partial paths.
+- PER-FIELD PARTIAL EXPIRY, interpretation documented: a fetch's subgraph query is FIXED at plan time, so "refetch only the expired fields" within one fetch would require per-request query rewriting — out of scope and not what the OLD implementation did either.
+  The deliverable is the mixed-TTL semantics ACROSS fetches: each policy's fields live under its own key with its own TTL, so when the short-TTL portion expires only THAT subgraph is re-fetched (the e2e row pins it: inventory refetches, reviews serves from cache).
+- A missing entity (null) in the reduced response merges nothing and writes nothing — negative caching rides the loader's whole-response `EmptyEntity` signal, which the partial path deliberately does not reinterpret.
+- `cachetesting` gained exact-input recording (`GatedDataSource.RecordInput`, `FakeRegistry.Inputs`, `PlanResult.Inputs`) for the acceptance criterion "the subgraph request contains exactly the missing representations".
+
+## What was implemented
+
+- `resolve/cache_controller.go` — `FetchCacheHandle.PartialInput`.
+- `resolve/loader.go` — the four touches above.
+- `cache/partial.go` — `filterBatchInput` + `onPartialBatchResult`.
+- `cache/controller.go` — the partial decision in the batch arm; the extracted shared helpers; the partial dispatch in `OnFetchResult`.
+
+Tests:
+
+- `partial_test.go` — `filterBatchInput` byte-exact rows + fallbacks; the partial split (exact partition, EXACT reduced input bytes, lookups for all buckets); realign with FULL merged targets at original positions and writes ONLY for fetched buckets; the adversarial set from the reviewer guidance (duplicated representations/multi-target buckets, all-hit → `SkipFullHit`, all-miss → `Fetch`, single-element batch); failure-in-fetched-subset (splice intact, zero writes); the config gate; shadow-wins.
+- `partial_e2e_test.go` — batch partial over real plans: the reviews subgraph receives EXACTLY the missing representation (recorded input asserted; the canned response only matches a reduced request, so a full batch would fail loudly), complete response with cached and fetched reviews at their original positions; the mixed-TTL expiry row (only the expired subgraph re-fetched).
+
+## What to look into (review focus)
+
+- The realign (the task's declared risk center): `fetchedIndex` consumes the reduced batch strictly in uncovered-bucket order — verify against `filterBatchInput`'s keep-order and the adversarial rows.
+- Double-merge audit: a covered bucket is spliced by `spliceCachedItem` and can never consume a response entity (the fetched branch is the `else`); a fetched bucket is merged only by the hook because `mergeResult` returned early (`res.cachePartial`).
+- The four loader touches — confirm nothing else changed in `loader.go` (diff is small by design).
+- The per-field-expiry interpretation above — push back if per-request query rewriting was actually intended; it would be a plan/loader redesign, not a cache feature.
+
+## Verification evidence
+
+- All unit + e2e rows pass; `-race` clean over `engine/cache`, `cachetesting`, `resolve`, and the execution harness; every earlier task's row passes unchanged (the all-or-nothing acceptance criterion).
+- Full `v2` and `execution` suites pass, exit 0.
+- `golangci-lint` (v2.5.0, repo config minus `modernize`): 0 issues in BOTH modules; `gci`/`gofmt` clean.

--- a/docs/caching/reviews/20-art-observability.md
+++ b/docs/caching/reviews/20-art-observability.md
@@ -1,0 +1,45 @@
+# Reviewer notes — task 20: ART observability (verbose caching trace)
+
+Commit: (hash recorded in PROGRESS.md).
+Task file: [tasks/20-art-observability.md](../tasks/20-art-observability.md).
+Spec background: maintainer feedback R2.9; RFC-1 §3.5 (`CacheObserver`).
+
+## What this commit adds
+
+The production `cache.TraceObserver`: it assembles a per-fetch `CacheTrace` from the opaque `FetchCacheHandle` at request end and attaches it to the fetch's existing ART trace (`DataSourceLoadTrace.CacheTrace`, additive `cache` JSON section) — decision, per-item layer hit/miss (`served_from: l1|l2`), rendered keys (hashed under `HashAnalyticsKeys`), exact remaining TTLs, write reasons (refresh/backfill), negative hits, pending candidates, and shadow compares with `CacheAge`.
+This closes the final task; all 20 tasks of the plan are done.
+
+## Decisions made
+
+- ZERO observer calls outside the controller (the OLD implementation's ~461-call-site coupling is the anti-goal): the loader never sees the observer; the controller stamps two observability fields onto the handle at registration (`Trace` — the fetch's ART destination, nil when tracing is off — and `HashAnalyticsKeys`) and calls `OnFetchObserved(h)` per handle at `EndRequest`.
+  `registerHandle` centralizes what were four duplicated registration sites.
+- Trace assembly is EndRequest-time (single-threaded, no lock, no arena) and works because `endCacheRequest` runs via defer BEFORE `ResolveGraphQLResponse` returns — the caller (router) serializes fetch traces after resolve, so the attach is always visible.
+- `CompareShadow` computes compare results EAGERLY into plain values (nothing arena-owned survives the transaction) and keys them per handle under the observer's own mutex — ONE `TraceObserver` instance serves many concurrent requests; `OnFetchObserved` drains the entry even when tracing is off, so nothing accumulates across requests.
+- Accumulation rides existing state instead of new hooks: `ItemCacheState` gained `ServedFromLayer` (stamped at the L1/L2 serve points; CLEARED by the shadow stash — under shadow nothing was served) and the existing `WriteReason` field is now stamped at the write sites (`writeFetchedValue` → refresh; `spliceCachedItem` → refresh/backfill).
+  The per-item helpers now take `*ItemCacheState` (pointer) so the stamps persist on the handle.
+- `HashAnalyticsKeys` hashes the FULL key string (16-hex xxhash64) in trace output — the visible `cacheName` prefix is part of the key material by design.
+- Scope guard honored: `OnEntity`/`OnFieldValue` are deliberate no-ops; metrics/analytics export pipelines stay follow-ups.
+
+## What was implemented
+
+- `resolve/fetch.go` — `DataSourceLoadTrace.CacheTrace` + the `CacheTrace`/`CacheItemTrace`/`CacheShadowCompareTrace` JSON shapes.
+- `resolve/cache_controller.go` — `FetchCacheHandle.Trace`/`HashAnalyticsKeys`, `ItemCacheState.ServedFromLayer`.
+- `cache/controller.go` — `registerHandle` (+ `fetchLoadTrace` switch), layer/write-reason stamping, the `OnFetchObserved` loop in `EndRequest`.
+- `cache/observer.go` — the production `TraceObserver`.
+
+Tests:
+
+- `observer_test.go` (8 rows) — COMPLETE `CacheTrace` structures asserted for miss+fetch (refresh write), L2 hit (EXACT 40s remaining TTL via synctest), L1 hit (`served_from: l1`, no TTL), multi-key backfill, negative hit, shadow (EXACT 15s `CacheAge`, compares in the trace), `HashAnalyticsKeys` on (hashed = xxhash64 of the raw key) vs off (every other row), and tracing-off (nothing attached, compares drained).
+- `art_e2e_test.go` — over real plans with `TracingOptions.Enable`: L2 miss→hit (complete `cache` JSON sections pinned, real-clock TTLs normalized with exactness pinned by the synctest unit rows), L1 in-request hit on the chain fixture, shadow compare (complete section incl. the probe), partial batch (`FetchPartial` with the served and fetched items distinguished), and the regression row (tracing off → NO cache sections; the untouched full suites are the byte-identical proof).
+
+## What to look into (review focus)
+
+- The reviewer-guidance hard rule: grep `obs.` in the loader (zero hits) — all observer interaction lives in `controller.go`/`observer.go`.
+- The handle grew `Trace`/`HashAnalyticsKeys` — confirm you prefer this over an interface accessor on `resolve.Fetch` (chosen to keep the Fetch interface untouched; the handle is already the controller↔observer contract).
+- Cross-request hygiene in `TraceObserver.compares` (the drain-on-observe path) — a handle whose request dies before `EndRequest` would leak an entry; `EndRequest` is deferred at every resolve entry, so the leak needs a process-killing panic. Flag if you want a size cap anyway.
+
+## Verification evidence
+
+- All observer + ART rows pass; `-race` clean over `engine/cache`, `cachetesting`, `resolve`, and the execution harness.
+- Full `v2` and `execution` suites pass, exit 0 (the no-op/byte-identical regression).
+- `golangci-lint` (v2.5.0, repo config minus `modernize`): 0 issues in BOTH modules; `gci`/`gofmt` clean.

--- a/docs/caching/specs/2026-06-30-rfc-01-appendix-testing-strategy.md
+++ b/docs/caching/specs/2026-06-30-rfc-01-appendix-testing-strategy.md
@@ -1,0 +1,756 @@
+# RFC-1 Appendix: Testing strategy for the loader cache abstraction
+
+Status: final for review.
+Author: caching working group.
+Companion: RFC-1 (`2026-06-30-rfc-01-loader-cache-abstraction.md`) and RFC-2 (`2026-06-30-rfc-02-caching-planner.md`).
+Ground truth for this appendix: the coverage matrix (`scratchpad/caching-rfc/explore-coverage-scenarios.md`),
+the supergraph + plan-drift design (`scratchpad/caching-rfc/explore-supergraph-plandrift.md`),
+and the conventions survey (`scratchpad/caching-rfc/explore-conventions.md`).
+
+This is the detailed plan for achieving ~100% unit-test coverage of EVERY caching loader code path,
+using the RFC-1 interface fakes, with no network and no real cache backend.
+It is written so a Codex session can build the harness and the catalog row-by-row,
+with every row asserting on FULL values via `assert.Equal` (never `assert.Contains`, never fuzzy comparisons).
+
+Target Go 1.25: tests use `t.Context()`, table tests, `t.Run`, type-safe atomics (`atomic.Int64`),
+`slices`/`maps`/`cmp`, `for i := range n`, `errors.Is`, `wg.Go(fn)`,
+and — for every time/TTL/ordering concern — the Go 1.25 stdlib `testing/synctest` (`synctest.Test`, `synctest.Wait`).
+There is NO custom clock double and NO injectable `now func` seam anywhere in the strategy:
+the cache and loader call REAL `time.Now`/`time.Since`/`time.Until`/`time.Duration` comparisons,
+and `synctest` fakes the clock around them (§2.5).
+
+---
+
+> REVISION 2 (maintainer feedback — see PLAN §R2.10, which is AUTHORITATIVE and overrides this appendix on conflict).
+> Drop the `.golden` / plan-drift-snapshot approach entirely: assert COMPLETE responses with full-value `assert.Equal` (never `assert.JSONEq`, never fuzzy).
+> Build the integration/e2e framework ON TOP OF the `execution` package (reuse it, do not reimplement) and REUSE the existing `federationtesting` package, copying its approach.
+> Create DEDICATED caching subgraphs (not `commerce` alone) with good NESTING and real VARIANCE of TTL and other cache options, and cover the full scenario matrix — including PARTIAL EXPIRY of some fields, partial fetch, root-field split, and alias/argument reuse — with fully-implemented assertions and NO placeholders.
+> Every function of the (now modular) cache interfaces gets a meaningful unit test; HIGH coverage; no dead code.
+> The `commerce`/`config_factory`/goldie material below is superseded where it conflicts.
+
+## 1. Testing philosophy
+
+### 1.1 Caching is interfaces, so the loader plus caching is unit-testable in-process with fakes
+
+RFC-1 plugs caching into the loader through a small set of public interfaces only:
+`CacheController` -> `RequestCache` (`PrepareFetch`/`OnFetchSkipped`/`OnFetchResult`/`EndRequest`),
+the scoped `MergeArena.Begin() -> MergeSession -> Close()` lock,
+the two-level opaque `*FetchCacheHandle`,
+the `Decision` enum (including `DecisionFetchShadow`),
+and the optional `CacheObserver`.
+The loader branches on NOTHING but the `Decision` value and the `*FetchCacheHandle != nil` check (RFC-1 §3.1, §4.3).
+
+That is the whole point of the abstraction for testing:
+because the loader is mode-blind and talks only to interfaces,
+every loader cache seam can be driven from in-process fakes,
+and every controller code path (key render, coverage, freshness, reorder, write gate, backfill, shadow)
+can be driven from an in-memory store fake,
+so we reach ~100% path coverage WITHOUT a subgraph, an HTTP server, or a real L2 backend.
+The two observable surfaces every scenario asserts on are
+(1) the FAKE CACHE RECORD (an ordered, deterministic, normalized log of lifecycle/lookup/write calls and the returned `Decision`/handle), and
+(2) the RESPONSE BYTES (the fully assembled GraphQL response, asserted as the exact JSON string).
+
+### 1.2 Coverage target and how it is measured
+
+Target: ~100% statement and branch coverage of the loader cache glue
+(`cacheRequest`, `cachePrepare`, `cacheMerge`, `mergeArena`/`mergeSession`, the `mergeResult` carrier assignments,
+`endCacheRequest`, the `clone`/`Free` cache reset, `FetchConfiguration.Equals`' cache clause),
+plus the `resolve/cache` controller package.
+Because the two test layers straddle the module boundary (§1.3), coverage is measured with TWO commands, each instrumenting the v2 packages under test via `-coverpkg`:
+- the v2 controller-unit layer, run from `v2/`: `go test ./pkg/engine/resolve/cache/... -coverpkg=github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve/cache -covermode=atomic -race`;
+- the execution plan-driven layer, run from `execution/`: `go test ./engine/... -run Caching -coverpkg=github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve,github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve/cache -covermode=atomic -race` (the execution tests drive the real v2 loader, so they instrument and report on the v2 loader glue by import path).
+The cross-check in §5.10 maps each loader-glue branch to the row(s) that hit it, so a reviewer can confirm completeness without reading a coverage HTML report.
+
+### 1.3 Where the tests live: TWO layers across the module boundary
+
+The reviewer rule is "do NOT append tests to existing test files or add more test files to existing packages;
+create SEPARATE NEW PACKAGES to group tests logically."
+A second, harder constraint shapes the split: a real, drift-proof plan can ONLY be produced via real `wgc` composition + the execution engine's `config_factory` (§4),
+and `config_factory` plus the cosmo proto (`nodev1`) live in the EXECUTION module (`execution/go.mod`, separate from `v2/go.mod`; execution imports v2).
+`v2` must NOT take the cosmo-proto dependency.
+So the strategy is exactly TWO test layers, each a NEW package, on opposite sides of that module boundary:
+
+| Layer (NEW package) | Module | Sees | Holds | Inputs |
+|---|---|---|---|---|
+| (i) Controller unit tests — `v2/pkg/engine/resolve/cache`, white-box `package cache` and black-box `package cache_test` | v2 | white-box: unexported `cache` internals + in-package fakes; black-box: the public `cache` surface + `cachetesting` (`RealishCache`) | the controller LOGIC rows: key render, coverage walk, freshness sort, reorder, write/backfill gate, multi-key render-then-backfill, negative, shadow compare | CONSTRUCTED `*astjson.Value` + `FakeStore` + `RecordingObserver` (`resolve.CacheObserver`) + `synctest`, driving `cache.NewController`/`RealishCache` directly. NO plans. NO `resolve` loader. NO cosmo dependency. |
+| (ii) Plan-driven loader+cache integration tests — a new `package …_test` in `execution/engine` | execution | the v2 PUBLIC `resolve` surface (`ResolveGraphQLResponse`/`ArenaResolveGraphQLResponse`/`ResolveGraphQLDeferResponse`), `plan`, `postprocess`, `config_factory`, and the v2 `cachetesting` fakes | the loader-seam + lifecycle + dispatch rows, the mode matrix, flush, `MergeSession` discipline, concurrency, defer, and the end-to-end hit/multi-key rows | a REAL plan from real `wgc` composition -> `config_factory` -> `config_factory`'s `plan.Configuration` -> v2 planner + postprocess (RFC-2 caching pass) -> golden -> the v2 loader driven against a FAKE in-process datasource + the cache controller + `synctest`. |
+
+Module-boundary rationale (why this exact split):
+- Layer (i) is pure controller logic and needs no plan and no loader, so it lives in v2 next to the code it tests, reaching the unexported `cache` internals directly as a greenfield white-box package — and it stays cosmo-free.
+- Layer (ii) needs a PLAUSIBLE, drift-proof plan, which requires `config_factory` + the cosmo proto, which only exist in the execution module; so the plan-driven loader tests must live there.
+  They drive the loader through the PUBLIC `resolve` entry points and assert on the two OBSERVABLE surfaces every scenario already uses — the FAKE CACHE RECORD (`fake.Calls()`) and the RESPONSE BYTES — so they need no unexported `resolve` access (which the module boundary would forbid anyway).
+  The handful of seams the old plan once asserted through an `export_test.go` bridge (full-hit skip, prepare->merge handle threading, lock-once-per-hook) are now asserted OBSERVABLY instead: the recording fake owns the handle it returns, so it proves pointer identity prepare->merge itself; the gated datasource + `store.Ops()` prove no network ran on a full hit; and `-race` proves the lock discipline.
+  No `export_test.go`, no hand-built federation plans.
+
+This satisfies both reviewer asks at once: "validate that queries plan as the unit tests say" (a real planner over real composition, golden-snapshotted) and "test subgraphs are composable + planner config valid" (wgc composition + `config_factory`), while keeping `v2` free of the cosmo dependency.
+
+---
+
+## 2. The test doubles
+
+The doubles split along the module boundary (§1.3).
+The cosmo-FREE fakes that DRIVE THE LOADER — the recording cache, the in-memory `RealishCache` (which wraps the real `cache.Controller`), the gated datasource, the `FakeCacheController` — live in ONE v2 support package, `v2/pkg/engine/resolve/cache/cachetesting` (not a `_test` package); the execution layer (ii) imports it (execution imports v2).
+Because `cachetesting` imports `cache` (for `RealishCache`), the white-box layer (i) — itself `package cache` — does NOT import `cachetesting` (that would cycle); instead it uses small IN-PACKAGE fakes (`FakeStore`, `RecordingObserver`) and `cache.NewController` directly. `FakeStore` and `RecordingObserver` are described once below and are duplicated as a tiny in-package fake for the white-box layer and a `cachetesting` export for the loader-driving layer.
+The drift-proof `Plan(...)` harness (§4) is the ONLY double that needs `config_factory` + the cosmo proto, so it lives in a support file in the execution module beside `config_factory_federation.go`.
+There is no fake clock at all — `synctest` is the clock (§2.5).
+We REUSE the existing repo machinery wherever it exists and only add a seam where the survey proved none exists.
+
+### 2.1 Reused, do not reinvent
+
+- Real composition + planner config: `wgc router compose` driving a committed `config.json`, then `protojson.Unmarshal` into `nodev1.RouterConfig` and `engine.NewFederationEngineConfigFactory(ctx).BuildEngineConfiguration(&rc)` to obtain a VALID `plan.Configuration` — the exact pattern of `execution/engine/config_factory_federation_test.go:36-46` and `execution/engine/skipped_fetch_test.go:47-57`. This is the spine of §4; it is the reuse that makes the test subgraphs provably composable and the planner config provably valid.
+- DataSource stubbing: the generated `MockDataSource` (`//go:generate mockgen ... DataSource`) and the `mockedDS(t, ctrl, expectedInput, responseData)` helper (`resolve_federation_test.go:19`), and the `TestingTB` abstraction (`resolve_federation_test.go:13`) so harnesses work for benchmarks too.
+- JSON normalization for assertions: `compactJSONForAssert(t, input)` (`json_assert_test.go:9`); use it to normalize the EXPECTED response string so byte-for-byte `assert.Equal` is robust to insignificant whitespace, never `assert.JSONEq`/`assert.Contains`.
+- Golden snapshots: `github.com/sebdah/goldie/v2` — ALREADY used in the execution module (`execution/engine/federation_integration_test.go:15,71`, `goldie.New(t, goldie.WithNameSuffix(".json"))`) and wrapped in v2 at `pkg/testing/goldie/goldie.go`; the plan-drift golden (§4) lives in the execution layer, so it uses `sebdah/goldie/v2` directly the same way the neighboring execution tests do.
+- Key-hash assertions: the pooled xxhash digest pattern the loader already uses for batch keys (`pool.Hash64.Get()`, `keyGen.Reset(); keyGen.Write(bytes); keyGen.Sum64()`, `loader.go:1667-1669`); a test that asserts a rendered cache key recomputes it the SAME way rather than hard-coding a magic number, then `assert.Equal`s the full key string.
+- Atomic call counters: `atomic.Int64` exactly as `loader_hooks_test.go` counts `OnLoad`/`OnFinished`.
+- Fake time: the Go 1.25 stdlib `testing/synctest` (§2.5) — not a hand-rolled clock.
+
+### 2.2 `fakeCacheController` — proves lazy, once-per-request init
+
+```go
+// cachetesting/fakes.go
+type FakeCacheController struct {
+    begins atomic.Int64
+    rc     resolve.RequestCache // the RequestCache handed back on every BeginRequest
+}
+
+func (f *FakeCacheController) BeginRequest(*resolve.Context) resolve.RequestCache {
+    f.begins.Add(1)
+    return f.rc
+}
+func (f *FakeCacheController) Begins() int64 { return f.begins.Load() }
+```
+
+Used to assert `BeginRequest` is called EXACTLY once per request and lazily (only on the first cache-eligible fetch), rows B1/B2/M1.
+
+### 2.3 `FakeRequestCache` (recording) — the pure loader-seam driver
+
+This double records every call with FULL, NORMALIZED inputs and returns a SCRIPTED `(Decision, *FetchCacheHandle)`.
+It is what lets us assert what the loader hands the cache and how it dispatches the decision, WITHOUT any cache logic.
+
+```go
+// A normalized, comparable record — pointers/arena values are projected to bytes/strings
+// so the whole slice is asserted with one assert.Equal (rule 11). No Contains, ever.
+type Call struct {
+    Op           string            // "Prepare" | "Skipped" | "Result" | "End"
+    FetchPath    string            // item.ResponsePath, deterministic per fetch
+    Items        int               // len(in.Items)
+    InputBytes   string            // PrepareFetchInput.Input (canonical pre-injection, §3.6)
+    HeaderHash   uint64            // PrepareFetchInput.HeaderHash
+    ResponseData string            // MergeInput.ResponseData marshaled, "" when nil
+    HasErrors    bool
+    FetchFailed  bool
+    EmptyEntity  bool
+    StatusCode   int
+    Decision     resolve.Decision  // echoed from the scripted return (Prepare only)
+}
+
+type FakeRequestCache struct {
+    mu     sync.Mutex
+    calls  []Call
+    script map[string]ScriptedDecision // keyed by FetchPath
+    errs   map[string]error            // OnFetch* error injection, keyed by FetchPath+Op
+}
+
+type ScriptedDecision struct {
+    Decision resolve.Decision
+    Handle   *resolve.FetchCacheHandle // nil for NO-OP (DecisionFetch,nil)
+}
+
+func (f *FakeRequestCache) PrepareFetch(in resolve.PrepareFetchInput) (resolve.Decision, *resolve.FetchCacheHandle) {
+    s := f.script[pathOf(in.Item)]
+    f.record(Call{Op: "Prepare", FetchPath: pathOf(in.Item), Items: len(in.Items),
+        InputBytes: string(in.Input), HeaderHash: in.HeaderHash, Decision: s.Decision})
+    return s.Decision, s.Handle
+}
+// OnFetchSkipped / OnFetchResult / EndRequest record analogously and return f.errs[...].
+
+func (f *FakeRequestCache) Calls() []Call { f.mu.Lock(); defer f.mu.Unlock(); return slices.Clone(f.calls) }
+```
+
+`record` takes `f.mu`, so the slice is race-free under parallel fetches.
+For parallel scenarios where call ORDER is non-deterministic, tests normalize by sorting `Calls()` with `slices.SortFunc` on `(FetchPath, Op)` before the `assert.Equal` (the "normalize then assert structural equality" rule), so the assertion stays a full-value `assert.Equal` and never degrades to `Contains`.
+
+### 2.4 `RealishCache` (in-memory L1+L2) — the end-to-end behavior driver
+
+A real `RequestCache` (produced by a real `cache.Controller` over a `map[string][]byte` store) parameterized by mode,
+so the hit/miss/backfill/negative/shadow/multi-key rows exercise the ACTUAL candidate-render, coverage, freshness, reorder, and write logic.
+
+```go
+type Mode uint8
+const ( ModeNoop Mode = iota; ModeL1; ModeL2; ModeL1L2 ) // shadow is a per-policy bool, cross-cutting (RFC-1 §5)
+
+func NewRealishCache(tb testing.TB, mode Mode, store *FakeStore, obs resolve.CacheObserver) resolve.CacheController
+```
+
+It takes no clock: the real controller calls `time.Now`/`time.Since`/`time.Until` directly, and `synctest` (§2.5) fakes those for the rows that need TTL control.
+
+It records the SAME `Call` log as the recording fake (so the catalog asserts both surfaces uniformly) plus a store-op log (`Get`/`Set`) described in §2.6.
+
+### 2.5 `testing/synctest` — the fake clock (NO custom double, NO injectable now)
+
+The conventions survey is explicit: NO clock abstraction exists in the repo; `time.Now()` is called directly.
+The Go 1.25 stdlib `testing/synctest` makes that a feature, not a problem, so the strategy adds NO clock seam at all:
+the `resolve/cache` controller keeps calling REAL `time.Now`/`time.Since`/`time.Until` and comparing `time.Duration` TTLs directly,
+and tests that care about time run inside a `synctest` bubble where that real clock is faked.
+This is why the appendix proposes NO `cache.WithClock(...)` option and NO `now func()` field — there is nothing to inject.
+
+How a bubble works (the only three rules that matter here):
+- `synctest.Test(t, func(t *testing.T){ … })` runs the body in a bubble with a FAKE clock that starts at a fixed instant and advances ONLY when every goroutine in the bubble is durably blocked.
+- `synctest.Wait()` blocks the caller until all OTHER bubble goroutines are durably blocked — the deterministic-ordering primitive (used with the gates of §2.7, NOT with real latency).
+- Inside the bubble, `time.Sleep(d)` advances the fake clock by `d` instantaneously (no real wall-clock wait), so TTL EXPIRY is exercised by sleeping PAST the TTL and then re-reading.
+
+TTL-expiry pattern (replaces every "advance the FakeClock" step):
+
+```go
+func TestCaching_Negative_ExpiresAfterTTL(t *testing.T) { // row G4
+    synctest.Test(t, func(t *testing.T) {
+        store := cachetesting.NewFakeStore()
+        cc := cachetesting.NewRealishCache(t, cachetesting.ModeL2, store, nil)
+        // … write a negative entry with NegativeCacheTTL = 30s (real time.Now() is the fake clock) …
+
+        time.Sleep(31 * time.Second) // fake time jumps past the TTL, instantly
+        synctest.Wait()
+        // … re-run the fetch: the entry is now treated as expired -> miss -> network runs …
+    })
+}
+```
+
+Hard constraints `synctest` imposes on these tests (call them out so the harness stays bubble-safe):
+- ALL goroutines must be STARTED inside the bubble (the loader's per-fetch / per-defer-group goroutines are spawned by the public entry point invoked within the body, so they are in the bubble).
+- ONLY in-process fakes are allowed: the gated/fake datasource (§2.7) returns scripted bytes with no socket; a real `net/http` transport is NOT bubble-aware and is forbidden inside a bubble.
+- Use `time.Sleep` ONLY to advance the fake clock for TTL; NEVER as a latency knob to order concurrent fetches — ordering is done with gates + `synctest.Wait()` (§2.7, §6).
+
+Required by rows that control time: G4 (negative expiry), F8/F9 (TTL stamped / mutation override), G1/G3 (negative write/hit TTL), H2/H3 (shadow `CacheAge`), and the multi-candidate freshness rows D7-D10 (different remaining TTLs produced by writing/seeding at different fake instants).
+
+### 2.6 `FakeStore` — the L2 backend, TTL driven by the synctest clock
+
+The store models an L2 backend with its own expiry: each entry records an ABSOLUTE `ExpiresAt` computed from `time.Now()` at write time, and `Get` consults `time.Now()` so an entry past its expiry is a MISS.
+Inside a `synctest` bubble (§2.5) `time.Now()` is the fake clock, so both EXPIRY and the per-candidate RemainingTTL fall out of fake time with NO separate clock plumbing.
+
+```go
+type StoredEntry struct { Value []byte; ExpiresAt time.Time } // ExpiresAt = time.Now().Add(ttl) at write
+type FakeStore struct {
+    mu    sync.Mutex
+    data  map[string]StoredEntry
+    ops   []StoreOp // {Kind:"Get"|"Set", Key string, Value string, TTL time.Duration} — normalized, full-value asserted
+}
+// Seed writes an entry as if Set with this ttl at the CURRENT fake instant; remaining TTL is then ExpiresAt-time.Now().
+func (s *FakeStore) Seed(key string, v []byte, ttl time.Duration)
+// Get returns (miss) when time.Now() >= ExpiresAt; otherwise the value and remaining = ExpiresAt - time.Now().
+func (s *FakeStore) Get(key string) (StoredEntry, bool)
+func (s *FakeStore) Ops() []StoreOp
+```
+
+For the multi-candidate freshness ordering rows D7-D10, distinct remaining TTLs are produced inside the bubble either by seeding with different TTLs or by `time.Sleep`ing between seeds so the earlier entry has decayed further — both are exact and deterministic because the fake clock only moves on `time.Sleep`.
+The EXPIRY rows (G4) `time.Sleep` past the TTL; the shadow-age rows (H2/H3) `time.Sleep` to age an entry before the compare reads `CacheAge`.
+Tests assert `assert.Equal(t, []StoreOp{...}, store.Ops())` — every `Get` (key, in order) and every `Set` (key + EXACT bytes + EXACT ttl).
+
+### 2.7 Gate channels — deterministic fetch ordering (NOT latency)
+
+Commit e509453b mandates GATES, not sleeps/latency, for deterministic ordering across parallel and defer fetches; `synctest` makes this airtight.
+The gate wraps a canned response and blocks `Load` until released, optionally signaling arrival first.
+A gated `Load` that is parked on `<-g.Release` is a DURABLY blocked goroutine, so inside a bubble the test can call `synctest.Wait()` to be SURE every other fetch has reached its gate before it releases one — that is how "fetch A fully merges and writes L1 BEFORE fetch B prepares" is made deterministic without any real latency.
+The gate is an in-process fake (no socket), so it is bubble-safe (§2.5).
+
+```go
+type GatedDataSource struct {
+    Name    string
+    Resp    []byte
+    Err     error
+    Arrived chan<- string  // optional: fetch announces it reached the network
+    Release <-chan struct{} // test closes/sends to let the fetch proceed
+}
+func (g *GatedDataSource) Load(ctx context.Context, h http.Header, in []byte) ([]byte, error) {
+    if g.Arrived != nil { g.Arrived <- g.Name }
+    <-g.Release
+    return g.Resp, g.Err
+}
+func (g *GatedDataSource) LoadWithFiles(context.Context, http.Header, []byte, []*httpclient.FileUpload) ([]byte, error) {
+    panic("cache tests never upload files")
+}
+```
+
+This lets a test force "fetch A fully merges and writes L1 BEFORE fetch B prepares",
+which is exactly the ordering rows M2/M3/N1/N2 need to prove cross-fetch and cross-defer-group L1 reuse.
+
+### 2.8 `RecordingObserver` — shadow / analytics, and the nil path
+
+```go
+type RecordingObserver struct {
+    mu       sync.Mutex
+    compares []ShadowCompare // {CacheKey, EntityType, IsFresh, CacheAge time.Duration} — full-value asserted
+}
+func (o *RecordingObserver) CompareShadow(h *resolve.FetchCacheHandle, fresh *astjson.Value, s resolve.MergeSession) { ... }
+```
+
+v1 ships the observer NIL, so the shadow rows assert BOTH the wired-observer path AND that a nil observer force-fetches but records nothing (rows H6, H7).
+The `CacheAge` field is exact and assertable because it is `time.Now() - entry.writtenAt` against the synctest fake clock (§2.5): the shadow rows `time.Sleep` a known amount to age the entry, then assert the recorded `CacheAge` equals that amount.
+
+---
+
+## 3. The clean test supergraph and the scenario -> element table
+
+### 3.1 `commerce` — 3 subgraphs, 2 cross-subgraph entities, real wgc composition
+
+This is the canonical products/reviews/users federation supergraph the repo already plans in `loader_test.go:20-33`,
+minimally extended (a second `@key(fields:"sku")` on `Product`, plus by-key root fields `product(upc:)`/`user(id:)`),
+so ONE graph hits every matrix row.
+The multi-`@key`-on-one-type shape is itself an existing convention (`graphql_datasource_test.go:5069-5074`), so this reuses, not invents.
+
+Crucially, the SDLs are NOT `const` strings — they are real subgraph files, COMPOSED by `wgc`, exactly mirroring `execution/engine/testdata/config_factory_federation/` (§4).
+A new directory `execution/engine/testdata/cache_commerce/` holds:
+- `account_sdl.graphql`, `product_sdl.graphql`, `review_sdl.graphql` — the three subgraph SDLs (the extension over `config_factory_federation` is the second `Product @key(fields:"sku")` and the `product(upc:)`/`user(id:)` root fields);
+- `graph.yaml` — one `{ name, routing_url, schema.file }` per subgraph, like `testdata/config_factory_federation/graph.yaml`;
+- `compose.sh` — `npx -y wgc@latest router compose -i graph.yaml -o config.json` then `jq . config.json`, like `testdata/config_factory_federation/compose.sh`;
+- `config.json` — the COMMITTED composed supergraph config.
+
+Re-running `compose.sh` IS the composability guard: `wgc` fails if the three subgraphs do not compose, so a committed `config.json` is proof the graph is composable under federation. There is no hand-authored supergraph SDL and no "validated with rover" claim to drift — the committed artifact is the validation.
+
+- Products (owns `Product @key(fields:"upc") @key(fields:"sku")`): `topProducts(first:Int=5): [Product!]!`, `product(upc:String!): Product`.
+- Reviews (owns local `Review`; references `Product` and `User`): `latestReviews(first:Int=5): [Review!]!`; contributes `Product.reviews`; `User @key(fields:"id", resolvable:false)`.
+- Accounts (owns `User @key(fields:"id")`): `user(id:ID!): User`.
+
+### 3.2 Scenario-group -> supergraph element (from the design)
+
+| Coverage scenario | Supergraph element | Representative operation |
+|---|---|---|
+| Single-`@key` entity | `User @key(id)` (Accounts owns, Reviews references) | `{ user(id:"1"){ name } }` |
+| Multi-`@key` entity (best-effort) | `Product @key(upc) @key(sku)` | `{ topProducts{ upc sku name } }` |
+| Multi-key BACKFILL (candidate unrenderable at lookup) | `product(upc:)` returns `sku` only in the response | `{ product(upc:"1"){ name sku } }` |
+| Entity reference across subgraphs (fetch+cache in A/C, reuse in B) | `Review.product`, `Review.author` | `{ latestReviews{ body product{ name } author{ name } } }` |
+| Root-field-cached query | `topProducts`, `latestReviews` | `{ topProducts{ name price } }` |
+| Root field that RE-USES the entity cache (`EntityKeyMapping`) | `product(upc:)`, `user(id:)` | `{ product(upc:"1"){ name } }` after `topProducts` primed upc="1" |
+| Batch entity fetch | `topProducts{ reviews }`, `latestReviews{ author }` | `{ topProducts{ name reviews{ body } } }` |
+| Defer + caching reuse | `Product.reviews` deferred under `topProducts` | `{ topProducts{ name ... @defer { reviews{ body author{ name } } } } }` |
+
+### 3.3 The stage toggle mirrors the mandated implementation order
+
+The same composed `config.json` drives every stage; only the `postprocess.EnableCaching` provider wiring changes (which datasources get a cache config provider), via a `CacheStage` enum that mirrors the mandated order
+(structure -> L2 entities -> L2 root fields -> L2 root-reuses-entity -> L1):
+
+```go
+type CacheStage uint8
+const (
+    StageNoop CacheStage = iota // providers empty: strict NO-OP (RFC-1 §10, RFC-2 G11)
+    StageL2Entities             // policy on Product, User only
+    StageL2RootFields           // + topProducts, latestReviews
+    StageL2RootReusesEntity     // + product(upc:), user(id:)  (EntityKeyMapping rows)
+    StageL1                     // flip L1 eligibility; defer query proves request-lifetime shared L1
+)
+```
+
+Each implementation phase lands its catalog rows at the matching stage,
+so the suite grows monotonically and never tests a capability before it exists.
+
+---
+
+## 4. Plan-drift prevention harness: real wgc composition + config_factory
+
+### 4.1 Why this harness exists
+
+A plan-driven test (layer ii, §1.3) needs a PLAUSIBLE loader input — a `*resolve.GraphQLResponse` whose fetch tree carries the RFC-2-stamped `FetchCacheConfig`.
+There are two drift risks, and this harness closes BOTH:
+- a hand-built `*GraphQLResponse` literal drifts from the real planner/stamper (nothing keeps it honest);
+- a hand-built `plan.Configuration` (DataSources with hand-typed `FederationMetaData.Keys`/`Requires`/`Provides`, root/child nodes, field configs) drifts from a real, composable supergraph — and silently lets a test assert against a configuration the real graph could never produce.
+
+The fix is to derive EVERYTHING from a real `wgc`-composed supergraph through the execution engine's `config_factory`, exactly as the existing federation tests do, and then golden-snapshot the resulting plan:
+- composition is real (`compose.sh` -> committed `config.json`, §3.1), so the subgraphs are PROVABLY composable;
+- the planner configuration is built by `config_factory`, so it is PROVABLY a valid `plan.Configuration` for that graph;
+- the plan is produced by the real v2 planner + postprocess (with the RFC-2 caching pass), then snapshotted, so any planner/stamper change is a review-visible golden diff.
+
+This reuses the live, proven pipeline rather than inventing one. The exact reference files (read them to stay accurate):
+- `execution/engine/config_factory_federation.go`: `NewFederationEngineConfigFactory(ctx, opts...)` (`:80`) and `BuildEngineConfiguration(*nodev1.RouterConfig) (Configuration, error)` (`:127`), which calls `createPlannerConfiguration` (`:152`) to map `RouterConfig.EngineConfig` -> `plan.Configuration` (`Fields`/`Types`/`DataSources`), and `dataSourceMetaData` (`:309`) which builds each datasource's real `FederationMetaData.Keys`/`Requires`/`Provides` from `in.Keys`/`in.Requires`/`in.Provides`.
+- `execution/engine/config_factory_federation_test.go`: the load pattern — `os.ReadFile("testdata/.../config.json")` (`:36`), `protojson.Unmarshal(data, &rc)` into `nodev1.RouterConfig` (`:40-41`), `BuildEngineConfiguration(&rc)` (`:42`); `skipped_fetch_test.go:47-57` shows the same with a per-test URL rewrite.
+- `execution/engine/testdata/config_factory_federation/`: `account_sdl.graphql`/`product_sdl.graphql`/`review_sdl.graphql`, `graph.yaml`, `compose.sh`, `config.json` — the template the new `cache_commerce/` directory copies (§3.1).
+- imports: `nodev1 "github.com/wundergraph/cosmo/router/gen/proto/wg/cosmo/node/v1"`, `"google.golang.org/protobuf/encoding/protojson"` (both already used across `execution/engine`).
+
+### 4.2 The `Plan(...)` harness (execution-module support file)
+
+`config_factory` and `nodev1` are execution-module-only (§1.3), so the harness lives in the execution module beside `config_factory_federation.go`.
+It obtains a `plan.Configuration` from `config_factory`, runs the real planner + postprocess, golden-snapshots the plan, then swaps in fakes:
+
+```go
+// execution/engine/cachetesting_plan.go  (execution module; imports the cosmo proto + config_factory)
+type PlanResult struct {
+    Response *resolve.GraphQLResponse // == plan.SynchronousResponsePlan.Response, the loader's input
+    Fakes    *cachetesting.FakeRegistry // (subgraph,input) -> canned bytes / GatedDataSource (the v2 fakes)
+}
+
+// Plan composes -> config_factory -> real planner + postprocess (RFC-2 caching pass) ->
+// golden-snapshots the plan -> swaps each fetch's transport for an in-process fake.
+func Plan(tb testing.TB, stage cachetesting.CacheStage, query string, responses map[string]string) PlanResult {
+    tb.Helper()
+
+    // 1. Real composition output -> RouterConfig -> valid plan.Configuration (the §4.1 reuse).
+    data, err := os.ReadFile("testdata/cache_commerce/config.json")
+    require.NoError(tb, err)
+    var rc nodev1.RouterConfig
+    require.NoError(tb, protojson.Unmarshal(data, &rc))
+
+    f := NewFederationEngineConfigFactory(tb.Context())
+    conf, err := f.BuildEngineConfiguration(&rc)
+    require.NoError(tb, err)
+    cfg := conf.PlannerConfig() // small EXPORTED accessor added to engine.Configuration (§4.3)
+
+    // 2. Definition is the COMPOSED supergraph schema, not a hand-typed SDL.
+    def := unsafeparser.ParseGraphqlDocumentString(rc.EngineConfig.GraphqlSchema)
+    op := unsafeparser.ParseGraphqlDocumentString(query)
+    require.NoError(tb, asttransform.MergeDefinitionWithBaseSchema(&def))
+
+    norm := astnormalization.NewWithOpts(
+        astnormalization.WithExtractVariables(),
+        astnormalization.WithInlineFragmentSpreads(),
+        astnormalization.WithRemoveFragmentDefinitions(),
+        astnormalization.WithRemoveUnusedVariables(),
+        astnormalization.WithEnableDefer(),
+    )
+    var report operationreport.Report
+    norm.NormalizeOperation(&op, &def, &report)
+    astvalidation.DefaultOperationValidator().Validate(&op, &def, &report)
+    require.False(tb, report.HasErrors(), report.Error())
+
+    // 3. Real planner + postprocess WITH the RFC-2 caching pass, gated per stage.
+    planner, err := plan.NewPlanner(cfg)
+    require.NoError(tb, err)
+    raw := planner.Plan(&op, &def, "", &report)
+    require.False(tb, report.HasErrors(), report.Error())
+
+    proc := postprocess.NewProcessor(
+        postprocess.EnableCaching(cacheProvidersForStage(cfg, stage), federationByDS(cfg), &def),
+    )
+    proc.Process(raw)
+
+    resp := planResponse(tb, raw) // handles Synchronous + Defer + Subscription plan kinds
+
+    // 4. Visibility + drift guard: golden the plan shape AND what RFC-2 stamped.
+    goldie.New(tb, goldie.WithNameSuffix(".golden")).Assert(tb, tb.Name(), []byte(renderPlanWithCache(resp)))
+
+    // 5. Only mutation of the planner output: transport -> in-process fake (§4.4).
+    fakes := cachetesting.NewFakeRegistry(responses)
+    cachetesting.SwapDataSources(resp.Fetches, fakes)
+    return PlanResult{Response: resp, Fakes: fakes}
+}
+```
+
+`renderPlanWithCache` writes `resp.Fetches.QueryPlan().PrettyPrint()` (`fetchtree.go:165,256`)
+plus, per fetch, `cfg.String()` and a compact `KeySpec` dump (both required by RFC-1 §3.6),
+so the golden shows BOTH the plan shape and the stamped cache config; `goldie -update` regenerates it.
+`postprocess.EnableCaching(providers, federation, definition)` is RFC-2's option (RFC-2 §5.1): `cacheProvidersForStage` returns providers only for the datasources active at `stage` (so `StageNoop` passes an empty map -> the caching pass is a no-op), and `federationByDS` reads each datasource's `FederationMetaData` out of `cfg.DataSources`.
+
+### 4.3 The one exported accessor (refactor-in-place)
+
+`engine.Configuration.plannerConfig` is unexported (`engine_config.go:23`), and `BuildEngineConfiguration` returns it wrapped (`config_factory_federation.go:140-143`).
+The harness needs the `plan.Configuration` out of it, so add ONE small exported accessor next to the existing `DataSources()`/`FieldConfigurations()` getters (`engine_config.go:62-68`):
+
+```go
+// PlannerConfig exposes the built plan.Configuration for plan-driven tests.
+func (e *Configuration) PlannerConfig() plan.Configuration { return e.plannerConfig }
+```
+
+This is a refactor-in-place in the execution engine package; no behavior change.
+
+### 4.4 No hand-built plans, anywhere
+
+There are NO hand-built `*GraphQLResponse` trees and NO hand-built `plan.Configuration` in the suite.
+Layer (i) (the v2 controller unit tests) needs no plan at all — it drives the cache controller with constructed `*astjson.Value` inputs (§1.3).
+Layer (ii) always goes through `Plan(...)`, which has exactly one source of truth for any plausible plan (the real planner over the real composition) and a golden that makes any legitimate change reviewable.
+The loader-seam dispatch that an earlier draft asserted with tiny hand-built `SingleFetch`/`EntityFetch` literals is instead asserted on the smallest real plan `Plan(...)` can produce (a single root-field query, a single by-key entity query), so even the seam fixtures cannot drift.
+
+### 4.5 The DataSource swap
+
+`SwapDataSources` (a v2 fake helper) walks the fetch tree (`FetchTreeNode.Item`/`ChildNodes`, kinds at `fetchtree.go:19-24`)
+and replaces each fetch's `DataSource` field (settable, `fetch.go:170,210,258`) with a fake/gated in-process source keyed by `(Info, Input)`.
+The tree SHAPE stays the planner's; only the transport is faked — which is also what keeps the plan-driven tests bubble-safe under `synctest` (no real socket, §2.5).
+
+---
+
+## 5. The full scenario catalog (checklist)
+
+Every row from the matrix, grouped as the matrix groups them.
+Each row asserts on the FULL recorded calls (`assert.Equal(t, []Call{...}, fake.Calls())` and/or `assert.Equal(t, []StoreOp{...}, store.Ops())`)
+AND the FULL response bytes (`assert.Equal(t, compactJSONForAssert(t, want), buf.String())`).
+No `assert.Contains`, no `assert.JSONEq`, no fuzzy comparison anywhere.
+`[ttl]` marks a row that runs inside a `synctest` bubble and controls time (seed/write TTLs, `time.Sleep` past an expiry, or age an entry — §2.5); `[gate]` marks a row that uses gate channels + `synctest.Wait()` for deterministic ordering (§2.7). There is no `[clock]` marker — `synctest` is the clock.
+
+### 5.1 A. Loader-seam gates — NO-OP and config gating (driven by `FakeRequestCache`)
+
+- [ ] **A1** controller nil: fake never constructed; `cacheRequest()` nil; zero `BeginRequest`; response == non-cached baseline.
+- [ ] **A2** controller set, all `Cache` nil: zero `PrepareFetch`; `BeginRequest` NOT called; response == baseline.
+- [ ] **A3** `Cache != nil` but `!L1 && !L2`: `cachePrepare` returns at the guard; zero `PrepareFetch`; response == baseline.
+- [ ] **A4** `Cache.L1` true but controller nil: `cacheRequest()` nil; zero `PrepareFetch`; response == baseline (lower gate wins).
+- [ ] **A5** `prepared.skipLoad` pre-set (null parent / auth reject / render error): `cachePrepare` early-returns; `cacheHandle` stays nil; `cacheMerge` no-ops.
+- [ ] **A6** unknown fetch type (default switch arm): `cfg` stays nil; zero `PrepareFetch`.
+- [ ] **A7** controller set AND `Cache.L2` true: `BeginRequest` once, `PrepareFetch` called — the ONLY combination that activates caching.
+
+### 5.2 B. Lazy request-lifetime init + lifecycle
+
+- [ ] **B1** `BeginRequest` lazy + once: 3 eligible fetches -> exactly 1 `BeginRequest`; all 3 `PrepareFetch` get the SAME `RequestCache`.
+- [ ] **B2** `BeginRequest` skipped when no eligible fetch: never called.
+- [ ] **B3** `EndRequest` once per sync request (`ResolveGraphQLResponse`); `ctx.requestCache` nilled after.
+- [ ] **B4** `EndRequest` once on `ArenaResolveGraphQLResponse` (proves the arena entry also wires the defer).
+- [ ] **B5** `endCacheRequest` no-op when caching unused: `requestCache==nil` -> no `EndRequest`, no panic.
+- [ ] **B6** `clone` resets request cache: `cpy.requestCache==nil`, `cpy.cacheController` still set.
+- [ ] **B7** `Free` is defensive: `endCacheRequest` invoked, then `cacheController` nilled.
+- [ ] **B8** double `endCacheRequest` idempotent (B3 then B7): `EndRequest` fires exactly once total.
+
+### 5.3 C. PrepareFetch decision dispatch (scripted `FakeRequestCache`, one row per decision)
+
+- [ ] **C1** `DecisionFetch` + handle: `skipLoad` false; network runs; `cacheMerge`->`OnFetchResult`; normal fetched response.
+- [ ] **C2** `DecisionFetch, nil`: handle nil; `cacheMerge` returns at `handle==nil`; NO `OnFetchResult`.
+- [ ] **C3** `DecisionSkipFullHit`: `skipLoad=true` AND `res.fetchSkipped=true`; `loadPhase` early-returns; `OnFetchSkipped`; cached response, NO "failed to fetch" error.
+- [ ] **C4** `DecisionFetchShadow` (handle `Shadow=true`): `skipLoad` false; network runs; `OnFetchResult`; FRESH response (cache value never served).
+- [ ] **C5** `DecisionFetchPartial` (v2 seam): v1 branch no-op; `skipLoad` false; dispatches to `OnFetchSkipped` Partial arm (asserts the seam compiles + dispatches).
+- [ ] **C6** skip-path spurious-error guard: `DecisionSkipFullHit` with empty `res.out` MUST NOT render `renderErrorsFailedToFetch`; response has data, no errors array (the §4.7 #1 invariant).
+- [ ] **C7** OnLoad/OnFinished not fired on full hit: with `LoaderHooks` set, `res.loaderHookContext` nil -> `OnFinished` NOT called (§4.7 #3, atomic-counter assert == 0).
+- [ ] **C8** handle threaded prepare->merge: the SAME `*FetchCacheHandle` instance the recording fake returned from `PrepareFetch` reaches `OnFetch*` (pointer identity asserted BY the fake itself — it owns and records the handle pointer on both calls, so no unexported `resolve` access is needed).
+
+### 5.4 D. Hit determination — coverage / freshness / reorder (`RealishCache`, seeded L2)
+
+- [ ] **D1** full hit, single covering candidate: `Get`->hit; coverage passes; `SkipFullHit`; reorder skipped; spliced.
+- [ ] **D2** miss (no entry): `Get`->miss; `Fetch`; `PendingCandidates` empty; `OnFetchResult` writes.
+- [ ] **D3** coverage FAIL (entry missing a required field): treated as MISS -> `Fetch`; assert the stale partial value was NOT served.
+- [ ] **D4** null accepted only where Nullable: `field:null`, spec `Nullable=true` -> coverage passes -> full hit.
+- [ ] **D5** null rejected at non-nullable spec node -> miss/Fetch.
+- [ ] **D6** alias/arg-aware mismatch: value cached under `friends_<hashA>`, request is `friends(first:20)`=`friends_<hashB>` -> miss/Fetch (the §9.1 correctness-hole guard). `[ttl]`
+- [ ] **D7** multi-candidate freshness pick: 2 entries different `RemainingTTL`; both `Get`s recorded; freshest (larger TTL) chosen; `SelectedRemainingTTL`==larger. `[ttl]`
+- [ ] **D8** freshness tie / known-beats-unknown: known TTL beats unknown; stable tie order. `[ttl]`
+- [ ] **D9** merge-synthesis when no single covers: union covers -> merged value; `NeedsWriteback=true`; `MustWriteBack=true`; reorder RUN; canonical rewrite queued. `[ttl]`
+- [ ] **D10** older-candidate fallback: union does not cover, an older single covers -> accepted; `NeedsWriteback=true`. `[ttl]`
+- [ ] **D11** reorder to selection order: chosen value rebuilt to `ProvidesData` order; extra fields appended; response key order matches selection order.
+- [ ] **D12** AND-reduction all covered -> `SkipFullHit` (batch/multi-item).
+- [ ] **D13** AND-reduction one uncovered -> whole fetch flips to `Fetch` (all-or-nothing v1).
+- [ ] **D14** `ProvidesData==nil` disables walk: treated as miss/Fetch; no panic.
+
+### 5.5 E. Multi-key candidates — best-effort render-then-backfill (see §8 for sketches)
+
+- [ ] **E1** all candidates renderable at lookup: 2 `RenderedKeys`; `Get` under BOTH; `PendingCandidates` empty.
+- [ ] **E2** hit on a NON-primary key: candidate[0] misses, candidate[1] hits; both `Get`s recorded; serves from candidate[1].
+- [ ] **E3** some renderable at lookup, more after response -> backfill ALL: lookup `Get` once (cand0); `PendingCandidates`=[cand1]; after fetch re-render cand1; `Set` under BOTH keys; `WriteReason` backfill for cand1.
+- [ ] **E4** none renderable at lookup -> skip cache: zero `RenderedKeys`; no `Get`; `Fetch`; candidates re-rendered + written post-fetch.
+- [ ] **E5** backfill on read-hit (`MustWriteBack`): full hit on cand0; cand1 renderable from the HIT value; `OnFetchSkipped` `Set`s the missing key (no network).
+- [ ] **E6** refresh vs backfill reason tags: `Set` records carry correct `WriteReason` (metadata only, does not gate).
+- [ ] **E7** single-`@key` entity = one-element candidate list: exactly 1 candidate, 1 `RenderedKey` (degenerate of E1).
+
+### 5.6 F. Write / backfill gate — `OnFetchResult` (`!FetchFailed && !HasErrors && ResponseData != nil && Type()!=Null`)
+
+- [ ] **F1** clean success writes: `Set` with fresh bytes + `cfg.TTL`.
+- [ ] **F2** transport failure (`res.err!=nil` -> `FetchFailed`, `ResponseData==nil`): ZERO `Set`; assert gate keys off `FetchFailed`/`ResponseData==nil` NOT `HasErrors` (the §3.3 blocking-bug guard).
+- [ ] **F3** empty body (`len(res.out)==0`): ZERO `Set`.
+- [ ] **F4** parse failure (`res.response==nil`): ZERO `Set`; no panic.
+- [ ] **F5** GraphQL errors (`HasErrors`): ZERO `Set` (transient error must not persist).
+- [ ] **F6** data == JSON null (not EmptyEntity): ZERO positive `Set` (blocked by `Type()!=Null`).
+- [ ] **F7** status fallback (non-2xx + shape-mismatch null): gate blocks.
+- [ ] **F8** TTL stamped from config: `Set` ttl == `cfg.TTL` exactly. `[ttl]`
+- [ ] **F9** mutation TTL override: `Set` ttl == `MutationTTLOverride`, not `cfg.TTL`. `[ttl]`
+
+### 5.7 G. Negative caching (`EmptyEntity`)
+
+- [ ] **G1** negative WRITE on empty entity (`EmptyEntity`, `NegativeCacheTTL>0`, not FetchFailed): `Set` a NULL sentinel under the key with `NegativeCacheTTL`. `[ttl]`
+- [ ] **G2** negative write SKIPPED when `NegativeCacheTTL==0`: ZERO `Set`.
+- [ ] **G3** negative HIT served: `Get`->null sentinel; `NegativeHit=true`; `FromCache=TypeNull`; merge skipped; `SkipFullHit`; null entity, no network. `[ttl]`
+- [ ] **G4** negative entry expired -> miss: `time.Sleep` past the `NegativeCacheTTL` inside the synctest bubble; entry treated as expired; network runs. `[ttl]`
+- [ ] **G5** EmptyEntity AND FetchFailed: gate blocks (FetchFailed wins) -> NO negative write.
+- [ ] **G6** null-bubble suppression preserved: loader's `setSkipErrors`/null-bubble path untouched; no synthetic non-null error.
+
+### 5.8 H. Shadow mode (`RecordingObserver`, entity-only compare)
+
+- [ ] **H1** shadow L2 read + stash + force-fetch: `Get` hit; `ShadowStash[i]` populated; `DecisionFetchShadow`; `handle.Shadow=true`; network STILL runs; FRESH response.
+- [ ] **H2** shadow compare MATCH: `time.Sleep` to age the seeded entry; `CompareShadow` BEFORE writes; `IsFresh=true`; recorded `CacheAge`==slept duration; order compare->write-L1->write-L2; L2 overwritten. `[ttl]`
+- [ ] **H3** shadow compare MISMATCH: `IsFresh=false`; L2 overwritten with fresh. `[ttl]`
+- [ ] **H4** shadow L1 hit wins (no shadow): L1 `SkipFullHit`, no refetch, no `CompareShadow` (shadow is L2-only).
+- [ ] **H5** root-field shadow asymmetry: force-refetch + overwrite L2 but `CompareShadow` NOT recorded (entity-only).
+- [ ] **H6** shadow compare no-ops without analytics: nil observer / `ProvidesData==nil` -> still force-fetches, records nothing.
+- [ ] **H7** NO-OP / L1-only never yields `DecisionFetchShadow` (mode-matrix assert).
+
+### 5.9 I/J/K/L. Fetch shapes, modes, flush, MergeSession
+
+- [ ] **I1-I8** entity (`EntityFetch`) / root-field (`SingleFetch`) / batch (`BatchEntityFetch`) shapes: entity-scope keys + `EntityMergePath`; root-field-scope key + `cfg.L1=false`; `BatchEntityKey=true` + per-element multi-key + `BatchIndex`; batch full-hit/all-miss/mixed (mixed -> full re-fetch, NO partial realign in v1); batch empty short-circuit; root->entity L1 promotion is a v1 miss.
+- [ ] **J1-J7** modes NO-OP / L1 / L2 / L1+L2 over the SAME query: assert the loader branches ONLY on `Decision`; L1 hit short-circuits L2 `Get`; L2 hit populates L1; mode-blindness (data-equal responses).
+- [ ] **K1-K4** EndRequest flush: deferred writes ACCUMULATE then flush ONE batch per cache instance at `EndRequest`; write-through flushes immediately (empty `EndRequest` flush); flush holds BYTES not `*Value` (no `MergeSession` at flush); nothing-to-flush case.
+- [ ] **L1-L7** MergeSession: `Begin()` takes `DataBuffer.Lock` once / `Close()` releases once (under `-race`); `ParseBytes` lazy + malformed->error no panic; `StructuralCopy` avoids aliasing; `MergeValues`/`WithPath` discard `changed`; `NewObject`/`NewArray`/`String`/`Null` arena-backed; no session opened from `loadPhase`.
+
+### 5.10 O/P. Error/edge paths and `Equals` nil-safety
+
+- [ ] **O1** `OnFetchSkipped` error -> `cacheMerge` returns it, `resolveSingle` propagates (wrapped).
+- [ ] **O2** `OnFetchResult` error -> propagated.
+- [ ] **O3** nested-merge branch unhooked (dead `res.nestedMergeItems`): cache hooks do NOT fire; no double-handle.
+- [ ] **O4** `EmptyEntity` computed only when `res.response!=nil`: full-hit skip guards before `isEmptyEntityFetch`; no nil-deref.
+- [ ] **O5** malformed cached bytes in `PrepareFetch`: `ParseBytes` errors; candidate skipped; no panic.
+- [ ] **O6** header-hash nil-guard: no `SubgraphHeadersBuilder` -> `HeadersForSubgraphRequest` returns `(nil,0)`; key uses hash 0; no panic.
+- [ ] **O7** cache-key fidelity: key derived from `PrepareFetchInput.Input` (canonical pre-injection), NOT post-prepare bytes; read key == write key (byte-identical invariant).
+- [ ] **P1** both `Cache==nil` -> prior dedup result.
+- [ ] **P2** one nil one set -> not equal.
+- [ ] **P3** both set, equal -> dedup.
+- [ ] **P4** both set, differ in any field (TTL / CacheName / a candidate Representation) -> not equal (`slices.EqualFunc` over `Candidates` via `Object.Equals`).
+- [ ] **P5** KeySpec candidate deep-compare: differ only in one candidate's `Representation` -> distinguished.
+
+### 5.11 Coverage cross-check (every loader-glue branch is hit)
+
+- `cacheRequest`: nil controller A1/A4; lazy create B1; reuse existing (B1 second fetch).
+- `cachePrepare`: `skipLoad` pre-set A5; Single/Entity/Batch arms I1/I2/I3; default arm A6; `cfg==nil` A2; `!L1&&!L2` A3; rc nil A4; decision arms C1-C5.
+- `cacheMerge`: handle nil C2/A5; SkipFullHit/Partial->Skipped C3/C5; Fetch/Shadow->Result C1/C4; `res.response!=nil` guard O4; `FetchFailed` composition F2/F3/F4; error return O1/O2.
+- `mergeResult` carriers (`response`/`responseData`/`responseHasErrors`): read by F*/G*/H*; dead-when-off A1.
+- `endCacheRequest`/`clone`/`Free`: B3-B8, N6.
+- `MergeSession` ops: L1-L7.
+- Decisions: Fetch C1/C2; SkipFullHit C3; FetchPartial C5; FetchShadow C4/H1.
+
+---
+
+## 6. Concurrency tests (run under `-race`, ordered by gates inside a synctest bubble)
+
+These run with the `-race` detector and use GATE channels (§2.7), never latency, for deterministic ordering (commit e509453b).
+They live in the execution plan-driven layer (they need real plans + the public defer entry points) and run inside a `synctest.Test` bubble: every loader goroutine is spawned by the public entry point invoked within the body (so all goroutines are IN the bubble), the datasources are in-process gated fakes (no socket, bubble-safe), and ordering is forced with gates + `synctest.Wait()` rather than latency.
+They prove the per-defer-group loaders share ONE request-lifetime L1 on `Context` under the scoped `MergeSession` lock,
+and that lazy init and parallel writes are race-free.
+
+- [ ] **M1** parallel fetches, lazy init race-free: 1 group, N parallel eligible fetches; `BeginRequest` EXACTLY once (lazy-init under `DataBuffer.Lock`); no race. `[gate]`
+- [ ] **M2** parallel writes to shared L1: 2 parallel entity fetches, same type, both miss; both write L1 under the lock; first-writer-wins / merge-on-collision; no corruption. `[gate]`
+- [ ] **M3** per-defer-group loaders share ONE L1: initial loader + defer-group loader, same `Context`; L1 written by the initial fetch is visible to the defer group's fetch (shared `ctx.requestCache` by reference). `[gate]`
+- [ ] **M4** each hook = single lock acquisition: each `PrepareFetch`/`OnFetch*` takes `DataBuffer.Lock` once for its whole multi-op sequence; no per-op relock; no deadlock. `[gate]`
+- [ ] **M5** error propagation under parallel: one parallel fetch's `OnFetchResult` errors -> propagated out of the group (the commit c619ff12 path); other fetches unaffected. `[gate]`
+
+Sketch for the ordering primitive (M3, the load-bearing "L1 reuse across loaders" proof):
+
+```go
+func TestCaching_SharedL1_AcrossDeferGroups(t *testing.T) {
+    synctest.Test(t, func(t *testing.T) {
+        store := cachetesting.NewFakeStore()
+        pr := Plan(t, cachetesting.StageL1,
+            `{ topProducts { name ... @defer { reviews { product { name } } } } }`, /* responses */ nil)
+        // wire the initial Product fetch to a GatedDataSource that signals + waits,
+        // and the deferred Product _entities fetch to a fake that MUST hit L1 (asserted via store.Ops()==no Get to network)
+
+        ctx := resolve.NewContext(t.Context())
+        ctx.SetCacheController(cachetesting.NewRealishCache(t, cachetesting.ModeL1, store, nil)) // no clock arg
+
+        var buf bytes.Buffer
+        r := resolve.New(t.Context(), resolve.ResolverOptions{})
+        // ResolveGraphQLDeferResponse spawns the per-defer-group loader goroutines INSIDE the bubble.
+        _, err := r.ResolveGraphQLDeferResponse(ctx, pr.Response, nil, &buf)
+        require.NoError(t, err)
+
+        synctest.Wait() // all bubble goroutines durably blocked: the request is fully resolved
+
+        assert.Equal(t, compactJSONForAssert(t, wantFrames), buf.String()) // full response
+        assert.Equal(t, wantStoreOps, store.Ops())                         // deferred fetch served from L1, no second network read
+    })
+}
+```
+
+Ordering is forced with the §2.7 gates: the test releases the initial Product fetch, calls `synctest.Wait()` to be sure it has fully merged and written L1, and only then releases the deferred fetch — so "L1 reuse across loaders" is deterministic with no latency.
+Where parallel ordering is genuinely free (M1/M2), the recorded `Calls()`/`Ops()` are sorted with `slices.SortFunc` before `assert.Equal`,
+so the assertion remains a full-value structural comparison and never weakens to `Contains`.
+
+---
+
+## 7. Defer + caching combined
+
+The interaction RFC-1 calls out explicitly: an entity cached by the initial fetch served to a deferred fetch,
+a deferred fetch populating L1, and cache-vs-defer ordering / gates.
+Driven via the PUBLIC `ResolveGraphQLDeferResponse`, with gates for deterministic frame order.
+
+FIXTURE GAP (first pass, commit D3): the `commerce` supergraph could NOT express N1/N2/M3 (an initial fetch whose L1 entry is reused by a same-entity deferred fetch in a LATER group) without weakening the proof —
+a duplicate initial/deferred selection of the same entity normalizes to a synchronous plan (no defer group), and a nested-defer shape produces a real defer group but the initial selection does not COVER the deferred selection, so `optimizeL1Cache` correctly narrows `l1:false` and nothing is reused.
+Proving cross-defer-group L1 SERVING needs a richer fixture: an initial entity fetch whose `ProvidesData` is a strict superset of a deferred same-entity fetch across groups.
+M1/M2 (lazy-init-once, parallel writes to the shared L1) ARE provable on `commerce` and are covered; N1/N2/M3 remain open pending that fixture.
+
+- [ ] **N1** entity cached by initial fetch served to deferred fetch: deferred `PrepareFetch` -> L1 full hit -> `SkipFullHit`; deferred subgraph NOT hit; initial frame + deferred frame, deferred served from cache. `[gate]`
+- [ ] **N2** deferred fetch populates L1 visible to a later group: group B hits L1 written by group A (visible because scheduled after A's `cacheMerge`). `[gate]`
+- [ ] **N3** single `EndRequest` after ALL defer groups: exactly ONE `EndRequest` flushes deferred L2 writes from the initial fetch AND every group. `[gate]`
+- [ ] **N4** defer ordering not broken by cache hits: `SkipFullHit` on one branch does not reorder defer frames; gates still drive deterministic emit order. `[gate]`
+- [ ] **N5** cache + defer gate interplay: a deferred fetch's lookup/merge happens inside its group's locked region; no cross-group arena race (under `-race`). `[gate]`
+- [ ] **N6** subscription event isolation: two events via `clone`; each has its OWN L1 (clone nilled `requestCache`); no cross-event bleed.
+
+N1 asserts the full two-frame response bytes AND the full `Call` log showing the deferred fetch decided `SkipFullHit` with zero network `Get` to its subgraph.
+N3 asserts `assert.Equal(t, int64(1), fakeController.endCount.Load())` plus the full backend `Ops()` after the request.
+
+---
+
+## 8. Multi-key tests (best-effort render-then-backfill)
+
+The multi-key model: render every renderable candidate at lookup, look up under ALL rendered keys (a hit on ANY serves),
+re-render the previously-unrenderable candidates from fresh data at write, backfill ALL renderable keys (RFC-1 §3.6/§3.7, RFC-2 §6.3).
+Driven by `RealishCache` over `Product @key(upc) @key(sku)` (multi) and `User @key(id)` (single).
+
+- [ ] **E1** all renderable at lookup (`topProducts{upc sku name}`): both candidates render -> 2 `RenderedKeys`; `Get` under `Product:upc=…` and `Product:sku=…`; `PendingCandidates` empty; hit on either serves. Assert the full ordered `Ops()` shows BOTH `Get`s.
+- [ ] **E2** hit on a NON-primary key: seed only the `sku` key; `Get(upc)`->miss, `Get(sku)`->hit; serves from `sku`; full response from cache.
+- [ ] **E3** backfill ALL after response (`product(upc:"1"){name sku}`): lookup renders only the `upc` candidate (arg-derived) -> one `Get`; `PendingCandidates`=[sku]; MISS; real fetch returns `sku`; `OnFetchResult` re-renders `sku` and `Set`s under BOTH keys; assert `Ops()` == `[Get upc, Set upc refresh, Set sku backfill]` with exact bytes + ttl.
+- [ ] **E4** none renderable at lookup: all candidate fields absent in selected data -> zero `RenderedKeys`, no `Get`, `Fetch`; candidates re-rendered + written post-fetch.
+- [ ] **E5** backfill on read-hit (`MustWriteBack`, no network): full hit on `upc`; `sku` renderable from the served value; `OnFetchSkipped` `Set`s the `sku` key; assert `Ops()` == `[Get upc, Set sku backfill]`, response from cache.
+- [ ] **E6** refresh vs backfill reason tags: a pre-populated key rewritten == `refresh`, an absent key populated == `backfill`; assert the `WriteReason` on each `StoreOp`.
+- [ ] **E7** single-`@key` entity (`user(id:)`): exactly 1 candidate, 1 `RenderedKey`; degenerate of E1, proves the multi-key code handles the one-element list.
+
+Each multi-key row asserts the EXACT ordered `[]StoreOp` (so a missing/extra `Get` or `Set`, a wrong key, wrong bytes, or wrong `WriteReason` fails)
+AND the full response bytes, per rule 11.
+
+---
+
+## 9. Unified test structure and naming convention
+
+So every caching test looks the same and a reviewer can read any one of them cold.
+
+### 9.1 Naming
+
+- Plan-driven rows (layer ii, the execution-module `package …_test`): `TestCaching_<Area>_<Scenario>`, e.g. `TestCaching_Negative_HitServed`, `TestCaching_MultiKey_BackfillAll`.
+- Controller unit rows (layer i, the v2 white-box `package cache`): `TestController_<Unit>_<Case>`, e.g. `TestController_Coverage_NullRejectedAtNonNullable`.
+- Subtests use descriptive `t.Run("<full sentence>", ...)`; matrix IDs (A1, D7, …) appear in the subtest name in brackets so the catalog maps 1:1 to test output, e.g. `t.Run("[D7] freshest candidate is chosen", ...)`.
+
+### 9.2 Table shape (modern Go 1.25)
+
+```go
+func TestCaching_Decision_Dispatch(t *testing.T) {
+    tests := []struct {
+        name      string
+        stage     cachetesting.CacheStage
+        query     string
+        responses map[string]string
+        script    map[string]cachetesting.ScriptedDecision
+        wantCalls []cachetesting.Call
+        wantBody  string
+    }{
+        {name: "[C1] miss fetches and writes", /* ... */},
+        {name: "[C3] full hit skips network", /* ... */},
+    }
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            pr := Plan(t, tt.stage, tt.query, tt.responses) // execution-module harness (§4.2)
+            fake := cachetesting.NewRecordingCache(tt.script) // v2 fake
+            ctx := resolve.NewContext(t.Context())
+            ctx.SetCacheController(fake)
+
+            var buf bytes.Buffer
+            r := resolve.New(t.Context(), resolve.ResolverOptions{})
+            _, err := r.ResolveGraphQLResponse(ctx, pr.Response, nil, &buf)
+            require.NoError(t, err)
+
+            assert.Equal(t, tt.wantCalls, fake.Calls())                          // FULL recorded calls
+            assert.Equal(t, cachetesting.Compact(t, tt.wantBody), buf.String())  // FULL response bytes
+        })
+    }
+}
+```
+
+Rows marked `[ttl]`/`[gate]` wrap the body in `synctest.Test(t, func(t *testing.T){ … })` (§2.5, §6); rows with no time/ordering concern (most decision-dispatch rows) need no bubble.
+
+### 9.3 Assertion conventions (rule 11, restated for this suite)
+
+- ALWAYS `assert.Equal` on the WHOLE value: the full `[]Call`, the full `[]StoreOp`, the full response string.
+- NEVER `assert.Contains`, `assert.JSONEq`, `assert.GreaterOrEqual`, or any substring/fuzzy match.
+- Non-deterministic bits are NORMALIZED, then asserted structurally:
+  - pointers and arena `*astjson.Value` are projected to marshaled bytes/strings in the `Call`/`StoreOp` records (§2.3, §2.6);
+  - free parallel ordering is made deterministic by gates (§2.7) or by sorting the record slice with `slices.SortFunc` before the single `assert.Equal`;
+  - rendered cache keys are recomputed with the repo's xxhash pattern (§2.1) and asserted as full strings, never hard-coded magic numbers.
+- `require.*` for preconditions that must abort (`require.NoError`, `require.False(report.HasErrors())`); `assert.*` for the checks.
+- Use `t.Context()` for the resolver context, `t.Helper()` in every harness function, table tests + `t.Run` everywhere.
+
+### 9.4 What each layer owns (so there is no duplication)
+
+Two SUPPORT packages, built once:
+- `v2/pkg/engine/resolve/cache/cachetesting` (v2, cosmo-free) owns the loader-driving fakes — the recording cache, `RealishCache` (wraps the real `cache.Controller`), `GatedDataSource`, `FakeCacheController` — plus `FakeStore`/`RecordingObserver`, the `CacheStage` enum, and the `Call`/`StoreOp` record types. Imported by layer (ii) (execution imports v2). There is no clock here — `synctest` is the clock. The white-box layer (i) does NOT import it (cycle: `cachetesting` imports `cache`); layer (i) uses tiny in-package `FakeStore`/`RecordingObserver` fakes instead.
+- the execution-module support file owns the `Plan(...)` harness (real `wgc` composition -> `config_factory` -> planner + postprocess(caching) -> golden, §4) and the `cache_commerce` testdata, because only the execution module may depend on `config_factory` + the cosmo proto.
+
+Two TEST layers (§1.3):
+- Layer (i) — v2 controller unit tests — owns the controller LOGIC rows driven on the cache surface directly with CONSTRUCTED `*astjson.Value` + `FakeStore` + `synctest`, no plan: coverage/freshness/reorder/key-render (D), write/backfill gate (F), multi-key render-then-backfill (E), negative (G), shadow-compare (H compare-side), and the `FetchCacheConfig.Equals` nil-safety (P). It splits into white-box `package cache` for rows that touch unexported internals (using in-package `FakeStore`/`RecordingObserver`) and black-box `package cache_test` for rows driven through `RealishCache` (which legally imports `cachetesting`).
+- Layer (ii) — the execution-module `package …_test` — owns everything that needs the real loader against a real plan, driven via the PUBLIC `ResolveGraphQLResponse`/`ArenaResolveGraphQLResponse`/`ResolveGraphQLDeferResponse`: the loader-seam dispatch + lifecycle (A/B/C), flush + `MergeSession` discipline (K/L, asserted observably + under `-race`), the mode matrix (J), the end-to-end hit/multi-key behavior, defer + caching (N), and concurrency (M). Time-sensitive and ordered rows run inside a `synctest` bubble (§2.5, §6).
+- The few seams an earlier draft reached through unexported `resolve` access are asserted OBSERVABLY in layer (ii) — the recording fake proves prepare->merge handle identity, the gated datasource + `store.Ops()` prove no-network-on-hit, and `-race` proves lock discipline — so no `export_test.go` bridge exists.

--- a/docs/caching/specs/2026-06-30-rfc-01-loader-cache-abstraction.md
+++ b/docs/caching/specs/2026-06-30-rfc-01-loader-cache-abstraction.md
@@ -1,0 +1,1112 @@
+# RFC-1: Loader cache abstraction for the defer branch
+
+Status: final for review.
+Author: caching working group.
+Branch under change: `feat/eng-7770-add-defer-support-part-4`, code under `v2/pkg/engine/resolve/`.
+Ground truth: `scratchpad/caching-rfc/DOSSIER.md` (CURRENT defer-branch + OLD caching-base evidence, cited as `file:line`).
+
+This RFC is the synthesis of three independent drafts (A minimal-opaque, B typed-explicit, C layered-ports) and three judge reviews.
+The aggregate judge scores were close (A 159, B 153, C 141 summed across reviewers, with two reviewers preferring A and one preferring B).
+The structural base is **B (typed-explicit)**, because RFC-1's core deliverable is the compile-checked cross-RFC OUTPUT CONTRACT that RFC-2 must satisfy, and B's typed per-fetch config plus typed two-level handle make that contract concrete and reviewable.
+Onto B we graft, surgically, the ideas the reviewers identified as strictly better:
+
+- from A: the full-hit skip mechanic that reuses the existing `mergeResult` early-return (the one blocking bug in B), folding `ProvidesData` into the per-fetch config instead of re-adding `FetchInfo.ProvidesData`, and folding the end-of-tree flush into a request-end lifecycle hook so every root (including the defer-entry path B and C miss) is covered;
+- from C: a dedicated `CacheObserver` port to quarantine analytics, trace, and shadow-compare (the churn that drove OLD's 461 references) off the lookup/write surface, a per-candidate `CacheKeyTemplate` as the "sole source of truth for read/write/invalidate keys" (one per candidate in the multi-key model), and the cache-key-fidelity contract promoted from a flagged risk to a hard clause.
+
+Every must-fix raised by the reviewers is resolved in §4, §6, §10, and §11, with file:line proof for the three correctness-critical ones (skip path, nested-merge, OnLoad/OnFinished).
+
+---
+
+> REVISION 2 (maintainer feedback — see PLAN §R2, which is AUTHORITATIVE and overrides this RFC on conflict).
+> The runtime side changes materially:
+> L1 stores `*astjson.Value` in memory (NOT `[]byte`); parse once; only L2 marshals; L1 and L2 SHARE the same keys (no prefix-free L1 keyspace) (R2.4).
+> Bring back store-time normalization (schema names on write, aliases on read) + argument-suffix keys so values are reusable across fetches with different aliases/args (R2.5).
+> PARTIAL FETCHING is IN CORE: serve from L1, then L2 for the missing keys, then the subgraph for what is still missing, then splice/realign (batch: refetch only the missing representations) (R2.3).
+> Replace the `MergeArena`/`MergeSession` facade with an explicit begin/commit TRANSACTION on the astjson data object (R2.6).
+> The cache MAY be more integrated with the loader, live in ONE common package, and DRIFT from the interface shapes below where that simplifies reading/merging; do NOT `switch` over concrete fetch types — add methods to the `Fetch` interface (R2.6).
+> ART must expose verbose caching behavior (R2.9).
+
+## 1. Summary and goals
+
+### 1.1 What this RFC delivers
+
+RFC-1 adds a clean abstraction layer to the loader so that L1 + L2 response + entity caching can be (re-)implemented entirely OUTSIDE `loader.go`.
+The OLD implementation re-authored the loader's control flow at ~461 cache call-sites and ~1433 inserted lines, with config bolted onto `FederationMetaData` (DOSSIER §1).
+This RFC replaces that with one small, mostly-additive commit that exposes a single mode-blind cache working surface, a self-contained per-fetch cache configuration, and a two-level opaque handle, such that four interchangeable cache implementations (NO-OP, L1-only, L2-only, L1+L2) plus shadow mode all ride the SAME interface and the loader never learns which is active.
+
+### 1.2 Goals
+
+- G1. ONE small, mostly-additive commit to `loader.go` plus minimal other `resolve` files, inserting calls at the existing prepare/load/merge seams (HR1).
+- G2. ONE cache abstraction such that NO-OP / L1-only / L2-only / L1+L2 are all implementations of it, with the loader blind to the mode and a nil controller zero-cost (HR2).
+- G3. Cover every runtime capability in DOSSIER §2 (HR3).
+- G4. A two-level opaque handle, per-fetch state plus per-item payload, mapped 1:1 against OLD `CacheKey`/`cachedData` (HR4).
+- G5. Correct under defer's per-defer-group Loader plus `DataBuffer.Lock` plus a shared arena (HR5).
+- G6. A self-contained caching configuration decoupled from `FederationMetaData`, behind a `CacheConfigProvider` port (HR6).
+- G7. A justified `responseData` surfacing decision (HR7), a module boundary with an `Equals` contract (HR8), a migration note (HR9), and impossible-to-misconfigure NO-OP gating (HR10).
+- G8. Merging RFC-1's commit ALONE — before any cache implementation exists — changes runtime behavior in ZERO ways.
+
+### 1.3 Non-goals
+
+- The caching planner pass that populates the per-fetch config: that is RFC-2.
+  RFC-1 defines only the OUTPUT contract RFC-2 must satisfy (§8).
+- Any concrete cache implementation: NO-OP / L1 / L2 / L1+L2 / shadow are all implemented in a follow-up impl PR, in a new `resolve/cache` package behind the interfaces defined here.
+- Partial entity / partial batch realign, walker-inlined analytics, and subscription / mutation caching are staged to v2; their loader SEAMS exist in v1 (§9).
+
+---
+
+## 2. Background
+
+### 2.1 Why the OLD coupling failed
+
+The OLD branch did not add hooks, it re-authored the loader.
+`resolveParallel` became a hand-rolled 6-phase pipeline (OLD `loader.go:266-503`) and `resolveSingle` a sequential mirror, with key derivation, lookup, merge, analytics, and tracing interleaved at ~461 call-sites, ~60 cache fields hand-threaded on the `result` struct (OLD `loader.go:137-192`), and ~12 on `Loader` (DOSSIER §1).
+That only worked because OLD kept the arena and parser main-thread-only.
+Configuration was bolted onto `FederationMetaData`: 6 collections plus 4 interface methods plus datasource forwarders (DOSSIER §5.1).
+The single biggest source of churn was analytics and trace, interleaved at nearly every cache site (DOSSIER §2.7) — which is why this RFC gives it its own port (§3.5).
+
+### 2.2 What the defer branch already gives us
+
+The CURRENT defer branch already did the structural work that makes a clean plug-in possible (DOSSIER §1, §3.1).
+Each fetch's lifecycle is split into three phases with explicit lock discipline (CURRENT `loader.go`):
+
+- `preparePhase` (`loader.go:318`) builds the input and selects the merge `items`, under `DataBuffer.Lock`.
+- `loadPhase` (`loader.go:349`) does the network with NO lock, and early-returns when `prepared.skipLoad` is set (`loader.go:350-352`).
+- `mergePhase` (`loader.go:360`) parses and merges the response into the tree, under `DataBuffer.Lock`, then calls `callOnFinished` (`loader.go:376-378`).
+
+`resolveSingle` (`loader.go:381-401`) orchestrates the three, carrying state on `preparedFetch` (`loader.go:403-412`) with a `skipLoad` flag that is the exact structural equivalent of OLD `cacheSkipFetch`.
+The OLD 6-phase pipeline is structurally incompatible because thread-safety is inverted — defer parses and merges inside goroutines under a mutex, OLD forbade goroutine arena use (DOSSIER §7 risk 1) — so caching must be re-expressed against these three seams, NOT ported.
+
+The other defining constraint is that the Loader is per-defer-group.
+`resolveDeferSingle` creates a fresh `NewLoader` per group sharing only the request `DataBuffer` and arena (CURRENT `resolve.go:605-612`), and the initial loader is separate (`resolve.go:504`).
+The request `*Context` is shared by reference across all groups, with its only defer-time mutation (`ctx.subgraphErrors`) written exclusively under `dc.db.Lock()` (verified in the comment at CURRENT `resolve.go:698-704`) — this is the exact precedent RFC-1 reuses to home the shared cache state (§6).
+
+---
+
+## 3. The abstraction
+
+All contract types live in the `resolve` package, in two new files `cache_controller.go` and `cache_config.go` (pure additions).
+They reference only `resolve` types plus `astjson`, `time`, and `arena`; they import NO federation types.
+The cache LOGIC (every implementation, key rendering, transforms, coverage/freshness/reorder, analytics) lives in a NEW sibling package `v2/pkg/engine/resolve/cache` that imports `resolve` one-way; `resolve` never imports it (§7.1, HR8).
+The wiring mirrors `LoaderHooks` (CURRENT `loader.go:40-48`) and `SetAuthorizer` / `SetRateLimiter` (CURRENT `context.go:189/226`): an interface value reached through `Context`, nil-checked at every call site, fed value objects.
+
+### 3.1 The two-tier controller (and why it is still ONE abstraction)
+
+The loader sees exactly ONE mode-blind working surface, `RequestCache`.
+A second, tiny interface, `CacheController`, exists only to scope that surface to a request — it is the lifecycle/factory tier, the exact analogue of how `Authorizer` is long-lived while producing per-call decisions.
+This is "one abstraction" in the sense HR2 demands: NO-OP / L1-only / L2-only / L1+L2 are all implementations of `RequestCache`, and the loader branches on nothing but the `Decision` value it returns.
+
+```go
+// CacheController is the long-lived, integrator-supplied lifecycle port. The
+// router sets one via Context.SetCacheController, exactly as it sets an Authorizer.
+// A nil controller is the global NO-OP and is zero-cost. NO-OP, L1-only, L2-only,
+// and L1+L2 (with shadow as a cross-cutting L2 variant) are NOT distinguished here;
+// they are all distinguished only by the RequestCache the controller hands back.
+type CacheController interface {
+	// BeginRequest is called once per request, lazily, under DataBuffer.Lock, the
+	// first time a cache-eligible fetch is prepared. It returns the request-lifetime
+	// shared working surface, which is then shared by reference across every
+	// per-defer-group Loader of this request (HR3-h, HR5). The returned value
+	// owns all per-request mutable state (the L1 map, mutation-inheritance flags,
+	// the analytics accumulator, the deferred L2 write set), so nothing mutable
+	// hangs on the long-lived controller and there is no cross-request sharing.
+	BeginRequest(ctx *Context) RequestCache
+}
+
+// RequestCache is the ONE mode-blind working surface the loader talks to. Its
+// PrepareFetch / OnFetchSkipped / OnFetchResult methods are invoked from
+// resolveSingle with NO loader lock held; each one acquires DataBuffer.Lock
+// itself, ONCE, by opening a MergeSession from the passed MergeArena (§3.4) and
+// holding it for its whole arena sequence. EndRequest runs once, single-threaded,
+// after the whole fetch tree (root + every defer group) has resolved, and needs
+// no lock. Because each hook holds DataBuffer.Lock for the duration of its
+// MergeSession, implementations need no internal lock for their request-lifetime
+// (arena-touching) state; the session's DataBuffer.Lock is its guard (§6).
+type RequestCache interface {
+	// PrepareFetch runs from resolveSingle after the render phase, with no loader
+	// lock held; it opens a MergeSession (§3.4) for its arena work. It best-effort
+	// renders every candidate key that CAN be rendered from the data available now
+	// (some candidates may be unrenderable, which is allowed), looks the cache up
+	// under ALL rendered keys (a hit on ANY serves the item), runs the always-on
+	// per-item coverage + multi-candidate freshness + reorder walk (DOSSIER §2.10),
+	// and returns a Decision plus the two-level handle the merge/flush steps read.
+	// A NO-OP returns DecisionFetch + nil.
+	PrepareFetch(in PrepareFetchInput) (Decision, *FetchCacheHandle)
+
+	// OnFetchSkipped runs from resolveSingle (after mergePhase) when PrepareFetch
+	// returned DecisionSkipFullHit (or DecisionFetchPartial, v2). It opens a
+	// MergeSession, splices the chosen, already-reordered cached values into items,
+	// and MAY emit best-effort multi-key write-back / backfill writes
+	// (handle.MustWriteBack). The fetch did not hit the network (DOSSIER §2.2, §2.5).
+	OnFetchSkipped(h *FetchCacheHandle, in MergeInput) error
+
+	// OnFetchResult runs from resolveSingle (after mergePhase) after a real network
+	// fetch (DecisionFetch or DecisionFetchShadow, or the fetched subset of
+	// DecisionFetchPartial). It opens a MergeSession, does negative-hit detection,
+	// best-effort multi-key render-then-backfill (re-render the still-unrendered
+	// candidate keys from the fresh data, then L1/L2 write or defer), and — when
+	// h.Shadow — the shadow compare BEFORE the write-back, preserving the OLD
+	// compare -> write-L1 -> write-L2 order (DOSSIER §2.11).
+	OnFetchResult(h *FetchCacheHandle, in MergeInput) error
+
+	// EndRequest runs once after the root tree AND every defer group have resolved,
+	// single-threaded. It flushes batched L2 writes (one Set per cache instance) and
+	// finalizes analytics/trace. It needs no lock and no arena (§6.4).
+	EndRequest()
+}
+```
+
+Note on the pair vs "ONE abstraction" (reviewer must-fix): the loader holds and calls `RequestCache` only; `CacheController` never appears at a hot call site, it is a one-method factory the loader invokes once per request to obtain the working surface.
+Collapsing them would force per-request mutable state onto a long-lived integrator object, which is exactly the cross-request-sharing race that sank one of the alternative drafts (reviewer must-fix on draft C's lifecycle).
+
+### 3.2 The decision enum (including FetchShadow)
+
+```go
+// Decision is what PrepareFetch tells the loader to do. It is the ONLY cache
+// concept the loader branches on.
+type Decision uint8
+
+const (
+	// DecisionFetch: miss, or caching disabled for this fetch. loadPhase fetches
+	// normally; the handle may be nil.
+	DecisionFetch Decision = iota
+
+	// DecisionSkipFullHit: every item is covered by a covering cache value (the
+	// AND-reduction of the per-item coverage walk, DOSSIER §2.10). The loader skips
+	// the network load. NOT terminal for the cache: OnFetchSkipped may still emit
+	// best-effort multi-key backfill/refresh L2 writes (handle.MustWriteBack, §2.2).
+	DecisionSkipFullHit
+
+	// DecisionFetchPartial: some items covered, some not. Fetch only the missed
+	// subset, then splice the cached subset and realign. STAGED to v2 (§9); a v1
+	// controller never returns this.
+	DecisionFetchPartial
+
+	// DecisionFetchShadow: cfg.ShadowMode AND the L2 read hit (DOSSIER §2.11). The
+	// loader treats it EXACTLY like a miss — skipLoad stays false, full render,
+	// write-back — so it is byte-identical to DecisionFetch on the loader side. The
+	// only deltas live in the handle (Shadow + ShadowStash) and the extra compare
+	// step inside OnFetchResult.
+	DecisionFetchShadow
+)
+```
+
+The enum needs `DecisionFetchShadow` because shadow decouples "read a cache value" from "serve a cache value" (DOSSIER §2.11): a full L2 hit must still fetch (so not `SkipFullHit`), partial is force-disabled (so not `FetchPartial`), and a plain `Fetch` would lose the L2-read-having-run, the stash, and the post-merge compare.
+
+### 3.3 Inputs to the hooks
+
+```go
+type PrepareFetchInput struct {
+	Ctx        *Context
+	Item       *FetchItem
+	Items      []*astjson.Value   // merge targets (selectItemsForPath, loader.go:480)
+	Config     *FetchCacheConfig  // RFC-2 output; nil => not cached (the gate, §10)
+	BatchStats [][]*astjson.Value // unique-rep -> targets, for batch fetches
+	Input      []byte             // canonical pre-injection rendered bytes (§3.6, cache-key fidelity)
+	HeaderHash uint64             // subgraph header hash, the sole L2 vary-by knob (§3.6)
+	Arena      MergeArena         // scoped-lock arena facade; open ONE MergeSession via Begin() (§3.4)
+}
+
+type MergeInput struct {
+	Item         *FetchItem
+	Items        []*astjson.Value
+	ResponseData *astjson.Value     // parsed response DATA sub-path, surfaced from mergeResult (HR7, §7); nil => no parseable data was produced (transport/empty/parse failure), an authoritative no-write gate
+	BatchStats   [][]*astjson.Value
+	HasErrors    bool               // subgraph response carried GraphQL errors (one of five write gates, §3.3)
+	FetchFailed  bool               // transport failure / empty body / parse failure: res.err != nil || len(res.out) == 0 || res.response == nil (the two §2.6 signals the prior draft dropped); an authoritative no-write gate
+	EmptyEntity  bool               // isEmptyEntityFetch over the FULL parsed response, for negative-hit detection (§3.7); a SUCCESSFUL-but-empty entity fetch, NOT a failure — it ROUTES to the negative-cache write, it does not block writes
+	StatusCode   int                // status-fallback signal (§2.6)
+	Arena        MergeArena         // scoped-lock arena facade; open ONE MergeSession via Begin() (§3.4)
+}
+```
+
+The write gate, made explicit (reviewer must-fix; DOSSIER §2.2 "Gate writes on success", §2.6).
+`MergeInput` now surfaces ALL FIVE failure signals DOSSIER §2.6 enumerates, where the prior draft surfaced only three:
+`FetchFailed` folds the two it dropped — `res.err` (transport failure) and empty `res.out` — plus the parse-failure case (`res.response == nil`);
+`HasErrors` is the GraphQL error-path match;
+`EmptyEntity` is the successful-but-empty entity fetch;
+`StatusCode` is the status fallback.
+These signals gate the REAL-FETCH write path (`OnFetchResult`): the authoritative rule a controller MUST follow before persisting a fetched value is `!in.FetchFailed && !in.HasErrors && in.ResponseData != nil && in.ResponseData.Type() != astjson.TypeNull`.
+`FetchFailed` and `HasErrors` block ALL fetched-value writes, including negative writes, because a transport/empty/parse failure or an errored response must never be cached (it would persist a transient error, DOSSIER §2.6);
+`EmptyEntity` is the ONE non-failure that still writes — it routes to the negative-cache sentinel path when `cfg.NegativeCacheTTL > 0` (a successful fetch that legitimately returned no entity).
+`ResponseData == nil` is the structural backstop for the EARLY failure paths: the transport (`res.err`), empty-body (`len(out) == 0`), and parse-failure paths return before `res.responseData` is assigned (§4.4), so the data pointer is nil exactly when no data was parsed at all; the later status-fallback / shape-mismatch paths run AFTER the assignment and leave a JSON-`null` (non-nil pointer), which is blocked instead by the `Type() != astjson.TypeNull` clause plus `StatusCode`/`HasErrors`, while the legitimate null-data / empty-entity case is the one routed by `EmptyEntity`.
+This is why `HasErrors` alone is NOT the gate: the transport/empty/parse paths reach `OnFetchResult` with `HasErrors == false` because `responseHasErrors` is assigned only after them (~`loader.go:680`), so without `FetchFailed`/`ResponseData == nil` a contract-following controller would cache a failed fetch (the reviewer's blocking bug).
+These signals do NOT constrain the cache-hit write-back path (`OnFetchSkipped`): there was no network fetch, so `res.response`/`FetchFailed` are not about a failed fetch — the best-effort multi-key backfill/refresh writes that path emits operate on already-validated cached values gated by `handle.MustWriteBack` (§3.7, DOSSIER §2.2), not by these signals.
+
+`ProvidesData` is NOT a parameter: it is folded into `FetchCacheConfig.ProvidesData` (§3.6), so the loader never references `*Object` for caching, and there is no `FetchInfo.ProvidesData` re-add and therefore no `Object`/`Field` `Copy()` drift (DOSSIER §7 risk 9).
+The controller reads `cfg.ProvidesData` at lookup time inside `PrepareFetch`; it is request-independent plan data consumed as a runtime decision input (DOSSIER §2.10).
+
+### 3.4 The merge-arena facade
+
+The facade is a SCOPED (transactional) lock, not a per-op one.
+A cache merge over several items is a multi-op sequence (the §2.10 candidate-parse -> merge-synthesis -> reorder ladder, then the splice or write), so a facade that took `DataBuffer.Lock` per method call would re-acquire the lock dozens of times for one fetch.
+Instead the controller opens a `MergeSession` ONCE via `Begin()`, runs ALL its arena ops on that session, and releases the lock with `Close()` (via `defer`).
+A plain `Lock()`/`Unlock()` pair would work, but the `Begin() -> MergeSession -> Close()` shape makes "arena ops only while the lock is held" impossible to misuse: every arena/parser op is a method ON the session, so there is no way to touch the arena without a held lock, and there is no closure-allocation overhead of a `Transaction(func())` callback.
+
+```go
+// MergeArena is the narrow, lock-guarded facade over the Loader's jsonArena. The
+// cache controller may touch arena memory ONLY through a MergeSession, which it
+// opens by calling Begin() ONCE at the top of a hook (PrepareFetch /
+// OnFetchSkipped / OnFetchResult) and releases with Close() (via defer). Begin()
+// acquires DataBuffer.Lock; Close() releases it. The session is the SINGLE scoped
+// lock taken around the whole multi-op sequence — the candidate-parse ->
+// merge-synthesis -> reorder pipeline (DOSSIER §2.10) and the splice/write —
+// instead of re-locking per op, which reduces lock contention. A MergeArena/
+// MergeSession must never be retained past the hook, and never be opened from the
+// off-lock loadPhase (DOSSIER §7 risk 7).
+type MergeArena interface {
+	// Begin enters the locked merge region and returns the session through which
+	// all arena/parser ops run. It acquires DataBuffer.Lock once for the caller.
+	Begin() MergeSession
+}
+
+// MergeSession is the scoped, lock-held handle for one multi-op arena sequence.
+// Every arena/parser op is a method here, so a controller cannot touch the arena
+// without a held session ("ops only while locked" is unmisusable by construction).
+// Close releases DataBuffer.Lock and MUST be called (via defer) exactly once.
+type MergeSession interface {
+	ParseBytes(b []byte) (*astjson.Value, error)                    // lazy candidate parse onto the arena
+	StructuralCopy(v *astjson.Value) *astjson.Value                 // avoid MergeValues aliasing corruption (OLD loader_cache_transform.go:22-48)
+	MergeValues(dst, src *astjson.Value) (*astjson.Value, error)
+	MergeValuesWithPath(dst, src *astjson.Value, path ...string) (*astjson.Value, error)
+	NewObject() *astjson.Value
+	NewArray() *astjson.Value
+	String(s string) *astjson.Value
+	Null() *astjson.Value
+	Close() // releases DataBuffer.Lock; use via defer
+}
+```
+
+The contract: every arena op requires a held `MergeSession`; the arena and parser are touched ONLY inside a session; `Begin()`/`Close()` bracket exactly one scoped lock region per hook.
+The implementation is a tiny loader-side value, `type mergeArena struct{ a arena.Arena; db *DataBuffer }`, built on demand by `l.mergeArena()`; `Begin()` calls `l.dataBuffer.Lock()` and returns a session bound to `l.jsonArena`, and `Close()` calls `l.dataBuffer.Unlock()`.
+The session discards the `changed` bool that `astjson.MergeValuesWithPath` returns today (CURRENT `loader.go:724`), matching how defer already discards it (DOSSIER §7 risk 18).
+It is never constructed on the no-op path (it is built only after the controller is known non-nil), and the loader does NOT hold `DataBuffer.Lock` when it calls a cache hook (§4.3, §6.4), so the session's `Begin()` is the single acquisition.
+
+### 3.5 The observer port (analytics / trace / shadow-compare isolation)
+
+Analytics, trace, and the shadow comparison are the churn-prone concern that dominated OLD's 461 references (DOSSIER §2.7).
+RFC-1 quarantines them behind their own port so they evolve with zero impact on the lookup/write surface.
+
+```go
+// CacheObserver is the optional analytics/trace/shadow-compare port. It is composed
+// INSIDE a RequestCache implementation (the loader never calls it directly). A nil
+// observer means no observability and is zero-cost. Defined in v1; the walker hooks
+// (OnEntity/OnFieldValue) are wired in v2 to avoid colliding with defer's walker
+// rewrite (DOSSIER §4.3, §7 risk 10).
+type CacheObserver interface {
+	BeginRequest(ctx *Context)
+	EndRequest(ctx *Context)
+	// OnFetchObserved derives per-fetch trace + counters from the finished handle,
+	// so trace and analytics read the same opaque state the writer used.
+	OnFetchObserved(h *FetchCacheHandle)
+	// CompareShadow runs the DOSSIER §2.11 staleness probe; the writer calls it
+	// before overwriting L2, preserving compare -> write-L1 -> write-L2 order. It
+	// runs inside OnFetchResult's already-open MergeSession (it does not open its
+	// own). It no-ops unless analytics is enabled and cfg.ProvidesData != nil, and
+	// it records only for entity fetches (root-field shadow force-refetches without
+	// comparing, the OLD asymmetry at OLD loader_cache.go applyRootFetchL2Results).
+	CompareShadow(h *FetchCacheHandle, fresh *astjson.Value, s MergeSession)
+	// OnEntity / OnFieldValue are the resolvable-walker hooks (DOSSIER §2.7); v2.
+	OnEntity(h *FetchCacheHandle, entity *astjson.Value)
+	OnFieldValue(coordinate GraphCoordinate, value FieldValue)
+}
+```
+
+Keeping `CacheObserver` off the loader surface is what prevents the ~22 trace fields and the per-result analytics accumulators from leaking back into `loader.go` (DOSSIER §2.7); they live on the handle (§4) and are read only here.
+
+### 3.6 The self-contained per-fetch config (runtime side)
+
+```go
+// FetchCacheConfig is the self-contained, federation-free per-fetch cache config
+// stamped by RFC-2 onto SingleFetch / EntityFetch / BatchEntityFetch. The loader
+// carries it forward-only (it never reads a field, only hands it to the controller);
+// the cache package interprets it. A nil *FetchCacheConfig means caching disabled
+// for this fetch, which is the gate that makes a not-run planner pass behave as
+// NO-OP (HR10). It imports NO federation types: federation @key selection sets are
+// a plan-time INPUT only, frozen into KeySpec by RFC-2 (HR6, §7).
+type FetchCacheConfig struct {
+	L1 bool // participate in per-request L1 entity cache
+	L2 bool // participate in cross-request L2 cache
+
+	CacheName                   string
+	TTL                         time.Duration
+	NegativeCacheTTL            time.Duration // > 0 enables negative caching (DOSSIER §2.6)
+	IncludeSubgraphHeaderPrefix bool          // fold the subgraph header hash into the L2 key
+	EnablePartialCacheLoad      bool          // partial L1/entity (v2)
+	PartialBatchLoad            bool          // partial batch realign (v2)
+	ShadowMode                  bool          // L2 read-but-never-serve probe (DOSSIER §2.11)
+	HashAnalyticsKeys           bool
+
+	KeySpec CacheKeySpec // frozen multi-key derivation, DATA only, no federation types
+
+	// ProvidesData is the field tree the fetch returns. It is request-independent
+	// plan data, but it is consumed at RUNTIME by the coverage walk in PrepareFetch
+	// (DOSSIER §2.10), not only at plan time. Folding it here (rather than re-adding
+	// FetchInfo.ProvidesData) keeps loader.go from referencing *Object and sidesteps
+	// the Object/Field Copy() drift (DOSSIER §7 risk 9).
+	ProvidesData *Object
+
+	// Mutation populate inheritance (request-lifetime carry; DOSSIER §2.8, §7 risk 3).
+	PopulateL2OnMutation bool
+	MutationTTLOverride  time.Duration
+}
+
+// Equals lets FetchConfiguration.Equals (plan dedup) deep-compare cache config.
+// Only ever called with both receivers non-nil (the nil case is handled at the
+// call site, §3.8). KeySpec is pure data, so this is a structural walk.
+func (c *FetchCacheConfig) Equals(other *FetchCacheConfig) bool
+
+// String renders a compact, nil-safe summary for the plan pretty-printer (which
+// already guards nils, commit 921e48ae in fetchtree.go) and for logs.
+func (c *FetchCacheConfig) String() string
+
+type CacheScope uint8
+
+const (
+	CacheScopeRootField CacheScope = iota
+	CacheScopeEntity
+)
+
+// CacheKeySpec is DATA ONLY (no renderer, no federation types). It models the
+// MULTI-KEY identity of an entity / root field: an entity type may declare MORE
+// THAN ONE @key set, so Candidates is a LIST of candidate key templates. None is
+// "required" — each candidate is INDEPENDENTLY and BEST-EFFORT renderable from
+// whatever data is available at the moment it is rendered. The cache package
+// builds ONE CacheKeyTemplate PER candidate; each template is the SOLE source of
+// truth for read, write, and invalidate of THAT key, so the three paths cannot
+// silently diverge (the byte-identical-keys invariant, DOSSIER §2.3). Frozen ONCE
+// from @key at plan time.
+type CacheKeySpec struct {
+	Scope     CacheScope
+	TypeName  string
+	FieldName string
+
+	// Candidates is the list of candidate key templates (one per @key set). At
+	// LOOKUP time PrepareFetch renders every candidate it CAN render from the data
+	// at hand (some may be unrenderable because their fields are absent — allowed)
+	// and looks the cache up under ALL rendered keys; a hit on ANY serves the item.
+	// At WRITE time OnFetchResult re-renders the candidates that were unrenderable
+	// at lookup, now from the fresh response data, and populates all keys that are
+	// renderable (best-effort multi-key render-then-backfill, §2.2). The
+	// interfaceObject / entityInterface __typename remap is baked INTO each
+	// candidate's Representation, so there is no separate TypenameOverride field.
+	Candidates []CacheKeyCandidate
+
+	// EntityKeyMappings (root-arg <-> @key) contribute additional candidates rather
+	// than a separate key space: a key derivable from root-field args is renderable
+	// at lookup, while one derivable only from the returned entity data becomes
+	// renderable at write — both are just candidates in the best-effort model (§2.2).
+	//
+	// v1 REUSE CONSTRAINT (first pass, commit C2): the entity candidate a by-key
+	// root field renders from these mappings is keyed EXACTLY as an entity fetch
+	// keys it, so reuse only works when the by-key root-field policy and the entity
+	// policy share the same CacheName (read key == write key). Cross-name reuse
+	// would need a mapping-carried target cache name; it is out of scope for v1.
+	EntityKeyMappings []EntityKeyMapping
+}
+
+// CacheKeyCandidate is ONE candidate @key template, frozen from a single @key set
+// at plan time. Representation is the *resolve.Object key template that RFC-2's
+// shared representationvariable.BuildRepresentationVariableNode produces from that
+// one @key set (RFC-2 §6.1): a federation-pointer-free node tree with the
+// interfaceObject / entityInterface __typename remap already baked in, so the
+// candidate is a complete key template on its own. It subsumes the old single-key
+// KeyFields + TypenameOverride pair. A candidate renders only when every field its
+// Representation references is present in the data at hand; an unrenderable
+// candidate is skipped at lookup and retried at write, never an error.
+type CacheKeyCandidate struct {
+	Representation *Object // the frozen @key representation node for this one candidate
+}
+
+// CacheWriteReason is metadata only; it does NOT gate writes (DOSSIER §2.2).
+type CacheWriteReason string
+
+const (
+	CacheWriteReasonRefresh  CacheWriteReason = "refresh"  // a key already populated, re-written with fresh data
+	CacheWriteReasonBackfill CacheWriteReason = "backfill" // a candidate key unrenderable/absent at lookup, populated now
+)
+```
+
+`EntityKeyMapping` moves into `resolve` as a value type (the OLD `EntityKeyMappingConfig`, OLD `caching.go:96`), so `FetchCacheConfig` stays self-contained and `Equals` is a structural `slices.Equal` walk over pure data.
+`Equals` over `CacheKeySpec` walks `Candidates` with `slices.EqualFunc`, comparing each candidate's `Representation` via the existing `Object.Equals` shape walk (CURRENT `node_object.go:42`), so two fetches that differ in any candidate key are not deduped.
+
+Cache-key fidelity (DOSSIER §7 risk 17, promoted to a contract clause).
+The loader passes `PrepareFetchInput.Input` as the canonical pre-injection rendered bytes, and `PrepareFetchInput.HeaderHash` as the subgraph header hash from the nil-guarded wrapper `ctx.HeadersForSubgraphRequest(name)` (verified CURRENT `context.go:105-111`; it nil-checks `SubgraphHeadersBuilder` and returns `(nil, 0)` when unset, so cache-key derivation never panics on a request with no header builder).
+The controller derives all keys from these plus the `@key`/arg values, and folds the header hash into the L2 key as the sole vary-by knob (there is no Cache-Control/max-age/vary concept, DOSSIER §2.3).
+This keys off the same canonical form that single-flight dedups on (risk 16), NOT off the post-prepare bytes that `executeSourceLoad` mutates (`extensions` at CURRENT `loader.go:1940`, `fetch_reasons` at `1956`).
+
+### 3.7 The two-level opaque handle (HR4)
+
+The handle replaces the ~60 OLD `result` cache fields with one carrier on `preparedFetch`.
+It is a concrete `resolve` struct, not `any`, for debuggability and to avoid boxing on the merge path — but the loader treats it strictly opaquely: it stores it on `preparedFetch`, threads it back to the merge hook, and never reads a field.
+It is two-level — per-fetch state PLUS a slice of per-item payloads — because flattening loses multi-candidate freshness selection, per-entity coverage, and the per-item multi-key render-then-backfill state (DOSSIER §3.3).
+
+```go
+// FetchCacheHandle is the per-fetch opaque cache state, carried on preparedFetch.
+// Allocated by PrepareFetch ONLY when the controller actually touches the fetch; a
+// nil controller means the loader never allocates one.
+type FetchCacheHandle struct {
+	Decision       Decision                 // what PrepareFetch decided (drives the merge dispatch + debuggability)
+	WasHit         bool                     // OLD res.cacheSkipFetch (a covering value was found)
+	MustWriteBack  bool                     // OLD res.cacheMustBeUpdated (a hit still needs L2 writes, §2.2)
+	BatchEntityKey bool                     // batch-entity-key mode (per-element multi-key render on write)
+	Shadow         bool                     // FetchShadow: run compare in OnFetchResult before write-back
+	ShadowStash    map[int]ShadowCacheEntry // OLD res.shadowCachedValues, keyed by item index
+	Items          []ItemCacheState         // per-item payload (OLD res.l1CacheKeys / res.l2CacheKeys)
+	Analytics      any                      // observer-owned accumulators; opaque even here
+}
+
+// String renders {decision:SkipFullHit items:3 hits:3 writeback:1 shadow:false}
+// for logs and panics.
+func (h *FetchCacheHandle) String() string
+
+// ItemCacheState is the per-item (per-CacheKey) payload, one per merge target.
+// Mapped against OLD resolve.CacheKey + embedded cachedData (caching.go:27-65),
+// with the OLD requested-vs-rendered-key + missing-key framing REPLACED by the
+// best-effort multi-key model: RenderedKeys are the candidate keys that rendered
+// at lookup; PendingCandidates are the candidates that did not, retried at write.
+type ItemCacheState struct {
+	Item                 *astjson.Value      // OLD CacheKey.Item        — splice target / write source (itemToStore)
+	FromCache            *astjson.Value      // OLD CacheKey.FromCache   — chosen+reordered value; nil=miss, TypeNull=negative hit
+	RenderedKeys         []string            // candidate keys SUCCESSFULLY rendered at lookup (the renderable subset of OLD CacheKey.Keys); looked up (hit on ANY serves) and the default write set. R2.4 OVERRIDE: L1 and L2 SHARE the same keys (no prefix-free L1 keyspace) — derive each key once and reuse it for both layers.
+	PendingCandidates    []CacheKeyCandidate // candidates NOT renderable at lookup (fields absent); re-rendered from fresh data in OnFetchResult and, if now renderable, added to the write set (best-effort backfill, §2.2) — generalizes OLD CacheKey.missingKeys + the requested/rendered split
+	FromCacheCandidates  []CacheCandidate    // OLD cachedData.fromCacheCandidates — freshest-first cached entries matched across RenderedKeys (DOSSIER §2.10)
+	SelectedRemainingTTL time.Duration       // OLD cachedData.fromCacheRemainingTTL — cache-age analytics/trace
+	NeedsWriteback       bool                // OLD cachedData.fromCacheNeedsWriteback — merged/older chosen -> rewrite canonical
+	EntityMergePath      []string            // OLD CacheKey.EntityMergePath — root<->entity wrap/extract. GAP (first pass): the loader does not currently pass the fetch's post-processing merge path into the cache hooks, so v1 leaves this empty and splices/writes at the item root (correct for the commerce _entities shape). A fetch with a non-root merge path needs the loader to surface that path (a small MergeInput/PrepareFetchInput addition) or a controller-side derivation.
+	BatchIndex           int                 // OLD CacheKey.BatchIndex  — original batch position for realign
+	NegativeHit          bool                // OLD CacheKey.NegativeCacheHit — subgraph-null sentinel routing
+	WriteReason          CacheWriteReason    // refresh / backfill (metadata only)
+}
+
+type CacheCandidate struct {
+	Value        []byte        // OLD fromCacheCandidate.value (lazily parsed via MergeSession.ParseBytes)
+	RemainingTTL time.Duration // OLD fromCacheCandidate.remainingTTL
+}
+
+type ShadowCacheEntry struct {
+	CachedValue  *astjson.Value // OLD shadowCacheEntry.cachedValue, on the merge arena
+	CacheKey     string
+	RemainingTTL time.Duration
+}
+```
+
+Phase ownership: `PrepareFetch` WRITES every field except `NegativeHit` / `WriteReason` (those are stamped in `OnFetchResult` from the fresh response); `PrepareFetch` writes `PendingCandidates`, and `OnFetchResult` re-renders and clears them from the fresh data (the multi-key backfill, §2.2); `OnFetchSkipped` / `OnFetchResult` / `EndRequest` READ the payload.
+The field-by-field mapping to OLD `CacheKey` / `cachedData` is the inline column above (HR4).
+
+### 3.8 The Equals call site
+
+`SingleFetch` embeds `FetchConfiguration` (CURRENT `fetch.go:96-98`), and `EqualSingleFetch` deduplicates single fetches via `l.FetchConfiguration.Equals(&r.FetchConfiguration)` (CURRENT `fetch.go:80`, `283-309`).
+The new field is a POINTER `Cache *FetchCacheConfig` (nil = the unambiguous "not cached" gate, and most fetches are uncached so no inline struct is carried), and the `Equals` clause is nil-safe at the call site, so the method is only ever invoked with both receivers non-nil:
+
+```go
+// inside FetchConfiguration.Equals (CURRENT fetch.go:283-309)
+if (fc.Cache == nil) != (other.Cache == nil) {
+	return false
+}
+if fc.Cache != nil && !fc.Cache.Equals(other.Cache) {
+	return false
+}
+```
+
+This avoids the nil-pointer-receiver footgun (a reviewer flagged draft C's nil-receiver `Equals`) while keeping the comparison compile-checked (a reviewer flagged that an `any`-typed config would force a reflect/assert comparison).
+In v1 `Cache` is nil at dedup time, because RFC-2 stamps it AFTER `createConcreteSingleFetchTypes` (DOSSIER §6.4), so both sides are nil and the clause returns the prior result — zero behavior change.
+The clause exists so the contract holds the instant any producer stamps config earlier (DOSSIER §7 risk 11).
+`EntityFetch` / `BatchEntityFetch` carry the same `Cache *FetchCacheConfig` field but are built post-dedup, so they need no `Equals` of their own.
+
+---
+
+## 4. The one loader/resolve commit (HR1)
+
+This is ONE commit.
+It compiles as a no-op: every hook is guarded by `l.ctx.cacheController == nil`, every new field is zero-valued, and merging it alone changes runtime behavior in zero ways (§10.2, G8).
+A second, behavior-neutral move-commit relocates the cache files into the new `cache` package (§7.1); it touches no runtime behavior.
+
+### 4.1 File-by-file edit list
+
+| File | Edit | Why |
+|---|---|---|
+| `cache_controller.go` (NEW) | `CacheController`, `RequestCache`, `Decision`, `PrepareFetchInput`, `MergeInput`, `MergeArena`, `MergeSession`, `CacheObserver`, `FetchCacheHandle`, `ItemCacheState`, `CacheCandidate`, `ShadowCacheEntry`, plus the `mergeArena`/`mergeSession` impl. | The runtime contract + scoped-lock facade (§3). Pure additions. |
+| `cache_config.go` (NEW) | `FetchCacheConfig`, `CacheKeySpec`, `CacheKeyCandidate`, `CacheScope`, `CacheWriteReason`, `EntityKeyMapping`. | The self-contained multi-key config (§3.6, §7). Each `CacheKeyCandidate` carries a `*resolve.Object` Representation (the existing resolve type), so no `KeyField` type is needed. Pure additions. |
+| `loader.go` (a) | `preparedFetch` (`403-412`): add `cacheHandle *FetchCacheHandle`. | Carry the opaque handle across phases. |
+| `loader.go` (b) | `result` (`99-142`): add `responseData *astjson.Value`, `responseHasErrors bool`, and `response *astjson.Value` (the FULL parsed response, the input `isEmptyEntityFetch` needs). | Surface the response data sub-path, the error flag, AND the full response to the merge hook (HR7, §7). |
+| `loader.go` (c) | `resolveSingle` (`381-401`): after `preparePhase` (lock released) call `l.cachePrepare(prepared)`; after `mergePhase` call `l.cacheMerge(prepared)`. | Seams S1 + S4, OUTSIDE the phase locks so the controller's `MergeSession` is the single `DataBuffer.Lock` acquisition (§3.4, §6.4). |
+| `loader.go` (d) | `preparePhase` (`318-347`): NO change (it renders under `DataBuffer.Lock` and releases on return). | Lock released before the cache lookup. |
+| `loader.go` (e) | `mergeResult`: assign `res.response = response` right after the successful parse (`628-635`), `res.responseData` (`645-650`), and `res.responseHasErrors` (after the `hasErrors` block ~`680`), each where already computed. | Surface the data sub-path, the full response, and the error flag; no signature change (HR7). |
+| `loader.go` (f) | `mergePhase` (`360-379`): NO change (it merges under `DataBuffer.Lock` and releases on return). | `cacheMerge` runs after it, lock-free, so the splice/write session is the single acquisition. |
+| `loader.go` (g) | NEW helpers: `cacheRequest`, `cachePrepare`, `cacheMerge`, `mergeArena`. | Keep all branching out of the phase bodies. |
+| `loader.go` (h) | `loadPhase` (`349-358`): NO change. | Reuse `prepared.skipLoad` (S3 = 0 edits). |
+| `context.go` (i) | `Context` (`42-44`): add `cacheController CacheController` and `requestCache RequestCache`. | The port + the shared-state home (§6). |
+| `context.go` (j) | `SetCacheController` setter near `SetAuthorizer` (`189`). | Router wires the controller, mirroring `SetAuthorizer`. |
+| `context.go` (k) | `endCacheRequest()` method: if `requestCache != nil` call `EndRequest()` then nil it. | The single request-end lifecycle hook (§4.5). |
+| `context.go` (l) | `clone` (`283-305`): `cpy.requestCache = nil`. | A cloned resolution (subscription event, `resolve.go:1103`) gets its OWN L1 (§6.3). |
+| `context.go` (m) | `Free` (`307-322`): defensively call `endCacheRequest()`, then nil `cacheController`. | Teardown. |
+| `fetch.go` (n) | `FetchConfiguration` (`255-281`): add `Cache *FetchCacheConfig`; `EntityFetch` (`206-215`) and `BatchEntityFetch` (`166-175`): add `Cache *FetchCacheConfig`. | RFC-2 stamps config on all three concrete types (DOSSIER §6.4). |
+| `fetch.go` (o) | `FetchConfiguration.Equals` (`283-309`): the nil-safe clause of §3.8. | Plan dedup must see cache config (HR8). |
+| `resolve.go` (p) | `defer ctx.endCacheRequest()` at ALL FOUR request entry functions: `ResolveGraphQLResponse` (sync, `339`; flush at `360`), `ArenaResolveGraphQLResponse` (sync-arena, `383`; flush at `425`), `ResolveGraphQLDeferResponse` (defer root, `472`), and `executeSubscriptionUpdate` (subscription, `878`; loader at `910`/`912`). | Single request-end flush/finalize, covering BOTH sync entries (so the Arena sync path also flushes L2) and the defer-entry path (§4.5). |
+
+That is TWO behavior-touching call sites (`cachePrepare` and `cacheMerge`, both in `resolveSingle`, outside the phase locks), plus FOUR request-end lifecycle `defer`s (one per entry function), plus the setter / struct fields / lazy-init.
+Everything else is type declarations and zero-valued fields.
+
+### 4.2 Call-site / LOC budget vs OLD
+
+- OLD: ~461 cache call-sites, ~1433 inserted lines in `loader.go`, ~60 `result` cache fields (DOSSIER §1).
+- RFC-1: 2 behavior call-sites + 4 lifecycle defers (one per entry function) + 4 helpers + 1 nil-checked lazy-init.
+  Net new lines in existing files (`loader.go` / `context.go` / `fetch.go` / `resolve.go`): roughly 70-100, of which ~40 are the helper bodies.
+  The two new contract files are reviewable in isolation.
+- Reduction factor on call-sites: ~461 -> ~6, roughly two orders of magnitude.
+
+### 4.3 S1 — cache lookup after the render phase
+
+`preparePhase` and `mergePhase` are UNCHANGED: each takes `DataBuffer.Lock` for its own render / merge work and releases it on return (CURRENT `loader.go:319-320`, `361-362`).
+The cache hooks are inserted in `resolveSingle`, which orchestrates the three phases, so they run with NO loader lock held — the controller's `MergeSession` is therefore the SINGLE `DataBuffer.Lock` acquisition around its multi-op sequence (§3.4, §6.4).
+
+Before (CURRENT `loader.go:381-401`):
+
+```go
+prepared, err := l.preparePhase(item)
+// ... err / nil-prepared handling ...
+if err := l.loadPhase(ctx, prepared); err != nil {
+	return errors.WithStack(err)
+}
+return l.mergePhase(prepared)
+```
+
+After (two cache calls bracket the network, both lock-free):
+
+```go
+prepared, err := l.preparePhase(item) // renders under DataBuffer.Lock; lock released on return
+// ... err / nil-prepared handling unchanged ...
+l.cachePrepare(prepared)              // S1: lookup + coverage + decision (no-op when controller/cfg nil)
+if err := l.loadPhase(ctx, prepared); err != nil {
+	return errors.WithStack(err)
+}
+if err := l.mergePhase(prepared); err != nil {
+	return errors.WithStack(err)
+}
+return l.cacheMerge(prepared)         // S4: write / skip-splice / shadow (no-op when handle nil)
+```
+
+`cachePrepare` derives the per-fetch config from the fetch type and bails on every render-skip:
+
+```go
+// cacheRequest lazily obtains the request-lifetime working surface. The once-create
+// runs under DataBuffer.Lock so it is race-free across the parallel fetches of a
+// group and across per-defer-group Loaders, given exactly one DataBuffer per
+// request (§6.2). It does NOT hold the lock across the hook: PrepareFetch /
+// OnFetch* open their OWN MergeSession for arena work (§3.4).
+func (l *Loader) cacheRequest() RequestCache {
+	if l.ctx.cacheController == nil {
+		return nil
+	}
+	l.dataBuffer.Lock()
+	defer l.dataBuffer.Unlock()
+	if l.ctx.requestCache == nil {
+		l.ctx.requestCache = l.ctx.cacheController.BeginRequest(l.ctx)
+	}
+	return l.ctx.requestCache
+}
+
+func (l *Loader) cachePrepare(prepared *preparedFetch) {
+	if prepared == nil || prepared.skipLoad {
+		return // render already decided to skip — NOT a cache decision (see below)
+	}
+	var cfg *FetchCacheConfig
+	switch f := prepared.item.Fetch.(type) {
+	case *SingleFetch:
+		cfg = f.Cache
+	case *EntityFetch:
+		cfg = f.Cache
+	case *BatchEntityFetch:
+		cfg = f.Cache
+	}
+	if cfg == nil || (!cfg.L1 && !cfg.L2) {
+		return // zero-cost: no controller call, no key render, no lookup, no allocation
+	}
+	rc := l.cacheRequest()
+	if rc == nil {
+		return
+	}
+	_, hash := l.ctx.HeadersForSubgraphRequest(prepared.res.ds.Name) // nil-guarded wrapper (CURRENT context.go:105-111); returns (nil, 0) when no header builder is set
+	decision, handle := rc.PrepareFetch(PrepareFetchInput{
+		Ctx: l.ctx, Item: prepared.item, Items: prepared.items, Config: cfg,
+		BatchStats: prepared.res.batchStats, Input: prepared.input, HeaderHash: hash,
+		Arena: l.mergeArena(), // PrepareFetch opens ONE MergeSession from this (§3.4)
+	})
+	prepared.cacheHandle = handle
+	switch decision {
+	case DecisionSkipFullHit:
+		// Full hit: skip the network AND the merge. Setting BOTH flags reuses the
+		// existing mergeResult early-return (loader.go:620) so no spurious error is
+		// rendered, and skips the network via the existing loadPhase guard.
+		prepared.skipLoad = true
+		prepared.res.fetchSkipped = true
+	case DecisionFetchPartial:
+		// v2: send only the missed subset, then OnFetchSkipped splices the cached
+		// subset and mergeResult merges the fresh subset (§9).
+	case DecisionFetch, DecisionFetchShadow:
+		// skipLoad stays false; the handle (and h.Shadow) drives the merge.
+	}
+}
+```
+
+The `prepared.skipLoad` guard is load-bearing: every existing render-skip site sets `prepared.skipLoad` (null parent CURRENT `loader.go:1451`, render error `1461`, auth/rate-limit reject `1470`, skip-null/empty item `1507/1519/1529`, trace-mode skips `1547/1726`, empty batch `1701`), so the cache lookup never runs for a fetch the loader already decided to skip.
+Those sites set `res.fetchSkipped` for the trace branches at `loader.go:1545` and `1724` inside `preparePhase`, which runs (and returns) strictly before `cachePrepare`, so our `cachePrepare` (which may set `res.fetchSkipped` for a full hit) runs after them and cannot corrupt the `LoadSkipped` trace.
+
+Full-hit modelling — why both flags, grafted from draft A and verified.
+Setting `res.fetchSkipped = true` makes `mergeResult` return `nil` at its existing guard `if res.fetchSkipped { return nil }` (CURRENT `loader.go:620-622`), WITHOUT falling through to `len(res.out) == 0` at `623` and rendering `renderErrorsFailedToFetch(emptyGraphQLResponse)` at `624`.
+This is the one-line fix for the blocking skip-path bug a reviewer found in the typed-explicit base (which set only `skipLoad`): on a full hit `res.out` is empty, so without `res.fetchSkipped` every cache hit would render a spurious error.
+Setting `skipLoad` (already required) makes `loadPhase` early-return (CURRENT `loader.go:350`).
+The cached, already-reordered values are then spliced by `OnFetchSkipped` (§4.4), so no synthetic bytes are produced and no re-parse happens.
+
+### 4.4 S4 — `mergeResult` carrier + `cacheMerge` (write / splice / shadow)
+
+`mergeResult` stashes the values it already computes onto `res` (no signature change, HR7, §7).
+Placement is exact so both fields are set before every null-data early return that a write path cares about:
+
+```go
+// CURRENT loader.go:628-635, immediately after the parse succeeds (and BEFORE
+// every subsequent early return), one free pointer assignment of the full response:
+res.response = response // NEW — the input isEmptyEntityFetch needs (it does response.Get("data","_entities"))
+// CURRENT loader.go:645-650, after responseData is computed:
+res.responseData = responseData // NEW
+// ... after the hasErrors block (CURRENT loader.go:652-680), before the
+// null-data branch at 683 and the isEmptyEntityFetch early-return at 686-688:
+res.responseHasErrors = hasErrors // NEW
+```
+
+`res.response` is assigned right after `astjson.ParseBytesWithArena` returns successfully (CURRENT `loader.go:628`), so it is the EXACT value `isEmptyEntityFetch` consumes (`response.Get("data","_entities")`, CURRENT `loader.go:686/788-799`), and it is nil on every pre-parse failure path (`res.err` at `601`, empty `res.out` at `623`, parse error at `628-635`), which is precisely the `FetchFailed`/`ResponseData == nil` signal the write gate keys off (§3.3).
+All three assignments are dead weight when caching is off (written, never read), preserving the no-op guarantee (§10.2); none changes control flow.
+
+`mergePhase` is UNCHANGED: it runs `mergeResult` then `callOnFinished` under `DataBuffer.Lock` and returns, releasing the lock.
+`resolveSingle` then calls `cacheMerge` (§4.3) with the lock free, so `OnFetchSkipped` / `OnFetchResult` open their OWN `MergeSession` for the splice / write (§3.4):
+
+```go
+func (l *Loader) cacheMerge(prepared *preparedFetch) error {
+	h := prepared.cacheHandle
+	if h == nil {
+		return nil // controller nil, or this fetch not cached
+	}
+	res := prepared.res
+	in := MergeInput{
+		Item: prepared.item, Items: prepared.items,
+		ResponseData: res.responseData, BatchStats: res.batchStats,
+		HasErrors:   res.responseHasErrors,
+		FetchFailed: res.err != nil || len(res.out) == 0 || res.response == nil, // transport/empty/parse failure (§3.3)
+		StatusCode:  res.statusCode, Arena: l.mergeArena(), // OnFetch* opens ONE MergeSession from this
+	}
+	if res.response != nil {
+		// Only meaningful (and only nil-safe) when a response actually parsed;
+		// on a full-hit skip res.response is nil and EmptyEntity is irrelevant
+		// because cacheMerge dispatches to OnFetchSkipped, which ignores it.
+		in.EmptyEntity = isEmptyEntityFetch(prepared.item, res.response)
+	}
+	rc := l.cacheRequest() // already created during cachePrepare; non-nil because h != nil
+	switch h.Decision {
+	case DecisionSkipFullHit, DecisionFetchPartial:
+		return rc.OnFetchSkipped(h, in)
+	default: // DecisionFetch, DecisionFetchShadow
+		return rc.OnFetchResult(h, in)
+	}
+}
+```
+
+The merge hook is gated only on `prepared.cacheHandle != nil`, so it never fires for fetches the controller did not touch (auth/null-parent skips never produced a handle, because `cachePrepare` is gated on `!prepared.skipLoad`).
+On a full hit, `mergePhase` returned with `mergeResult` having early-returned `nil` (fetchSkipped) and `callOnFinished` a no-op (the cache hit set no `loaderHookContext`, §4.7), so `cacheMerge` dispatches to `OnFetchSkipped`, which opens a `MergeSession` and splices each `ItemCacheState.FromCache` (already reordered to selection order in `PrepareFetch`) into `ItemCacheState.Item`, and may emit best-effort multi-key backfill / refresh L2 writes when `MustWriteBack`.
+On a real fetch, `cacheMerge` dispatches to `OnFetchResult`, which applies the full write gate `!in.FetchFailed && !in.HasErrors && in.ResponseData != nil && in.ResponseData.Type() != astjson.TypeNull` (§3.3) before persisting anything, does negative-hit detection (driven by `EmptyEntity`, the ONE non-failure that still writes a sentinel), re-renders the still-unrendered candidate keys (`ItemCacheState.PendingCandidates`) from the fresh data and writes ALL renderable keys to L1/L2 (or defers, §2.2), and — when `h.Shadow` — runs `CompareShadow` before the writes.
+The gate cannot be reduced to `!HasErrors`: a transport, empty-body, or parse failure reaches `OnFetchResult` with `HasErrors == false` (because `responseHasErrors` is assigned only at ~`loader.go:680`, after those early returns) and `ResponseData == nil`, so `FetchFailed` (equivalently `ResponseData == nil`) is the load-bearing signal that stops a failed fetch from being cached (the reviewer's blocking write-gate bug).
+
+### 4.5 S6 — request-end flush via `EndRequest` (and why this covers every root)
+
+The reviewers showed that wiring the flush into `LoadGraphQLResponseData` (as two of the drafts did) MISSES the defer paths: the defer-entry loader fetches via `loader.ResolveFetchNode(response.Response.Fetches)` (CURRENT `resolve.go:510`), and each defer group via `groupLoader.ResolveFetchNode(group.Fetches)` (CURRENT `resolve.go:615`), neither of which calls `LoadGraphQLResponseData`.
+
+RFC-1 instead folds the flush into `EndRequest`, called once per request via `defer ctx.endCacheRequest()` at ALL FOUR request entry functions (two sync, one defer, one subscription):
+
+- sync: `ResolveGraphQLResponse` (CURRENT `resolve.go:339`, calls `LoadGraphQLResponseData` at `362`) AND `ArenaResolveGraphQLResponse` (CURRENT `resolve.go:383`, calls `LoadGraphQLResponseData` at `425`) — both sync entries get the defer, so the arena sync path also flushes L2;
+- defer: `ResolveGraphQLDeferResponse` (CURRENT `resolve.go:472`), so the flush runs after `resolveDeferTree` returns (called at CURRENT `resolve.go:570`), i.e. after the parallel `g.Wait()` inside `resolveDeferTree` (CURRENT `resolve.go:715`), single-threaded;
+- subscription: `executeSubscriptionUpdate` (CURRENT `resolve.go:878`; loader at `910`, `LoadGraphQLResponseData` at `912`).
+
+`ctx.endCacheRequest()` no-ops when `requestCache` is nil, so it is free when caching was never used.
+Because the request-lifetime surface is shared by reference across all groups (§6), one `EndRequest` flushes the deferred L2 writes contributed by the initial fetch AND every defer group.
+
+Justification for deferring the flush to request end (a reviewer must-fix).
+The deferred L2 write set holds BYTES, marshaled inside `OnFetchResult` under the lock, so `Flush`/`EndRequest` needs no arena and no lock (§6.4).
+L2 writes are a side effect that populates the cache for FUTURE requests; they are not part of the current response, which for incremental delivery is already on the wire (the initial frame is flushed at CURRENT `resolve.go:536`).
+So persisting them at request end is correct and simplest.
+A per-defer-group early flush (to make L2 visible sooner) is a v2 option (§9); it would add one `Flush` call after each group's render but does not change correctness.
+
+### 4.6 What does NOT change
+
+- `loadPhase` (CURRENT `loader.go:349-358`): zero change; full hits already early-return via `skipLoad`, and the off-lock phase never touches cache state (S3 budget = 0).
+- `mergeResult` control flow: zero new branches; only the three additive carrier assignments of §4.4 (`res.response`, `res.responseData`, `res.responseHasErrors`) and the reused `fetchSkipped` early-return.
+- The batch dedup loop (CURRENT `loader.go:1645-1693`) and the `len(batchStats) == len(batch)` assertion (`743`): zero change in v1 (full-batch); partial-batch makes the loop cache-aware later (§9).
+- The nested-merge branch (CURRENT `loader.go:366-374`): zero change; not hooked in v1, and proven safe (§4.7).
+- `preparePhase` / `mergePhase` bodies: zero change; the cache hooks run in `resolveSingle` after each phase returns (§4.3), so the phase lock scopes only the render / merge, never the cache work.
+- `NewLoader` signature: unchanged; the shared surface lives on `Context` (`requestCache`) and is created lazily inside `cacheRequest` under the lock, so the 5 `NewLoader` call sites (CURRENT `resolve.go:359/422/504/612/910`) are untouched.
+
+### 4.7 Three correctness invariants, with proof
+
+These are the reviewer-flagged correctness risks; each is resolved against verified CURRENT code, not hand-waved.
+
+1. Skip-path spurious error (blocking).
+   Resolved by setting `res.fetchSkipped = true` together with `prepared.skipLoad` on `DecisionSkipFullHit` (§4.3), which hits the existing early-return at CURRENT `loader.go:620-622` and never reaches the empty-response error at `623-624`.
+
+2. Nested-merge gap.
+   `res.nestedMergeItems` is declared and read in `mergePhase` (CURRENT `loader.go:115`, `366-369`) but is NEVER assigned anywhere in the repository (verified: a repo-wide search for any assignment to `nestedMergeItems` returns nothing).
+   It is a forward-looking, currently-dead field on the defer branch.
+   Therefore no cached fetch can ever land on the nested-merge branch in v1, so leaving it unhooked is correct, not a silent data risk.
+   Forward guard: when a future change begins populating `nestedMergeItems`, the cache hook must be added INSIDE that loop with per-nested-item handle binding (a distinct `FetchCacheHandle` per nested item), NOT by reusing one whole-fetch handle across each nested item; this RFC records that requirement so the gap cannot be reintroduced silently.
+
+3. OnLoad / OnFinished invariant.
+   On `DecisionSkipFullHit`, `loadPhase` is skipped, so `executeSourceLoad` never runs, so `res.loaderHookContext` stays nil (it is set only at CURRENT `loader.go:2072-2079`, inside `executeSourceLoad`).
+   `callOnFinished` is guarded by `res.loaderHookContext != nil` (CURRENT `loader.go:453`), so a cache hit does NOT fire `OnFinished` — which is exactly the documented contract: `OnFinished` is called only when `OnLoad` was (CURRENT `loader.go:45-47`).
+   No extra guard is needed; a cache hit behaves like every other skip (auth reject, null parent) with respect to LoaderHooks.
+
+---
+
+## 5. The four modes plus shadow ride the SAME interface
+
+The mode is controller-internal config, invisible to `loader.go` (DOSSIER §3.5).
+Shadow is not a fifth mode but a cross-cutting variant of any L2-enabled mode.
+
+| Mode | `PrepareFetch` returns | `OnFetchResult` / `OnFetchSkipped` | `EndRequest` |
+|---|---|---|---|
+| NO-OP | `DecisionFetch, nil` (no key render, no lookup, no handle) | not called (handle nil) | nothing |
+| L1-only | render L1 key, coverage-walk the shared L1 map; all covered -> `SkipFullHit` | `OnFetchResult`: write normalized entities to shared L1; `OnFetchSkipped`: splice from L1 | nothing |
+| L2-only | render every renderable candidate key, `Get` under ALL of them, multi-candidate select + reorder; all covered -> `SkipFullHit` (+ `MustWriteBack` when a candidate was unrenderable/absent or the value was synthesized) | `OnFetchResult`: re-render pending candidates from fresh data, `Set` all renderable keys or defer; `OnFetchSkipped`: splice + multi-key backfill/refresh | flush deferred Sets, one per cache instance |
+| L1+L2 | render both; L1 -> L2 -> subgraph order, coverage at each layer | write L1 + L2; splice + writeback | flush L2 |
+| + shadow (L2 variant) | L2 read + stash into `ShadowStash`, return `DecisionFetchShadow` (skipLoad stays false) | `OnFetchResult`: `CompareShadow` (compare -> write-L1 -> write-L2) | flush L2 (fresh) |
+
+The no-op guarantee is structural, not configured (HR2): when `cacheController` is nil the loader never enters cache code, never allocates a handle, never touches a map, never builds the arena facade.
+A NO-OP or L1-only controller never produces a `DecisionFetchShadow`, so that case is invisible to those modes.
+`DecisionSkipFullHit` is the AND-reduction of the per-item coverage walk (DOSSIER §2.10), not a single per-fetch lookup; one uncovered item degrades to `DecisionFetchPartial` (partial mode) or `DecisionFetch` (all-or-nothing).
+
+### 5.1 Capability coverage (HR3 a-i)
+
+- (a) Pre-fetch lookup + best-effort multi-key render + runtime `ProvidesData` coverage validation + multi-candidate freshness selection + reorder-before-merge (DOSSIER §2.10): entirely inside `PrepareFetch`, driven by `cfg.KeySpec.Candidates` + `cfg.ProvidesData`; it renders every candidate key it can (the renderable subset into `ItemCacheState.RenderedKeys`, the rest into `PendingCandidates`), looks the cache up under all rendered keys, then the candidate-collect -> freshness-sort -> coverage-validate -> reorder walk runs through the `MergeSession` and writes the per-item `ItemCacheState`. Always-on, gated only by `cfg.ProvidesData != nil`, not by partial mode.
+- (b) Shadow via the `FetchShadow` decision (DOSSIER §2.11): `DecisionFetchShadow` + `handle.Shadow` + `handle.ShadowStash`; `CacheObserver.CompareShadow` in `OnFetchResult` before the writes; entity-fetch-only comparison, root-field force-refetch only (the OLD asymmetry).
+- (c) Post-fetch write as best-effort multi-key render-then-backfill (DOSSIER §2.2): `OnFetchResult` (real fetch) and `OnFetchSkipped` (hit that still writes back via `MustWriteBack`) re-render the candidate keys that were unrenderable at lookup (`ItemCacheState.PendingCandidates`) from the fresh data and, if more keys are now renderable, populate the cache for ALL renderable keys (otherwise just the `RenderedKeys` from lookup); `ItemCacheState.{RenderedKeys,PendingCandidates,NeedsWriteback,WriteReason}` carry the contract. This generalizes and replaces the OLD requested-vs-rendered-key + missing-key-set framing.
+- (d) Negative caching (DOSSIER §2.6): `ItemCacheState.{NegativeHit, FromCache=TypeNull}`; `MergeInput` surfaces ALL FIVE §2.6 failure signals — `FetchFailed` (transport/empty/parse, the two the prior draft dropped + parse), `HasErrors`, `EmptyEntity`, `StatusCode`, and `ResponseData == nil` — so `OnFetchResult` reproduces the OLD null detection AND correctly distinguishes a successful-but-empty entity fetch (negative write) from a transport/empty/parse failure (no write at all, §3.3); the loader's `setSkipErrors`/`isEmptyEntityFetch` paths are untouched.
+- (e) Partial / batch splice-merge: the loader SEAM exists in v1 (`DecisionFetchPartial`, `MergeInput.BatchStats` in both hooks, `ItemCacheState.BatchIndex`); the realign + dedup-loop rewrite is staged to v2 (§9).
+- (f) End-of-tree batched L2 flush (DOSSIER §2.2): `EndRequest` (§4.5).
+- (g) Analytics / trace observer (DOSSIER §2.7): the `CacheObserver` port (§3.5); v1 ships it nil (no-op), v2 wires the walker hooks.
+- (h) Per-request shared L1 (request-lifetime cache state) visible across per-defer-group Loaders: the `RequestCache` lives on the by-reference-shared `Context` (§6).
+- (i) Lifecycle (begin/end request): `CacheController.BeginRequest` (lazy, once) and `RequestCache.EndRequest` (once, after the whole tree).
+
+---
+
+## 6. Thread-safety under defer
+
+### 6.1 The constraints (DOSSIER §2.8, §7 risks 1/2/7)
+
+- The Loader is per-defer-group: `resolveDeferSingle` builds a fresh `NewLoader` per group (CURRENT `resolve.go:612`); the initial loader is separate (`resolve.go:504`); they share only the request `DataBuffer` and `arena`.
+- There is exactly ONE `DataBuffer` per request; its `Lock()` serializes every prepare and merge across the initial tree and every defer group.
+- The `jsonArena` is shared across groups and serialized ONLY by `DataBuffer.Lock` (CURRENT `resolve.go:607-611`); off-lock arena use is a data race.
+
+### 6.2 Where the shared state hangs and how it is created
+
+The request-lifetime shared cache state — the `RequestCache`, owning the per-request L1 entity store, the mutation-inheritance flags, the analytics accumulator, and the deferred L2 write set — lives on `Context`, in the unexported `requestCache` field, NOT on any per-group Loader.
+It exists for the lifetime of ONE request and is shared by reference across that request's per-defer-group Loaders.
+
+This per-request L1 store is intrinsic to L1 caching (it is how the L1 store survives across defer groups, the final implementation phase) and has NOTHING to do with the OLD `@requestScoped` directive feature: that directive (and its `requestScopedL1` map, `RequestScopedFieldPolicy`/`RequestScopedFieldConfig` types, pre-planning widening rewrite, and inject/export hooks) is OUT OF SCOPE and removed entirely from both RFCs; only the request-lifetime sharing of the L1 store is retained, renamed away from "request scoped" to avoid confusion.
+
+| Shared request-lifetime cache state | Lives on | Guard |
+|---|---|---|
+| L1 entity store (OLD `loader.go:349`) | `RequestCache` on `Context` | `DataBuffer.Lock` |
+| mutation populate-inheritance flags (OLD `loader.go:215/219`) | `RequestCache` on `Context` | `DataBuffer.Lock` |
+| analytics accumulator (OLD `context.go:55`) | `RequestCache` on `Context` | `DataBuffer.Lock` (accumulate) / single-thread (finalize) |
+| deferred L2 write set (OLD `loader.go:677`) | `RequestCache` on `Context` | `DataBuffer.Lock` (append) / single-thread (flush) |
+
+`Context` is shared by reference across defer groups — the parallel defer branch does NOT clone the Context, its only defer-time mutation (`ctx.subgraphErrors`) being written exclusively under `dc.db.Lock()` (verified comment CURRENT `resolve.go:698-704`).
+So L1 populated by one group is visible to groups scheduled after it (HR3-h).
+
+`requestCache` is created lazily, ONCE, under `DataBuffer.Lock`, inside `cacheRequest` (called from `cachePrepare` in `resolveSingle`, §4.3).
+`cacheRequest` takes `DataBuffer.Lock` for just the once-create read-and-set of `ctx.requestCache`, so the lazy `BeginRequest` is race-free across the parallel fetches of a group and across per-defer-group Loaders, with no extra mutex and no `NewLoader` signature change.
+This correctness depends on there being exactly one `DataBuffer` per request, which is verified (CURRENT `resolve.go:503/612` both pass the same `db`); if a future change introduced a second `DataBuffer` per request, the lazy-init would need a dedicated mutex.
+
+### 6.3 Subscription isolation
+
+`Context.clone` (CURRENT `context.go:283-305`, used for the subscription-event re-resolve at CURRENT `resolve.go:1103`) sets `cpy.requestCache = nil`, so a genuinely separate resolution builds its own L1 — correct isolation across subscription events.
+The `cacheController` port is copied by value (`cpy := *c`), so the clone still has caching available; only the per-request mutable surface is reset.
+Subscription cache wiring (the trigger lifecycle, invalidation) is itself v2 (§9); RFC-1 fixes only the clone seam so events cannot share L1 once subscription caching lands.
+
+### 6.4 How it is lock-guarded, and the off-lock rule
+
+- `PrepareFetch`, `OnFetchSkipped`, `OnFetchResult` run from `resolveSingle` with NO loader lock held, and EACH opens ONE `MergeSession` via `MergeArena.Begin()` (which takes `DataBuffer.Lock`) for its whole arena sequence, releasing it with `Close()` (§3.4).
+  So all mutation of the shared maps, all arena allocation, and all candidate parse / merge-synthesis / reorder happen under the session's single `DataBuffer.Lock` hold; the controller needs no internal lock for its request-lifetime state.
+  The session is a SCOPED lock taken ONCE around the multi-op sequence, not re-acquired per arena op — that is the contention reduction the scoped facade buys (§3.4).
+- The off-lock `loadPhase` never touches the controller, the maps, or the arena; the only thing caching contributes to it is the `skipLoad` bool set during prepare. Opening a `MergeSession` from `loadPhase` is forbidden (DOSSIER §7 risk 7).
+- A `MergeArena`/`MergeSession` is handed to the controller only for the duration of one hook; the controller must not retain it past the call, and every arena op is a `MergeSession` method so there is no way to touch the arena outside a held session.
+  v1 does the L2 `Get` inside `PrepareFetch`'s session (matching the dossier's "splice under lock", DOSSIER §2.1); moving the L2 read off-lock is a v2 optimization that would do the network `Get` BEFORE `Begin()` and parse into the arena only inside the session (DOSSIER §7 risk 7) — the same `Begin()`/`Close()` API, still one acquisition.
+- The GC-arena hazard (a heap `*Value` stored inside arena-noscan memory, CURRENT `loader.go:218-227`) is avoided because every cached `*Value` stored in arena containers is produced via `MergeSession.ParseBytes`/`StructuralCopy`, exactly as the OLD `populateL1Cache` did on the main thread.
+- `EndRequest` runs single-threaded after the whole tree resolves (§4.5); the deferred L2 write set holds bytes, so the flush needs neither lock nor arena.
+
+---
+
+## 7. Self-contained caching configuration
+
+### 7.1 Module boundary (HR8)
+
+- A NEW package `v2/pkg/engine/resolve/cache` holds ALL implementation: the controller implementations (NO-OP is a nil controller; plus L1 / L2 / L1+L2), the `CacheKeyTemplate` and the two OLD templates, the `CacheKeyVariableRenderer`, the transform pipeline (OLD `loader_cache_transform.go`), candidate selection / coverage validation / reorder, analytics (OLD `cache_analytics.go`), the dormant `circuit_breaker.go`, and subscription/trigger cache (OLD `trigger_cache.go`).
+  It imports `resolve`; `resolve` never imports it (no cycle).
+- `resolve` keeps ONLY: the contract types (§3, two new files), the opaque `cacheHandle` slot on `preparedFetch`, the `Cache *FetchCacheConfig` slot on the three fetch structs, the `cacheController`/`requestCache` fields on `Context`, and the four glue helpers in `loader.go`.
+  No cache LOGIC lives in `resolve`.
+- On the defer branch the OLD cache files were already deleted (DOSSIER §7 risk 8), so this is greenfield: the cache package is purely additive, there is no literal file move of runtime code, only a clean re-home of the logic from the OLD branch.
+
+Why `FetchConfiguration.Equals` forces `FetchCacheConfig.Equals` (HR8): plan dedup deep-compares fetch configs (CURRENT `fetch.go:283-309`, DOSSIER §7 risk 11).
+If two otherwise-identical fetches differ only in cache policy, they must not dedup to one (silent policy loss), and two identical fetches with equal-but-distinct config instances must still dedup (a dedup miss otherwise).
+So the config exposes a concrete, compile-checked `Equals(*FetchCacheConfig) bool`, called via the nil-safe clause of §3.8.
+The runtime HANDLE (§3.7) needs no `Equals`: it is per-execution, never part of a cached plan.
+
+### 7.2 The plan-side policy model (parallel to FederationMetaData)
+
+This is the dossier §5.4 model, defined as its OWN types in a `cacheconfig` (plan-side) package, never inside `FederationMetaData`:
+
+```go
+type CachingConfiguration struct { // sibling of FederationMetaData on the DataSource config, subgraph-local
+	Entities      []EntityCachePolicy
+	RootFields    []RootFieldCachePolicy
+	Mutations     []MutationCachePolicy
+	Subscriptions []SubscriptionCachePolicy
+	KeySpecs      []CacheKeySpec // frozen multi-key specs (candidate key templates) from @key at plan time
+}
+
+type EntityCachePolicy struct {
+	TypeName, CacheName         string
+	TTL, NegativeCacheTTL       time.Duration
+	IncludeSubgraphHeaderPrefix bool
+	EnablePartialCacheLoad      bool
+	HashAnalyticsKeys           bool
+	ShadowMode                  bool
+}
+type RootFieldCachePolicy struct {
+	TypeName, FieldName, CacheName string
+	TTL                            time.Duration
+	IncludeSubgraphHeaderPrefix    bool
+	ShadowMode, PartialBatchLoad   bool
+}
+type MutationCachePolicy struct {
+	FieldName              string
+	Invalidate, PopulateL2 bool
+	TTLOverride            time.Duration
+}
+type SubscriptionCachePolicy struct {
+	TypeName, FieldName, CacheName string
+	TTL                            time.Duration
+	IncludeSubgraphHeaderPrefix    bool
+	EnableInvalidationOnKeyOnly    bool
+}
+```
+
+### 7.3 The `CacheConfigProvider` port
+
+```go
+// CacheConfigProvider exposes caching policy WITHOUT touching the FederationInfo
+// interface. A datasource config returns nil when caching is not configured, so a
+// NO-OP build never constructs any caching type (DOSSIER §5.5). It replaces the 4
+// caching methods the OLD branch bolted onto FederationInfo (DOSSIER §5.1).
+type CacheConfigProvider interface {
+	EntityPolicy(typeName string) (EntityCachePolicy, bool)
+	RootFieldPolicy(typeName, fieldName string) (RootFieldCachePolicy, bool)
+	MutationPolicy(fieldName string) (MutationCachePolicy, bool)
+	SubscriptionPolicy(typeName, fieldName string) (SubscriptionCachePolicy, bool)
+	KeySpec(scope CacheScope, typeName, fieldName string) (CacheKeySpec, bool)
+}
+
+// New accessor on the datasource config, parallel to (not on) FederationInfo:
+//   func (d dataSourceConfiguration[T]) Caching() CacheConfigProvider // nil => no caching
+```
+
+### 7.4 The federation boundary, explicitly
+
+```
+FederationMetaData.Keys (@key selection sets) + interfaceObject/entityInterface remaps + EntityKeyMapping
+        │  PLAN-TIME INPUT ONLY (read once, by value, by RFC-2)
+        ▼
+CacheKeySpec  (frozen: Scope, TypeName, FieldName, Candidates []CacheKeyCandidate (each a *Object Representation with __typename remap baked in), EntityKeyMappings)
+        │  packed into
+        ▼
+resolve.FetchCacheConfig  (federation-free runtime config; imports NO federation types)
+        │  carried on the fetch structs, consumed by the controller
+        ▼
+loader.go  (forward-only; never reads a field)
+```
+
+- KEY-DERIVATION coupling is legitimate and plan-time only: `@key` selection sets, entity membership (`HasEntity`), interfaceObject/entityInterface `__typename` remaps, and root-arg <-> `@key` mappings are read ONCE by RFC-2 and frozen into `CacheKeySpec` (DOSSIER §5.3).
+- POLICY coupling is removed: no `fedConfig.EntityCacheConfig`/`RootFieldCacheConfig` lookups at decision time; policy comes from `CacheConfigProvider` only.
+- The RUNTIME side (`FetchCacheConfig`, the loader, the controller) imports NO federation type; `@key` reaches the runtime only as the already-frozen `CacheKeySpec` inside `FetchCacheConfig`.
+- The cache package builds ONE `CacheKeyTemplate` per candidate in `CacheKeySpec.Candidates`; each template is the sole source of truth for read, write, and invalidate of THAT candidate key, enforcing the byte-identical-keys invariant (DOSSIER §2.3) across the best-effort multi-key lookup and backfill.
+
+The OLD runtime contract `resolve.FetchCacheConfiguration` was ALREADY federation-free (DOSSIER §5.2), so the decoupling is a plan-time refactor — the runtime never imported federation in the first place.
+
+### 7.5 Migration note for external config producers (HR9)
+
+Today cosmo populates caching fields ON `FederationMetaData`, and caching rides the `FederationInfo` interface plus `dataSourceConfiguration[T]` forwarders (DOSSIER §5.1, §5.5).
+On THIS branch those fields no longer exist: defer already removed the per-fetch `Caching`, `FetchInfo.ProvidesData`, `ExecutionOptions.Caching`, and the `FederationMetaData` caching collections (DOSSIER §7 risk 8) — so there is nothing to be backward-compatible WITH on the engine types, which makes the migration cleaner.
+
+Recommended path:
+
+- Provide a one-release compatibility shim in the plan layer, `cacheconfig.FromFederation(...) CachingConfiguration`, that reads cosmo's existing caching source-of-truth and produces the new `CachingConfiguration`, so existing cosmo deployments keep working unchanged.
+- In parallel, migrate cosmo's config producer to populate `CachingConfiguration` directly and to return a real provider from `dataSourceConfiguration[T].Caching()`.
+- Once cosmo is migrated, drop the shim.
+- Preserve the behavior-critical rules during translation (DOSSIER §5.5): `RootFieldCachePolicy`'s all-root-fields-share-identical-policy-or-L2-disabled rule; the dual mutation-populate semantics (`EnableEntityL2CachePopulation` reused for single-subgraph populate); and that a true NO-OP now needs the structural gate (§10), which the OLD `DisableEntityCaching` lacked (it only disabled L2 while still building L1 and key templates).
+- Because both gates default OFF (§10), cosmo can ship the engine upgrade with no controller set first (pure no-op), then wire `SetCacheController` and populate `CachingConfiguration` in a later, isolated change.
+
+This is primarily RFC-2's responsibility; RFC-1 fixes the boundary so the migration is a plan-time refactor, never a runtime one.
+
+---
+
+## 8. The OUTPUT contract for RFC-2
+
+RFC-2 (the caching planner pass) MUST satisfy exactly this loader-side contract.
+If it does, the loader integration in this RFC consumes its output with zero further loader edits.
+
+1. Per concrete fetch type (`*SingleFetch`, `*EntityFetch`, `*BatchEntityFetch`), stamp a fully-populated `*resolve.FetchCacheConfig` (§3.6) onto the fetch's `Cache` field, running AFTER `createConcreteSingleFetchTypes` so all three carry it (DOSSIER §6.4).
+   A nil `Cache` means caching off for that fetch and is the gate of §10.
+2. Self-contained AND multi-key: `FetchCacheConfig` and its `CacheKeySpec` contain NO federation types or pointers into `FederationMetaData`; ALL of an entity's `@key` sets are read once and frozen by value into `CacheKeySpec.Candidates` as a LIST of candidate key templates, NONE marked required (each is best-effort renderable at runtime, §3.6); a single-key entity simply yields a one-element list (§7.4, DOSSIER §6.5).
+3. Carry the full runtime payload the controller needs: the L1/L2 enable flags, `CacheName`, `TTL`, `NegativeCacheTTL`, `IncludeSubgraphHeaderPrefix`, `EnablePartialCacheLoad`, `PartialBatchLoad`, `ShadowMode`, `HashAnalyticsKeys`; the frozen `CacheKeySpec` (the list of `Candidates []CacheKeyCandidate`, each carrying a `*Object` Representation with the `__typename` remap baked in — the multiple @key sets, none required — plus `EntityKeyMappings`); the mutation `PopulateL2OnMutation`/`MutationTTLOverride`; and the fetch-level `ProvidesData *Object` consumed at RUNTIME by the coverage walk (DOSSIER §2.10), packed into the config rather than re-added as a `FetchInfo` field.
+4. `Equals`-stable: two fetches with differing cache config must produce `FetchCacheConfig` values that `Equals` distinguishes (§3.8), or plan dedup corrupts cache behavior (§7.1).
+5. Request-independent: the postprocessed plan is cached and reused across requests (CURRENT `execution_engine.go:304-305`); write only static config, and derive all per-request key material (variable values, header hash, global prefix) at loader prepare time inside `PrepareFetch`, not baked in.
+6. Walk EVERY fetch tree (root + each defer group), respecting `DeferID` as fetch identity (`EqualSingleFetch` guard CURRENT `fetch.go:50-53`).
+7. Gate off entirely when caching is NO-OP (the pass does not run, or stamps nil), composing with RFC-1's runtime nil-check (§10).
+8. Provide the plan-side `CacheConfigProvider` (§7.3) as the policy source, decoupled from `FederationInfo`/`dataSourceConfiguration[T]`.
+
+RFC-2's own structure (one additive `FetchTreeProcessor` after `createConcreteSingleFetchTypes`, plus keeping `optimize_l1_cache.go`) is specified in DOSSIER §6 and is out of scope here.
+The OLD `@requestScoped` directive feature (and its pre-planning widening rewrite) is OUT OF SCOPE for both RFCs and is not part of this contract.
+
+---
+
+## 9. v1 vs v2 staging
+
+| Capability | v1 | v2 |
+|---|---|---|
+| NO-OP / L1-only / L2-only / L1+L2 full-response + full-batch caching | yes | — |
+| Per-item coverage + multi-candidate freshness + reorder (DOSSIER §2.10) | yes (always-on, runs inside `PrepareFetch`, gated only by `ProvidesData != nil`) | — |
+| Full-hit splice + best-effort multi-key render-then-backfill / refresh | yes | — |
+| Negative caching | yes | — |
+| Shadow mode | yes (entity-fetch compare; root-field force-refetch only, the OLD asymmetry) | — |
+| End-of-tree batched L2 flush | yes (`EndRequest`) | — |
+| Per-request shared L1 (request-lifetime state) across defer groups | yes | — |
+| Analytics / trace | `CacheObserver` port present, nil (no-op) | full accumulators + walker `OnEntity`/`OnFieldValue` hooks |
+| Partial L1 entity caching | SEAM only (`DecisionFetchPartial`) | impl: cache-aware dedup loop (CURRENT `loader.go:1645-1693`) + response realign |
+| Partial batch load | SEAM only (`ItemCacheState.BatchIndex`, `MergeInput.BatchStats`) | impl: filtered variables + realign (OLD `caching.go:299`, `loader_cache.go:1591`) |
+| Nested-merge (`res.nestedMergeItems`) cache interplay | not hooked (proven dead, §4.7) | hook with per-nested-item handle binding, IF a writer is introduced |
+| Subscription / mutation invalidation | out (clone seam fixed, §6.3) | trigger `OnTriggerInit`/`OnTriggerEvent` hook + `EntityCachePopulation` plan annotation |
+
+Critical staging note (DOSSIER §2.4 caveat, OQ 1): "full-batch needs zero loop change" is true ONLY of the loader's dedup/realign loop and the variable-filter path.
+Hit determination is per-item even for full-batch: the controller's candidate-collect -> freshness-sort -> coverage-validate -> reorder walk ships in v1 regardless, and its AND-reduction yields `DecisionSkipFullHit`.
+Staging only defers the realign / variable-filter seam.
+
+Partial seam fidelity (a reviewer must-fix): when `DecisionFetchPartial` is implemented in v2, BOTH the fresh-fetch merge (`mergeResult` over the filtered response) AND the cached-subset splice (`OnFetchSkipped`-style) occur — it is not splice-only.
+
+---
+
+## 10. NO-OP gating (HR10)
+
+### 10.1 Two independent gates compose
+
+| | planner NO-OP (every `Cache` nil) | planner ON (configs stamped) |
+|---|---|---|
+| runtime NO-OP (`cacheController == nil`) | nothing happens (the common default) | configs present but never consulted -> NO-OP |
+| runtime ON (controller set) | controller present but `PrepareFetch` never called (cfg nil) -> NO-OP | caching active |
+
+1. Runtime gate (RFC-1): `l.ctx.cacheController == nil` ⇒ `cacheRequest` returns nil ⇒ both call sites skip ⇒ the loader path is byte-identical to today, with no key render, no lookup, no handle allocation.
+2. Per-fetch gate (RFC-1 + RFC-2): `item.Fetch.Cache == nil` (or `!L1 && !L2`) ⇒ `cachePrepare` returns before calling `PrepareFetch`, even when a controller is present.
+3. Planner gate (RFC-2): if the post-pass does not run, every fetch's `Cache` stays nil.
+
+The lower of the two gates always wins, and the lowest is NO-OP, so "L1-only runtime + NO-OP planner" or "configs stamped + no controller" both degrade to a full NO-OP by construction.
+A real cache requires BOTH a non-nil controller AND a non-nil per-fetch config.
+There is no third place caching can switch on: the loader's only knowledge of caching is the two hook calls plus the request-end flush, all guarded by these gates.
+This is the gate the OLD branch lacked: `DisableEntityCaching` only disabled L2 while still building L1 and key templates (DOSSIER §5.5).
+
+### 10.2 The commit is a strict no-op before any cache exists
+
+With no `SetCacheController` call, `l.ctx.cacheController` is nil everywhere, every `Cache` field is nil, and the `FetchConfiguration.Equals` clause sees both-nil and returns its prior result.
+The three additive `result` fields (`response`, `responseData`, `responseHasErrors`) are written by `mergeResult` but never read.
+The `preparedFetch.cacheHandle` field stays nil.
+The contract types compile standalone (they reference only `resolve` types plus `astjson`/`time`/`arena`).
+Therefore merging RFC-1's commit ALONE — before any `cache`-package implementation exists — changes runtime behavior in ZERO ways (G8).
+
+---
+
+## 11. Risks and open questions
+
+Carried from DOSSIER §7/§8, with how this design addresses each:
+
+- Risk 1 (pipeline gone / thread-safety inverted): designed against the 3 phases, never ported (§2.2, §4).
+- Risk 2 (per-group Loader / L1 lifecycle): one `RequestCache` on the by-reference-shared `Context`, guarded by `DataBuffer.Lock` (§6).
+- Risk 3 (mutation populate inheritance): explicit request-lifetime carry on `RequestCache` + `FetchCacheConfig.PopulateL2OnMutation`/`MutationTTLOverride` (§3.6, §6.2).
+- Risk 5 (responseData not surfaced): carrier-widening on `result`, set where already computed (§7 below, §4.4).
+- Risk 7 (off-lock arena race): arena reachable only through a `MergeSession` whose `Begin()`/`Close()` bracket a single `DataBuffer.Lock` hold per hook; never opened from `loadPhase`; L2 read inside the prepare session in v1 (§3.4, §6.4).
+- Risk 9 (Object/Field Copy drift): no `Object`/`Field` fields added in v1 (`ProvidesData` folded into config, analytics staged), so no `Copy()` edit in this commit (§3.3, §3.6).
+- Risk 11 (Equals deep-compares config): concrete `FetchCacheConfig.Equals` + nil-safe clause (§3.8, §7.1).
+- Risk 15 (`result` field collision, `fetchSkipped` vs `cacheSkipFetch`): unified onto `fetchSkipped` + `skipLoad` (§4.3, §4.7).
+- Risk 16 (single-flight precedence): the cache short-circuits BEFORE single-flight; a miss/partial falls through to single-flight on the canonical input, and the L2 key is derived from the same canonical pre-injection form single-flight dedups on (§3.6) — flagged for the impl PR to wire precedence explicitly.
+- Risk 17 (cache-key fidelity vs post-prepare input mutation): promoted to a hard contract clause — keys derived from `PrepareFetchInput.Input` (canonical pre-injection bytes) + `HeaderHash`, independent of the post-prepare `extensions`/`fetch_reasons` injection at CURRENT `loader.go:1940/1956` (§3.6).
+- Risk 18 (astjson `MergeValues` 3->2 returns): the `MergeSession` facade hides the `changed` bool, matching how defer already discards it (§3.4).
+
+Open questions for review:
+
+- OQ 1 (partial scope): v1 ships full-response/full-batch + the always-on per-item coverage walk; partial realign is v2 (§9).
+- OQ 5 (analytics scope): v1 ships the `CacheObserver` port nil; full analytics + the walker hooks are a separate additive change to avoid the defer walker collision (§3.5, §9).
+- OQ 6/7 (request-lifetime state home + defer L1 visibility): state lives on `Context` (the established setter pattern), shared by reference; a defer group's L1 writes are visible to fetches scheduled AFTER that group's `cacheMerge` — confirm this ordering is the intended L1 semantics.
+- OQ 10 (subscription/mutation): out of v1; the clone-nil seam is fixed now (§6.3), the trigger lifecycle hook is v2.
+
+---
+
+## Appendix A: HR checklist
+
+| HR | Where | One-line resolution |
+|---|---|---|
+| HR1 | §4 | 2 behavior call-sites + 4 lifecycle defers (one per entry function); ~70-100 LOC in existing files; file-by-file table (§4.1). |
+| HR2 | §3.1, §5 | ONE mode-blind `RequestCache`; nil controller zero-cost; factory tier justified, not a second loader-facing surface. |
+| HR3 | §5.1 | a-i each mapped to a hook/port + seam. |
+| HR4 | §3.7 | typed two-level `FetchCacheHandle` + `ItemCacheState`, mapped 1:1 to OLD `CacheKey`/`cachedData`. |
+| HR5 | §6 | `RequestCache` on by-ref `Context`, lazy-init + all hooks under `DataBuffer.Lock`, `MergeArena` off-lock-forbidden, clone-nil. |
+| HR6 | §7 | `FetchCacheConfig` federation-free, `CacheKeySpec` frozen, `CacheConfigProvider` port, boundary diagram (§7.4). |
+| HR7 | §7-below, App. B | widen `result` with `response` (full, for `isEmptyEntityFetch`) + `responseData` + `responseHasErrors`, set where already computed; not re-parse, not signature change. |
+| HR8 | §3.8, §7.1 | new `cache` package one-way; concrete compile-checked `Equals` forced by `FetchConfiguration.Equals`. |
+| HR9 | §7.5 | one-release `FromFederation` shim; both gates default off so cosmo migrates in stages. |
+| HR10 | §10 | two independent gates compose; half-on is impossible by construction. |
+| no-op-before-impl | §10.2 | controller nil + all `Cache` nil + unused result fields ⇒ zero behavior change. |
+
+## Appendix B: responseData surfacing decision (HR7)
+
+Choice: WIDEN THE RESULT CARRIER (add `result.response` + `result.responseData` + `result.responseHasErrors`), NOT widen `mergeResult`'s signature, and NOT re-parse `res.out`.
+
+- Re-parsing `res.out` in the hook is wrong on cost and correctness: it duplicates the parse on every cached fetch, and forces the hook to re-derive `SelectResponseDataPath`, the batch array, and the null/empty-entity decisions `mergeResult` already computes (CURRENT `loader.go:645-712`); two derivations of "what is the response data" is how read/write key spaces silently diverge (DOSSIER §2.3).
+- Widening `mergeResult`'s signature is the larger, more error-prone diff: it has ~15 return points, and threading the extra return values ripples through the `nestedMergeItems` loop and every caller (CURRENT `loader.go:366-378`).
+- Three fields, not two, because the cache needs TWO different views of the response: `responseData` is the DATA sub-path (`response.Get(SelectResponseDataPath...)`, CURRENT `loader.go:646`) the controller writes to cache, while `isEmptyEntityFetch` (the negative-hit / write-gate signal, HR3-d) consumes the FULL response (`response.Get("data","_entities")`, CURRENT `loader.go:686/788-799`). Surfacing both as carrier fields lets the loader keep `isEmptyEntityFetch` as the SINGLE source of truth for empty-entity detection — `cacheMerge` computes `EmptyEntity` from `res.response` (guarded by `res.response != nil`) rather than re-implementing the rule in the cache package, which would be a second derivation prone to drift (DOSSIER §2.3).
+- Widening the carrier is minimal and safe: `result` is already the per-fetch state object passed through all three phases and already carries `batchStats` (CURRENT `loader.go:113`); the assignments set exactly the values `mergeResult` already computed, with `res.response` set right after the parse (CURRENT `loader.go:628-635`, before every early return) and `res.responseData`/`res.responseHasErrors` placed so both precede the null-data early returns at CURRENT `loader.go:686-688/711` (so negative-cache detection sees the right flags); `response`/`responseData` are arena-backed and read by `OnFetchResult` inside the `MergeSession` it opens in `cacheMerge` (the request-lifetime `jsonArena` is not reset between `mergePhase` and `cacheMerge`, so the pointers stay valid); and all three fields are dead weight when caching is off, preserving the no-op guarantee.
+- Because `res.response` is assigned only on a successful parse, `res.response == nil` (and equivalently `res.responseData == nil`) is the structural fetch-failed signal the write gate keys off (§3.3), so the same carrier widening that surfaces the data ALSO supplies the failed-fetch no-write gate — one decision, three uses (write data, empty-entity routing, fetch-failed gate).
+- The shadow compare (DOSSIER §2.11) needs the same `responseData`, so one decision serves it too.
+
+## Appendix C: OLD-capability -> new-home mapping (proving nothing is dropped)
+
+| OLD capability / call-site cluster (DOSSIER §) | OLD site | New home |
+|---|---|---|
+| Render L1/L2 keys (read/write/invalidate, one format) (§2.3) | `prepareCacheKeys`, `rootFieldL2CachePrefix`, invalidate path | one `CacheKeyTemplate` per candidate in `CacheKeySpec.Candidates`, in `cache` pkg (§7.4) |
+| Per-entity L1 lookup + skip (§2.1) | `tryL1CacheLoad` | `RequestCache.PrepareFetch` -> `DecisionSkipFullHit` |
+| Bulk/sequential L2 read (§2.1) | `bulkL2Lookup`/`tryL2CacheLoad` | `RequestCache.PrepareFetch` (inside its `MergeSession`, v1) |
+| Full-hit short-circuit (§2.1) | `res.cacheSkipFetch` | `prepared.skipLoad` + `res.fetchSkipped` (§4.3) |
+| Coverage validation (§2.10) | `validateItemHasRequiredData` family | inside `PrepareFetch`, from `cfg.ProvidesData` |
+| Multi-candidate freshness + reorder (§2.10) | `resolveMultiCandidateCacheValue`, `reorderCacheValueToSelectionOrder` | inside `PrepareFetch`, via the `MergeSession`; written to `ItemCacheState` |
+| Full-hit splice (§2.5) | `loader.go:1517-1540` merge | `RequestCache.OnFetchSkipped` |
+| Batch hit/partial/empty merge (§2.5) | `mergeBatchCacheHit`/`PartialResponse`/`EmptyResponse` | `OnFetchSkipped` (full-batch v1; partial v2) |
+| L1 entity store + root->entity promotion (§2.2) | `populateL1Cache`, `populateL1CacheForRootFieldEntities` | `OnFetchResult` -> shared L1 on `RequestCache` |
+| L2 set + write-set + key-sync + TTL (§2.2) | `updateL2Cache`/`prepareL2CacheSet`/`prepareL2WriteKeys` | `OnFetchResult` (write-through or defer) |
+| Best-effort multi-key render-then-backfill (re-render unrendered candidates from data, populate all renderable keys, reason) (§2.2) | `shouldWriteRequestedKey`/`shouldWriteRenderedKey`, `CacheWriteReason` | `OnFetchSkipped`/`OnFetchResult`, via `ItemCacheState.{RenderedKeys,PendingCandidates,WriteReason,NeedsWriteback}` |
+| Deferred batched flush (§2.2) | `writeL2CacheSetContributors` | `RequestCache.EndRequest` (§4.5) |
+| Negative caching (§2.6) | `cacheKeysToNegativeEntries`, `NegativeCacheHit` | `ItemCacheState.{NegativeHit,FromCache=Null}`; `MergeInput.EmptyEntity` |
+| Variable/representation remap for partial batch (§2.4) | `filterBatchVariablesForPartialFetch`, `CacheKey.BatchIndex` | `DecisionFetchPartial` + `ItemCacheState.BatchIndex` (seam v1, impl v2) |
+| Transform pipeline schema<->alias (§2.5) | `loader_cache_transform.go` | `cache` pkg, via `MergeSession.StructuralCopy` |
+| Analytics accumulators + ~22 trace fields (§2.7) | `result` analytics fields, `cacheTrace*`, `buildCacheTrace` | `FetchCacheHandle.Analytics` + `CacheObserver` (§3.5) |
+| Walker-inlined analytics (§2.7) | `resolvable.go:830-880/672-708` | `CacheObserver.OnEntity`/`OnFieldValue` (v2) |
+| Subgraph fetch timing (§2.7) | `executeSourceLoad` timing | `CacheObserver` (v2) |
+| Per-request L1 entity store (request-lifetime, §2.8) | `l.l1Cache` | `RequestCache` on `Context`, lock-guarded (§6.2) |
+| Mutation populate inheritance (§2.8) | `enableMutationL2CachePopulation` etc. | `RequestCache` flags + `cfg.PopulateL2OnMutation`/`MutationTTLOverride` |
+| Lifecycle init/finalize (§2.9) | `LoadGraphQLResponseData` init, `Free`, `initCacheAnalytics` | `CacheController.BeginRequest` (lazy) / `RequestCache.EndRequest` |
+| Invalidation, subscription per-event cache (§2.9) | `processExtensionsCacheInvalidation`, `trigger_cache.go` | trigger lifecycle hook (v2); helpers moved to `cache` pkg |
+| Shadow read + stash + force-fetch (§2.11) | `prepareL2LookupState`/`saveShadowCachedValue` | `DecisionFetchShadow` + `FetchCacheHandle.{Shadow,ShadowStash}` |
+| Shadow compare + event (§2.11) | `compareShadowValues`, `ShadowComparisonEvent` | `CacheObserver.CompareShadow` (compare -> write-L1 -> write-L2) |
+| Circuit breaker (dormant) (§4.3) | `circuit_breaker.go` | `cache` pkg (move-only) |
+| Config on `FederationMetaData` / `FederationInfo` (§5.1) | 6 collections + 4 methods + forwarders | `CachingConfiguration` + `CacheConfigProvider` (§7.2-7.3) |

--- a/docs/caching/specs/2026-06-30-rfc-02-caching-planner.md
+++ b/docs/caching/specs/2026-06-30-rfc-02-caching-planner.md
@@ -1,0 +1,1089 @@
+# RFC-2: The caching planner passes for the defer branch
+
+Status: final for review.
+Author: caching working group.
+Branch under change: `feat/eng-7770-add-defer-support-part-4`, code under `v2/pkg/engine/plan/` and `v2/pkg/engine/postprocess/`.
+Companion contract: RFC-1 (`docs/caching/specs/2026-06-30-rfc-01-loader-cache-abstraction.md`) — the loader-side abstraction and the self-contained runtime config types.
+Ground truth: `scratchpad/caching-rfc/DOSSIER.md` (esp. §6 "Caching planner contract"), plus `analysis-A-planner.md` (OLD caching planner/visitor/postprocess) and `analysis-B-planner-current.md` (CURRENT defer plan pipeline + add-a-pass recipe).
+
+This RFC is the synthesis of three independent drafts (A minimal-derive, B faithful-phased, C layered-SRP) and three judge reviews.
+The structural base is **B (faithful-phased)**: it wins the two correctness-critical dimensions the brief weights highest — `ProvidesData` fidelity (PR5) and RFC-1 contract fit (PR8) — while staying fully additive.
+Onto B we graft, surgically, the ideas the reviewers judged strictly better:
+
+- from C: the thin, logic-free `cachingPlanner` FACADE that houses the single NO-OP gate, and the named, physically-isolated `cacheKeySpecFreezer` unit so a reviewer confirms "no federation pointer reaches runtime" by reading one file, and folding `computeHasAliases` into the stamper rather than a separate pass;
+- from A: the CROSS-TREE `optimizeL1Cache` (collect entity fetches across the root tree AND every `Defers[i].Fetches`, because the L1 store lives for the request lifetime and is shared across defer groups — the request-lifetime L1 store, RFC-1 §6.2), the no-op golden test as the hard PR1/PR8 zero-impact proof, and A's honest enumeration of derive-lossiness as the written justification for WHY B re-adds the visitor.
+
+Every must-fix raised by the reviewers is resolved, with `file:line` proof for the correctness-critical ones (the P1 registration mechanism, the `*FetchInfo` carrier stability, the representation-helper absence, the policy-field shapes, and the L1 eligibility/narrow split).
+
+---
+
+> REVISION 2 (maintainer feedback — see PLAN §R2, which is AUTHORITATIVE and overrides this RFC on conflict).
+> The "five forbidden files" / zero-diff-to-core-visitors rule (PR1) is REMOVED: existing planners/visitors MAY be extended when convenient; the surviving rule is a PREFERENCE for new single-responsibility caching visitors (R2.1).
+> Per-root-field cache isolation (RFC-03) is folded INTO CORE and may touch `path_builder_visitor.go` (R2.2).
+> Rename the passes — no "freezer"/"stamper"; use plain names since we are just configuring caching on fetches (R2.7).
+> Caching is wired through the engine `Configuration` (`SetCaching(...)`), not only `postprocess.EnableCaching` (R2.8).
+> Also fix the first-pass P1 reality (the second filter-free walk, see §9.2 note).
+
+## 1. Summary and goals
+
+### 1.1 What this RFC delivers
+
+RFC-1 landed the runtime side: the loader carries an opaque `Cache *FetchCacheConfig` on `SingleFetch`/`EntityFetch`/`BatchEntityFetch`, hands it to a `RequestCache` controller at the prepare/merge seams, and reads `cfg.ProvidesData` at lookup time for coverage validation (RFC-1 §3.6, §8).
+RFC-2 is the PRODUCER that fills those types in.
+It adds DEDICATED, NEW caching passes — not extensions of the existing planners — that stamp the self-contained `resolve.FetchCacheConfig` (and the per-field cache normalize metadata it needs) onto the fetch tree, reading federation `@key` info ONLY as a plan-time input frozen by value.
+
+### 1.2 Goals
+
+- G1. ADDITIVE ONLY: zero edits to the bodies of the five planner/visitor files the brief forbids; new files plus list-insertion registration wiring only (PR1).
+- G2. Cross the federation→caching boundary EXACTLY ONCE, at plan time, by value, in one named unit; retain no federation pointer into runtime (PR2).
+- G3. Stamp a populated `*FetchCacheConfig` onto all three concrete fetch types, AFTER `createConcreteSingleFetchTypes`, writing the concrete types directly (PR3).
+- G4. Walk EVERY fetch tree (root + each defer group + subscription), `DeferID`-correct, request-independent (PR4).
+- G5. RE-ADD a dedicated plan-time `ProvidesData` visitor (not derive), reproducing OLD entity-boundary / `__typename`-dedup / inline-fragment / alias-and-arg-aware semantics (PR5).
+- G6. Keep the L1 optimization its own single-responsibility pass (PR6).
+- G7. Decompose into small, single-responsibility, independently unit-testable passes behind a thin facade (PR7).
+- G8. Consume RFC-1's `cacheconfig.CacheConfigProvider`/`*CachePolicy` types VERBATIM, with composed NO-OP gating so a mode mismatch is impossible by construction (PR8).
+- G9. Record that the `@requestScoped` directive feature is OUT OF SCOPE entirely (removed by review) and prove the rest of caching works without it (PR9).
+- G10. Determinism, plan-cache safety, the third `DeferResponsePlan` kind, per-node annotations, and the `Copy()`/side-table interaction with defer (PR10).
+- G11. The whole pass set is a strict NO-OP until a `CacheConfigProvider` is supplied: adding RFC-2's code changes plans in ZERO ways until a provider exists.
+
+### 1.3 Non-goals
+
+- NOT re-designing RFC-1.
+  RFC-2 CONSUMES, and does NOT redefine, the resolve-package types RFC-1 declares (`FetchCacheConfig`, the revised multi-key `CacheKeySpec`, its per-`@key` candidate type, `CacheScope`, `EntityKeyMapping`).
+  The plan-side config types RFC-1 specifies in §7.2-7.3 (`CachingConfiguration`, `CacheConfigProvider`, the `*CachePolicy` structs) are physically DECLARED by RFC-2 in a new `plan/cacheconfig` package (§11.2), to RFC-1's exact shapes — RFC-2 declares them to spec, it does not invent fields or diverge.
+- NOT implementing the cache store.
+  No `RequestCache`/controller implementation, no key rendering, no L1/L2 backend — those live in the `resolve/cache` package behind RFC-1's interfaces (RFC-1 §7.1).
+- NOT the runtime loader integration — that is RFC-1.
+
+---
+
+## 2. Background
+
+### 2.1 The OLD caching coupling into the existing visitors/postprocess
+
+The OLD branch wove caching into the planner at THREE layers, only one of which was a clean post-pass (analysis-A §0, §6):
+
+1. The planning visitor (`visitor.go`, ~138 lines): a `caching *cachingPlannerState` field driven through the hot path of the response-shaping walk — `EnterField`/`LeaveField` build a parallel per-planner `ProvidesData` tree (`trackFieldForPlanner`/`popFieldsForPlanner`), `resolveFieldValue` stamps `Object.CacheAnalytics`, `configureFetch` derives the whole `FetchCacheConfiguration` (analysis-A §1, §2.1).
+   `cachingPlannerState` (943 new lines) is technically a separate struct but is a SHADOW WALK fused into the primary walk, reading private `Visitor` state.
+2. The path builder (`path_builder_visitor.go`, ~60 lines): `isolatedRootField` forces each cached query root field into its own fetch (analysis-A §2.2).
+3. The node-selection visitor + a new 766-line sibling `node_selection_visitor_request_scoped.go`: the `@requestScoped` widening pre-planning analysis (analysis-A §2.3, §4).
+
+Only `postprocess/optimize_l1_cache.go` (572 lines) was a genuinely standalone `FetchTreeProcessor` that read the finished fetch tree and flipped one boolean (`Caching.UseL1Cache`) per fetch (analysis-A §3).
+That is the architectural template RFC-2 generalizes: the caching planner should be passes over the fully-planned fetch tree (plus ONE dedicated plan-time visitor for the one concern that genuinely needs walk-time context), NOT edits inside the core visitors.
+
+All configuration was bolted onto `FederationMetaData` (6 collections + 4 `FederationInfo` methods + datasource forwarders, analysis-A §2.5, dossier §5.1); RFC-2 replaces that with a self-contained plan-side `cacheconfig` package.
+
+### 2.2 The CURRENT defer plan pipeline and where a pass plugs in
+
+The CURRENT pipeline (analysis-B §1), `Planner.Plan` (`planner.go:92`):
+
+1. `selectOperation` (`planner.go:100`).
+2. `prepareOperation` (`planner.go:105`) — runs `prepareOperationWalker` (`planner.go:58-60`: `InlineFragmentAddOnType` + `deferInfoCollector`), the precedent for a dedicated own-walker pass.
+3. DataSource hashing (`planner.go:113-115`).
+4. `SelectNodes` (`planner.go:118-128`) — assigns fields to datasources.
+5. `CreatePlanningPaths` (`planner.go:133-142`) — `[]PlannerConfiguration`.
+6. Planning visitor walk (`planner.go:154-219`) — builds `GraphQLResponse.Data` + flat `RawFetches`; the cost visitor is registered here as a PEER on the same walker (`planner.go:170-182`).
+7. Postprocess (`execution_engine.go:304`) — `Processor.Process` converts `RawFetches`→`Fetches` (`*FetchTreeNode`), dedups, appends fetchIDs, resolves templates, creates concrete types, organizes into sequence/parallel/defer.
+8. Plan cached and reused across requests (`execution_engine.go:305`) — so any stamped config MUST be request-independent.
+
+The postprocess add-a-pass recipe (analysis-B §3): one new file (struct + `ProcessFetchTree` copying the Single/Parallel/Sequence walk), plus ~5 small edits to `postprocess.go` (field on a processor struct, an option, instantiation, a call in `Process`), with ZERO edits to existing pass bodies.
+For caching the pass must run AFTER `createConcreteSingleFetchTypes` (inside `processFlatFetchTree`, `postprocess.go:47`), once per fetch tree (analysis-B §6).
+
+Two structural facts force the design:
+
+- `createConcreteSingleFetchTypes` builds NEW `EntityFetch`/`BatchEntityFetch` that embed only `FetchDependencies` (`fetch.go:166`/`:206`), NOT `FetchConfiguration`, and copy `Info` BY REFERENCE (`create_concrete_single_fetch_types.go:71`/`:116`); anything stamped on the raw `SingleFetch` before conversion is lost on the entity types (analysis-B §2, §6).
+- A `DeferResponsePlan` (`plan.go:66`) has N fetch trees: the root `Response.Response.Fetches` plus one `*DeferFetchGroup{DeferID, Fetches}` per `DeferID` (`response.go:105`); a single-tree port silently skips deferred operations (analysis-B §5, dossier §7 risk 14).
+
+---
+
+## 3. How RFC-2 satisfies the RFC-1 contract
+
+RFC-1 §8 lists eight obligations.
+RFC-2 satisfies each, consuming RFC-1's resolve-package types verbatim (never redefining one) and declaring the plan-side `cacheconfig` types to RFC-1's exact §7.2-7.3 spec.
+
+| RFC-1 §8 clause | RFC-2 mechanism | Section |
+|---|---|---|
+| 1. Stamp populated `*FetchCacheConfig` on all 3 concrete types, AFTER `createConcreteSingleFetchTypes`; nil = off | `cacheConfigStamper`, invoked by the facade after conversion, type-switches all three | §7 (PR3) |
+| 2. Self-contained: no federation types/pointers; ALL `@key` sets frozen by value as multi-key candidates | `cacheKeySpecFreezer` is the SOLE federation reader, copies OUT by value via the shared `representationvariable` package | §6 (PR2) |
+| 3. Carry the full runtime payload (flags, TTLs, the multi-key `CacheKeySpec`, `ProvidesData`, mutation flags) | the stamper assembles from provider policy + frozen spec + the P1 `ProvidesData` side-table | §7, §9 |
+| 4. `Equals`-stable so dedup cannot lose policy | RFC-1's nil-safe `FetchConfiguration.Equals` clause (RFC-1 §3.8); RFC-2 stamps POST-dedup so `Cache` is nil at dedup time | §7.4 (PR4) |
+| 5. Request-independent (plan is cached/reused) | only static config written; per-request key material derived at runtime in `PrepareFetch` | §8 (PR4, PR10) |
+| 6. Walk every fetch tree, respect `DeferID` | the facade is invoked once per tree (root + each `Defers[i].Fetches` + subscription) | §8 (PR4) |
+| 7. Gate off entirely when NO-OP | empty provider map ⇒ facade returns before touching a node ⇒ every `Cache` nil; composes with RFC-1's runtime nil-check | §11 (PR8) |
+| 8. Provide `CacheConfigProvider`, decoupled from `FederationInfo` | new plan-side `cacheconfig` package, reached via `dataSourceConfiguration[T].Caching()`; passes read it, never `FederationInfo` | §11 (PR8) |
+
+What RFC-1 CONSUMES from what RFC-2 stamps:
+
+- `cfg.ProvidesData *resolve.Object` — read at RUNTIME by the coverage walk inside `PrepareFetch` (RFC-1 §3.6, dossier §2.10), alias-and-arg-aware; RFC-2 builds it (§9).
+- `cfg.KeySpec` — the multi-key spec; the cache package builds ONE `CacheKeyTemplate` per candidate (the sole source of truth for read/write/invalidate keys, RFC-1 §7.4), then renders every candidate best-effort at lookup and re-renders the still-unrendered ones at write time; RFC-2 freezes ALL `@key` sets into it (§6).
+- `cfg.L1`/`cfg.L2` and the scalar policy fields — gate which controller mode runs; RFC-2 sets eligibility, `optimizeL1Cache` narrows L1 (§7, §10).
+
+---
+
+## 4. The new pass / visitor inventory
+
+Five units ship in v1 (one plan-time visitor, the facade, the freezer, the stamper, the L1 pass); one is staged to v2.
+NONE edits an existing visitor or pass body.
+The freezer additionally depends on a small, behavior-preserving refactor that extracts the representation-variable builder into a shared package (§6.1) — its own early structural commit, not a new pass.
+
+| # | Name | File (new) | Single responsibility | Run phase | Input | Output | Stage |
+|---|---|---|---|---|---|---|---|
+| P1 | `cacheProvidesDataVisitor` | `plan/cache_provides_data_visitor.go` | Build, per fetch, the `*resolve.Object` field tree the fetch returns (entity-boundary skip, `__typename` dedup, inline-fragment path normalization, alias→`OriginalName`, `CacheArgs`); attach as a `*FetchInfo`-keyed side-table | plan-time, registered as a PEER on the EXISTING `planningWalker` (like `costVisitor`) | operation+definition AST, `planningVisitor.fieldPlanners`, planners | `map[*resolve.FetchInfo]*resolve.Object` on `GraphQLResponse` | v1 |
+| F | `cachingPlanner` (facade) | `postprocess/caching_planner.go` | Thin, logic-free orchestrator: hold the single NO-OP gate, stamp each tree, then run the cross-tree L1 pass | post-plan, invoked once per plan from `Processor.Process` | provider map, federation metadata by DataSourceID, the trees, the `ProvidesData` side-table | (drives the leaf passes) | v1 |
+| H | `cacheKeySpecFreezer` | `postprocess/cache_key_spec_freezer.go` | The SOLE federation reader: turn EVERY resolvable `@key` set (+ interfaceObject/entityInterface remaps + root-arg↔`@key` mappings) into a multi-key `resolve.CacheKeySpec` BY VALUE, one best-effort candidate per `@key` set, via the shared `representationvariable` package | post-plan, called per fetch by the stamper | `plan.FederationMetaData`, definition AST, fetch identity | multi-key `resolve.CacheKeySpec` (pure data) | v1 |
+| P2 | `cacheConfigStamper` | `postprocess/cache_config_stamper.go` | Assemble + stamp a self-contained `*resolve.FetchCacheConfig` on `SingleFetch`/`EntityFetch`/`BatchEntityFetch` from policy + frozen spec + `ProvidesData`; fold `computeHasAliases`; leave nil when no policy | post-plan `FetchTreeProcessor`, AFTER `createConcreteSingleFetchTypes` | the tree, provider, freezer, side-table | `.Cache` on each concrete fetch | v1 |
+| P3 | `optimizeL1Cache` | `postprocess/optimize_l1_cache.go` | Narrow `cfg.L1 = canRead \|\| canWrite` via `ProvidesData` subset/superset + `DependsOnFetchIDs` ordering, CROSS-tree | post-plan, AFTER P2, ONCE over all trees | all stamped trees | refined `cfg.L1` | v1 |
+| S | `cacheSubscriptionAnnotator` | `postprocess/cache_subscription_annotator.go` | Stamp `GraphQLSubscription.EntityCachePopulation` + mutation `PopulateL2OnMutation`/`MutationTTLOverride` | post-plan, subscription/mutation trees | subscription/mutation policy | subscription/mutation annotations | v2 |
+
+The OLD `@requestScoped` pre-planning rewrite (`cacheRequestScopedRewrite`) is NOT in this inventory: the `@requestScoped` directive feature is out of scope entirely (removed by review, §12) — it is neither a v1 nor a v2 pass.
+
+Run-order diagram (CURRENT pipeline, NEW steps marked):
+
+```
+Planner.Plan (planner.go:92)
+  selectOperation        (planner.go:100)
+  prepareOperation       (planner.go:105)
+  SelectNodes            (planner.go:118)
+  CreatePlanningPaths    (planner.go:133)
+  register planningVisitor field visitors    (planner.go:162-168)
+  register costVisitor    (planner.go:170-182)   ← existing peer precedent
+  ── register P1 cacheProvidesDataVisitor ──     ← NEW peer on the SAME walker, registered LAST (like costVisitor)
+  planningWalker.Walk    (planner.go:216)        ← P1 runs here, reads fieldPlanners
+  ── P1.attachTo(plan) ──                         ← NEW, after the walk (like costVisitor.finalCostTree at :222-224)
+  return raw plan        (planner.go:229)
+
+postprocess.Processor.Process (postprocess.go:190)
+  ... mergeFields → createFetchTree → processFlatFetchTree (incl. createConcreteSingleFetchTypes, postprocess.go:47) ...
+  [for DeferResponsePlan: extractDeferFetches (postprocess.go:205)]
+  ── cachingPlanner.Annotate(resp, trees...) ──   ← NEW: H+P2 per tree, then P3 cross-tree
+  organizeFetchTree / buildDeferTree (unchanged)
+```
+
+Why this granularity: see §10.
+The short version: P1 is the only concern that genuinely needs walk-time context (enclosing type, inline-fragment ancestors, per-planner ownership, operation-AST arguments); H/P2/P3 are pure functions of the finished fetch tree; the freezer is a named helper invoked by the stamper so federation is read in exactly one file; the facade carries no logic and houses the single NO-OP gate.
+
+---
+
+## 5. Additive insertion points (PR1)
+
+Every touch point is a list-insertion or a new registration call.
+ZERO bodies of `node_selection_visitor.go`, `path_builder_visitor.go`, `required_fields_visitor.go`, `node_selection_builder.go`, or `visitor.go` change.
+`planner.go` and `postprocess.go` are NOT in the forbidden list; the edits there are new orchestration calls and registrations, never edits to a pass/visitor body.
+
+### 5.1 `postprocess/postprocess.go` — five additive edits, zero pass-body edits
+
+1. One field on `Processor` (`postprocess.go:21-28`), mirroring the existing standalone `extractDeferFetches`/`buildDeferTree` fields (`:26-27`):
+
+```go
+type Processor struct {
+	disableExtractFetches  bool
+	collectDataSourceInfo  bool
+	fetchTreeProcessors    *FetchTreeProcessors
+	responseTreeProcessors *ResponseTreeProcessors
+	extractDeferFetches    *extractDeferFetches
+	buildDeferTree         *buildDeferTree
+	cachingPlanner         *cachingPlanner // NEW (facade; nil-safe + empty-provider no-op)
+}
+```
+
+2. One field + one option on `processorOptions` (`postprocess.go:61-74`) and a new `ProcessorOption`:
+
+```go
+type processorOptions struct {
+	// ... existing fields ...
+	cacheProviders  map[string]cacheconfig.CacheConfigProvider // NEW: DataSourceID -> provider; nil/empty => no-op
+	cacheFederation map[string]plan.FederationMetaData         // NEW: DataSourceID -> @key input for the freezer
+	cacheDefinition *ast.Document                              // NEW: schema AST; the shared representationvariable builder resolves field types against it (§6.1)
+}
+
+// EnableCaching wires the per-datasource cache config providers, the federation
+// metadata the key-spec freezer reads as plan-time input, and the schema definition
+// the shared representationvariable builder needs to freeze @key sets (§6.1). When the
+// provider map is empty the caching passes are no-ops, so RFC-2 changes plans in zero
+// ways until a provider is supplied (RFC-1 §10).
+func EnableCaching(
+	providers map[string]cacheconfig.CacheConfigProvider,
+	federation map[string]plan.FederationMetaData,
+	definition *ast.Document,
+) ProcessorOption {
+	return func(o *processorOptions) {
+		o.cacheProviders = providers
+		o.cacheFederation = federation
+		o.cacheDefinition = definition
+	}
+}
+```
+
+3. Instantiate in `NewProcessor` (`postprocess.go:139`), additive:
+
+```go
+freezer := &cacheKeySpecFreezer{federation: opts.cacheFederation, definition: opts.cacheDefinition}
+cachingPlanner: &cachingPlanner{
+	providers: opts.cacheProviders,
+	freezer:   freezer,
+	stamper:   &cacheConfigStamper{providers: opts.cacheProviders, freezer: freezer},
+	l1:        &optimizeL1Cache{disable: len(opts.cacheProviders) == 0},
+},
+```
+
+4. Call the facade from `Process` (`postprocess.go:190`), once per plan.
+This is the SANCTIONED additive insertion point (analysis-B §3); `Process` is the orchestrator, not a pass body.
+
+Before (CURRENT `postprocess.go:190-232`, abridged — existing inline comments elided):
+
+```go
+func (p *Processor) Process(pre plan.Plan) {
+	switch t := pre.(type) {
+	case *plan.SynchronousResponsePlan:
+		p.responseTreeProcessors.mergeFields.Process(t.Response.Data)
+		p.createFetchTree(t.Response)
+		p.fetchTreeProcessors.processFlatFetchTree(t.Response.Fetches)
+		p.fetchTreeProcessors.organizeFetchTree(t.Response.Fetches)
+
+	case *plan.DeferResponsePlan:
+		p.responseTreeProcessors.mergeFields.Process(t.Response.Response.Data)
+		p.createFetchTree(t.Response.Response)
+		p.fetchTreeProcessors.processFlatFetchTree(t.Response.Response.Fetches)
+		p.extractDeferFetches.Process(t)
+		p.fetchTreeProcessors.organizeFetchTree(t.Response.Response.Fetches)
+		for _, deferResp := range t.Response.Defers {
+			p.fetchTreeProcessors.organizeFetchTree(deferResp.Fetches)
+		}
+		p.buildDeferTree.Process(t.Response)
+		t.Response.Defers = nil
+
+	case *plan.SubscriptionResponsePlan:
+		p.responseTreeProcessors.mergeFields.Process(t.Response.Response.Data)
+		p.createFetchTree(t.Response.Response)
+		p.appendTriggerToFetchTree(t.Response)
+		p.fetchTreeProcessors.processFlatFetchTree(t.Response.Response.Fetches)
+		p.fetchTreeProcessors.resolveInputTemplates.ProcessTrigger(&t.Response.Trigger)
+		p.fetchTreeProcessors.organizeFetchTree(t.Response.Response.Fetches)
+	}
+}
+```
+
+After (only the `// NEW` lines are inserted; every existing line is byte-identical):
+
+```go
+func (p *Processor) Process(pre plan.Plan) {
+	switch t := pre.(type) {
+	case *plan.SynchronousResponsePlan:
+		p.responseTreeProcessors.mergeFields.Process(t.Response.Data)
+		p.createFetchTree(t.Response)
+		p.fetchTreeProcessors.processFlatFetchTree(t.Response.Fetches)
+		p.cachingPlanner.Annotate(t.Response, t.Response.Fetches) // NEW
+		p.fetchTreeProcessors.organizeFetchTree(t.Response.Fetches)
+
+	case *plan.DeferResponsePlan:
+		p.responseTreeProcessors.mergeFields.Process(t.Response.Response.Data)
+		p.createFetchTree(t.Response.Response)
+		p.fetchTreeProcessors.processFlatFetchTree(t.Response.Response.Fetches)
+		p.extractDeferFetches.Process(t)
+		// NEW: stamp root + every defer group; cross-tree L1 over all of them.
+		p.cachingPlanner.Annotate(t.Response.Response, deferTrees(t.Response)...) // NEW
+		p.fetchTreeProcessors.organizeFetchTree(t.Response.Response.Fetches)
+		for _, deferResp := range t.Response.Defers {
+			p.fetchTreeProcessors.organizeFetchTree(deferResp.Fetches)
+		}
+		p.buildDeferTree.Process(t.Response)
+		t.Response.Defers = nil
+
+	case *plan.SubscriptionResponsePlan:
+		p.responseTreeProcessors.mergeFields.Process(t.Response.Response.Data)
+		p.createFetchTree(t.Response.Response)
+		p.appendTriggerToFetchTree(t.Response)
+		p.fetchTreeProcessors.processFlatFetchTree(t.Response.Response.Fetches)
+		p.cachingPlanner.Annotate(t.Response.Response, t.Response.Response.Fetches) // NEW
+		p.fetchTreeProcessors.resolveInputTemplates.ProcessTrigger(&t.Response.Trigger)
+		p.fetchTreeProcessors.organizeFetchTree(t.Response.Response.Fetches)
+	}
+}
+```
+
+5. One tiny free helper (`deferTrees`) that collects the root tree plus each `Defers[i].Fetches` into one slice:
+
+```go
+// deferTrees returns the root fetch tree plus every defer group's tree, so the
+// facade stamps each tree and runs the cross-tree L1 pass over all of them.
+func deferTrees(d *plan.DeferResponsePlan) []*resolve.FetchTreeNode {
+	trees := make([]*resolve.FetchTreeNode, 0, 1+len(d.Response.Defers))
+	trees = append(trees, d.Response.Response.Fetches)
+	for _, g := range d.Response.Defers {
+		trees = append(trees, g.Fetches)
+	}
+	return trees
+}
+```
+
+Placement proof:
+`Annotate` runs AFTER `processFlatFetchTree` (which ends at `createConcreteSingleFetchTypes`, `postprocess.go:47`) and BEFORE `organizeFetchTree`.
+`organizeFetchTree` only reorders/groups nodes (`orderSequenceByDependencies`, `createParallelNodes`); it never mutates fetch contents (analysis-B §6), so stamping before it is order-independent and the annotations survive.
+For defer, the facade runs after `extractDeferFetches` has split the flat tree (`postprocess.go:205`) and before `buildDeferTree` nils `Defers` (`postprocess.go:218`).
+
+### 5.2 `plan/planner.go` — three additive blocks, all `!= nil`-guarded
+
+1. P1 registration on the EXISTING `planningWalker`, mirroring the `costVisitor` precedent (VERIFIED `planner.go:170-182`).
+The cost visitor is registered LAST on the same walker via `RegisterEnterFieldVisitor`/`RegisterLeaveFieldVisitor` and reads `p.planningVisitor.fieldPlanners` (`planner.go:177`); its own comment (`planner.go:170-174`) says it must be registered last because it depends on `fieldPlanners`.
+P1 uses the IDENTICAL pattern, so its `EnterField` observes `fieldPlanners[ref]` after the planning visitor's `SetVisitorFilter` (`planner.go:162`) has populated it (`visitor.go:232-235`):
+
+```go
+	// existing cost-visitor registration block ends at planner.go:181 ...
+	// NEW: provides-data visitor, registered AFTER the cost visitor, same pattern.
+	// Reads fieldPlanners for per-field fetch ownership; edits no visitor body. (P1)
+	if p.cacheProvidesData != nil {
+		p.cacheProvidesData.planners = plannersConfigurations
+		p.cacheProvidesData.fieldPlanners = p.planningVisitor.fieldPlanners
+		p.planningWalker.RegisterEnterFieldVisitor(p.cacheProvidesData)
+		p.planningWalker.RegisterLeaveFieldVisitor(p.cacheProvidesData)
+	}
+```
+
+2. P1 carrier resolution after the walk (`planner.go:216-229`), mirroring how the cost calculator reads `p.costVisitor.finalCostTree()` after the walk (`planner.go:222-224`):
+
+```go
+	p.planningWalker.Walk(operation, definition, report)
+	if report.HasErrors() {
+		return
+	}
+	// NEW: resolve fetchID -> *FetchInfo and stash the side-table on the plan (§9.3).
+	if p.cacheProvidesData != nil {
+		p.cacheProvidesData.attachTo(p.planningVisitor.plan)
+	}
+```
+
+3. Construction of P1 in `NewPlanner` (`planner.go:57-75`), an additive `Planner` field built only when a provider set is configured.
+
+Net `planner.go` footprint: three small additive blocks (P1 registration, P1 carrier resolution, P1 construction), all guarded by `!= nil`; zero edits to the five forbidden visitor files.
+(There is no pre-planning `@requestScoped` rewrite to insert between `prepareOperation` and `SelectNodes` — that feature is out of scope entirely, §12.)
+
+### 5.3 Engine wiring
+
+The engine builds `map[DataSourceID]cacheconfig.CacheConfigProvider` and `map[DataSourceID]plan.FederationMetaData` ONCE from `plan.Configuration` (each datasource's `Caching()` provider per RFC-1 §7.3, plus its `FederationConfiguration()`), and hands them — together with the schema `definition` AST the shared `representationvariable` builder needs (§6.1) — to the `Processor` via `postprocess.EnableCaching(providers, federation, definition)` at the existing `NewProcessor(...)` call site (analysis-B §1, `execution_engine.go:304`) and to the `Planner` for P1 enablement.
+When the integrator supplies no providers, neither side is wired and the pipeline is unchanged.
+
+### 5.4 The `resolve` per-field metadata addition (the one node_object.go edit)
+
+The runtime coverage walk is alias-AND-arg-aware (RFC-1 §2.10, dossier §2.10): it matches `SchemaFieldName()+computeArgSuffix(CacheArgs)` against the cached bytes.
+So `cfg.ProvidesData`'s `*resolve.Field` nodes MUST carry `OriginalName` (alias→schema name) and `CacheArgs`, and `*resolve.Object` needs the `HasAliases` fast-path gate (OLD `node_object.go:13/41-51/135/143`).
+These fields do NOT exist on the defer branch (`node_object.go:8-16`, `:103-112`), and OLD's `resolve.ComputeHasAliases` was deleted (verified: no occurrence on the defer branch).
+
+RFC-2 RE-ADDS them additively to `resolve` (a new `resolve` file plus four field additions), and updates `Object.Copy()`/`Field.Copy()` (`node_object.go:18-28`/`:119-134`) ADDITIVELY to carry them:
+
+```go
+// resolve/node_object.go (additive fields)
+type Object struct {
+	// ... existing fields ...
+	HasAliases bool `json:"-"` // RFC-2: fast-path gate for L1 normalize
+}
+type Field struct {
+	// ... existing fields ...
+	OriginalName []byte         `json:"-"` // RFC-2: schema name when Name is an alias
+	CacheArgs    []CacheFieldArg `json:"-"` // RFC-2: arg name + variable, sorted
+}
+type CacheFieldArg struct{ Name, VariableName string }
+```
+
+This is NOT a forbidden-body edit: `node_object.go` (the `resolve` package) is not in the PR1 list, and the change is purely additive (new fields + carrying them in `Copy()`).
+It is also drift-safe by construction (PR10, §13.3): the only tree that carries these fields in v1 is the caching-owned `ProvidesData` tree, which is NEVER reached by defer's response-tree `Copy()`; the `Copy()` update is belt-and-suspenders against a future writer.
+
+---
+
+## 6. Federation→caching boundary (PR2)
+
+The federation→caching boundary is crossed EXACTLY ONCE, at plan time, BY VALUE, inside the named `cacheKeySpecFreezer` unit (`postprocess/cache_key_spec_freezer.go`) — promoted from a helper to its own physically-isolated file (graft from C) so a reviewer confirms "no federation pointer reaches runtime" by reading ONE file.
+
+Boundary diagram (RFC-1 §7.4):
+
+```
+plan.FederationMetaData.Keys (ALL resolvable @key selection sets)   +   interfaceObject/entityInterface remaps   +   root-arg↔@key mappings
+        │  PLAN-TIME INPUT ONLY — read once, by value, by the freezer
+        ▼
+representationvariable.BuildRepresentationVariableNode(definition, keySet, fed)   (shared package, §6.1; one *resolve.Object per @key set, federation-pointer-free)
+        │  one best-effort candidate per @key set
+        ▼
+cacheKeySpecFreezer.freeze(...) → multi-key resolve.CacheKeySpec{ Scope, TypeName, FieldName, Candidates []resolve.CacheKeyCandidate, EntityKeyMappings []resolve.EntityKeyMapping }
+        │  packed into
+        ▼
+resolve.FetchCacheConfig.KeySpec   (federation-free; imports NO federation type)
+        │  carried on the 3 fetch structs
+        ▼
+loader.go (RFC-1)  (forward-only; never reads a field)
+```
+
+The spec is MULTI-KEY (RFC-1's revised `CacheKeySpec`, §6.3): an entity type may declare more than one `@key`, and none is made required.
+`Candidates` lists one independently, best-effort-renderable key template per resolvable `@key` set — at lookup the controller renders every candidate it CAN from the data on hand, and at write it re-renders the ones that were not yet renderable (RFC-1 §2.10, §3.7).
+
+What is read as INPUT (legitimate key-derivation coupling, dossier §5.3):
+
+- `FederationMetaData.HasEntity(typeName)` (`federation_metadata.go:39`) — which types get an entity spec.
+- `FederationMetaData.RequiredFieldsByKey(typeName)` (`federation_metadata.go:35`) / `Keys` (`:11`) — ALL resolvable `@key` selection sets; each becomes one multi-key candidate (§6.3).
+- interfaceObject/entityInterface remaps — the `__typename` written into each candidate's representation node (baked in by the shared builder, no separate `TypenameOverride` field needed per candidate).
+- root-arg↔`@key` mappings (the OLD `EntityKeyMapping`/`FieldMapping`, dossier §5.3, listed there as acceptable plan-time input frozen into `CacheKeySpec`) — frozen into `EntityKeyMappings`.
+
+What is NEVER read (policy coupling, removed, dossier §5.3): no `EntityCacheConfig`/`RootFieldCacheConfig` lookups on `FederationInfo`; policy comes only from `CacheConfigProvider` (§11).
+
+### 6.1 The representation-variable builder: extract to a shared package (a reviewer must-fix)
+
+All three drafts assumed reuse of `BuildRepresentationVariableNode`/`MergeRepresentationVariableNodes` from `plan/representation_variable.go`.
+VERIFIED on the defer branch: that file does NOT exist in `plan`.
+Equivalents exist but are UNEXPORTED and live in a sibling datasource package — `buildRepresentationVariableNode`/`mergeRepresentationVariableNodes` at `pkg/engine/datasource/graphql_datasource/representation_variable.go:21`/`:123`.
+RFC-2 MUST NOT reach into another package's private helpers, and MUST NOT copy-paste them (two divergent `@key`→representation walkers is exactly the silent-key-skew hazard §6 exists to prevent).
+
+The fix is a refactor-in-place, not a re-add: EXTRACT `BuildRepresentationVariableNode`/`MergeRepresentationVariableNodes` (and the internal `representationVariableVisitor` + merge helpers) into a NEW shared, exported package `v2/pkg/engine/plan/representationvariable` (verified: that path does not exist today), and REFACTOR `graphql_datasource` IN PLACE to import and call the exported functions instead of its local unexported copies (`graphql_datasource.go:855`/`:865`).
+Then BOTH the GraphQL data source AND the caching `cacheKeySpecFreezer` share ONE implementation.
+
+```go
+// v2/pkg/engine/plan/representationvariable/representationvariable.go (NEW, exported)
+//
+// Shared by graphql_datasource (builds the _entities `representations` variable) and
+// the caching cacheKeySpecFreezer (freezes @key sets into multi-key cache candidates).
+// One @key selection set -> one *resolve.Object representation node, federation-
+// pointer-free (it walks the parsed key fragment against the definition and allocates
+// fresh resolve.Field/Object nodes), with the interfaceObject/entityInterface
+// __typename remap already baked in.
+package representationvariable
+
+func BuildRepresentationVariableNode(
+	definition *ast.Document,
+	cfg plan.FederationFieldConfiguration, // one @key selection set
+	federationCfg plan.FederationMetaData,
+) (*resolve.Object, error)
+
+// MergeRepresentationVariableNodes folds multiple key nodes into ONE representation
+// object — used by graphql_datasource for the single `representations` variable. The
+// caching freezer does NOT call it: multi-key caching keeps the candidates SEPARATE.
+func MergeRepresentationVariableNodes(objects []*resolve.Object) *resolve.Object
+```
+
+This refactor is its OWN early structural commit (it precedes the caching passes), it touches `graphql_datasource` (the two call sites move to the exported names) and `plan/representationvariable` (the moved code), and it MUST preserve graphql_datasource behavior — guarded by the existing `graphql_datasource/representation_variable_test.go`, which exercises the same code paths through the call sites and pins the output byte-for-byte (PLAN note for §15).
+No import cycle: `representationvariable` imports `plan`/`resolve`/`ast`/`astvisitor`; `plan` does not import it; both consumers already depend on `plan`.
+
+The freezer then reuses the shared builder and freezes EVERY resolvable `@key` set as an independent, best-effort candidate (multi-key, §6.3) in ONE reviewable file:
+
+```go
+// postprocess/cache_key_spec_freezer.go
+//
+// cacheKeySpecFreezer is the SOLE federation -> caching boundary crossing. It reads
+// FederationMetaData as plan-time INPUT and emits a multi-key resolve.CacheKeySpec BY
+// VALUE. It retains NO pointer into FederationMetaData; the result is self-contained
+// runtime data (RFC-1 §7.4). It builds each candidate via the shared
+// representationvariable package (§6.1), so caching and the data source share one
+// @key->representation implementation.
+type cacheKeySpecFreezer struct {
+	federation map[string]plan.FederationMetaData // by DataSourceID, read-only
+	definition *ast.Document                      // schema, threaded in (§5.3); read-only
+}
+
+// freeze returns the frozen multi-key spec for a fetch, or ok=false when the fetch has
+// no datasource/coordinate identity. Called once per fetch by the stamper.
+func (f *cacheKeySpecFreezer) freeze(scope resolve.CacheScope, info *resolve.FetchInfo) (resolve.CacheKeySpec, bool) {
+	if info == nil || len(info.RootFields) == 0 {
+		return resolve.CacheKeySpec{}, false // tolerate Info==nil (DisableIncludeInfo)
+	}
+	fed, ok := f.federation[info.DataSourceID]
+	if !ok {
+		return resolve.CacheKeySpec{}, false
+	}
+	typeName := info.RootFields[0].TypeName
+	spec := resolve.CacheKeySpec{
+		Scope:     scope,
+		TypeName:  typeName,
+		FieldName: info.RootFields[0].FieldName,
+	}
+	if scope == resolve.CacheScopeEntity {
+		if !fed.HasEntity(typeName) {
+			return resolve.CacheKeySpec{}, false // no @key -> no entity spec
+		}
+		// MULTI-KEY: freeze one candidate per resolvable @key set; none is privileged
+		// as "required". Each candidate is INDEPENDENTLY, best-effort renderable at
+		// RUNTIME (RFC-1 §2.10, §3.7, §6.3) — a candidate whose fields are absent in
+		// the data is simply not rendered at lookup and is retried at write. Ordered
+		// deterministically by selection-set string (§13.1).
+		keySets := fed.RequiredFieldsByKey(typeName) // = Keys.FilterByTypeAndResolvability(typeName, true)
+		slices.SortFunc(keySets, func(a, b plan.FederationFieldConfiguration) int {
+			return strings.Compare(a.SelectionSet, b.SelectionSet)
+		})
+		for _, keySet := range keySets {
+			node, err := representationvariable.BuildRepresentationVariableNode(f.definition, keySet, fed)
+			if err != nil {
+				continue // defensive: skip a malformed @key fragment rather than fail the whole spec
+			}
+			spec.Candidates = append(spec.Candidates, resolve.CacheKeyCandidate{Representation: node})
+		}
+		if len(spec.Candidates) == 0 {
+			return resolve.CacheKeySpec{}, false // no usable @key -> no entity spec
+		}
+	}
+	spec.EntityKeyMappings = freezeEntityKeyMappings(fed, typeName) // root-arg <-> @key, by value
+	return spec, true
+}
+```
+
+DERIVATION NOTE (first pass, commit C1): OLD carried `EntityKeyMappings` as EXTERNAL config; this branch has none, so `freezeEntityKeyMappings` DERIVES them structurally.
+For a ROOT-FIELD fetch it resolves the field's return type from the `definition` (`NodeFieldDefinitionByName` -> `FieldDefinitionTypeNameString`), collects the field's argument names (`NodeInputValueDefinitions`), and for each resolvable `@key` set (parsed into field names via `RequiredFieldsFragment` + `SelectionSetFieldNames`) emits a mapping ONLY when EVERY key field name matches a root-arg name (so `product(upc:)` maps `Product @key(upc)` but not `@key(sku)`).
+So the freezer signature is really `freezeEntityKeyMappings(definition, fed, rootTypeName, rootFieldName)`, and the mappings are frozen onto the ROOT-FIELD spec (not the entity spec); entity fetches already key by representation and need no mappings.
+Operator-declared name-mismatch overrides remain staged (§15.2 R4).
+
+Each `resolve.CacheKeyCandidate.Representation` is the `*resolve.Object` the shared builder returns — federation-pointer-free, with the `__typename`/interfaceObject/entityInterface remap baked in, so the candidate is a complete key template on its own (it subsumes the old single-key `KeyFields`+`TypenameOverride` pair).
+After `freeze` returns, nothing in the runtime path holds a reference into `FederationMetaData`: `CacheKeySpec` is strings + `[]CacheKeyCandidate` (value trees) + `[]EntityKeyMapping` (value types).
+This is the PR2 guarantee: one crossing, plan-time, by value, no pointers retained into runtime — and now ONE shared builder, so caching and the data source cannot drift.
+
+### 6.2 Why RFC-2 freezes the key spec and does NOT call `provider.KeySpec()`
+
+RFC-1 §7.3's `CacheConfigProvider` exposes a `KeySpec(...)` method, and RFC-1 §7.2 carries `CachingConfiguration.KeySpecs`.
+RFC-2 DELIBERATELY does not consume either: it freezes `CacheKeySpec` itself, reading `FederationMetaData` once (sanctioned by RFC-1 §7.4: "read ONCE by RFC-2 and frozen into `CacheKeySpec`").
+This preserves the single-source-of-truth key invariant — the cache key mirrors entity identity, so `@key` is the only legitimate source; routing it through the provider would create a second source that could silently diverge.
+A reviewer who sees the unused `KeySpec()` method should read it as a forward-compatibility hook, not a contract gap; this is stated so the freeze decision is explicit (a reviewer must-fix).
+
+### 6.3 The multi-key model (canonical, shared with RFC-1)
+
+An entity type may declare MORE THAN ONE `@key` set, and RFC-2 does NOT make them all required.
+The freezer freezes ALL resolvable `@key` sets into RFC-1's revised multi-key `CacheKeySpec.Candidates` — one independently, best-effort-renderable candidate per set, none privileged as "required":
+
+- LOOKUP (runtime `PrepareFetch`, RFC-1 §2.10): render EVERY candidate that CAN be rendered from the data available at fetch time; some candidates may be unrenderable because their fields are absent, and that is allowed; look the cache up under ALL successfully-rendered keys; a hit on ANY rendered candidate serves the item.
+- WRITE / populate (runtime `OnFetchResult`, RFC-1 §3.7): after the subgraph response returns, RE-render the candidates that were NOT renderable at lookup time using the freshly returned data; if more candidates are now renderable, populate the cache for ALL renderable keys, otherwise populate just the keys rendered at lookup.
+
+This generalizes and REPLACES the old single-key "requested-key vs rendered-key + missing-key set" write-back framing — RFC-2 expresses key derivation purely as a best-effort multi-key render-then-backfill, and the per-item handle payload (RFC-1 §3.7) carries the set of keys rendered at lookup plus the set still-unrendered (retried at write).
+RFC-2's only obligation is to freeze the full candidate list by value; the runtime render/backfill is RFC-1's.
+
+---
+
+## 7. Stamping onto the three concrete fetch types after createConcreteSingleFetchTypes (PR3)
+
+`createConcreteSingleFetchTypes` converts a `*SingleFetch` into a `*EntityFetch` (`create_concrete_single_fetch_types.go:104`) or `*BatchEntityFetch` (`:59`); both embed only `FetchDependencies` (`fetch.go:166`/`:206`), NOT `FetchConfiguration`, and copy `Info` BY REFERENCE (`:71`/`:116`).
+So config stamped on the raw `SingleFetch.FetchConfiguration` before conversion would be LOST for the entity types.
+RFC-1 therefore put `Cache *FetchCacheConfig` directly on all three concrete structs (RFC-1 §3.8, §4.1 row n), and RFC-2 runs the stamper AFTER conversion, writing the concrete types directly.
+
+```go
+// postprocess/cache_config_stamper.go
+type cacheConfigStamper struct {
+	providers map[string]cacheconfig.CacheConfigProvider
+	freezer   *cacheKeySpecFreezer
+}
+
+// process walks one fetch tree and stamps each cache-eligible concrete fetch.
+func (s *cacheConfigStamper) process(node *resolve.FetchTreeNode, pd map[*resolve.FetchInfo]*resolve.Object) {
+	if node == nil {
+		return
+	}
+	switch node.Kind {
+	case resolve.FetchTreeNodeKindSingle:
+		s.stamp(node.Item.Fetch, pd)
+	case resolve.FetchTreeNodeKindParallel, resolve.FetchTreeNodeKindSequence:
+		for _, child := range node.ChildNodes {
+			s.process(child, pd)
+		}
+	}
+}
+
+func (s *cacheConfigStamper) stamp(fetch resolve.Fetch, pd map[*resolve.FetchInfo]*resolve.Object) {
+	cfg := s.buildConfig(fetch, pd) // nil => not eligible
+	if cfg == nil {
+		return // leave Cache nil so the loader no-ops (PR8)
+	}
+	switch f := fetch.(type) {
+	case *resolve.SingleFetch:
+		f.Cache = cfg
+	case *resolve.EntityFetch:
+		f.Cache = cfg
+	case *resolve.BatchEntityFetch:
+		f.Cache = cfg
+	}
+}
+```
+
+`buildConfig` is where policy lookup, the §6 freeze, and the §9 `ProvidesData` attach come together.
+It consumes RFC-1's `*CachePolicy` types VERBATIM and reads ONLY their real fields (the must-fix against inventing `AllowL1`/`EnableL2`/`EntityKeyMappings()`):
+
+```go
+func (s *cacheConfigStamper) buildConfig(fetch resolve.Fetch, pd map[*resolve.FetchInfo]*resolve.Object) *resolve.FetchCacheConfig {
+	info := fetch.FetchInfo()
+	if info == nil || len(info.RootFields) == 0 {
+		return nil // tolerate Info==nil (DisableIncludeInfo) -> no key material -> no-op
+	}
+	provider := s.providers[info.DataSourceID]
+	if provider == nil {
+		return nil // this datasource has no caching configured -> leave Cache nil
+	}
+
+	var cfg resolve.FetchCacheConfig
+	switch {
+	case fetchIsEntity(fetch): // *EntityFetch / *BatchEntityFetch / SingleFetch w/ RequiresEntity*(fetch.go:262/266)
+		pol, ok := provider.EntityPolicy(info.RootFields[0].TypeName) // RFC-1 §7.3, verbatim
+		if !ok {
+			return nil
+		}
+		spec, ok := s.freezer.freeze(resolve.CacheScopeEntity, info)
+		if !ok {
+			return nil
+		}
+		cfg = resolve.FetchCacheConfig{
+			L1: true, // L1-ELIGIBLE; optimizeL1Cache (P3) narrows to canRead||canWrite (§10)
+			L2: pol.TTL > 0 || pol.NegativeCacheTTL > 0, // derived from real fields (see §7.1)
+			CacheName:                   pol.CacheName,
+			TTL:                         pol.TTL,
+			NegativeCacheTTL:            pol.NegativeCacheTTL,
+			IncludeSubgraphHeaderPrefix: pol.IncludeSubgraphHeaderPrefix,
+			EnablePartialCacheLoad:      pol.EnablePartialCacheLoad,
+			ShadowMode:                  pol.ShadowMode,
+			HashAnalyticsKeys:           pol.HashAnalyticsKeys,
+			KeySpec:                     spec,
+		}
+	default: // root-field fetch
+		pol, ok := rootFieldPolicyForAllRootFields(provider, info) // all-or-nothing rule, §7.2
+		if !ok {
+			return nil
+		}
+		spec, _ := s.freezer.freeze(resolve.CacheScopeRootField, info)
+		cfg = resolve.FetchCacheConfig{
+			L1: false, // root fields only ACT as L1 providers (root->entity promotion, v2)
+			L2: pol.TTL > 0,
+			CacheName:                   pol.CacheName,
+			TTL:                         pol.TTL,
+			IncludeSubgraphHeaderPrefix: pol.IncludeSubgraphHeaderPrefix,
+			ShadowMode:                  pol.ShadowMode,
+			PartialBatchLoad:            pol.PartialBatchLoad,
+			KeySpec:                     spec,
+		}
+	}
+
+	cfg.ProvidesData = pd[info]                 // from P1 (§9); consumed at runtime by the coverage walk
+	resolve.ComputeHasAliases(cfg.ProvidesData) // stamper-side helper folds the alias/arg fast-path flag onto the tree (§9.3)
+	if !cfg.L1 && !cfg.L2 && !cfg.ShadowMode {
+		return nil // nothing to do -> leave Cache nil so the loader no-ops (PR8)
+	}
+	return &cfg
+}
+```
+
+`fetchIsEntity` keys off the concrete Go type (`*EntityFetch`/`*BatchEntityFetch`) or `RequiresEntityFetch`/`RequiresEntityBatchFetch` on a `SingleFetch` (`fetch.go:262`/`:266`).
+`computeHasAliases` is re-added as a small caching-package function and folded into the stamper as ONE call on the freshly assembled `cfg.ProvidesData` (graft from C, avoiding over-fragmentation); it sets `cfg.ProvidesData.HasAliases` if any descendant carries an `OriginalName`/`CacheArgs`.
+
+### 7.1 L2 enablement is derived from the policy's real fields (a reviewer must-fix)
+
+RFC-1 §7.2's `EntityCachePolicy` has NO L1/L2 bool — its fields are `{TypeName, CacheName, TTL, NegativeCacheTTL, IncludeSubgraphHeaderPrefix, EnablePartialCacheLoad, HashAnalyticsKeys, ShadowMode}`, and `RootFieldCachePolicy` is `{TypeName, FieldName, CacheName, TTL, IncludeSubgraphHeaderPrefix, ShadowMode, PartialBatchLoad}`.
+RFC-2 therefore DERIVES `cfg.L2` structurally: `pol.TTL > 0 || pol.NegativeCacheTTL > 0` for entities, `pol.TTL > 0` for root fields.
+It NEVER reads non-existent fields like `AllowL1`/`EnableL2`/`EntityKeyMappings()` (draft A's verbatim violation).
+`cfg.L1` is set STRUCTURALLY (entity fetch ⇒ eligible `true`; root field ⇒ `false`), then NARROWED by P3 (§10).
+Open question (flag for RFC-1 authors, §15): confirm L2 should be inferred from TTL rather than carried as an explicit enable signal; if an explicit bool is intended, it must be added to the `*CachePolicy` structs in RFC-1, not invented here.
+
+### 7.2 The root-field all-or-nothing rule (replacing the path-builder isolation hook)
+
+The OLD branch forced each cached query root field into its own fetch via `isolatedRootField` in `path_builder_visitor.go` (analysis-A §2.2) so a fetch never mixed root fields with different policies; absent isolation, OLD's fallback rule was to DISABLE L2 when root fields in a fetch did not share an identical policy (dossier §5.5).
+`path_builder_visitor.go` is in the PR1 forbidden list, so RFC-2 does NOT re-add that hook.
+Instead `rootFieldPolicyForAllRootFields` walks `info.RootFields`, and returns `(policy, true)` ONLY when every root field resolves to the SAME policy; otherwise it returns `false` and the stamper leaves `Cache` nil.
+This reproduces OLD's conservative fallback (disable rather than mis-cache) additively, with zero edits to the path builder.
+
+Per-root-field fetch isolation (the OPTIMIZATION that let differing root fields each cache, OLD `isolatedRootField`) is NOT dropped: it is DEFERRED to a SEPARATE RFC, RFC-03 (`docs/caching/specs/2026-06-30-rfc-03-per-root-field-cache-isolation.md`).
+That RFC will specify the additive mechanism (a pre-planning / path-building isolation that forces each cached root field into its own fetch so differing policies can each cache) without re-opening the PR1 forbidden visitor bodies.
+v1 ships the conservative all-or-nothing decline above (correct, just less granular); RFC-03 is a pure optimization layered on top and changes none of RFC-2's v1 contract.
+
+---
+
+## 8. Fetch-tree walking: root + defer groups + subscription + DeferID + request-independence (PR4)
+
+A plan has N fetch trees, not one (analysis-B §5, dossier §7 risk 14): the root tree plus one per `DeferFetchGroup` (`response.go:105`), plus the subscription tree.
+The facade `Annotate` is invoked once per plan and stamps EVERY tree:
+
+```go
+// AnnotateFetchTree stamps each tree (root + every defer group) and then runs the
+// CROSS-tree L1 pass once over all of them. The single NO-OP gate lives here.
+func (c *cachingPlanner) Annotate(resp *resolve.GraphQLResponse, trees ...*resolve.FetchTreeNode) {
+	if c == nil || len(c.providers) == 0 || resp == nil {
+		return // composed NO-OP gate (§11): no provider => zero plan change
+	}
+	pd := resp.CacheProvidesData() // the *FetchInfo-keyed side-table from P1 (§9.3)
+	for _, tree := range trees {
+		c.stamper.process(tree, pd)
+	}
+	c.l1.processTrees(trees...) // cross-tree narrowing (§10)
+}
+```
+
+`DeferID` identity (RFC-1 §8.6, dossier §6.5):
+RFC-2 does NOT need to reason about `DeferID` itself.
+`EqualSingleFetch` already refuses to dedup across defer scopes (`fetch.go:49-53`, the `DeferID` guard at `:51`), and `extractDeferFetches` (`postprocess.go:205`) has already split the flat tree into per-`DeferID` groups BEFORE `Annotate` runs.
+Each group is a distinct tree of distinct fetches with their own `*FetchInfo` pointers, so stamping each tree independently is automatically `DeferID`-correct, and the same physical fetch never appears in two trees (no double-stamp).
+
+Request-independence (RFC-1 §8.5, dossier §6.5):
+the postprocessed plan is cached and reused across requests (`execution_engine.go:304-305`).
+The stamper writes ONLY static config: flags, TTLs, `CacheName`, the frozen `KeySpec` (value data), and the `ProvidesData` tree (request-independent plan data).
+It derives NO per-request key material — variable values, header hash, and global prefix are all derived at runtime inside `PrepareFetch` (RFC-1 §3.6, §8.5).
+P3 reads only static structure (`ProvidesData` + `DependsOnFetchIDs`).
+So the cached plan is safe to share.
+
+---
+
+## 9. ProvidesData: RE-ADD a dedicated visitor (PR5)
+
+### 9.1 Decision: re-add the visitor, do NOT derive
+
+RFC-2 re-introduces a dedicated plan-time `ProvidesData` visitor (P1) and does NOT derive `ProvidesData` from the merged response `Data` tree in a post-pass.
+This is the correctness-critical decision; the justification is grounded in verified source (the lossiness analysis grafted from draft A, now proven against the defer branch):
+
+1. After merge, per-fetch attribution is LOST.
+   `mergeFields` (`postprocess.go:193`) collapses fields from multiple planners into one `*resolve.Object`, and `FieldInfo.Merge` (VERIFIED `node_object.go:173-185`) merges only `ParentTypeNames` and `Source.IDs` — it does NOT merge `FetchID`, so a `@shareable`/multi-subgraph field keeps a SINGLE surviving `FetchID`.
+   Partitioning the merged tree by `Info.FetchID` therefore yields a TOO-SMALL `ProvidesData` for shared fields.
+   At runtime the coverage walk would then wrongly accept an incomplete cached value as a full hit — a real under-coverage stale/incomplete serve, not a missed hit (the reviewer's blocking objection to deriving).
+
+2. The merged response `Field` is ARG-BLIND.
+   `resolve.Field` (VERIFIED `node_object.go:103-112`) carries `Name`, `Value`, `OnTypeNames`, `Info` — but NO arguments.
+   RFC-1 §2.10 requires alias-AND-arg-aware coverage (a value cached under `friends_<hashA>` must not satisfy `friends(first:20)` = `friends_<hashB>`).
+   A derived tree cannot recover `CacheArgs`, so arg-blind coverage can SERVE STALE values — a correctness hole.
+
+3. The three OLD normalizations need WALK-TIME context the flat tree has lost: entity-boundary detection (enclosing type + planner transition), `__typename` injected-vs-requested disambiguation, and inline-fragment path normalization all live at field-visit time (OLD `caching_planner_state.go:91-370`, analysis-A §2.1).
+
+The visitor gets per-field fetch ownership for FREE from `planningVisitor.fieldPlanners` (the same field the cost visitor reads, `planner.go:177`), captures alias+args at field-visit time, and is a verbatim port of OLD `trackFieldForPlanner`/`popFieldsForPlanner`/`createFieldValueForPlanner` — so it reproduces the runtime coverage input byte-for-byte.
+The cost is one extra plan-time visitor reading a read-only planner output; that is a strictly smaller, better-understood surface than re-deriving ownership + three normalizations + args from a different data structure.
+
+### 9.2 The registration mechanism (verified, a reviewer must-fix)
+
+P1 is a NEW visitor file registered as a PEER on the EXISTING `planningWalker`, NOT a standalone pre-/parallel walker.
+This is the ONLY mechanism that can see per-field fetch ownership: `fieldPlanners` is the planning visitor's own map (`visitor.go:64-66`), populated during the walk (`visitor.go:232-235`).
+A separate `prepareOperationWalker`-style walk (`planner.go:57-60`) runs before planner ownership exists and could not produce correct `ProvidesData` — so a standalone own-walker pre-planning pass would be wrong for P1, and the cost-visitor peer pattern is right.
+The precedent is VERIFIED: the `CostVisitor` registers on the same `planningWalker` via `RegisterEnterFieldVisitor`/`RegisterLeaveFieldVisitor` (`planner.go:180-181`), reads `p.planningVisitor.fieldPlanners` (`:177`), and the code comment (`:170-174`) says it must be registered LAST because it depends on `fieldPlanners`.
+P1 registers right after it, identically (§5.2).
+
+> IMPLEMENTATION CORRECTION (first pass, commit A1b): the "peer on the SAME walk, like `CostVisitor`" plan did NOT hold on this branch, for two reasons discovered only at implementation time.
+> First, `Visitor.AllowVisitor` filters out non-planner peers (so P1's `EnterField` never fires on the main walk), and editing `visitor.go` to change that is forbidden (PR1).
+> Second, `fieldPlanners` is populated during `LeaveField`, so even an unfiltered `EnterField`-time peer would read it empty.
+> The working solution: P1 runs as a SECOND, filter-free walk on the same `planningWalker` AFTER the main walk (`ResetVisitors()` + `SetVisitorFilter(nil)` + register only P1 + `Walk(...)` + `attachTo`), gated entirely by `cacheProvidesData != nil`.
+> That second walk runs ONLY P1, never re-runs the planning visitor, and therefore never rebuilds the plan — so the NO-OP golden and every existing planner test are byte-identical, and the cost is one extra plan-time walk per unique cached operation.
+> `CostVisitor` gets away with the peer pattern because it reads `fieldPlanners` in `LeaveField`, not `EnterField`; a future spec revision should describe P1 as this gated second walk rather than a same-walk peer.
+
+```go
+// plan/cache_provides_data_visitor.go (body ported from OLD caching_planner_state.go)
+type cacheProvidesDataVisitor struct {
+	*astvisitor.Walker
+	operation, definition *ast.Document
+	planners              []PlannerConfiguration
+	fieldPlanners         map[int][]int           // fieldRef -> plannerIDs (read-only, from planningVisitor)
+	objects               map[int]*resolve.Object // fetchID -> root ProvidesData object
+}
+
+func (v *cacheProvidesDataVisitor) EnterField(ref int) {
+	for _, plannerID := range v.fieldPlanners[ref] {
+		v.trackField(plannerID, ref) // append a resolve.Field with OriginalName + CacheArgs (from the operation AST);
+		                             // descend object frames; entity-boundary reset (OLD trackFieldForPlanner)
+	}
+}
+func (v *cacheProvidesDataVisitor) LeaveField(ref int) {
+	for _, plannerID := range v.fieldPlanners[ref] {
+		v.popField(plannerID, ref) // OLD popFieldsForPlanner
+	}
+}
+```
+
+### 9.3 How the tree is built and attached (the `*FetchInfo` carrier)
+
+`ProvidesData` is built at plan time but consumed by the post-pass.
+The carrier is a side-table `map[*resolve.FetchInfo]*resolve.Object`, NOT a fetchID-keyed map and NOT a re-added `FetchInfo.ProvidesData` field.
+Using a side-table keyed by `*FetchInfo` (B's mechanism) rather than re-adding `FetchInfo.ProvidesData` (C's mechanism) honors RFC-1 §3.3, which deliberately avoids that field.
+
+`*FetchInfo` is the identity-stable key across the plan→postprocess boundary (VERIFIED):
+
+- `deduplicateSingleFetches` keeps the SURVIVOR's `Item` and its `Info` pointer; deduped duplicates have identical selections, so the survivor's `ProvidesData` is correct.
+- `fetchIDAppender` does not reassign `FetchID` and never touches `Info`; even if it did, the `*FetchInfo` key is immune to a fetchID change.
+- `createConcreteSingleFetchTypes` copies `Info` BY REFERENCE into the concrete types (`Info: fetch.Info`, `create_concrete_single_fetch_types.go:71`/`:116`), so the `*EntityFetch`/`*BatchEntityFetch` expose the SAME `*FetchInfo` pointer the plan-time visitor saw.
+
+So the stamper does `pd[fetch.FetchInfo()]` and gets the right tree.
+`attachTo` resolves fetchID→`*FetchInfo` once, after the walk, while fetchIDs still equal the planner IDs the visitor keyed on:
+
+```go
+// attachTo converts the fetchID-keyed map to a *FetchInfo-keyed side-table on the
+// plan, the carrier the stamper consumes (§9.3). Iterating v.objects is sorted by
+// fetchID for determinism (§13.1).
+func (v *cacheProvidesDataVisitor) attachTo(p Plan) {
+	resp := responseOf(p) // *GraphQLResponse for sync/defer/subscription
+	out := make(map[*resolve.FetchInfo]*resolve.Object, len(v.objects))
+	for _, fetchID := range sortedKeys(v.objects) {
+		if info := infoForFetchID(resp, fetchID); info != nil {
+			out[info] = v.objects[fetchID]
+		}
+	}
+	resp.SetCacheProvidesData(out)
+}
+```
+
+The carrier is a transient, request-independent, unexported field on `resolve.GraphQLResponse` with two accessors (additive, changes no existing behavior):
+
+```go
+// on resolve.GraphQLResponse (additive, unexported; request-independent plan data)
+cacheProvidesData map[*FetchInfo]*Object
+
+func (r *GraphQLResponse) SetCacheProvidesData(m map[*FetchInfo]*Object) { r.cacheProvidesData = m }
+func (r *GraphQLResponse) CacheProvidesData() map[*FetchInfo]*Object     { return r.cacheProvidesData }
+```
+
+This avoids response-tree `Copy()` drift entirely (PR10, §13): the `ProvidesData` tree is its OWN object tree, never part of the response `Data` tree that defer's `build_defer_tree` deep-copies.
+A regression assertion verifies the stamp pass resolves the right tree via `fetch.FetchInfo()` after dedup + appendFetchID + conversion (§14).
+
+---
+
+## 10. The dedicated L1-optimize pass (PR6)
+
+`optimizeL1Cache` (P3) is its OWN single-responsibility `FetchTreeProcessor` (`postprocess/optimize_l1_cache.go`), a faithful re-home of OLD `optimize_l1_cache.go` (analysis-A §3).
+It is a PURE NARROWING pass: the stamper sets `cfg.L1 = true` for L1-eligible entity fetches (§7), and P3 REFINES it to `cfg.L1 = canRead || canWrite`, turning L1 OFF where it cannot help.
+This makes the "eligibility then narrow" description match the code (a reviewer must-fix against B's earlier ambiguity): the stamper is the sole eligibility setter, P3 the sole narrower, and P3 never turns L1 on.
+
+It runs AFTER P2 so every cache-eligible fetch already carries a `*FetchCacheConfig` (with `ProvidesData`), and reads from there instead of the removed `FetchInfo.ProvidesData`:
+
+- collect entity fetches across ALL trees: `*EntityFetch`, `*BatchEntityFetch`, or `*SingleFetch` with `RequiresEntityFetch`/`RequiresEntityBatchFetch` (`fetch.go:262`/`:266`), with `entityType = info.RootFields[0].TypeName`, `providesData = fetch.Cache.ProvidesData`, `dependsOn = deps.DependsOnFetchIDs` (port of OLD `collectEntityFetches`/`extractEntityFetchInfo`, OLD `optimize_l1_cache.go:76-146`).
+- for each entity fetch, `cfg.L1 = canRead || canWrite`:
+  - `canRead` = a prior fetch (or the union of priors) of the same entity type provides a SUPERSET of this fetch's fields (`hasValidProvider`/`collectAncestorUnion`, OLD `:229-265`, `:461-537`).
+  - `canWrite` = a later fetch of the same type needs a SUBSET of this fetch's `ProvidesData` (`hasValidConsumer`, OLD `:271-297`).
+  - ordering resolved purely from `DependsOnFetchIDs` (`executesBefore`/`isInDependencyChain`, OLD `:300-337`).
+
+The field-coverage primitives (`objectProvidesAllFields`, `nodeProvidesAllFields`, `treeContainsAllFields`, `unionObjects`, OLD `:353-572`) port verbatim — they already operate on `resolve.Object`/`resolve.Field` (`node_object.go:8`/`:103`).
+`setL1` is the OLD `setUseL1Cache` three-arm switch re-targeted onto `cfg.L1`, guarding `f.Cache != nil`:
+
+```go
+func (o *optimizeL1Cache) setL1(fetch resolve.Fetch, value bool) {
+	switch f := fetch.(type) {
+	case *resolve.SingleFetch:
+		if f.Cache != nil { f.Cache.L1 = value }
+	case *resolve.EntityFetch:
+		if f.Cache != nil { f.Cache.L1 = value }
+	case *resolve.BatchEntityFetch:
+		if f.Cache != nil { f.Cache.L1 = value }
+	}
+}
+```
+
+### 10.1 Cross-tree collection (graft from A)
+
+`processTrees(roots ...*resolve.FetchTreeNode)` collects entity fetches across the root tree AND every `Defers[i].Fetches` in a SINGLE pass, then runs the subset/superset decision over the combined set:
+
+```go
+func (o *optimizeL1Cache) processTrees(roots ...*resolve.FetchTreeNode) {
+	if o.disable {
+		return
+	}
+	var entities []*entityFetchInfo
+	for _, r := range roots {
+		entities = append(entities, o.collectEntityFetches(r)...) // across all trees
+	}
+	for _, ef := range entities {
+		if !cacheL1Eligible(ef.fetch) { // stamper marked it ineligible -> nothing to narrow
+			continue
+		}
+		if !o.hasValidProvider(ef, entities) && !o.hasValidConsumer(ef, entities) {
+			o.setL1(ef.fetch, false)
+		}
+	}
+}
+```
+
+The L1 store lives for the request lifetime and is shared across defer groups (the request-lifetime L1 store, RFC-1 §6.2), so a root-tree entity fetch can provide L1 to a defer-group consumer.
+A per-tree pass would turn L1 off for a root provider whose only consumer lives in a defer group (safe but suboptimal); the cross-tree pass captures these provider/consumer pairs.
+Narrowing is conservative-safe in both directions: turning `cfg.L1` off only forgoes an optimization, never breaks correctness — so even if a future change reorders defer collection, the worst case is a missed L1 hit, never incorrect data.
+Root-field→entity L1 promotion (OLD `:148-222`, `RootFieldL1EntityCacheKeyTemplates`) is staged to v2 with the rest of root-field L1; v1 ships the entity subset/superset decision, which the loader treats as a cache miss when a promotion is absent (correct, just less optimal).
+
+### 10.2 The all-false residual `Cache` after narrowing
+
+The stamper sets `cfg.L1 = true` for every entity-eligible fetch BEFORE P3 runs, so an entity fetch always carries a non-nil `Cache`.
+When P3 then narrows `cfg.L1` off and the policy also left `L2` and `Shadow` false, the fetch is left holding a non-nil but all-false `FetchCacheConfig`.
+This is harmless: RFC-1's runtime controller no-ops a config with no active layer (it produces no lookup and no write), so behaviour is identical to a nil `Cache`.
+For plan cleanliness and to keep the no-op golden diff minimal, P3 MAY re-null such a fully-inert `Cache` as its last step (`if !cfg.L1 && !cfg.L2 && !cfg.Shadow { f.SetCache(nil) }`); this is an optional tidy, not a correctness requirement.
+
+---
+
+## 11. Separation of concerns (PR7) and composed NO-OP gating (PR8)
+
+### 11.1 Separation of concerns
+
+The OLD design failed review because it was a MEGA-VISITOR: `cachingPlannerState` (943 lines) fused into the primary walk, stamping four node kinds from inside `EnterField`/`LeaveField`/`resolveFieldValue`/`configureFetch` (analysis-A §2.1).
+RFC-2 decomposes it along the axis that makes each piece independently reviewable and testable, plus a thin facade:
+
+| Concern | Owner | Why it lives there | Could it move? |
+|---|---|---|---|
+| Build `ProvidesData` (P1) | peer visitor on `planningWalker` | Needs walk-time context + per-planner ownership (§9.1) | No — only phase with that context |
+| Orchestrate + gate (facade) | `cachingPlanner` | Logic-free sequencing + the single NO-OP gate | n/a |
+| Freeze `@key` (H) | `cacheKeySpecFreezer` | The SOLE federation reader; pure value output | Helper invoked by the stamper; own file for review |
+| Assemble + stamp (P2) | `cacheConfigStamper` | Pure function of the finished concrete tree + policy + P1 output | No earlier (needs concrete types, §7) |
+| L1 cross-fetch decision (P3) | `optimizeL1Cache` | Pure function of stamped `ProvidesData` + dependency ordering | No earlier (needs all configs present, §10) |
+
+Granularity justification (not too coarse, not over-fragmented):
+
+- NOT one pass: a single "do all caching" pass would re-fuse pre-planning, walk-time, and post-plan concerns — the OLD anti-pattern.
+- NOT ten passes: the freezer is a helper INSIDE the stamper's traversal (one walk freezes and stamps, two testable units), and `computeHasAliases`/the `ProvidesData`→`cfg` copy are folded into the stamper (single calls, no independent meaning) rather than spun out (graft from C).
+- L1 stays SEPARATE from stamp because it is a CROSS-fetch decision (reads OTHER fetches) whereas stamp is PER-fetch — different inputs, different testability, different reasons to change.
+- Federation is touched in exactly ONE file (H), so "does caching leak federation into runtime" is a one-file review.
+- Caching touches the new files plus the additive registrations; the five forbidden visitor files show ZERO diff.
+
+### 11.2 CacheConfigProvider integration (consume RFC-1 verbatim)
+
+RFC-2 declares the plan-side `cacheconfig` package implementing RFC-1 §7.2-7.3's EXACT type shapes — adding no fields, inventing none — and consumes them.
+The provider is placed in the plan-side `cacheconfig` package, NOT in `resolve` (the must-fix against draft C): RFC-1 §7.2-7.3 put the policy model and provider plan-side, decoupled from `FederationInfo`, preserving the one-way `resolve`→`cacheconfig` direction (`resolve` must not import the policy types).
+
+```go
+// plan/cacheconfig/provider.go — RFC-1 §7.3, declared per spec, consumed verbatim.
+type CacheConfigProvider interface {
+	EntityPolicy(typeName string) (EntityCachePolicy, bool)
+	RootFieldPolicy(typeName, fieldName string) (RootFieldCachePolicy, bool)
+	MutationPolicy(fieldName string) (MutationCachePolicy, bool)
+	SubscriptionPolicy(typeName, fieldName string) (SubscriptionCachePolicy, bool)
+	KeySpec(scope resolve.CacheScope, typeName, fieldName string) (resolve.CacheKeySpec, bool) // present per spec; unused by RFC-2 (§6.2)
+}
+```
+
+The provider is reached parallel to (not on) `FederationInfo`, via the accessor RFC-1 §7.3 specifies: `func (d dataSourceConfiguration[T]) Caching() CacheConfigProvider` — nil when caching is not configured.
+
+### 11.3 Composed NO-OP gating — mode mismatch impossible by construction
+
+Two independent gates compose (RFC-1 §10.1):
+
+| | planner NO-OP (every `Cache` nil) | planner ON (configs stamped) |
+|---|---|---|
+| runtime NO-OP (`cacheController == nil`) | nothing happens (default) | configs present, never consulted → NO-OP |
+| runtime ON (controller set) | controller present, `PrepareFetch` never called (cfg nil) → NO-OP | caching active |
+
+RFC-2 owns the planner column; it gates at FOUR points, all defaulting OFF:
+
+1. empty provider map ⇒ `Annotate` returns before touching a node; P1 is never registered (§5).
+2. a datasource with `provider == nil` ⇒ `buildConfig` returns nil, `Cache` stays nil (§7).
+3. a `(type[,field])` the provider returns `(_, false)` for ⇒ `buildConfig` returns nil (§7).
+4. a config with `!L1 && !L2 && !ShadowMode` ⇒ `buildConfig` returns nil (§7).
+
+The runtime side gates at `cacheController == nil` and `item.Fetch.Cache == nil` (RFC-1 §10.1).
+The LOWER gate always wins and the lowest is NO-OP, so "L1-only runtime + NO-OP planner" and "configs stamped + no controller" both degrade to a full NO-OP.
+A real cache requires BOTH a non-nil controller AND a non-nil per-fetch config — there is no third switch (RFC-1 §10.1).
+This is the gate the OLD branch lacked: `DisableEntityCaching` only disabled L2 while still building L1 + key templates (dossier §5.5).
+
+### 11.4 Strict no-op before any provider exists
+
+With no `EnableCaching(...)` option: `opts.cacheProviders` is empty, the facade returns at its guard, P1 is not constructed/registered, every fetch's `Cache` stays nil, and RFC-1's `FetchConfiguration.Equals` clause sees both-`Cache`-nil and returns its prior result (RFC-1 §3.8).
+Merging RFC-2's code ALONE — before any provider is wired — changes plans in ZERO ways (proven by the no-op golden test, §14).
+
+---
+
+## 12. @requestScoped: out of scope entirely (PR9)
+
+The `@requestScoped` DIRECTIVE FEATURE is OUT OF SCOPE entirely — removed by review, not staged.
+RFC-2 ships NO `@requestScoped` support in v1 OR v2: there is no `cacheRequestScopedRewrite` pre-planning pass, no rename-map response post-pass, no `RequestScopedPolicy` on the provider, no `RequestScoped` field on the stamped config, and no reference to the OLD `node_selection_visitor_request_scoped.go` widening rewrite.
+The OLD pre-planning widening (`collectRequestScopedParticipants`/`computeRequestScopedMissing`/`addFieldRequirementsToOperation`, `visitor.go:396-403/425-427`) is therefore NOT ported.
+
+Every other caching capability in RFC-1's v1 set works without it (entity L1/L2, root-field response cache, coverage/freshness/reorder, negative caching, shadow), so removing the feature changes nothing else in this RFC.
+
+Important distinction (do not conflate the two):
+removing the `@requestScoped` directive feature does NOT touch the request-lifetime L1 store — the per-request L1 cache state that lives for the lifetime of ONE request and is shared by reference across the per-defer-group Loaders (RFC-1 §6.2).
+That shared request cache state is intrinsic to L1 caching (the final implementation phase) and is RETAINED; it is the reason `optimizeL1Cache` collects entity fetches cross-tree (§10.1).
+Only the directive-driven field-widening feature is gone.
+
+---
+
+## 13. Determinism, plan cache, DeferResponsePlan, per-node annotations, Copy()/side-table (PR10)
+
+### 13.1 Determinism
+
+Every pass emits identical output for identical input across runs, or the cached plan (`execution_engine.go:304-305`) becomes nondeterministic.
+Rules RFC-2 follows:
+
+- the fetch-tree walk is structural (Single/Parallel/Sequence recursion, `fetchtree.go:17-22`), so output follows tree order, not map order.
+- wherever a pass iterates a Go map (P1's `objects` in `attachTo`, P3's per-type provider sets), it SORTS by a stable key (fetchID, then coordinate) before producing output — the precedent is `inverseMap` sorting "for deterministic plans/tests" (`planner.go:159`).
+- the freezer orders the multi-key `Candidates` deterministically (sort the `@key` sets by selection-set string before building, §6.1) so the candidate list is stable; it does NOT merge variants (multi-key keeps them separate). `CacheArgs` is sorted on the `ProvidesData` tree (OLD `caching_planner_state.go:165-170`).
+- `EntityKeyMappings` and each candidate's representation node are value-cloned (the shared builder allocates fresh `resolve` nodes), so no shared mutable state leaks between plans.
+
+### 13.2 Plan cache and DeferResponsePlan
+
+Covered in §8: only static config is written; the third plan kind `DeferResponsePlan` (`plan.go:66`) is handled by stamping the root tree plus each `Defers[i].Fetches` (`postprocess.go:211-213` mirror) before `buildDeferTree` nils `Defers`; N trees per plan are all walked; the cross-tree L1 pass spans them.
+
+### 13.3 Per-object / per-field annotations and the Copy() interaction
+
+RFC-2 AVOIDS the defer `Copy()` drift (dossier §7 risk 9) by construction:
+
+- The L1-normalize metadata (`OriginalName`, `CacheArgs`, `HasAliases`) is written ONTO THE CACHING-OWNED `ProvidesData` TREE, not the response tree.
+  That tree is a SEPARATE `*resolve.Object` built by P1 and carried in `FetchCacheConfig.ProvidesData`; it is NEVER reached by defer's `build_defer_tree`/`Object.Copy()`/`Field.Copy()` (`node_object.go:18`/`:119`), which walk only the response `Data` tree.
+  So even though §5.4 adds these fields to `resolve.Object`/`resolve.Field` and updates `Copy()` additively, there is no shared-node `Copy()` interaction with defer on the tree that actually carries the metadata.
+- Response-tree analytics annotations (`Object.CacheAnalytics`, `Field.CacheAnalyticsHash`) are NOT written in v1, because RFC-1 ships the analytics observer NIL (RFC-1 §3.5, §9; the walker hooks are v2).
+  So v1 writes NOTHING onto the shared response tree.
+  When analytics lands in v2, those annotations use a NODE-KEYED SIDE-TABLE (keyed by stable coordinate) rather than fields on `Object`/`Field` (the explicit graft from C), dodging the defer shared-node copy hazard entirely.
+
+This is the PR10 resolution: per-field cache metadata lives on the caching-owned `ProvidesData` side-tree (immune to defer `Copy()`), the plan→postprocess carrier is a `*FetchInfo`-keyed side-table (§9.3, immune to fetchID reassignment and to response-tree `Copy()`), and the shared response tree is left untouched in v1.
+
+---
+
+## 14. Testing strategy
+
+Per-pass unit tests (each pass is a small, asserted-output unit, §11.1; assertions follow the repo convention — assert the FULL value with `assert.Equal`, never `Contains` or fuzzy comparison):
+
+- H `cacheKeySpecFreezer`: table tests over `(FederationMetaData, definition, scope, type[, field])` → assert the FULL multi-key `resolve.CacheKeySpec` value inline (single `@key` → one candidate, composite `@key`, nested object `@key`, MULTIPLE `@key` sets → one independent candidate each, deterministically ordered, none required; interfaceObject/entityInterface `__typename` baked into the candidate representation; no-`@key` → `(zero, false)`).
+  Mutate the source `FederationMetaData` after freezing and re-assert equality (no pointer aliasing into federation).
+  The shared `representationvariable` package extraction (§6.1) is guarded SEPARATELY by the existing `graphql_datasource/representation_variable_test.go` (behavior preserved through the call sites); a golden assertion confirms the freezer's candidate node and the data source's representation node come from the SAME builder.
+- P1 `cacheProvidesDataVisitor`: feed `(operation, definition, fieldPlanners)` and assert the full `map[*FetchInfo]*Object` per fetch — entity-boundary reset, `__typename` dedup, inline-fragment `OnTypeNames`, alias→`OriginalName`, `CacheArgs` capture.
+  The PR5 FIDELITY GATE (a reviewer must-fix): golden-compare P1's per-fetch `ProvidesData` trees against the OLD branch's trees for the federation fixtures; per RFC-1 §2.10 a too-small `ProvidesData` silently disables hits and an arg-blind one serves stale data, so this is a HARD test, not a claim.
+- P2 `cacheConfigStamper`: feed a finished concrete fetch tree + a fake provider; assert the FULL `*FetchCacheConfig` stamped on each `*SingleFetch`/`*EntityFetch`/`*BatchEntityFetch`, and assert nil where policy is absent (the four NO-OP gates, §11.3).
+  Carrier regression assertion (a reviewer must-fix): build a tree that goes through dedup + appendFetchID + `createConcreteSingleFetchTypes`, then assert the stamper resolves the right `ProvidesData` via `fetch.FetchInfo()`.
+- P3 `optimizeL1Cache`: port the OLD pass's tests; assert `cfg.L1` per fetch for provider/consumer/union/dependency-chain scenarios, PLUS a defer case feeding `processTrees(root, defer1, defer2)` asserting cross-tree provider/consumer narrowing (§10.1).
+
+Golden plan tests (the integration proof, via `datasourcetesting.RunTest`):
+
+- NO-OP golden (graft from A; the hard PR1/PR8 proof): run the EXISTING planner golden suite with NO provider wired and assert the postprocessed plans are BYTE-IDENTICAL to today (every `Cache` nil).
+- Caching golden: with a provider configured, assert the WHOLE postprocessed plan across sync, defer (root + multiple defer groups, asserting each `Defers[i].Fetches` carries `Cache`), and subscription — exact-match snapshots via the plan pretty-printer (which nil-guards, commit 921e48ae).
+- Defer + `DeferID`: assert a fetch and its deferred twin get independent `Cache` values and are not merged (`EqualSingleFetch` guard, `fetch.go:49-53`).
+- Determinism: run each plan twice and assert byte-identical plans.
+- Plan-cache safety: assert no per-request data appears in any stamped `Cache` (golden plan has only static fields).
+
+---
+
+## 15. v1 vs v2 staging and risks / open questions
+
+### 15.1 Staging
+
+| Capability | v1 | v2 |
+|---|---|---|
+| `cacheProvidesDataVisitor` (re-add, exact OLD semantics) + `*FetchInfo` carrier | yes | — |
+| `representationvariable` shared-package extraction (refactor graphql_datasource in place, §6.1) | yes (early structural commit) | — |
+| `cacheKeySpecFreezer` (ALL `@key` sets → multi-key `CacheKeySpec` by value, via shared `representationvariable`) | yes | — |
+| `cacheConfigStamper` on all 3 concrete types + folded `computeHasAliases` | yes | — |
+| `optimizeL1Cache` (entity subset/superset, CROSS-tree) | yes | root-field→entity L1 promotion |
+| Entity L1/L2 + root-field response cache + negative + shadow (config side) | yes | — |
+| `CacheConfigProvider` + composed NO-OP gates | yes | — |
+| Per-field L1-normalize metadata on `ProvidesData` (`OriginalName`/`CacheArgs`/`HasAliases`) | yes | — |
+| Per-root-field fetch isolation (vs the v1 all-or-nothing rule) | NO (conservative: decline when policies differ, §7.2) | — (deferred to a separate RFC, RFC-03, §7.2) |
+| `@requestScoped` widening | NO (out of scope entirely, removed by review, §12) | NO (out of scope entirely; not a v2 pass) |
+| Response-tree analytics (`Object.CacheAnalytics`, `Field.CacheAnalyticsHash`) | NO (observer nil, RFC-1 §3.5) | node-keyed side-table (not `Object`/`Field` fields) |
+| Subscription `EntityCachePopulation` + mutation populate/invalidation | NO | `cacheSubscriptionAnnotator` |
+| Partial L1 / partial batch realign | policy bits stamped only (`EnablePartialCacheLoad`/`PartialBatchLoad`); loader seam is v2 (RFC-1 §9) | loader impl |
+
+Critical staging note (mirrors RFC-1 §9): v1 produces everything the v1 controller needs (NO-OP / L1 / L2 / L1+L2 / shadow, full-response + full-batch, always-on coverage/freshness/reorder).
+Analytics, subscription/mutation caching, and partial realign are staged because they collide with the defer walker rewrite or need the v2 loader seams — exactly where RFC-1 draws its v1/v2 line.
+(`@requestScoped` is not on this list: it is out of scope entirely, removed by review, §12; per-root-field isolation is likewise deferred to RFC-03, §7.2.)
+
+### 15.2 Risks and open questions
+
+- R1 (P1 ownership read): P1 reads `planningVisitor.fieldPlanners`; if that map ever diverges from what the planning visitor emitted, `ProvidesData` is subtly wrong.
+  Mitigation: the golden-compare against OLD trees (§14); the cost visitor already relies on the same field (`planner.go:177`), so the dependency is precedented.
+- R2 (`*FetchInfo` carrier requires `Info` enabled): when `DisableIncludeInfo` is set, `Info` is nil and the carrier degrades to no caching.
+  Mitigation: codify "enable `FetchInfo` whenever a provider is configured" as a hard, tested wiring precondition, so a `DisableIncludeInfo`+provider combo degrades to a clean no-op rather than silent uncached behavior (graft from C).
+- R3 (L2 inferred from TTL): RFC-1's `*CachePolicy` has no L1/L2 bool, so RFC-2 infers `L2 = TTL>0 || NegativeCacheTTL>0`.
+  Open question: confirm with RFC-1 authors whether an explicit L2-enable signal is intended; if so it belongs in the `*CachePolicy` struct, not invented here (§7.1).
+- R4 (`EntityKeyMappings` source): RFC-2 freezes `EntityKeyMappings` from federation (dossier §5.3), never from the policy struct.
+  Open question: if operator-declared root-arg↔`@key` overrides are needed beyond what federation exposes (OLD carried them on `RootFieldCacheConfiguration`), that config must arrive through a dedicated provider method; v1 freezes the structurally-derivable mappings and stages overrides.
+- R5 (CacheConfigProvider migration): moving policy off `FederationInfo` touches external producers (cosmo).
+  Mitigation: RFC-1 §7.5's one-release `FromFederation` shim; RFC-2 only consumes the provider, so the migration is plan-side and isolated.
+- R6 (the one `node_object.go` edit): re-adding `OriginalName`/`CacheArgs`/`HasAliases` + additive `Copy()` is the only `resolve`-type change beyond RFC-1's `Cache` field.
+  Mitigation: it is additive, not a forbidden-body edit, and the tree it annotates is never defer-`Copy()`'d (§13.3); alternatively a node-keyed side-table avoids even that, at the cost of an extra map lookup in the runtime coverage walk.
+
+---
+
+## 16. Appendix A: OLD-concern → new-home mapping (no existing visitor edited; scope decisions called out)
+
+| OLD caching concern (analysis-A) | OLD site | New home in RFC-2 | Existing visitor edited? |
+|---|---|---|---|
+| Per-planner `ProvidesData` tree build (`trackFieldForPlanner`/`popFieldsForPlanner`/`createFieldValueForPlanner`) | `caching_planner_state.go:91-197,234-284,372-384`, driven from `visitor.go` `EnterField`/`LeaveField` | P1 `cacheProvidesDataVisitor`, PEER on `planningWalker` (§9) | No — `visitor.go` untouched; P1 is a separate registered visitor |
+| Entity-boundary / `__typename`-dedup / inline-fragment path normalization | `caching_planner_state.go:286-370` | P1 (ported verbatim) | No |
+| Alias→`OriginalName`, `CacheArgs`, `HasAliases` | `visitor.go:425-427`, `caching_planner_state.go:159-170`, `node_object.go` | P1 captures onto the `ProvidesData` tree; `computeHasAliases` folded into the stamper; fields re-added additively to `resolve` (§5.4) | No — `node_object.go` (resolve) is additive, not a forbidden file |
+| `FetchCacheConfiguration` derivation from fed config | `caching_planner_state.go:594-746`, `configureFetch` `visitor.go:1450` | P2 `cacheConfigStamper` from `CacheConfigProvider` policy (§7) | No |
+| Multi-key `CacheKeySpec` candidates from ALL `@key` sets | `representation_variable.go`, `graphql_datasource.go` | H `cacheKeySpecFreezer` via the shared `representationvariable` package (§6.1) — helpers EXTRACTED from `graphql_datasource` (unexported there on defer) into `plan/representationvariable`, `graphql_datasource` refactored in place to call them; one best-effort candidate per `@key` set | No forbidden-visitor edit (`graphql_datasource.go` refactor is behavior-preserving, guarded by its tests) |
+| `optimize_l1_cache` `UseL1Cache` decision | `postprocess/optimize_l1_cache.go` (OLD) | P3 `optimizeL1Cache`, re-homed, CROSS-tree, narrows `cfg.L1` (§10) | No — own pass |
+| Per-root-field cache isolation (`isolatedRootField`) | `path_builder_visitor.go:113-119,564-588,1332-1359` | v1 all-or-nothing decline in the stamper (§7.2); per-fetch isolation NOT dropped — DEFERRED to a separate RFC, RFC-03 (`docs/caching/specs/2026-06-30-rfc-03-per-root-field-cache-isolation.md`, §7.2) | No — `path_builder_visitor.go` untouched |
+| `@requestScoped` widening + rename maps | `node_selection_visitor_request_scoped.go` (766), `visitor.go:396-403/425-427` | OUT OF SCOPE entirely (removed by review, §12) — no v1 or v2 pass | No |
+| Required-field alias preservation | `required_fields_visitor.go:226,238,313-318` | Only relevant to `@requestScoped`, which is out of scope (§12); no v1 or v2 change | No — `required_fields_visitor.go` never needs a change |
+| Subscription `EntityCachePopulation`, mutation impact/populate | `caching_planner_state.go:463,807-852` | v2 `cacheSubscriptionAnnotator` (§4) | No |
+| Cache config on `FederationMetaData`/`FederationInfo` | `federation_metadata.go` (+323), 4 methods, forwarders | plan-side `cacheconfig` package + `CacheConfigProvider` (§11.2) | No — `federation_metadata.go` untouched |
+
+The five PR1-forbidden files — `node_selection_visitor.go`, `path_builder_visitor.go`, `required_fields_visitor.go`, `node_selection_builder.go`, `visitor.go` — have ZERO body edits in v1.
+Every OLD concern lands in a new file or an additive registration, with two DELIBERATE scope decisions made explicit by review: `@requestScoped` widening is out of scope entirely (removed, §12), and per-root-field cache isolation is deferred to a separate RFC, RFC-03 (§7.2) — neither is a silent drop.
+The one non-additive touch is the behavior-preserving extraction of the representation-variable builder into the shared `representationvariable` package (`graphql_datasource` refactored in place, guarded by its existing tests, §6.1) — not a forbidden-visitor edit.

--- a/docs/caching/specs/2026-06-30-rfc-02-caching-planner.md
+++ b/docs/caching/specs/2026-06-30-rfc-02-caching-planner.md
@@ -139,7 +139,7 @@ The OLD `@requestScoped` pre-planning rewrite (`cacheRequestScopedRewrite`) is N
 
 Run-order diagram (CURRENT pipeline, NEW steps marked):
 
-```
+```text
 Planner.Plan (planner.go:92)
   selectOperation        (planner.go:100)
   prepareOperation       (planner.go:105)
@@ -395,7 +395,7 @@ The federation→caching boundary is crossed EXACTLY ONCE, at plan time, BY VALU
 
 Boundary diagram (RFC-1 §7.4):
 
-```
+```text
 plan.FederationMetaData.Keys (ALL resolvable @key selection sets)   +   interfaceObject/entityInterface remaps   +   root-arg↔@key mappings
         │  PLAN-TIME INPUT ONLY — read once, by value, by the freezer
         ▼

--- a/docs/caching/specs/2026-06-30-rfc-03-per-root-field-cache-isolation.md
+++ b/docs/caching/specs/2026-06-30-rfc-03-per-root-field-cache-isolation.md
@@ -1,0 +1,422 @@
+# RFC-3: Per-root-field cache isolation
+
+Status: final for review.
+Author: caching working group.
+Branch under change: `feat/eng-7770-add-defer-support-part-4`, code under `v2/pkg/engine/plan/`.
+Companion contracts: RFC-1 (`docs/caching/specs/2026-06-30-rfc-01-loader-cache-abstraction.md`, the runtime cache config) and RFC-2 (`docs/caching/specs/2026-06-30-rfc-02-caching-planner.md`, the caching planner passes).
+Ground truth: `scratchpad/caching-rfc/DOSSIER.md` (esp. §5.5 "all root fields in a fetch must share identical policy or L2 is disabled") and `scratchpad/caching-rfc/explore-isolatedRootField.md` (the OLD `isolatedRootField` mechanism and the additive-approach analysis).
+
+RFC-2 §7.2 ships the conservative, correct-but-coarse all-or-nothing rule for root-field fetches and explicitly forward-references THIS file for the per-field isolation optimization it deliberately defers (RFC-2 §7.2, §11 staging table line ~1025, appendix line ~1062).
+RFC-3 is that follow-on.
+It is a pure optimization layered on top of RFC-2 v1, and it changes NONE of RFC-2's v1 contract:
+with RFC-3 off, the planner produces byte-identical plans to RFC-2 v1, which in turn produce byte-identical plans to the pre-caching branch.
+
+---
+
+> REVISION 2 (maintainer feedback — see PLAN §R2, which is AUTHORITATIVE).
+> This is NO LONGER an out-of-core, deferred, separately-gated RFC: per-root-field cache isolation (splitting sibling root fields that resolve to the same datasource but carry different cache configs into their own fetches) is REQUIRED and folded into the CORE plan (R2.2).
+> Because the "forbidden files" rule is removed (R2.1), the mechanism MAY edit `path_builder_visitor.go` directly rather than routing around it — implement the clean up-front merge-prevention described below.
+
+## 1. Summary and motivation
+
+### 1.1 The concrete problem
+
+The path builder merges sibling query root fields from the SAME datasource into ONE fetch.
+On the current branch this happens in `planWithExistingPlanners` (`path_builder_visitor.go:829-902`):
+when `MergeAliasedRootNodes` is set (`datasource_configuration.go:425-433`), a second top-level root field on the same datasource joins the planner that already owns the first, so both render into one subgraph operation and one `SingleFetch`.
+
+Caching then meets a hard rule, carried verbatim from the OLD implementation and reproduced additively by RFC-2.
+The dossier states it (dossier §5.5, OLD `caching_planner_state.go:700-745`):
+
+> `RootFieldCacheConfig` requires ALL root fields in a fetch to share an IDENTICAL policy, or L2 is silently disabled for that fetch.
+
+RFC-2 §7.2 re-expresses this as `rootFieldPolicyForAllRootFields`, which walks `info.RootFields` and returns a policy ONLY when every root field resolves to the same one;
+otherwise the stamper leaves `Cache` nil and the whole fetch is L2-declined.
+This is the conservative "disable rather than mis-cache" fallback — it never serves wrong data, it just caches less.
+
+A single merged fetch hits this rule in two ways:
+
+- A cached root field merged with an UNCACHED sibling.
+  The uncached field resolves to no policy, so `rootFieldPolicyForAllRootFields` returns `(_, false)` and L2 is disabled for BOTH.
+  The cacheable field silently stops being cached.
+- Two cached root fields with DIFFERENT policies.
+  For example `me` configured to cache in `users`/30s and `cat` configured to cache in `pets`/60s:
+  the policies differ, so L2 is disabled for BOTH.
+
+### 1.2 Why this is also an optimization, not only a fix
+
+Even when two cached root fields share an IDENTICAL policy — so the all-or-nothing rule is satisfied and L2 stays enabled — merging them is suboptimal.
+A merged fetch can only be cached as a COARSE unit:
+its single L2 entry covers the whole combined response, so an operation that selects only one of the two fields misses, and a change to either field's data invalidates the entry for both.
+
+Isolating each cached root field into its own single-root-field fetch gives each field its OWN L2 key, so it reuses across operations that select different subsets, and so the work later in the implementation order — root fields that RE-USE the entity cache — can match a root-field fetch against an entity-cache entry one field at a time.
+
+Isolation therefore does two things at once:
+it recovers correctness (no accidental L2-disable when policies are mixed), and it improves hit rate (finer cache granularity and better reuse).
+
+### 1.3 What RFC-3 delivers
+
+A DEDICATED, gated isolation mechanism that forces each qualifying cached query root field into its OWN planner, hence its own `SingleFetch`, and prevents any other top-level root field from being folded into it.
+Each isolated fetch then carries its own `*resolve.FetchCacheConfig` (stamped by RFC-2's existing stamper, §7) with its own `CacheName`/`TTL`/`KeySpec`, and the isolated fetches run in parallel.
+
+The mechanism is driven by RFC-1's self-contained `cacheconfig.CacheConfigProvider`, never by `FederationMetaData`, and it is gated so that when no provider is configured it is provably never entered:
+the path builder takes its existing branches and produces byte-identical plans.
+RFC-2 §7.2's all-or-nothing stamper rule is RETAINED as the residual safety net for any fetch that still ends up mixed.
+
+---
+
+## 2. Background
+
+### 2.1 What OLD `caching-base` did
+
+Per-root-field isolation lived entirely in the path builder and the caching planner state, not in the loader.
+It had two cooperating halves (explore §1).
+
+The planner half — a flag plus three sites (OLD `path_builder_visitor.go`):
+
+1. `objectFetchConfiguration.isolatedRootField bool` (OLD `:116-119`):
+   "marks planners for cached query root fields that must not merge with other root fields."
+2. `handlePlanningField` (OLD `:554-599`) computed `isMutationRoot` and `isCachedQueryRoot := c.isCachedQueryRootField(...)`;
+   when either was true it went straight to `addNewPlanner` (a brand-new isolated planner) instead of `planWithExistingPlanners`, and for the cached-root case it stamped the flag.
+3. `isCachedQueryRootField` (OLD `:1340-1358`) was the gate:
+   false when entity caching was globally disabled;
+   only for `OperationTypeQuery`;
+   only for DIRECT children of the root (`strings.Count(currentPath, ".") == 1`);
+   and only when the field had explicit config (`RootFieldCacheConfig(typeName, fieldName) != nil`).
+4. The merge guard in `planWithExistingPlanners` (OLD `:783-791`):
+   ```go
+   // Don't merge other query root fields into isolated planners (cached root fields).
+   if c.isParentPathIsRootOperationPath(parentPath) && plannerConfig.ObjectFetchConfiguration().isolatedRootField {
+       continue
+   }
+   ```
+
+The config half — `configureFetchCaching` (OLD `caching_planner_state.go:594-746`) produced the per-fetch config and applied the all-or-nothing rule (OLD `:697-745`):
+for a root-field fetch, ANY uncached root field, or any two root fields whose policies differed in `CacheName`/`TTL`/`IncludeSubgraphHeaderPrefix`, disabled L2 for the whole fetch.
+
+Net effect:
+each cached query root field became its own planner, hence its own `SingleFetch`, with no other top-level root field folded in, so the all-or-nothing rule was trivially satisfied (one field, one policy) and each fetch got its own independent `Enabled`/`CacheName`/`TTL`.
+
+### 2.2 Why the current defer branch needs a fresh additive approach
+
+The current branch has NO `isolatedRootField` at all (verified: `objectFetchConfiguration` at `path_builder_visitor.go:112-126` has no such field, and `grep isolat pkg/engine/plan/*.go` is empty), and NO `RootFieldCacheConfig` / `DisableEntityCaching` (also empty).
+So the OLD mechanism is entirely absent; it would have to be re-introduced.
+
+RFC-2's architecture deliberately does NOT re-introduce it in the core plan.
+RFC-2 PR1 puts `path_builder_visitor.go` on the forbidden list and keeps the planner-visitor diff at zero, because the whole RFC-2 philosophy is additive passes with a byte-identical planner visitor (RFC-2 §5, §11.1, appendix §16).
+RFC-2 reproduces only the SAFE half — the all-or-nothing decline, re-expressed additively in the post-planning stamper as `rootFieldPolicyForAllRootFields` (RFC-2 §7.2) — and forward-references this RFC for the isolation optimization, calling out that it is "not dropped" but layered on later (RFC-2 §7.2, §11, §16).
+
+This RFC honors that split.
+It re-introduces isolation as its own focused, gated unit so the one seam it needs gets its own review, while RFC-2's "existing planners untouched" guarantee holds for everyone who does not enable caching.
+
+---
+
+## 3. Design
+
+### 3.1 The central tension: isolation is a merge decision, not a post-pass
+
+The rest of caching (RFC-2) is shaped as passes over the FINISHED fetch tree, after `createConcreteSingleFetchTypes`.
+Isolation cannot take that shape.
+
+Whether two root fields share a fetch is a PLANNING-MERGE decision made during path building.
+By the time the fetch tree is concrete, the two fields' input templates, response-tree attribution, and dependencies are already FUSED into one `SingleFetch`:
+the subgraph operation string renders both fields, the response `Data` tree attributes both subtrees to one `FetchID`, and there is one dependency edge set.
+A post-planning pass that tried to "un-merge" that fetch back into two would have to re-split the rendered operation, re-derive per-field response attribution, and recompute dependencies — exactly the work the planner already did, redone against a lossier data structure (explore §4, §5.3).
+
+So isolation must influence the merge decision UP FRONT.
+That is the one place caching genuinely needs to touch `path_builder_visitor.go`, and it is the reason this is a separate, deferred RFC rather than part of RFC-2's zero-diff core (§7).
+
+The design below makes that touch as additive as the concern allows:
+all decision logic and all tests live in a NEW file;
+the seam into the forbidden visitor is two small guarded call sites plus one additive flag field;
+and the seam is gated so it is provably never entered when caching is off (byte-identical plans).
+
+### 3.2 The dedicated isolation unit
+
+The mechanism is a single, named, independently-testable unit, `rootFieldIsolation`, in a NEW file `plan/root_field_isolation.go`.
+It owns the gate predicate and nothing else.
+The path builder holds one `*rootFieldIsolation` field (nil when caching is not configured) and calls it at the two cooperating sites.
+
+```go
+// plan/root_field_isolation.go (NEW)
+//
+// rootFieldIsolation decides whether a query root field must be planned into its
+// own fetch so it can carry an independent cache policy (RFC-3). It is the SOLE
+// owner of the isolation gate. When the caching provider set is empty the whole
+// unit is nil and the path builder takes its existing branches unchanged, so plans
+// are byte-identical to RFC-2 v1.
+type rootFieldIsolation struct {
+	// providers is the per-datasource caching provider set (RFC-1 §7.3), the SAME
+	// map RFC-2 wires into the postprocess stamper. Reading RootFieldPolicy here,
+	// not FederationMetaData, keeps the federation->caching decoupling intact.
+	providers map[string]cacheconfig.CacheConfigProvider
+}
+
+// shouldIsolate reports whether field is a cached query root field that must be
+// isolated into its own planner. It mirrors the OLD isCachedQueryRootField gate
+// (explore §1.1, site 2), reading the self-contained provider instead of
+// FederationMetaData.
+func (r *rootFieldIsolation) shouldIsolate(field *currentFieldInfo, operationType ast.OperationType) bool {
+	if r == nil || len(r.providers) == 0 {
+		return false // caching not configured -> never isolate (byte-identical plans)
+	}
+	if operationType != ast.OperationTypeQuery {
+		return false // queries only; mutations isolate via the existing isMutationRoot path (§5, D2)
+	}
+	if strings.Count(field.currentPath, ".") != 1 {
+		return false // direct children of the root operation only
+	}
+	provider := r.providers[field.ds.DataSourceID()] // keyed by DataSourceID, exactly as RFC-2 keys its provider map
+	if provider == nil {
+		return false
+	}
+	_, ok := provider.RootFieldPolicy(field.typeName, field.fieldName)
+	return ok // isolate only when this exact root field has a cache policy
+}
+```
+
+(The datasource-key lookup mirrors how RFC-2 keys its provider map by DataSourceID;
+the exact accessor is settled in PLAN against `dataSourceConfiguration[T].Caching()`, RFC-1 §7.3, RFC-2 §11.2 — the point is it reads the provider, never `FederationConfiguration()`.)
+
+The two cooperating halves wire into the existing path builder.
+
+Half one — start a new planner instead of merging (the additive branch in `handlePlanningField`, `path_builder_visitor.go:657-673`).
+Current code:
+
+```go
+isMutationRoot := c.isMutationRoot(field.currentPath)
+
+if isMutationRoot {
+	plannerIdx, planned = c.addNewPlanner(field, isMutationRoot)
+} else {
+	plannerIdx, planned = c.planWithExistingPlanners(field)
+	if !planned {
+		plannerIdx, planned = c.addNewPlanner(field, isMutationRoot)
+	}
+}
+```
+
+After (only the `// RFC-3` lines are added; every existing line is byte-identical, and the new branch is dead code when `c.rootFieldIsolation` is nil):
+
+```go
+isMutationRoot := c.isMutationRoot(field.currentPath)
+isCachedQueryRoot := c.rootFieldIsolation.shouldIsolate(field, c.operationType()) // RFC-3; false when caching off
+
+if isMutationRoot || isCachedQueryRoot { // RFC-3 adds the second disjunct
+	plannerIdx, planned = c.addNewPlanner(field, isMutationRoot)
+	if planned && isCachedQueryRoot { // RFC-3
+		c.planners[plannerIdx].ObjectFetchConfiguration().isolatedRootField = true
+	}
+} else {
+	plannerIdx, planned = c.planWithExistingPlanners(field)
+	if !planned {
+		plannerIdx, planned = c.addNewPlanner(field, isMutationRoot)
+	}
+}
+```
+
+Half two — refuse to merge another top-level root field into an isolated planner (the additive guard at the top of the `planWithExistingPlanners` loop, `path_builder_visitor.go:830`).
+`isParentPathIsRootOperationPath` ALREADY EXISTS on this branch (`path_builder_visitor.go:904-906`), so the guard reuses it verbatim:
+
+```go
+for plannerIdx, plannerConfig := range c.planners {
+	// RFC-3: never fold another top-level operation field into an isolated
+	// (cached) root-field planner; its own subtree still merges normally.
+	if c.isParentPathIsRootOperationPath(field.parentPath) && plannerConfig.ObjectFetchConfiguration().isolatedRootField {
+		continue
+	}
+	// ... existing body unchanged ...
+}
+```
+
+The flag itself is one additive field on `objectFetchConfiguration` (`path_builder_visitor.go:112-126`):
+
+```go
+type objectFetchConfiguration struct {
+	// ... existing fields ...
+	isolatedRootField bool // RFC-3: cached query root field; reject other top-level root fields
+}
+```
+
+### 3.3 The entity-root-node trap (a first-class invariant)
+
+The merge guard keys off `field.parentPath` being a root operation path (`query`/`mutation`/`subscription`), NOT off `field.suggestion.IsRootNode`.
+This is load-bearing, and getting it wrong is the subtle correctness bug the OLD comment warned about (explore §1.1, site 3).
+
+Entity types are ALSO datasource root nodes:
+a `Product` reachable by `@key` is an `IsRootNode` at its own coordinate.
+If the guard used `IsRootNode`, it would wrongly block NESTED entity and child fields from merging into the isolated planner that legitimately needs them — the isolated root field's own subtree would be torn apart.
+`isParentPathIsRootOperationPath` blocks ONLY fields whose parent is the top-level operation, so the isolated root field's own subtree (including nested entities) still merges normally.
+RFC-3 treats this as a named invariant with a dedicated test (§6).
+
+### 3.4 Per-field isolation (the granularity decision)
+
+RFC-3 isolates PER FIELD:
+every cached query root field gets its own planner, even two cached root fields that happen to share an identical policy.
+This mirrors OLD and is the deliberate choice over per-policy-group batching (the alternative is weighed and rejected in §5, D1).
+Per-field maximizes the runtime benefit that motivates the optimization — each field gets its own L2 key, reuses across operations that select different subsets, and can be matched against the entity cache one field at a time — and it keeps the merge guard a single, simple predicate with no policy comparison in the hot path.
+
+### 3.5 Runtime shape
+
+Each isolated root field becomes a distinct `*SingleFetch`.
+RFC-2's stamper (§7) then runs over the now-isolated tree exactly as it does today and stamps each fetch's `*resolve.FetchCacheConfig` from its single root field's policy;
+because each isolated fetch has exactly one root field, `rootFieldPolicyForAllRootFields` returns `(policy, true)` and L2 is enabled per fetch with that field's own `CacheName`/`TTL`/`KeySpec`.
+
+The isolated fetches carry NO `DependsOnFetchIDs` between each other (they are independent top-level roots), so they execute in PARALLEL (the OLD planner test confirmed FetchID 0 and FetchID 1 with no dependency edge, explore §3).
+At runtime RFC-1's controller does an independent L2 `Get`/`Set` per fetch, under that fetch's own cache name, TTL, and keys (RFC-1 §3).
+
+The cost is the cold-cache amplification:
+N single-field fetches mean N subgraph round-trips where one batched operation would have served all N (explore §3).
+The benefit is warm-cache reuse:
+each field is served from L2 independently and its network fetch is skipped.
+This cost/benefit (more round-trips on cold cache, finer reuse on warm cache) is exactly why isolation is an optimization that can be deferred, not a correctness requirement (§7).
+
+### 3.6 Rejected alternative: a post-planning fetch-tree split pass
+
+A design that WOULD be purely additive in RFC-2's literal sense — a new `FetchTreeProcessor`, zero edits to any visitor body — is a post-planning pass that re-partitions a merged root-field `SingleFetch` into per-policy-group fetches.
+RFC-3 considered and rejected it (explore §4, §5.3).
+
+To split a merged `SingleFetch` after `createConcreteSingleFetchTypes`, the pass would have to:
+re-derive a separate input template (subgraph operation) for each policy group, by re-splitting the already-rendered operation;
+re-attribute response-tree fields to the new per-group `FetchID`s;
+and recompute `DependsOnFetchIDs`.
+That is high complexity and high risk — it redoes the planner's merge/attribution work against the lossier finished tree, precisely the data structure that no longer carries per-field provenance cleanly (RFC-2 §9.1 documents the analogous attribution loss for `ProvidesData`).
+
+Up-front merge PREVENTION is strictly simpler and lower-risk:
+it lets the planner never fuse the fields in the first place, so no input template, attribution, or dependency ever needs to be re-derived.
+RFC-3 accepts the single narrow, gated, separately-reviewed visitor seam (§3.2) in exchange for avoiding the split pass entirely.
+
+---
+
+## 4. Interaction with RFC-2 and RFC-1
+
+### 4.1 RFC-2's passes are shape-agnostic and need no change
+
+RFC-3 changes the SHAPE of the fetch tree (more, smaller root-field fetches);
+it does not change the CONTENT of any pass.
+RFC-2's passes all operate on whatever tree the planner produced:
+
+- P1 `cacheProvidesDataVisitor` (RFC-2 §9) reads per-field fetch ownership from `planningVisitor.fieldPlanners` AFTER path building, so it sees the isolated planners and builds correct per-fetch `ProvidesData` automatically.
+- The stamper `cacheConfigStamper` (RFC-2 §7) walks the finished tree and stamps each fetch; with isolation on, each root-field fetch has one root field, so the all-or-nothing rule is trivially satisfied and each gets its own `Cache`.
+- `rootFieldPolicyForAllRootFields` (RFC-2 §7.2) is RETAINED as the residual safety net.
+  With RFC-3 on it almost always sees a single-field fetch and returns `(policy, true)`;
+  if any fetch somehow remains mixed (a datasource where merging is forced by other rules), it still declines L2 for that fetch rather than mis-caching.
+  RFC-3 makes the rule's "disable" branch rare, it does not remove the rule.
+- `optimizeL1Cache` (RFC-2 §10) narrows `cfg.L1` cross-tree from `ProvidesData` + `DependsOnFetchIDs`;
+  more, smaller fetches are just more nodes to consider, and narrowing is conservative-safe either way.
+
+Ordering:
+RFC-3 acts during path building, BEFORE RFC-2's P1 walk and BEFORE the postprocess stamper.
+So the sequence is: RFC-3 isolates planners -> P1 builds `ProvidesData` over the isolated planners -> postprocess stamps the isolated fetches.
+No RFC-2 pass needs to be reordered or modified.
+
+### 4.2 RFC-1's runtime config
+
+Each isolated fetch carries its own `*resolve.FetchCacheConfig` (RFC-1 §3.6) with its own `L2`, `CacheName`, `TTL`, and frozen multi-key `KeySpec`.
+The loader and controller (RFC-1 §3) treat each isolated fetch independently;
+because there are no `DependsOnFetchIDs` between them, the loader schedules them in parallel and the controller does an independent lookup/write per fetch.
+RFC-3 adds NO new runtime type and NO new field to `FetchCacheConfig`;
+it only changes how many fetches exist to be stamped.
+
+### 4.3 The federation decoupling holds
+
+The gate reads `cacheconfig.CacheConfigProvider.RootFieldPolicy(typeName, fieldName)` (RFC-1 §7.3), the SAME provider RFC-2 consumes, reached parallel to `FederationInfo`.
+It never calls `field.ds.FederationConfiguration()` for the isolation decision.
+So no federation pointer re-enters the planning decision, consistent with RFC-1 §7.4 and RFC-2 PR2.
+
+---
+
+## 5. Decisions and alternatives
+
+- D1. Isolate PER FIELD, not per policy group.
+  Per-field gives every cached root field its own L2 key (maximum reuse and the cleanest path to root-fields-reusing-the-entity-cache), and keeps the merge guard a single predicate with no policy comparison.
+  The alternative, per-policy-group (same-policy cached root fields share one batched fetch), saves cold-cache round-trips but reintroduces coarse-granularity caching — the very thing §1.2 wants to fix — and complicates the guard with a per-policy equality check in the path-building hot path.
+  RFC-3 picks per-field, matching OLD;
+  per-policy-group batching can be revisited later if cold-cache amplification proves to dominate in practice (D4).
+
+- D2. Query-only;
+  composes cleanly with mutation isolation.
+  `shouldIsolate` returns false for any non-`Query` operation, and mutations continue to isolate through the existing `isMutationRoot` branch (`path_builder_visitor.go:657-673`, `:1391-1399`).
+  A field can never be both:
+  `isMutationRoot` requires `OperationTypeMutation`, `shouldIsolate` requires `OperationTypeQuery`.
+  So `addNewPlanner` is still called once, and there is no double-isolation.
+  Subscriptions are out of scope (the subscription branch in the path builder is separate, and subscription caching is staged to RFC-2 v2).
+
+- D3. Inside defer groups, isolation composes with the per-defer-group fetch trees.
+  A cached query root field is a direct child of the operation root (`strings.Count(currentPath, ".") == 1`);
+  defer applies to sub-selections, so the isolation decision is made at the top level and the isolated planner's deferred sub-fields still merge into its subtree under the existing `field.deferID` checks (`path_builder_visitor.go:839-848`).
+  `extractDeferFetches` (postprocess) then splits those into per-`DeferID` group trees as usual.
+  The merge guard only blocks OTHER top-level operation fields, so it does not interfere with defer extraction.
+  A test (§6) pins this.
+
+- D4. No cold-cache amplification cap in v1.
+  Isolation only triggers for root fields the operator EXPLICITLY configured with a cache policy, so the amplification is opt-in and bounded by the number of cache-configured root fields in one operation.
+  A cap would add config surface and a behavior cliff for a cost that only appears on cold cache.
+  RFC-3 ships without a cap (matching OLD) and flags amplification as a monitored risk;
+  if it dominates, the per-policy-group batching of D1 is the natural mitigation.
+
+- D5. The gate reads the self-contained provider, not `FederationMetaData` (§4.3).
+  This is a hard rule, verified in reviewer guidance.
+
+- Alternative rejected: the post-planning fetch-tree split pass (§3.6).
+  It is the only design that would keep `path_builder_visitor.go` at a literal zero diff, but it is rejected as high-complexity and high-risk;
+  up-front merge prevention is simpler and lower-risk.
+
+---
+
+## 6. Reviewer guidance
+
+- NO-OP proof (the PR-equivalent of RFC-2's zero-impact gate).
+  With no `CacheConfigProvider` wired, assert the postprocessed plans are BYTE-IDENTICAL to pre-RFC-3 (full-plan `assert.Equal`, golden plans).
+  This proves the new branch in `handlePlanningField` and the new guard in `planWithExistingPlanners` are never entered when caching is off.
+
+- The entity-root-node trap (§3.3).
+  Add a test with a NESTED entity (e.g. `Product` by `@key`) under an isolated cached root field, and assert the nested entity/child fields still merge into the isolated planner's subtree — confirming the guard keys off `parentPath` being a root operation path, NEVER off `IsRootNode`.
+
+- Parallelism.
+  Assert isolated fetches carry no `DependsOnFetchIDs` between each other (they run in parallel).
+
+- The all-or-nothing safety net still applies.
+  Assert that RFC-2 §7.2's `rootFieldPolicyForAllRootFields` is unchanged and still declines L2 for any residual mixed-policy fetch (a defensive case isolation makes rare, not impossible).
+
+- Port the three OLD planner tests (explore §3.1) and assert FULL plans with `assert.Equal` (per the project rule: never `assert.Contains`, never fuzzy comparison):
+  1. `query Q { me { id username } cat { name } }` with `me`->users/30s, `cat`->pets/60s produces TWO parallel raw fetches, FetchID 0 `{L2, CacheName:"users", TTL:30s}` and FetchID 1 `{L2, CacheName:"pets", TTL:60s}`, neither with `DependsOnFetchIDs`.
+  2. `query Q { me { id } user(id:"1") { username } }` with only `me` cached produces FetchID 0 (cached `me`) isolated from FetchID 1 (uncached `user`, no `Cache`).
+  3. With caching not configured, isolation is skipped, the fields merge into ONE fetch, and the all-or-nothing rule declines L2 — byte-identical to RFC-2 v1.
+
+- Defer composition (D3).
+  Add a test with a cached root field whose subtree contains a deferred fragment, and assert the isolated root field and its deferred sub-fetch land in the correct per-`DeferID` trees.
+
+- Federation decoupling (D5).
+  Confirm `shouldIsolate` reads `CacheConfigProvider.RootFieldPolicy`, never `field.ds.FederationConfiguration()`;
+  no federation pointer enters the isolation decision.
+
+- Surgical-diff review.
+  The change to `path_builder_visitor.go` must be exactly: one additive field on `objectFetchConfiguration`, the second disjunct + flag-set in `handlePlanningField`, and the one guard at the top of `planWithExistingPlanners`.
+  All decision logic and all tests live in `plan/root_field_isolation.go` and its test file.
+
+---
+
+## 7. Why it is deferred from the core plan
+
+RFC-3 is intentionally NOT part of the core caching plan, for three reasons.
+
+- It is a pure optimization, not correctness.
+  RFC-2 v1's all-or-nothing decline never mis-caches;
+  it just caches less when root-field policies are mixed.
+  RFC-3 recovers the lost caching and improves granularity, but the system is correct without it.
+
+- It is the ONE caching feature that must touch `path_builder_visitor.go`, which RFC-2 PR1 forbids to keep the planner-visitor diff at zero (RFC-2 §5, §16).
+  Carving it into its own RFC preserves RFC-2's "existing planners untouched" guarantee for every integrator who does not enable caching, and gives the single visitor seam its own focused review.
+  The rest of caching reaches runtime with ZERO planner-visitor edits;
+  this one optimization is where, and only where, that bar is relaxed — under a gate that makes the relaxation invisible when caching is off.
+
+- It layers cleanly on top and changes none of RFC-2's v1 contract (RFC-2 §7.2, §11).
+  With RFC-3 off, plans are byte-identical to RFC-2 v1.
+  RFC-2's passes need no modification to accommodate it (§4.1).
+
+Where it slots in the mandated implementation order:
+structure first, then L2 for ENTITIES, then L2 for ROOT FIELDS, then L2 for ROOT FIELDS that RE-USE the entity cache, then L1.
+Per-root-field granularity is an enhancement to the L2-root-fields stage — it only matters once root fields cache at all — so it naturally trails into that stage and after it, ahead of the L1 work.
+It ships LAST among the L2-root-field items:
+RFC-2 v1's conservative all-or-nothing decline is correct from the start, and RFC-3 upgrades it to per-field caching once the L2-root-field machinery is in place.

--- a/docs/caching/tasks/01-representation-variable-extraction.md
+++ b/docs/caching/tasks/01-representation-variable-extraction.md
@@ -1,0 +1,45 @@
+# Task 01 — Extract the representation-variable builder into a shared package
+
+Phase: 0 (Structure).
+Dependencies: none.
+References: RFC-2 §6.1; CODING_GUIDELINES §3.
+
+## Problem
+
+The `@key` → representation-node builder that cache-key construction needs is unexported and lives in `graphql_datasource`.
+Copy-pasting it would create two divergent `@key`→representation walkers — the silent key-skew hazard the whole key model exists to prevent.
+
+## Scope
+
+Extract, do not re-add; no caching code yet.
+
+- New exported package `v2/pkg/engine/plan/representationvariable`.
+- Move `buildRepresentationVariableNode` → `BuildRepresentationVariableNode` and `mergeRepresentationVariableNodes` → `MergeRepresentationVariableNodes` (from `v2/pkg/engine/datasource/graphql_datasource/representation_variable.go`, plus the internal `representationVariableVisitor` and merge helpers).
+- Refactor `graphql_datasource` IN PLACE to call the exported functions at its two call sites (`graphql_datasource.go`, build + merge).
+- MOVE the tests too: the representation-variable tests move into the new package (per-package test ownership); the datasource-level behavior guard stays where it exercises the call sites.
+
+## Implementation outline
+
+- Pure move + re-export + two-call-site rewrite.
+- No import cycle: `representationvariable` imports `plan`/`resolve`/`ast`/`astvisitor`; `plan` does not import it.
+- Signatures:
+  - `BuildRepresentationVariableNode(definition *ast.Document, cfg plan.FederationFieldConfiguration, federationCfg plan.FederationMetaData) (*resolve.Object, error)` — one `@key` selection set → one federation-pointer-free `*resolve.Object` with the interfaceObject/entityInterface `__typename` remap baked in.
+  - `MergeRepresentationVariableNodes(objects []*resolve.Object) *resolve.Object` — used by the datasource for its single `representations` variable; the caching `cacheKeyBuilder` (task 06) will NOT call it (multi-key keeps candidates separate).
+
+## Tests
+
+- The EXISTING `graphql_datasource` representation-variable behavior must still pass byte-for-byte (behavior-preservation guard).
+- New `representationvariable` package tests (moved + extended): table tests over `(definition, one @key set, federation)` asserting the FULL `*resolve.Object` node with `assert.Equal` — single `@key`, composite, nested-object, interfaceObject/entityInterface `__typename` baked in.
+
+## Acceptance criteria
+
+- [ ] Zero behavior change: the full existing datasource suite passes unmodified.
+- [ ] Both call sites use the exported names; no unexported copy remains in `graphql_datasource`.
+- [ ] No new import cycle.
+- [ ] Tests moved with the code, not left behind.
+- [ ] Lint-clean in `v2`.
+
+## Reviewer guidance
+
+- Confirm this is a pure move (diff should read as relocation + rename, not rewrite).
+- Confirm the merge helper is exported but unused by caching (it exists for the datasource only).

--- a/docs/caching/tasks/02-runtime-contract-and-loader-seam.md
+++ b/docs/caching/tasks/02-runtime-contract-and-loader-seam.md
@@ -1,0 +1,70 @@
+# Task 02 — Runtime cache contract + no-op loader seam + CacheTransaction
+
+Phase: 0 (Structure).
+Dependencies: none (independent of task 01).
+References: RFC-1 §3, §4, §6, §10; deviations D2, D4, D5, D8 (PLAN §7).
+
+## Problem
+
+The loader has no cache abstraction.
+The controller package and the planner passes need the runtime OUTPUT contract to exist and be wired as a strict no-op first, so every later task plugs into stable seams.
+
+## Scope
+
+One mostly-additive change that compiles and behaves identically with no controller set; no cache implementation.
+
+Contract types (new files in `resolve`):
+
+- `resolve/cache_controller.go`: `CacheController` (`BeginRequest(ctx) RequestCache`), `RequestCache` (`PrepareFetch`, `OnFetchSkipped`, `OnFetchResult`, `EndRequest`), `Decision` (`DecisionFetch`, `DecisionSkipFullHit`, `DecisionFetchPartial`, `DecisionFetchShadow`), `PrepareFetchInput`, `MergeInput`, `CacheObserver`, `FetchCacheHandle`, `ItemCacheState`, `CacheCandidate`, `ShadowCacheEntry`.
+- `resolve/cache_transaction.go`: the `CacheTransaction` abstraction (D2) — `TransactionBeginner` with `Begin() *CacheTransaction`; methods on the transaction: `ParseBytes`, `StructuralCopy`, `MergeValues`, `MergeValuesWithPath`, `NewObject`, `NewArray`, `String`, `Null`, `Commit()`.
+  `Begin()` acquires `DataBuffer.Lock` once; `Commit()` releases it (call via `defer`).
+  Every arena/parser op is a method ON the transaction, so the arena cannot be touched without a held transaction; a transaction must never be retained past the hook or opened from the off-lock load phase.
+- `resolve/cache_config.go`: `FetchCacheConfig` (+ nil-safe `Equals`, `String`), `CacheKeySpec`, `CacheKeyCandidate` (one frozen `@key` representation per candidate), `CacheScope`, `CacheWriteReason`, `EntityKeyMapping`.
+
+Fetch polymorphism (D8):
+
+- `fetch.go`: add `Cache *FetchCacheConfig` to `FetchConfiguration`, `EntityFetch`, `BatchEntityFetch`.
+- Extend the `Fetch` interface with cache accessors and shape predicates, e.g. `CacheConfig() *FetchCacheConfig`, `SetCacheConfig(*FetchCacheConfig)`, `IsEntityFetch() bool`, `IsBatchEntityFetch() bool`, implemented on all concrete types.
+  All caching code (loader seam, passes, controller) uses these methods; NO `switch` over concrete fetch types.
+  While here, improve other fetch-type-switch sites encountered in the code being touched (e.g. re-express existing switches through the new predicates where it is a clear simplification) — surgical, one commit note per site.
+- `FetchConfiguration.Equals`: the nil-safe cache clause (`(a==nil)!=(b==nil)` → not equal; both non-nil → `a.Equals(b)`), so plan dedup can never lose or conflate cache policy.
+
+Loader seam (`loader.go`, `resolve.go`, `context.go`):
+
+- `preparedFetch.cacheHandle *FetchCacheHandle`.
+- `result` carriers: `response`, `responseData`, `responseHasErrors` — assigned in `mergeResult` where already computed (full response right after the successful parse; data sub-path after it is computed; error flag after the hasErrors block), so `response == nil` is the structural fetch-failed signal.
+- `MergeInput` also carries the fetch's post-processing MERGE PATH (D4), so entity/batch values splice at the correct target, not silently at the item root.
+- Two behavior call sites in `resolveSingle`, both OUTSIDE the phase locks: `cachePrepare` after the prepare phase, `cacheMerge` after the merge phase; helpers `cacheRequest` (lazy once-per-request `BeginRequest` under `DataBuffer.Lock`), `cachePrepare`, `cacheMerge`.
+- Full-hit modeling: `DecisionSkipFullHit` sets BOTH `prepared.skipLoad` (skips the network) and `res.fetchSkipped` (reuses the existing `mergeResult` early-return so no spurious "failed to fetch" error is rendered).
+- `cachePrepare` early-returns when `prepared.skipLoad` is already set (render-skip sites win) and when `cfg == nil || (!cfg.L1 && !cfg.L2)`.
+- `context.go`: `cacheController`/`requestCache` fields, `SetCacheController` (mirrors `SetAuthorizer`), `endCacheRequest()` (idempotent), `clone` sets `requestCache = nil` (subscription-event isolation), `Free` calls `endCacheRequest` defensively.
+- `resolve.go`: `defer ctx.endCacheRequest()` at ALL FOUR entry functions (`ResolveGraphQLResponse`, `ArenaResolveGraphQLResponse`, `ResolveGraphQLDeferResponse`, `executeSubscriptionUpdate`).
+
+Write-gate signals surfaced on `MergeInput` (all five): `FetchFailed` (transport / empty body / parse failure), `HasErrors`, `EmptyEntity` (computed via the loader's existing `isEmptyEntityFetch`, only when a response parsed), `StatusCode`, and `ResponseData == nil`.
+
+Integration posture (per maintainer feedback): the seam MAY be more integrated with the loader than a detached six-call-site design where that makes L1/L2/partial easier to reason about; keep the hooks as the default shape but do not contort the loader to avoid touching it.
+
+## Tests
+
+Pure, self-contained (no harness yet):
+
+- `FetchConfiguration.Equals` cache clause: appendix rows P1–P5 (both nil, one nil, equal, differ in any field, differ in one candidate `Representation`).
+- Nil-controller no-op: an existing-style loader test with no controller stays byte-identical; the full existing resolve suite passes.
+- `FetchCacheConfig.String` / `FetchCacheHandle.String` render nil-safely.
+- `Fetch` interface methods: table test asserting `CacheConfig`/predicates across all concrete fetch types.
+- `CacheTransaction`: `Begin`/`Commit` lock-once semantics compile-checked here; behavioral lock-discipline rows land with task 04/07 under `-race`.
+
+## Acceptance criteria
+
+- [ ] Merging this task ALONE changes runtime behavior in ZERO ways (no controller → no cache code entered, no allocation, no lock).
+- [ ] The two hook call sites are outside the phase locks; the transaction is the single `DataBuffer.Lock` acquisition per hook.
+- [ ] `clone`/`Free` reset the per-request surface; `endCacheRequest` is idempotent.
+- [ ] No `switch` over concrete fetch types anywhere in the new code.
+- [ ] Every new type carries a responsibility doc comment.
+- [ ] Lint-clean in `v2`.
+
+## Reviewer guidance
+
+- The write gate must key off `FetchFailed`/`ResponseData == nil`, never `HasErrors` alone (transport/empty/parse failures reach the merge hook with `HasErrors == false`).
+- Verify the merge-path surfacing (D4) carries the real fetch merge path and is nil/empty-safe.
+- Verify no `*Object` is referenced by `loader.go` (`ProvidesData` lives inside the config, consumed by the controller).

--- a/docs/caching/tasks/03-planner-wiring-and-engine-config.md
+++ b/docs/caching/tasks/03-planner-wiring-and-engine-config.md
@@ -1,0 +1,61 @@
+# Task 03 — Planner wiring, cacheconfig package, engine SetCaching
+
+Phase: 0 (Structure).
+Dependencies: tasks 01, 02.
+References: RFC-2 §5, §7.2–7.3, §11; deviations D3, D5, D6, D9 (PLAN §7).
+
+## Problem
+
+The planner has no caching producer, no policy model, and no `ProvidesData` carrier.
+These must exist as additive wiring that produces NO config until caching configuration is supplied, and the public entry point must be the engine `Configuration`, not a postprocess option.
+
+## Scope
+
+Policy model (leaf package, no cycle):
+
+- New `v2/pkg/engine/plan/cacheconfig` package: `CachingConfiguration`, `EntityCachePolicy`, `RootFieldCachePolicy`, `MutationCachePolicy`, `SubscriptionCachePolicy`, and the `CacheConfigProvider` interface (`EntityPolicy`, `RootFieldPolicy`, `MutationPolicy`, `SubscriptionPolicy`).
+- `dataSourceConfiguration[T].Caching() cacheconfig.CacheConfigProvider` accessor (nil = no caching for that datasource).
+- L2 is DERIVED from TTLs (D3): the policy structs carry NO explicit L1/L2 bools.
+
+Pass skeletons (logic lands in later tasks; D6 names):
+
+- Pass logic homes in the common `v2/pkg/engine/cache` package (D5); `postprocess` holds thin calls.
+- `ConfigureCaching` facade with the single NO-OP gate: returns immediately when no providers are configured.
+- `cacheKeyBuilder`, `fetchCacheConfigurator`, `optimizeL1Cache` — wired but inert skeletons.
+- `postprocess.go` additive edits: a `Processor` field, the `EnableCaching(providers, federation, definition)` option (internal), the facade call in `Process` for sync + defer (root tree plus every `Defers[i].Fetches`, after `processFlatFetchTree`/`extractDeferFetches`, before `organizeFetchTree`/`buildDeferTree`) + subscription arms, and a `deferTrees` helper collecting root + defer-group trees.
+
+P1 registration seam (visitor body lands in task 05; D9):
+
+- `plan/planner.go`: construct `cacheProvidesDataVisitor` only when caching is configured; after the main `planningWalker.Walk`, run the gated SECOND, filter-free walk (`ResetVisitors()` + `SetVisitorFilter(nil)` + register only P1 + `Walk` + `attachTo`), all `!= nil`-guarded.
+- Extending existing planner/visitor files is ALLOWED when it is the cleaner path; prefer new single-responsibility visitors.
+
+Per-field metadata carriers (additive):
+
+- `resolve/node_object.go`: `Object.HasAliases`, `Field.OriginalName`, `Field.CacheArgs` (+ `CacheFieldArg`), carried in `Object.Copy()`/`Field.Copy()`.
+- `resolve.GraphQLResponse`: unexported `cacheProvidesData map[*FetchInfo]*Object` + `SetCacheProvidesData`/`CacheProvidesData` accessors.
+
+Engine entry point (the public API):
+
+- Engine `Configuration` gains `SetCaching(...)` alongside `SetDataSources`/`SetFieldConfigurations`; `NewExecutionEngine(...)` picks it up and wires `postprocess.EnableCaching` + the P1 enablement internally.
+- Signature sketch: `engineConf.SetCaching(cacheconfig.CachingConfiguration)` per datasource (or a keyed set) — settle the exact shape against how `SetFieldConfigurations` is keyed, and record the decision in the commit notes.
+- Hard wiring precondition: configuring caching force-enables `FetchInfo` (a `DisableIncludeInfo` + caching combination degrades to a clean, tested no-op, never to silent uncached behavior).
+
+## Tests
+
+- NO-OP planner proof: the EXISTING planner/postprocess suites with NO caching configured produce byte-identical plans (every `Cache` nil).
+- Skeleton unit tests: facade with empty providers touches no node; `cacheconfig` policy structs round-trip; `node_object` `Copy()` carries the new fields (full-value `assert.Equal`).
+- Engine wiring test: `SetCaching` reaches the postprocess option and the P1 constructor; without `SetCaching` neither is constructed.
+
+## Acceptance criteria
+
+- [ ] With no `SetCaching`, plans are byte-identical to today (the planner no-op gate) and no caching type is constructed.
+- [ ] The four config gates default OFF: empty providers; per-datasource nil provider; per-coordinate `(_, false)`; all-flags-false config → nil `Cache`.
+- [ ] `cacheconfig` is a leaf package (imports `resolve` at most; no plan↔cache cycle).
+- [ ] The P1 second-walk seam never re-runs the planning visitor and never rebuilds the plan.
+- [ ] Lint-clean in `v2` and `execution` (the engine wiring touches execution).
+
+## Reviewer guidance
+
+- Confirm the facade runs after `createConcreteSingleFetchTypes` and before `organizeFetchTree`, and for defer plans before `buildDeferTree` nils `Defers`.
+- Confirm `cacheProvidesData` is a side-table on the response, never reached by defer's response-tree `Copy()`.
+- Confirm the engine `Configuration` is the ONLY public entry point; `postprocess.EnableCaching` stays internal.

--- a/docs/caching/tasks/04-test-infrastructure.md
+++ b/docs/caching/tasks/04-test-infrastructure.md
@@ -1,0 +1,61 @@
+# Task 04 — Test infrastructure: dedicated caching subgraphs + e2e framework + fakes
+
+Phase: 0 (Structure).
+Dependencies: tasks 02, 03.
+References: RFC-1 testing appendix (scenario catalog and doubles, re-based per D7); CODING_GUIDELINES §4; deviation D7 (PLAN §7).
+
+## Problem
+
+Caching needs provably-composable test subgraphs, drift-proof real-planner inputs, and a shared fake set, so the loader glue and the controller reach high coverage without a network or a real backend — and the integration layer must be built ON TOP OF the `execution` package, reusing the existing `federationtesting` approach, with NO golden snapshots.
+
+## Scope
+
+Dedicated caching subgraphs (execution module):
+
+- REUSE the existing `execution/federationtesting` package and COPY its approach; do NOT re-implement execution.
+- Create DEDICATED caching subgraphs (not `commerce` alone) with good NESTING and real VARIANCE of TTL and other cache options.
+  Minimum shapes the fixture set must express (they drive later tasks' scenarios):
+  - an entity with MULTIPLE `@key` sets (multi-key rows, tasks 08/15);
+  - cross-subgraph entity references and nested entities (coverage + batch rows, tasks 07/10);
+  - by-key root fields whose args map onto an entity `@key` (task 15);
+  - sibling root fields with DIFFERENT cache policies on one datasource (task 14);
+  - mixed TTLs on sibling fields of one type, so PARTIAL EXPIRY of some fields is expressible (tasks 09/19);
+  - a defer shape where an initial entity fetch's `ProvidesData` is a STRICT SUPERSET of a deferred same-entity fetch in a LATER group — this closes the first-pass fixture gap that made cross-defer-group L1 serving unprovable (task 18 rows N1/N2/M3).
+- Compose with REAL `wgc` (`compose.sh` running `npx -y wgc@latest router compose`), COMMIT the resulting `config.json`; re-running `compose.sh` is the composability guard.
+  Cross-validate composition with rover where the tooling allows.
+  Composition is the one network step: run `compose.sh` explicitly when creating or changing fixtures (expect a permission prompt for `npx wgc`), commit the resulting `config.json`, and build/test against the committed artifact.
+
+Harness (execution module):
+
+- A `Plan(tb, query, cachingConfig, responses)`-style helper: load the committed `config.json` (`protojson.Unmarshal` → `nodev1.RouterConfig`), build `plan.Configuration` via `engine.NewFederationEngineConfigFactory(...).BuildEngineConfiguration(&rc)` (add a small EXPORTED `PlannerConfig()` accessor to the execution `engine.Configuration` — refactor in place), run the REAL v2 planner + postprocess with caching configured through the engine `Configuration` (task 03), and swap each fetch's transport for an in-process fake/gated datasource.
+- NO `.golden` files (D7): plan-shape assertions are full-value `assert.Equal` on the rendered plan/config where a test needs them; response assertions are COMPLETE response strings.
+- e2e tests drive the PUBLIC entry points (`ResolveGraphQLResponse`, `ArenaResolveGraphQLResponse`, `ResolveGraphQLDeferResponse`); seams are asserted OBSERVABLY (the recording fake owns its handle → pointer identity; gated datasource + store ops → no network on a hit; `-race` → lock discipline). No `export_test.go` bridge.
+
+Fakes (v2, cosmo-free): `v2/pkg/engine/cache/cachetesting`:
+
+- `FakeCacheController` (counts `BeginRequest`), `FakeRequestCache` (records normalized `Call`s, returns scripted decisions), `FakeStore` (in-memory L2 with absolute `ExpiresAt`, ordered `StoreOp` log), `GatedDataSource` (gate channels for deterministic ordering), `RecordingObserver`.
+- NO custom clock and NO injectable `now`: time/TTL is faked with the Go 1.25 stdlib `testing/synctest` (sleeps advance fake time for TTL ONLY; ordering uses gates + `synctest.Wait()`).
+- `RealishCache` (an in-memory controller-backed cache for end-to-end rows) is SCAFFOLDED here only to the extent task 02's contract allows; its real backing grows with tasks 07–17.
+
+Module boundary: the plan-driven tests live in the EXECUTION module (where `wgc`/`config_factory`/cosmo proto are usable); `v2` never takes the cosmo-proto dependency; controller unit tests live in `v2` next to the cache package.
+
+## Tests
+
+This task's deliverable IS test infrastructure; it proves itself with:
+
+- The no-op e2e row: caching unconfigured → response and plan byte-identical to the non-caching baseline (the Phase 0 exit proof, appendix row A1-shaped).
+- A smoke row per fixture shape: each dedicated subgraph composes (`compose.sh` clean), plans, and resolves through the harness with canned responses, asserting the COMPLETE response.
+- Fake self-tests: `FakeStore` TTL expiry inside a `synctest` bubble; `GatedDataSource` ordering; `FakeRequestCache` records full normalized calls.
+
+## Acceptance criteria
+
+- [ ] `compose.sh` re-composes cleanly; `config.json` committed; the fixture set expresses ALL the shapes listed above (spot-check by planning each representative operation).
+- [ ] The harness produces real planner output; no hand-written `plan.Configuration` or fetch-tree literals anywhere.
+- [ ] No `.golden` files; no `assert.Contains`/`JSONEq`/fuzzy assertions; no custom clock.
+- [ ] `v2` takes no cosmo import; the execution module resolves local `v2` via `go.work` (`cd execution && go test ./...`).
+- [ ] Lint-clean in both modules.
+
+## Reviewer guidance
+
+- The fixture-gap closure (initial-superset-over-deferred-entity shape) is the load-bearing addition — verify a defer plan over it actually produces a real defer group whose deferred entity selection is covered by the initial fetch.
+- Verify all goroutine-spawning tests keep everything inside the `synctest` bubble and use only in-process fakes (no sockets).

--- a/docs/caching/tasks/05-provides-data-visitor.md
+++ b/docs/caching/tasks/05-provides-data-visitor.md
@@ -1,0 +1,41 @@
+# Task 05 — ProvidesData visitor (P1)
+
+Phase: A (L2 entities).
+Dependencies: tasks 03, 04.
+References: RFC-2 §9 (with the §9.2 first-pass correction, deviation D9); OLD `caching_planner_state.go` on the `caching-base` worktree.
+
+## Problem
+
+The runtime coverage walk needs, per fetch, the exact field tree the fetch returns — alias-aware and argument-aware.
+Deriving it from the merged response tree is lossy (per-fetch attribution is lost for shared fields; the merged tree is arg-blind), so a too-small tree silently disables hits and an arg-blind one serves stale data.
+
+## Scope
+
+- Full port of the OLD `ProvidesData` builder into `plan/cache_provides_data_visitor.go` as `cacheProvidesDataVisitor`:
+  entity-boundary reset, `__typename` dedup, inline-fragment `OnTypeNames`, alias→`OriginalName`, `CacheArgs` capture (sorted).
+- Execution model (D9): a gated SECOND, filter-free walk on the same `planningWalker` AFTER the main walk (`ResetVisitors()` + `SetVisitorFilter(nil)` + register only P1 + `Walk`), reading `planningVisitor.fieldPlanners` (populated by the main walk's `LeaveField`).
+  The second walk runs ONLY P1 and never rebuilds the plan.
+- `attachTo(plan)`: resolve fetchID → `*FetchInfo` after the walk (sorted by fetchID for determinism) and stash the `map[*FetchInfo]*Object` side-table on the `GraphQLResponse` via the task 03 accessors.
+  `*FetchInfo` is the identity-stable key across dedup, fetchID-append, and concrete-type conversion (all copy `Info` by reference).
+- `ComputeHasAliases` helper (folded into the configurator in task 06) sets the `HasAliases` fast-path flag when any descendant carries `OriginalName`/`CacheArgs`.
+
+## Tests
+
+- Unit: feed `(operation, definition, fieldPlanners)` and assert the FULL `map[*FetchInfo]*Object` per fetch with `assert.Equal` — entity-boundary reset, `__typename` dedup, inline fragments, aliases, args.
+- FIDELITY GATE: compare P1's per-fetch `ProvidesData` trees against the OLD branch's trees for the shared federation fixtures (full-tree `assert.Equal`, not spot checks).
+- ADVERSARIAL rows beyond the OLD set (first-pass lesson: verbatim ports carry latent OLD bugs): irrelevant-provider-sharing-a-consumer shapes, partial overlap, empty selections.
+- No-op proof: with caching unconfigured the second walk does not run; existing planner tests byte-identical.
+- Determinism: plan twice, assert identical side-tables.
+
+## Acceptance criteria
+
+- [ ] Per-fetch `ProvidesData` matches the OLD trees for every shared fixture (the fidelity gate).
+- [ ] Alias and argument capture verified (`OriginalName`, sorted `CacheArgs`).
+- [ ] The second walk is gated, runs only P1, and adds zero cost when caching is off.
+- [ ] Deferred fetches get their own trees (side-table keyed per `*FetchInfo`, immune to defer `Copy()`).
+- [ ] Lint-clean.
+
+## Reviewer guidance
+
+- The carrier must remain a side-table; never re-add a `FetchInfo.ProvidesData` field.
+- Verify `fieldPlanners` is read only after the main walk (it is populated in `LeaveField`).

--- a/docs/caching/tasks/06-entity-cache-configuration.md
+++ b/docs/caching/tasks/06-entity-cache-configuration.md
@@ -1,0 +1,46 @@
+# Task 06 — Entity cache configuration: cacheKeyBuilder + fetchCacheConfigurator (entity arm)
+
+Phase: A (L2 entities).
+Dependencies: tasks 01, 03, 05.
+References: RFC-2 §6, §7 (renamed per D6); deviations D3, D5, D6 (PLAN §7).
+
+## Problem
+
+Entity fetches carry no cache config, so the runtime has no keys, no coverage tree, and no policy to act on.
+Federation `@key` data must cross into runtime config exactly once, by value, in one reviewable unit.
+
+## Scope
+
+Both units live in the common `v2/pkg/engine/cache` package (D5), invoked by the postprocess facade from task 03.
+
+`cacheKeyBuilder` (the SOLE federation reader; was "freezer"):
+
+- For an entity fetch, build one `CacheKeyCandidate` per resolvable `@key` set via `representationvariable.BuildRepresentationVariableNode` (task 01) — deterministically ordered by selection-set string, none marked required (best-effort multi-key).
+- Skip a malformed `@key` fragment rather than fail the whole spec (annotate WHY at the skip site); zero usable keys → no entity spec → not cached.
+- Copies OUT by value; retains no pointer into `FederationMetaData`.
+
+`fetchCacheConfigurator` (was "stamper"), entity arm:
+
+- Walk the finished fetch tree (after `createConcreteSingleFetchTypes`), and for each entity fetch (via the task 02 `Fetch` predicates, no type switch):
+  look up `EntityPolicy(typeName)`; build the spec via `cacheKeyBuilder`; assemble `FetchCacheConfig` — `L1 = true` (eligible; task 16 narrows), `L2 = TTL > 0 || NegativeCacheTTL > 0` (D3), scalar policy fields, `KeySpec`, `ProvidesData` from the task 05 side-table (`pd[fetch.FetchInfo()]`), fold `ComputeHasAliases`.
+- Set via `fetch.SetCacheConfig(cfg)`; leave nil when no policy / no keys / all-flags-false.
+- Tolerate `Info == nil` → nil config (belt-and-suspenders under the task 03 FetchInfo precondition).
+
+## Tests
+
+- `cacheKeyBuilder` table tests: FULL multi-key `CacheKeySpec` for single/composite/nested/MULTIPLE `@key` sets (one candidate each, ordered); no-`@key` → `(zero, false)`; mutate the source `FederationMetaData` after building and re-assert equality (no pointer aliasing); assert the builder's candidate node equals the datasource's representation node for the same `@key` (same shared builder).
+- Configurator: FULL `*FetchCacheConfig` asserted on entity and batch-entity fetches; nil where policy absent (all four no-op gates); the carrier regression row — a tree through dedup + fetchID-append + concrete-type conversion still resolves the right `ProvidesData` via `fetch.FetchInfo()`.
+- Plan-level rows via the task 04 harness: entity fetches across sync AND defer plans (each `Defers[i].Fetches` entity fetch carries `Cache`), asserted with full-value `assert.Equal` on the rendered config; determinism (plan twice, identical).
+
+## Acceptance criteria
+
+- [ ] Federation is read in exactly ONE unit (`cacheKeyBuilder`); no federation type or pointer reaches `FetchCacheConfig`.
+- [ ] All three concrete fetch types receive config through the `Fetch` interface methods.
+- [ ] The no-op plan proof still holds with caching unconfigured.
+- [ ] No "freeze"/"stamp" vocabulary in code, comments, or tests (D6).
+- [ ] Lint-clean.
+
+## Reviewer guidance
+
+- One-file review for the federation boundary: read `cacheKeyBuilder` and confirm value-copy out, no retained pointers.
+- Confirm the configurator runs after concrete-type conversion (config set before conversion is lost for entity types).

--- a/docs/caching/tasks/07-entity-l2-controller-core.md
+++ b/docs/caching/tasks/07-entity-l2-controller-core.md
@@ -1,0 +1,54 @@
+# Task 07 — Entity L2 controller core (single candidate)
+
+Phase: A (L2 entities).
+Dependencies: tasks 02, 04, 06.
+References: RFC-1 §3, §4.4, §5, §6; appendix rows A/B/C/D(core)/F/K/L/O; deviations D2, D4, D5 (PLAN §7).
+
+## Problem
+
+Nothing implements `RequestCache`, so configured entity fetches do nothing.
+This task lands the L2-only entity controller for the SINGLE-candidate case; multi-key, normalization, and batch build on it (tasks 08–10).
+
+## Scope
+
+The controller lives in the common `v2/pkg/engine/cache` package, behind the task 02 interfaces, as clean, separable modules (L2 here; L1 in task 17; partial in task 19).
+
+- `Controller` (implements `CacheController`) + a request-scoped `requestCache` (implements `RequestCache`), created lazily once per request.
+- A `Store` interface for the L2 backend (`Get`/`Set` with TTL, batch-capable), with the in-memory `FakeStore`/`RealishCache` backing from `cachetesting` completed against it.
+- `PrepareFetch`: open ONE `CacheTransaction`; render the candidate key from the canonical input (`PrepareFetchInput.Input` + `HeaderHash`); `Get`; parse the cached bytes ONCE via `tx.ParseBytes`; run the always-on per-item coverage walk from `cfg.ProvidesData` (null accepted only where nullable; `ProvidesData == nil` disables the walk → miss); AND-reduce → `DecisionSkipFullHit` or `DecisionFetch`; fill `ItemCacheState`.
+- `OnFetchSkipped`: open a transaction; splice `FromCache` into the items at the surfaced MERGE PATH (D4), using `tx.StructuralCopy` to avoid aliasing.
+- `OnFetchResult`: apply the write gate (`!FetchFailed && !HasErrors && ResponseData != nil && Type() != Null`); marshal ONCE and defer the L2 `Set` (bytes) to the request-end flush.
+- `EndRequest`: flush deferred L2 writes, one `Set` batch per cache instance; bytes only — no lock, no arena, no transaction.
+- One `CacheKeyTemplate` per candidate — the sole source of read/write/invalidate keys; keys hashed with the repo's pooled xxhash pattern; L1 and L2 will SHARE these keys (derive once; task 17 reuses them).
+- TTL math calls real `time` directly (`time.Now`/`time.Since`/`time.Until`); NO injectable clock — tests use `testing/synctest`.
+- Shared request-lifetime state (deferred write set, later the L1 map) lives on the `requestCache`, guarded by the transaction's `DataBuffer.Lock`; document that invariant at the struct (external-lock guard, no internal mutex).
+
+## Tests
+
+Controller unit tests (v2, constructed astjson + fakes, no plans):
+
+- D core rows: D1 (full hit), D2 (miss), D3 (coverage fail → miss, stale partial NOT served), D4/D5 (nullability), D14 (`ProvidesData == nil`).
+- F write-gate rows F1–F8: clean write; transport/empty/parse failure → ZERO writes (gate keys off `FetchFailed`/`ResponseData == nil`, NOT `HasErrors`); GraphQL errors; JSON-null data; status fallback; TTL stamped exactly (`synctest`).
+- K flush rows K1–K4: accumulate then ONE batch per instance; flush holds bytes, never `*astjson.Value`; nothing-to-flush.
+
+Plan-driven e2e rows (execution module, task 04 harness, public entry points):
+
+- A gating rows A1–A7 (controller nil / config nil / flags false / eligible), B lifecycle rows B1–B8 (lazy once `BeginRequest`, `EndRequest` per entry function, clone/Free, idempotent end), C dispatch rows C1–C8 (incl. C3 full-hit skip with NO spurious error, C7 LoaderHooks not fired on a hit, C8 handle identity prepare→merge).
+- L transaction rows L1–L7 asserted observably + under `-race` (lock once per hook; `ParseBytes` on malformed bytes errors without panic; no transaction from the load phase).
+- O edge rows O1–O7 (hook error propagation, nil-guards, key fidelity: read key == write key from canonical input).
+- The end-to-end entity L2 hit: request 1 misses + writes; request 2 serves from L2 with the gated datasource proving zero network; COMPLETE responses asserted.
+
+## Acceptance criteria
+
+- [ ] All listed scenario rows implemented with full-value `assert.Equal`; no placeholders.
+- [ ] Write gate proven against transport/empty/parse failures (F2–F4) — the historical blocking bug.
+- [ ] One transaction per hook under `-race`; each response parsed once; each key derived once.
+- [ ] Splice honors the surfaced merge path (D4) — include one non-root-merge-path row.
+- [ ] The runtime no-op gate still holds (A rows).
+- [ ] Every exported function of the controller/store/template modules has a meaningful unit test and a responsibility doc comment.
+- [ ] Lint-clean in both modules.
+
+## Reviewer guidance
+
+- The full-hit path must set both `skipLoad` and `fetchSkipped` (no spurious "failed to fetch" error — row C6).
+- Watch for helper duplication with later tasks: predicates/type helpers belong on the `Fetch` interface or in ONE place in `engine/cache`.

--- a/docs/caching/tasks/08-multi-key-freshness-reorder.md
+++ b/docs/caching/tasks/08-multi-key-freshness-reorder.md
@@ -1,0 +1,41 @@
+# Task 08 — Multi-key candidates: render, freshness, reorder, backfill
+
+Phase: A (L2 entities).
+Dependencies: task 07.
+References: RFC-1 §3.6–3.7, §5.1; RFC-2 §6.3; appendix rows D7–D13, E1–E7.
+
+## Problem
+
+An entity may declare multiple `@key` sets.
+Lookup and write must treat every frozen candidate as independently, best-effort renderable — render what can be rendered now, look up under ALL rendered keys, and backfill the rest from fresh data — with multi-candidate freshness selection and reorder-to-selection-order when several cached values compete.
+
+## Scope
+
+Extends the task 07 controller; all inside the existing hook/transaction structure.
+
+- `PrepareFetch`: render EVERY renderable candidate (renderable → `ItemCacheState.RenderedKeys`; not renderable → `PendingCandidates`); `Get` under all rendered keys (a hit on ANY serves); collect `FromCacheCandidates` freshest-first; multi-candidate freshness selection (freshest wins; known TTL beats unknown; merge-synthesis when no single value covers but a union does → `NeedsWriteback`; older-single fallback); reorder the chosen value to selection order before it becomes `FromCache`.
+- `OnFetchResult`: re-render `PendingCandidates` from the fresh response data; write ALL renderable keys; tag `WriteReason` refresh vs backfill (metadata only, never gates).
+- `OnFetchSkipped`: on a hit that leaves other candidates renderable from the served value, emit best-effort backfill writes (`MustWriteBack`), no network.
+- Candidate values parse lazily via `tx.ParseBytes`, once each.
+
+## Tests
+
+Controller unit tests (constructed astjson, `synctest` for TTL variance):
+
+- D freshness rows D7–D13: freshest pick, tie/known-beats-unknown, merge-synthesis (`NeedsWriteback`/`MustWriteBack`), older-single fallback, reorder-to-selection-order, AND-reduction all-covered vs one-uncovered.
+- E multi-key rows E1–E7: all renderable; hit on a NON-primary key; backfill-all-after-response (exact ordered store ops: `[Get k0, Set k0 refresh, Set k1 backfill]` with exact bytes + TTL); none renderable → no Get, write post-fetch; read-hit backfill via `OnFetchSkipped`; refresh-vs-backfill tags; single-`@key` degenerate (one-element list).
+
+Plan-driven e2e rows (multi-key entity fixture from task 04):
+
+- Prime under key A, serve a request that renders only key B (cross-key hit), assert the COMPLETE response and the full ordered store-op log.
+
+## Acceptance criteria
+
+- [ ] Every E/D row asserts the EXACT ordered `[]StoreOp` — a missing/extra Get or Set, wrong key, wrong bytes, wrong reason, or wrong TTL fails.
+- [ ] No candidate is ever "required": unrenderable candidates skip silently at lookup and retry at write (each intentional skip commented WHY).
+- [ ] Read key == write key per candidate (one `CacheKeyTemplate` each).
+- [ ] Lint-clean; no helper duplicated from task 07.
+
+## Reviewer guidance
+
+- The freshness/merge ladder is the subtlest logic in the controller — insist on adversarial rows beyond the OLD test set (partial-overlap unions, empty union, all-stale candidates).

--- a/docs/caching/tasks/09-store-normalization.md
+++ b/docs/caching/tasks/09-store-normalization.md
@@ -1,0 +1,48 @@
+# Task 09 — Store-time normalization + argument-suffix keys
+
+Phase: A (L2 entities).
+Dependencies: task 07 (works with 08; sequencing with 08 is flexible).
+References: maintainer feedback R2.5; OLD `loader_cache_transform.go` on the `caching-base` worktree; appendix row D6.
+
+## Problem
+
+A value cached by one fetch must be reusable by another fetch that selects the same fields under DIFFERENT aliases, and fields selected with different ARGUMENTS must never collide.
+Without normalization, alias-shaped values poison the cache for other operations; without argument-suffix keys, `friends(first:5)` can serve `friends(first:20)` — a stale-data correctness hole.
+
+## Scope
+
+The transform module in `v2/pkg/engine/cache` (port + adapt the OLD transform pipeline):
+
+- WRITE path: normalize values to SCHEMA field names before caching, using the `ProvidesData` tree's `OriginalName` (alias → schema name); fold each field's arguments into the stored object keys as a deterministic argument suffix (from `CacheArgs`, sorted, hashed with the repo xxhash pattern).
+- READ path: denormalize a cached value back to the REQUESTING operation's aliases before splice, again driven by the requesting fetch's `ProvidesData`.
+- The coverage walk (task 07) matches on schema-name + arg-suffix, so an arg-mismatched cached field is a MISS, not a hit.
+- `HasAliases` is the fast-path gate: trees without aliases/args skip the transform entirely.
+- All transforms run inside the hook's `CacheTransaction` (arena-backed values, `StructuralCopy` where aliasing could corrupt).
+- Keep the transform a separable module (partial fetching in task 19 reuses it per-field).
+
+## Tests
+
+Controller unit tests (constructed astjson):
+
+- Round-trip: alias-shaped response → normalized stored form (schema names + arg suffixes, asserted as the FULL stored bytes) → denormalized back under a DIFFERENT alias set (full response asserted).
+- D6 arg-awareness: value cached under `friends_<hashA>` does NOT satisfy `friends(first:20)` = `friends_<hashB>` → miss.
+- No-alias fast path: `HasAliases == false` skips the transform (assert via the recorded ops / unchanged bytes).
+- Nested objects and lists normalize recursively; `__typename` preserved.
+
+Plan-driven e2e rows (task 04 fixtures):
+
+- Operation A caches an entity under aliases; operation B with different aliases over the same fields is served from cache; COMPLETE responses asserted for both.
+- Same field with different argument values: B is a MISS and fetches.
+
+## Acceptance criteria
+
+- [ ] Alias-independent reuse proven end to end (the e2e row above).
+- [ ] Argument-suffix keys proven both ways (same args → hit; different args → miss).
+- [ ] Each response still parsed once; transforms allocate via the transaction only.
+- [ ] The transform module has full unit coverage as a standalone unit.
+- [ ] Lint-clean.
+
+## Reviewer guidance
+
+- The arg-suffix derivation must be deterministic (sorted args) and shared between the write path and the coverage walk — one implementation, not two.
+- Watch allocation: normalization runs per cached entity; keep it arena-based and copy-minimal.

--- a/docs/caching/tasks/10-batch-entity-caching.md
+++ b/docs/caching/tasks/10-batch-entity-caching.md
@@ -1,0 +1,37 @@
+# Task 10 — Batch entity caching
+
+Phase: A (L2 entities).
+Dependencies: task 08.
+References: RFC-1 §5.1(e), appendix rows I1–I8; deviation D4 (PLAN §7).
+
+## Problem
+
+Batch entity fetches (`BatchEntityFetch`) carry many representations in one request; the controller must key, look up, and write PER ITEM, and splice batch hits back to the right merge targets — full-batch in this task (all-hit serves, any-miss refetches everything; partial refetch is task 19).
+
+## Scope
+
+- `PrepareFetch` batch arm: per unique representation (via `BatchStats`), render candidates and look up; record `ItemCacheState.BatchIndex` (original batch position) and `BatchEntityKey`; AND-reduce across ALL items — all covered → `DecisionSkipFullHit`, any uncovered → `DecisionFetch` (full refetch in this task).
+- `OnFetchSkipped`: splice each item's `FromCache` to its merge targets at the surfaced merge path (D4).
+- `OnFetchResult`: per-element multi-key render-then-backfill from the batch response.
+- Batch empty short-circuit preserved (the loader's existing empty-batch skip never reaches the cache).
+- Keep the per-item state exactly what task 19 (partial batch) will need — `BatchIndex` and per-item rendered/pending keys are load-bearing there.
+
+## Tests
+
+Controller unit tests: I rows — batch full hit (zero network), all-miss, MIXED → full refetch (assert the full store-op log shows lookups but the response comes entirely from the network), per-element multi-key backfill, batch empty short-circuit, `BatchIndex` recorded per item.
+
+Plan-driven e2e rows (task 04 nested/cross-subgraph fixtures):
+
+- A nested list query producing a real `BatchEntityFetch`: request 1 populates per-entity entries; request 2 full-batch hit with the gated datasource proving zero network; COMPLETE responses asserted.
+- A mixed run (some entities primed, some not) → full refetch, correct response, and writes for ALL entities afterward.
+
+## Acceptance criteria
+
+- [ ] Per-item keying proven: N distinct entities in one batch produce N `Get`s / N `Set`s with distinct keys (exact ordered ops asserted, normalized where ordering is free).
+- [ ] Batch splice lands each value at its correct merge target (non-root merge path row included).
+- [ ] Mixed batches never partially serve in this task (that is task 19), and never mis-merge.
+- [ ] Lint-clean.
+
+## Reviewer guidance
+
+- The batch dedup loop in the loader must remain UNCHANGED here; cache awareness of the dedup loop arrives only with partial fetching (task 19).

--- a/docs/caching/tasks/11-negative-caching.md
+++ b/docs/caching/tasks/11-negative-caching.md
@@ -1,0 +1,40 @@
+# Task 11 — Negative caching
+
+Phase: A (L2 entities).
+Dependencies: task 07.
+References: RFC-1 §3.3, §5.1(d); appendix rows G1–G6.
+
+## Problem
+
+A SUCCESSFUL-but-empty entity fetch should be cacheable as a null sentinel (so repeated lookups for a nonexistent entity skip the network), but a FAILED fetch must never be cached — confusing the two persists transient errors.
+
+## Scope
+
+- `OnFetchResult`: when `EmptyEntity && !FetchFailed && !HasErrors && cfg.NegativeCacheTTL > 0`, write a null sentinel under the item's keys with `NegativeCacheTTL`; stamp `ItemCacheState.NegativeHit` / `FromCache = TypeNull`.
+  `EmptyEntity` is the ONE non-failure that still writes; all failure signals block negative writes too (`FetchFailed` wins over `EmptyEntity`).
+- `PrepareFetch`: a null-sentinel hit serves as `DecisionSkipFullHit` with `FromCache = TypeNull`; merge skipped; the loader's null-bubble / `setSkipErrors` behavior untouched.
+- Negative TTL is its own knob; `NegativeCacheTTL == 0` disables the path entirely.
+
+## Tests
+
+Controller unit tests (`synctest` for TTL):
+
+- G1 negative write on empty entity (exact sentinel bytes + `NegativeCacheTTL` in the store op).
+- G2 skipped when `NegativeCacheTTL == 0` (zero writes).
+- G3 negative hit served (null entity, zero network, `NegativeHit` recorded).
+- G4 expiry: sleep past `NegativeCacheTTL` inside the bubble → miss → network runs.
+- G5 `EmptyEntity && FetchFailed` → gate blocks, NO negative write.
+- G6 null-bubble suppression preserved (no synthetic non-null error introduced by a negative hit).
+
+Plan-driven e2e row: a by-key entity query for a nonexistent entity — request 1 fetches empty and writes the sentinel; request 2 serves null with zero network; COMPLETE responses asserted.
+
+## Acceptance criteria
+
+- [ ] All G rows pass with full-value assertions.
+- [ ] `FetchFailed`/`HasErrors` block negative writes in every combination.
+- [ ] Expiry proven via `testing/synctest` (no custom clock).
+- [ ] Lint-clean.
+
+## Reviewer guidance
+
+- The sentinel must be distinguishable from "no entry" AND from a positive null-field value at read time; verify the read path routes on the sentinel, not on JSON null alone.

--- a/docs/caching/tasks/12-shadow-mode.md
+++ b/docs/caching/tasks/12-shadow-mode.md
@@ -1,0 +1,41 @@
+# Task 12 — Shadow mode (entity compare)
+
+Phase: A (L2 entities).
+Dependencies: task 07.
+References: RFC-1 §3.2, §3.5, §5.1(b); appendix rows H1–H4, H6, H7.
+
+## Problem
+
+Shadow mode must READ L2 but never SERVE it: force a real fetch, then compare cached vs fresh — a staleness probe that is byte-identical to a miss on the loader side and leaks nothing onto the loader surface.
+
+## Scope
+
+- `PrepareFetch`: on `cfg.ShadowMode` + an L2 hit, stash the cached value into `handle.ShadowStash` and return `DecisionFetchShadow` (`skipLoad` stays false; the loader treats it exactly like `DecisionFetch`).
+- `OnFetchResult`: when `handle.Shadow`, run `CacheObserver.CompareShadow` BEFORE the writes (compare → write-L1 → write-L2 order preserved), inside the hook's already-open transaction; entity fetches only (the root-field asymmetry lands in task 13).
+- A nil observer force-fetches and records nothing; NO-OP and L1-only modes never yield `DecisionFetchShadow`.
+- `RecordingObserver` (task 04) is the test double; production observer wiring arrives with ART (task 20).
+
+## Tests
+
+Controller unit tests (`synctest` where an entry is aged for `CacheAge`):
+
+- H1 read + stash + force-fetch (fresh response served; store shows the Get; network ran).
+- H2 compare MATCH (recorded `CacheAge` equals the slept duration; compare precedes writes; L2 overwritten).
+- H3 compare MISMATCH (`IsFresh = false`; L2 overwritten with fresh).
+- H4 L1-hit-wins (once task 17 lands, re-run: an L1 hit serves and no shadow compare fires; until then the row is L2-scoped).
+- H6 nil observer: force-fetch, nothing recorded.
+- H7 mode matrix: NO-OP / L1-only never produce `DecisionFetchShadow`.
+
+Plan-driven e2e row: shadow-configured entity — response is ALWAYS the fresh network value even on an L2 hit; the full observer record asserted.
+
+## Acceptance criteria
+
+- [ ] Shadow always force-fetches and serves FRESH data (never the cached value).
+- [ ] Compare → write-L1 → write-L2 order proven.
+- [ ] Loader-side behavior on `DecisionFetchShadow` is byte-identical to `DecisionFetch` (no new loader branch).
+- [ ] Lint-clean.
+
+## Reviewer guidance
+
+- Shadow is a cross-cutting L2 variant, not a fifth mode — confirm no mode enum grew.
+- The compare must run inside the existing transaction (no second lock acquisition).

--- a/docs/caching/tasks/13-root-field-l2.md
+++ b/docs/caching/tasks/13-root-field-l2.md
@@ -1,0 +1,41 @@
+# Task 13 — Root-field L2 caching (plan + runtime)
+
+Phase: B (L2 root fields).
+Dependencies: tasks 07, 09.
+References: RFC-2 §7.2; RFC-1 §3.5, §5.1(b); appendix rows D/F/I/J (root-field arms), H5.
+
+## Problem
+
+Root-field fetches carry no cache config, a merged fetch may mix policies, and root-field shadow must force-refetch WITHOUT comparing (the historical asymmetry).
+
+## Scope
+
+Two commits, plan then runtime (each independently reviewable).
+
+Commit 1 — plan side (extends task 06's configurator):
+
+- `fetchCacheConfigurator` root-field arm: `rootFieldPolicyForAllRootFields` — a policy only when EVERY root field in the fetch resolves to the SAME policy, else leave `Cache` nil (the conservative decline; task 14 makes mixed fetches rare by splitting them, and this rule stays as the residual safety net).
+- Config shape: `L1 = false` (root fields act only as L2 providers; root→entity L1 promotion is a follow-up), `L2 = TTL > 0` (D3), `CacheScopeRootField` key spec (type/field; candidates empty for a plain root field).
+
+Commit 2 — runtime (extends the task 07 controller):
+
+- Render the root-field-scope key (canonical input + header hash + arg suffix per task 09); `Get`/coverage/deferred `Set`, reusing the entity path's primitives — no parallel implementation.
+- Root-field shadow asymmetry: on `ShadowMode` + hit, force-refetch and overwrite L2 but DO NOT call `CompareShadow`.
+- Normalization (task 09) applies to root-field values the same way (alias-independent reuse across operations).
+
+## Tests
+
+- Configurator rows: single cached root field → FULL `Cache` asserted; mixed-policy merge and cached+uncached merge → `Cache` nil (full-value asserts).
+- Runtime rows: root-field arms of D (hit/miss/coverage), F (write gate), the J mode-matrix row over one query (NO-OP/L2 behave identically data-wise; loader branches only on `Decision`); H5 (shadow force-refetch, ZERO compares recorded); root-field flush.
+- Plan-driven e2e: a cached root field served from L2 on the second request (zero network, COMPLETE response); an alias-variant operation served from the same entry (task 09 reuse).
+
+## Acceptance criteria
+
+- [ ] Mixed-policy fetches decline L2 (nil `Cache`) — never mis-cache.
+- [ ] Root-field shadow records NO compare (H5).
+- [ ] Runtime reuses the entity primitives (review the diff for duplication).
+- [ ] Lint-clean in both modules.
+
+## Reviewer guidance
+
+- The root-field key is whole-response scoped per field coordinate — verify the key template includes type + field + args, and that read key == write key.

--- a/docs/caching/tasks/14-root-field-isolation.md
+++ b/docs/caching/tasks/14-root-field-isolation.md
@@ -1,0 +1,48 @@
+# Task 14 — Per-root-field cache isolation
+
+Phase: B (L2 root fields; ships last of the root-field work).
+Dependencies: task 13.
+References: RFC-3 (now IN CORE per maintainer feedback R2.2); deviation D5 (PLAN §7).
+
+## Problem
+
+The path builder merges sibling query root fields from the same datasource into ONE fetch.
+A merged fetch either loses caching entirely (mixed/uncached siblings → the task 13 all-or-nothing decline) or caches as one coarse unit (poor reuse, shared invalidation).
+Splitting cached root fields into their own fetches recovers caching for mixed policies AND gives each field its own L2 key.
+
+## Scope
+
+Isolation is a MERGE decision made during path building — a post-pass cannot un-merge a fused fetch — so this task edits `path_builder_visitor.go` directly (allowed; there are no forbidden files).
+
+- New unit `plan/root_field_isolation.go` owning the gate predicate `shouldIsolate(field, operationType)`:
+  caching configured; `OperationTypeQuery` only; direct children of the operation root only; the exact `(typeName, fieldName)` has a `RootFieldPolicy` from the datasource's `CacheConfigProvider` (NEVER from `FederationMetaData`).
+- `path_builder_visitor.go`, exactly three touches:
+  1. one additive flag on `objectFetchConfiguration` (e.g. `isolatedRootField bool`);
+  2. in `handlePlanningField`: isolate a cached query root into a NEW planner (second disjunct beside the existing mutation-root branch) and set the flag;
+  3. at the top of the `planWithExistingPlanners` loop: refuse to fold another TOP-LEVEL operation field into an isolated planner — keyed off `isParentPathIsRootOperationPath(field.parentPath)`, NEVER off `IsRootNode` (entity types are also root nodes; using `IsRootNode` would tear the isolated field's own subtree apart — the entity-root-node trap).
+- Per-field isolation (every cached root field its own planner), matching OLD; no cold-cache amplification cap (opt-in, bounded by configured fields; per-policy-group batching is a recorded future mitigation).
+- Downstream passes need NO changes: P1 sees the isolated planners; the configurator sees single-root-field fetches (the all-or-nothing rule trivially passes); isolated fetches carry no mutual `DependsOnFetchIDs` and run in parallel.
+
+## Tests
+
+- NO-OP proof: with caching unconfigured, `shouldIsolate` is never true and plans are BYTE-IDENTICAL (the new branches are provably dead).
+- Full-plan rows (task 04 fixture with differing sibling policies, `assert.Equal` on whole plans):
+  1. two cached siblings with different policies → TWO parallel fetches, each with its own FULL `Cache` (own name/TTL), no dependency edge;
+  2. cached + uncached sibling → cached isolated with `Cache`, uncached fetch without;
+  3. caching off → ONE merged fetch, byte-identical to pre-task plans.
+- Entity-root-node trap row: a nested entity under an isolated root field still merges into the isolated planner's subtree.
+- Defer composition row: an isolated root field with a deferred fragment lands its deferred sub-fetch in the correct per-`DeferID` tree.
+- e2e row: the two isolated siblings cached and served independently (one expires, the other still hits — uses the mixed-TTL fixture).
+
+## Acceptance criteria
+
+- [ ] `path_builder_visitor.go` diff is exactly the three touches above; all decision logic and tests live in the new unit.
+- [ ] The entity-root-node trap row passes (guard keys off parentPath).
+- [ ] The task 13 all-or-nothing rule remains as the residual safety net for any still-mixed fetch.
+- [ ] Byte-identical plans with caching off.
+- [ ] Lint-clean.
+
+## Reviewer guidance
+
+- Verify the gate reads `CacheConfigProvider.RootFieldPolicy`, never `FederationConfiguration()`.
+- Verify isolated fetches execute in parallel (no dependency edges between them).

--- a/docs/caching/tasks/15-entity-cache-reuse.md
+++ b/docs/caching/tasks/15-entity-cache-reuse.md
@@ -1,0 +1,42 @@
+# Task 15 — Root fields re-using the entity cache (EntityKeyMappings)
+
+Phase: C.
+Dependencies: tasks 08, 13.
+References: RFC-2 §6 derivation note; RFC-1 §3.6 (`EntityKeyMappings` as additional candidates); appendix rows E3, E5; deviation D10 (PLAN §7).
+
+## Problem
+
+A by-key root field (e.g. `product(upc:)`, `user(id:)`) returns exactly the entity the entity cache may already hold, but its root ARGUMENTS are not linked to the entity `@key`, so it cannot reuse those entries.
+
+## Scope
+
+Plan side (extends task 06's `cacheKeyBuilder`):
+
+- DERIVE `EntityKeyMappings` structurally (D10): resolve the root field's return type from the definition, collect its argument names, and for each resolvable `@key` set emit a mapping ONLY when every key field name matches a root-arg name (`product(upc:)` maps `@key(upc)` but not `@key(sku)`).
+  This branch carries no external mapping config; operator-declared overrides are a recorded follow-up.
+- Mappings are frozen BY VALUE onto the ROOT-FIELD spec (entity fetches key by representation and need none).
+- v1 reuse constraint (D10): reuse works only when the by-key root-field policy shares `CacheName` with the entity policy (read key == write key); document this at the policy structs.
+
+Runtime (extends the task 08 multi-key model):
+
+- At `PrepareFetch` for a root field with `EntityKeyMappings`: render an ENTITY candidate from the root args (mappings are additional candidates, not a separate key space) and look up the entity key space; a hit serves the root field from the entity entry (denormalized per task 09).
+- Backfill: after a fetch (or on a read-hit), re-render the remaining entity candidates from the returned data and write them (`OnFetchResult` / `OnFetchSkipped` with `MustWriteBack`).
+
+## Tests
+
+- Builder rows: FULL `EntityKeyMappings` asserted for `product(upc:)`/`user(id:)`-shaped fixtures; no mapping when args do not cover a key set; no federation pointer retained.
+- E3: lookup renders ONLY the arg-derived candidate; after the response the data-derived key (e.g. `sku`) is backfilled — exact ordered store ops asserted.
+- E5: read-hit backfill via `OnFetchSkipped`.
+- e2e (task 04 fixtures): `{ product(upc:"1") { name } }` served from an entity entry primed by a list field (e.g. `topProducts`) — zero network on request 2, COMPLETE response asserted; a mismatched-`CacheName` variant does NOT reuse (the constraint is enforced, not accidental).
+
+## Acceptance criteria
+
+- [ ] By-key root fields hit entity entries end to end.
+- [ ] The exact ordered `Get`/`Set` sequence asserted (a wrong key or missing backfill fails).
+- [ ] Mappings derived from definition + federation only; never from the policy struct.
+- [ ] The `CacheName` constraint tested both ways.
+- [ ] Lint-clean.
+
+## Reviewer guidance
+
+- Mappings must flow through the SAME best-effort candidate machinery as multi-key (no separate lookup path in the controller).

--- a/docs/caching/tasks/16-optimize-l1-pass.md
+++ b/docs/caching/tasks/16-optimize-l1-pass.md
@@ -1,0 +1,40 @@
+# Task 16 — optimizeL1Cache cross-tree narrowing
+
+Phase: D (L1).
+Dependencies: task 06.
+References: RFC-2 §10; OLD `postprocess/optimize_l1_cache.go` on the `caching-base` worktree; CODING_GUIDELINES §10.5.
+
+## Problem
+
+The configurator marks every entity fetch L1-eligible, but L1 only helps where a request-lifetime provider/consumer pair exists; everywhere else the eligibility is wasted work at runtime.
+
+## Scope
+
+A pure NARROWING pass in `v2/pkg/engine/cache`, run by the facade AFTER the configurator, ONCE over ALL trees:
+
+- Collect entity fetches across the root tree AND every `Defers[i].Fetches` (the L1 store is request-lifetime and shared across defer groups, so provider/consumer pairs span trees).
+- For each: `cfg.L1 = canRead || canWrite` —
+  `canRead`: a prior fetch (or union of priors) of the same entity type provides a SUPERSET of this fetch's `ProvidesData`;
+  `canWrite`: a later fetch of the same type needs a SUBSET of this fetch's `ProvidesData`;
+  ordering resolved purely from `DependsOnFetchIDs`.
+- The configurator is the sole eligibility setter; this pass NEVER turns L1 on.
+- Port the OLD field-coverage primitives (`objectProvidesAllFields`, union helpers, dependency-chain ordering); fix, do not inherit, the OLD `hasValidConsumer` union-fallback flaw (a provider counted as reused even when it contributed no field the shared consumer needed).
+- Optionally re-nil a fully-inert config (`!L1 && !L2 && !ShadowMode`) as the last step (tidy, not correctness).
+
+## Tests
+
+- Port the OLD provider/consumer/union/dependency-chain rows, PLUS adversarial rows the OLD set lacked: irrelevant-provider-sharing-a-consumer, partial overlap, empty union.
+- A defer case: `processTrees(root, defer1, defer2)` asserting CROSS-tree provider/consumer narrowing (root provider kept L1 because its only consumer lives in a defer group).
+- Never-turns-on row: a fetch the configurator left `L1 = false` stays false.
+- Determinism: run twice, identical output.
+
+## Acceptance criteria
+
+- [ ] Narrowing only (no row can flip L1 on).
+- [ ] Cross-tree pairs captured; per-tree-only behavior rejected by the defer row.
+- [ ] The OLD union-fallback flaw is fixed and pinned by a test.
+- [ ] Lint-clean.
+
+## Reviewer guidance
+
+- Wrong narrowing costs only a missed hit, never correctness — but insist on the adversarial rows anyway; this logic was the first pass's latent-bug source.

--- a/docs/caching/tasks/17-l1-runtime-store.md
+++ b/docs/caching/tasks/17-l1-runtime-store.md
@@ -1,0 +1,46 @@
+# Task 17 — Request-lifetime shared L1 store
+
+Phase: D (L1).
+Dependencies: tasks 09, 16.
+References: RFC-1 §6; maintainer feedback R2.4; appendix rows J1–J7, M1–M2 (M3/N rows complete in task 18).
+
+## Problem
+
+There is no L1 entity store shared across a request's per-defer-group loaders.
+An entity fetched by the initial tree should serve a deferred fetch of the same entity later in the SAME request, with zero marshaling.
+
+## Scope
+
+- The L1 store lives on the `RequestCache` on the by-reference-shared `Context` (created lazily once per request under `DataBuffer.Lock`), guarded by the hook's `CacheTransaction` — no internal mutex (document the external-lock invariant at the struct).
+- Storage model (R2.4): L1 stores `*astjson.Value` — NEVER `[]byte`, NEVER marshals; isolation via `tx.StructuralCopy` on write and on read (so merges cannot corrupt the stored value).
+- SHARED KEYS: L1 uses the SAME derived keys as L2 (the task 07 `CacheKeyTemplate` output) — derive each key once per fetch, use for both layers; no prefix-free L1 keyspace, no second derivation.
+- `PrepareFetch`: L1 → L2 → subgraph ordering with coverage at each layer; an L1 hit short-circuits the L2 `Get`.
+- `OnFetchResult`: write NORMALIZED entities (task 09) to L1 (structural copy) and to L2 when enabled — parse once, one normalized form feeds both layers (only the L2 write marshals).
+- `OnFetchSkipped`: splice from L1 (denormalized to the requesting fetch's aliases).
+- Subscription isolation: `clone` resets `requestCache` (task 02), so each event builds its own L1 — verify, don't re-implement.
+- This request-lifetime store is NOT the removed `@requestScoped` directive feature (D11).
+
+## Tests
+
+Controller unit tests: L1 map behavior (structural-copy isolation — mutate the source after write, the stored value is unaffected; and mutate a served value, the stored value is unaffected), shared-key assertion (the L1 key string equals the L2 key string for the same fetch), parse-once (op log shows a single parse per response).
+
+Plan-driven e2e rows:
+
+- J mode matrix J1–J7 over the same query (NO-OP / L1 / L2 / L1+L2): loader branches only on `Decision`; L1 hit short-circuits L2; L2 hit populates L1; data-equal responses across modes.
+- M1 lazy init race-free (N parallel eligible fetches → exactly one `BeginRequest`, `-race`, gates).
+- M2 parallel writes to the shared L1 (two same-type entity fetches, both miss, both write; no corruption, `-race`).
+- N6 subscription event isolation (two events via clone; no cross-event bleed).
+- An in-request reuse row on the sync path: fetch A populates L1, dependent fetch B (same entity, subset selection) serves from L1 with zero network.
+
+## Acceptance criteria
+
+- [ ] Zero marshaling on the L1 path (assert via the op logs: no `Set` bytes for L1, no parse on an L1 hit).
+- [ ] One key derivation per fetch feeding both layers.
+- [ ] All rows pass under `-race` with gate-based ordering (no latency sleeps).
+- [ ] The runtime no-op and mode-blindness gates still hold (J rows).
+- [ ] Lint-clean.
+
+## Reviewer guidance
+
+- The GC/arena hazard: every `*astjson.Value` stored in the L1 map must be produced via the transaction (`ParseBytes`/`StructuralCopy`), never a heap value smuggled into arena-noscan memory.
+- Watch the L1→L2 ordering: an L1 hit must not emit an L2 read or write-back unless coverage genuinely required L2.

--- a/docs/caching/tasks/18-defer-concurrency-coverage.md
+++ b/docs/caching/tasks/18-defer-concurrency-coverage.md
@@ -1,0 +1,34 @@
+# Task 18 — Defer + concurrency scenario coverage
+
+Phase: D (L1).
+Dependencies: task 17 (uses the task 04 fixture set, which was designed to close the first-pass fixture gap).
+References: appendix §6–§7 (rows M3–M5, N1–N5); CODING_GUIDELINES §4.5 (synctest), the gates-not-latency rule.
+
+## Problem
+
+The defer × caching interaction is where the first pass could not complete its proofs: the old `commerce` fixture could not express an initial fetch whose L1 entry is reused by a same-entity deferred fetch in a later group, so cross-defer-group L1 SERVING was never proven end to end.
+The task 04 fixture set includes the required shape (initial `ProvidesData` a strict superset of a deferred same-entity fetch); this task lands the proofs.
+
+## Scope
+
+Test-only task (plus any small fixes it flushes out); all rows run in the execution module through `ResolveGraphQLDeferResponse`, inside `synctest` bubbles, ordered with gate channels + `synctest.Wait()` (sleeps advance fake time for TTL ONLY), under `-race`.
+
+- N1: entity cached by the initial fetch SERVED to a deferred fetch — the deferred group's subgraph is never hit (gated datasource proves it); both frames asserted as COMPLETE responses.
+- N2: a deferred fetch populates L1 visible to a LATER group.
+- M3: per-defer-group loaders share ONE L1 via the by-reference `Context`.
+- N3: exactly ONE `EndRequest` after ALL groups; the flush carries deferred L2 writes from the initial fetch AND every group.
+- N4: a `SkipFullHit` on one branch does not reorder defer frames.
+- N5/M4: a deferred fetch's lookup/merge happens inside its group's transaction; each hook is a single lock acquisition; no cross-group arena race.
+- M5: one parallel fetch's hook error propagates out of the group; siblings unaffected.
+- If `optimizeL1Cache` narrows L1 off for a shape a row needs, the row's fixture (not the pass) is wrong — the fixture must present a genuine provider/consumer pair; fix the fixture.
+
+## Acceptance criteria
+
+- [ ] N1/N2/M3 pass — the first-pass carry-forward gap is CLOSED (cross-defer-group L1 serving proven end to end).
+- [ ] N3–N5, M4–M5 pass under `-race`.
+- [ ] No latency-based ordering anywhere (gates + `synctest.Wait()` only).
+- [ ] All frame assertions are COMPLETE response strings.
+
+## Reviewer guidance
+
+- Verify the N1 plan actually contains a real defer group whose entity selection is covered by the initial fetch (inspect the plan in the test, not just the frames) — this is exactly where the first pass was silently unable to test what it claimed.

--- a/docs/caching/tasks/19-partial-fetching.md
+++ b/docs/caching/tasks/19-partial-fetching.md
@@ -1,0 +1,49 @@
+# Task 19 — Partial fetching (partial cache load + partial batch realign)
+
+Phase: E.
+Dependencies: tasks 10, 17.
+References: maintainer feedback R2.3 (graduates the RFC-1 §9 v2 seam to core); OLD partial-batch machinery on the `caching-base` worktree (variable filtering + realign).
+
+## Problem
+
+Today a fetch is all-or-nothing: one uncovered item (or one expired field) refetches everything.
+With partial fetching a fetch resolves LAYER BY LAYER: serve what L1 has, look up the still-missing keys in L2, fetch ONLY what is still missing from the subgraph, then splice + realign.
+For batch entity fetches this means refetching only the missing representations.
+
+## Scope
+
+This is the one task expected to touch the loader beyond the task 02 seams (sanctioned: the cache may be more integrated with the loader where that improves clarity — keep the diff surgical and explained).
+
+- `DecisionFetchPartial` graduates from seam to implemented: `PrepareFetch` returns it when SOME items/fields are covered and some are not (gated by `cfg.EnablePartialCacheLoad` / `cfg.PartialBatchLoad`).
+- Single/entity fetches: the covered subset is spliced from cache (`OnFetchSkipped`-style), the fresh subset merges normally — BOTH happen for one fetch; per-field partial expiry (mixed TTLs on one value) serves the still-fresh fields and refetches the expired ones, using the task 09 transform's per-field granularity.
+- Batch fetches: filter the representations variable to the MISSING items only (cache-aware dedup loop), send the reduced batch, then REALIGN the response using `ItemCacheState.BatchIndex` so fetched and cached items land at their original positions.
+- Loader interplay: the partial path must compose with single-flight (dedup on the canonical input) and preserve error semantics (a failed partial fetch fails only the fetched subset's merge, never corrupts the spliced subset).
+- Keep partial a separable module in `engine/cache` (the L1/L2/partial modularity requirement).
+
+## Tests
+
+Controller unit tests:
+
+- Partial coverage split: exact partition of items into served/pending; the store-op log shows lookups for all, writes only for fetched.
+- Batch realign: mixed batch of N with K hits → filtered variables contain exactly N−K representations (asserted bytes); response realigned to original positions (full merged value asserted).
+- Per-field partial expiry: a value with field TTLs A fresh / B expired → B refetched, A served; full result asserted.
+- Failure in the fetched subset: spliced subset intact, error propagated per loader semantics.
+
+Plan-driven e2e rows (mixed-TTL and nested fixtures from task 04):
+
+- Batch: prime a subset of entities, run the list query — the gated datasource receives ONLY the missing representations (assert its exact input); COMPLETE response asserted.
+- Partial expiry end to end: sleep past the short TTL in a `synctest` bubble, re-run, assert the subgraph receives only the expired portion.
+
+## Acceptance criteria
+
+- [ ] Batch partial: the subgraph request contains exactly the missing representations (exact input bytes asserted).
+- [ ] Realign proven via `BatchIndex` (original order restored, no misplacement).
+- [ ] Per-field partial expiry works end to end.
+- [ ] All-or-nothing behavior remains for fetches with partial DISABLED (config-gated; earlier tasks' rows still pass).
+- [ ] Loader diff is minimal and each touch is explained in the commit notes.
+- [ ] Lint-clean in both modules.
+
+## Reviewer guidance
+
+- The realign is the risk center: insist on adversarial shapes (duplicated representations, all-hit degenerating to skip, all-miss degenerating to full fetch, single-element batch).
+- Verify the partial path never double-merges an item (spliced AND fetched).

--- a/docs/caching/tasks/20-art-observability.md
+++ b/docs/caching/tasks/20-art-observability.md
@@ -1,0 +1,34 @@
+# Task 20 — ART observability (verbose caching trace)
+
+Phase: E.
+Dependencies: tasks 12, 17.
+References: maintainer feedback R2.9 (graduates the observer from v2-staged to core); RFC-1 §3.5 (`CacheObserver`).
+
+## Problem
+
+Operators need to SEE caching behave: the playground (via ART — Advanced Request Tracing) must surface every caching aspect per fetch — L1 vs L2, hits/misses, shadow comparisons, backfills, key derivations, and remaining TTLs — without the observability concern leaking back onto the lookup/write surface (the coupling that sank the OLD implementation).
+
+## Scope
+
+- A production `CacheObserver` implementation in `engine/cache` that accumulates per-fetch cache trace from the `FetchCacheHandle` (`OnFetchObserved`) and the shadow compares (`CompareShadow`), keyed per fetch.
+- Wire the accumulated data into ART's existing per-fetch trace output (extend the fetch trace shape additively): decision, per-layer hit/miss, rendered keys (respecting `HashAnalyticsKeys` — hash key material when set), candidate freshness / `SelectedRemainingTTL`, write reasons (refresh/backfill), negative hits, shadow compare results with `CacheAge`.
+- The observer stays composed INSIDE the controller (the loader never calls it); a nil observer remains zero-cost and records nothing.
+- Trace assembly happens at `EndRequest`/finalize time — single-threaded, no lock, no arena; accumulation during hooks rides the existing transaction.
+- Scope guard: this is TRACE output; metrics/analytics export pipelines and the walker-inlined per-field hooks (`OnEntity`/`OnFieldValue`) stay follow-ups.
+
+## Tests
+
+- Observer unit tests: full accumulated trace asserted (`assert.Equal` on the complete structure) for hit, miss, backfill, negative, and shadow scenarios; `HashAnalyticsKeys` on/off both asserted; nil observer records nothing and costs no allocations on the hook path (benchmark-guard or allocation assert where the repo has precedent).
+- Plan-driven e2e rows: run representative scenarios (L2 hit, L1 hit, shadow compare, partial fetch) with ART enabled and assert the COMPLETE cache section of the trace output; `synctest` pins remaining-TTL values so they assert exactly.
+- Regression: with ART disabled and observer nil, response bytes are byte-identical to the pre-task suite (the no-op gate extended to observability).
+
+## Acceptance criteria
+
+- [ ] Every caching aspect listed above appears in ART output and is asserted exactly (no fuzzy TTL assertions — `synctest` makes them deterministic).
+- [ ] Nil observer: zero cost, zero output, byte-identical responses.
+- [ ] No observability code on the loader surface; the controller composes the observer.
+- [ ] Lint-clean in both modules.
+
+## Reviewer guidance
+
+- This concern caused the OLD implementation's worst coupling (~461 call sites); reject any change that adds observer calls outside the controller/handle boundary.

--- a/execution/cachingtesting/art_e2e_test.go
+++ b/execution/cachingtesting/art_e2e_test.go
@@ -109,11 +109,14 @@ func TestARTCacheTraceEndToEnd(t *testing.T) {
 		result := Plan(t, l1ChainQuery, productL1Caching(0), l1ChainResponses())
 		body := resolveTraced(t, result.Response, store)
 		assert.Equal(t, l1ChainExpected, body)
-		traces := cacheTraces(t, result.Response.Fetches)
-		require.Len(t, traces, 2)
-		assert.Contains(t, traces[0], `path:"deal.product" {"decision":"Fetch","hit":false`)
-		assert.Contains(t, traces[1], `"decision":"SkipFullHit","hit":true,"items":[{"keys":["`)
-		assert.Contains(t, traces[1], `"served_from":"l1","hit":true,"pending_candidates":1}]`)
+		// The key hashes are deterministic (xxhash64 of the canonical key
+		// preimage), so the WHOLE cache sections pin as literals: fetch A is a
+		// plain miss+refresh (its sku-derived key; the upc candidate pending),
+		// fetch B is the in-request L1 hit under the upc-derived key.
+		assert.Equal(t, []string{
+			`path:"deal.product" {"decision":"Fetch","hit":false,"items":[{"keys":["entities:f58e5d95ce10e65e"],"hit":false,"write_reason":"refresh","pending_candidates":1}]}`,
+			`path:"deal.product.reviews.@.product" {"decision":"SkipFullHit","hit":true,"items":[{"keys":["entities:153cc511c85713fb"],"served_from":"l1","hit":true,"pending_candidates":1}]}`,
+		}, cacheTraces(t, result.Response.Fetches))
 	})
 
 	t.Run("shadow compare", func(t *testing.T) {
@@ -152,11 +155,11 @@ func TestARTCacheTraceEndToEnd(t *testing.T) {
 		assert.Equal(t,
 			`{"data":{"products":[{"upc":"1","reviews":[{"body":"great table"}]},{"upc":"2","reviews":[{"body":"sturdy chair"}]}]}}`,
 			body)
-		traces := cacheTraces(t, second.Response.Fetches)
-		require.Len(t, traces, 1)
-		assert.Contains(t, traces[0], `"decision":"FetchPartial","hit":false`)
-		assert.Contains(t, traces[0], `"served_from":"l2","hit":true,"remaining_ttl_nanoseconds":-1`)
-		assert.Contains(t, traces[0], `"hit":false,"write_reason":"refresh"`)
+		// One partial fetch: bucket 1 (upc "1") served from L2 under the primed
+		// key, bucket 2 (upc "2") fetched over the reduced batch and refreshed.
+		assert.Equal(t, []string{
+			`path:"products" {"decision":"FetchPartial","hit":false,"items":[{"keys":["reviews:aa052522cb64dff0"],"served_from":"l2","hit":true,"remaining_ttl_nanoseconds":-1},{"keys":["reviews:258590a53d3c528e"],"hit":false,"write_reason":"refresh"}]}`,
+		}, cacheTraces(t, second.Response.Fetches))
 	})
 
 	t.Run("regression: tracing off leaves fetch traces nil", func(t *testing.T) {

--- a/execution/cachingtesting/art_e2e_test.go
+++ b/execution/cachingtesting/art_e2e_test.go
@@ -1,9 +1,8 @@
 package cachingtesting
 
 import (
+	"bytes"
 	"encoding/json"
-	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -13,1508 +12,1498 @@ import (
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/cache"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/cache/cachetesting"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
-	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 )
 
-// resolveTraced resolves with ART enabled and the production TraceObserver
-// composed into the controller, returning the response body.
-func resolveTraced(t *testing.T, resp *resolve.GraphQLResponse, store *cachetesting.FakeStore) string {
+// normalizedTraceBody makes a traced response body pinnable: subgraph double
+// URLs become their stable fixture form, real-clock cache-trace nanos become
+// -1, and the whole body is indented for reviewable pins.
+func normalizedTraceBody(t *testing.T, subgraphs Subgraphs, body string) string {
 	t.Helper()
-	ctx := resolve.NewContext(t.Context())
-	ctx.TracingOptions.Enable = true
-	ctx.SetCacheController(cache.NewController(cachetesting.StoreAdapter{Store: store}, cache.NewTraceObserver()))
-	return resolveWithContext(t, ctx, resp)
+	normalized := NormalizeCacheTraceClock(subgraphs.NormalizeURLs(body))
+	var buf bytes.Buffer
+	require.NoError(t, json.Indent(&buf, []byte(normalized), "", "  "))
+	return buf.String()
 }
 
-// fullTraces renders EVERY fetch's COMPLETE ART trace as path-labeled,
-// indented JSON — the whole DataSourceLoadTrace, cache section included — with
-// the real-clock fields normalized: durations zeroed, TTL and cache-age nanos
-// set to -1 when positive (their exact values are pinned by the synctest
-// observer unit rows).
-func fullTraces(t *testing.T, node *resolve.FetchTreeNode) string {
-	t.Helper()
-	var b strings.Builder
-	var walk func(node *resolve.FetchTreeNode)
-	walk = func(node *resolve.FetchTreeNode) {
-		if node == nil {
-			return
-		}
-		if node.Item != nil && node.Item.Fetch != nil {
-			if trace := loadTraceOf(node.Item.Fetch); trace != nil {
-				normalized := *trace
-				normalized.DurationSinceStartNano = 0
-				normalized.DurationLoadNano = 0
-				if normalized.DurationSinceStartPretty != "" {
-					normalized.DurationSinceStartPretty = "0s"
-				}
-				if normalized.DurationLoadPretty != "" {
-					normalized.DurationLoadPretty = "0s"
-				}
-				if trace.CacheTrace != nil {
-					cacheTrace := *trace.CacheTrace
-					cacheTrace.Items = append([]resolve.CacheItemTrace(nil), trace.CacheTrace.Items...)
-					for i := range cacheTrace.Items {
-						if cacheTrace.Items[i].RemainingTTLNano > 0 {
-							cacheTrace.Items[i].RemainingTTLNano = -1
-						}
-					}
-					cacheTrace.ShadowCompares = append([]resolve.CacheShadowCompareTrace(nil), trace.CacheTrace.ShadowCompares...)
-					for i := range cacheTrace.ShadowCompares {
-						if cacheTrace.ShadowCompares[i].CacheAgeNano > 0 {
-							cacheTrace.ShadowCompares[i].CacheAgeNano = -1
-						}
-					}
-					normalized.CacheTrace = &cacheTrace
-				}
-				raw, err := json.MarshalIndent(&normalized, "", "  ")
-				require.NoError(t, err)
-				fmt.Fprintf(&b, "=== path %q ===\n%s\n", node.Item.ResponsePath, raw)
-			}
-		}
-		for _, child := range node.ChildNodes {
-			walk(child)
-		}
-	}
-	walk(node)
-	return b.String()
-}
-
-func loadTraceOf(fetch resolve.Fetch) *resolve.DataSourceLoadTrace {
-	switch f := fetch.(type) {
-	case *resolve.SingleFetch:
-		return f.Trace
-	case *resolve.EntityFetch:
-		return f.Trace
-	case *resolve.BatchEntityFetch:
-		return f.Trace
-	default:
-		return nil
-	}
-}
-
-// TestARTCacheTraceEndToEnd asserts the COMPLETE cache sections of the ART
-// trace for the representative scenarios.
+// TestARTCacheTraceEndToEnd asserts the COMPLETE response bodies — data plus
+// the full ART trace in extensions, cache sections included — for the
+// representative scenarios. Runs through the REAL ExecutionEngine over HTTP
+// subgraph doubles.
 func TestARTCacheTraceEndToEnd(t *testing.T) {
 	t.Run("L2 miss then hit", func(t *testing.T) {
+		store := cachetesting.NewFakeStore()
+		controller := cache.NewController(cachetesting.StoreAdapter{Store: store}, cache.NewTraceObserver())
+		query := `{ me { favoriteProduct { upc stock } } }`
+		caching := map[string]cacheconfig.CachingConfiguration{
+			"inventory": {Entities: []cacheconfig.EntityCachePolicy{{TypeName: "Product", CacheName: "inventory", TTL: time.Minute}}},
+		}
+		users := Respond(`{"data":{"me":{"__typename":"User","id":"u1"}}}`)
+		products := Respond(`{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`)
+		inventory := Respond(`{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`)
+		subgraphs := Subgraphs{"users": users, "products": products, "inventory": inventory}
+		executionEngine := NewEngine(t, caching, subgraphs)
+
+		firstBody := normalizedTraceBody(t, subgraphs, ExecuteTraced(t, executionEngine, query, controller))
+		assert.Equal(t, `{
+  "data": {
+    "me": {
+      "favoriteProduct": {
+        "upc": "1",
+        "stock": 5
+      }
+    }
+  },
+  "extensions": {
+    "trace": {
+      "version": "1",
+      "info": {
+        "trace_start_time": "",
+        "trace_start_unix": 0,
+        "parse_stats": {
+          "duration_nanoseconds": 0,
+          "duration_pretty": "",
+          "duration_since_start_nanoseconds": 0,
+          "duration_since_start_pretty": ""
+        },
+        "normalize_stats": {
+          "duration_nanoseconds": 0,
+          "duration_pretty": "",
+          "duration_since_start_nanoseconds": 0,
+          "duration_since_start_pretty": ""
+        },
+        "validate_stats": {
+          "duration_nanoseconds": 0,
+          "duration_pretty": "",
+          "duration_since_start_nanoseconds": 0,
+          "duration_since_start_pretty": ""
+        },
+        "planner_stats": {
+          "duration_nanoseconds": 5,
+          "duration_pretty": "5ns",
+          "duration_since_start_nanoseconds": 20,
+          "duration_since_start_pretty": "20ns"
+        }
+      },
+      "fetches": {
+        "kind": "Sequence",
+        "children": [
+          {
+            "kind": "Single",
+            "fetch": {
+              "kind": "Single",
+              "path": "",
+              "source_id": "3",
+              "source_name": "3",
+              "trace": {
+                "raw_input_data": {},
+                "input": {
+                  "body": {
+                    "query": "{me {__typename id}}"
+                  },
+                  "header": {},
+                  "method": "POST",
+                  "url": "http://users.service"
+                },
+                "output": {
+                  "data": {
+                    "me": {
+                      "__typename": "User",
+                      "id": "u1"
+                    }
+                  },
+                  "extensions": {
+                    "trace": {
+                      "request": {
+                        "method": "POST",
+                        "url": "http://users.service",
+                        "headers": {
+                          "Accept": [
+                            "application/json"
+                          ],
+                          "Accept-Encoding": [
+                            "gzip",
+                            "deflate"
+                          ],
+                          "Content-Type": [
+                            "application/json"
+                          ]
+                        }
+                      },
+                      "response": {
+                        "status_code": 200,
+                        "status": "200 OK",
+                        "headers": {
+                          "Content-Length": [
+                            "47"
+                          ],
+                          "Content-Type": [
+                            "application/json"
+                          ]
+                        },
+                        "body_size": 47
+                      }
+                    }
+                  }
+                },
+                "single_flight_used": true,
+                "single_flight_shared_response": false,
+                "load_skipped": false
+              }
+            }
+          },
+          {
+            "kind": "Single",
+            "fetch": {
+              "kind": "Entity",
+              "path": "me",
+              "source_id": "0",
+              "source_name": "0",
+              "trace": {
+                "raw_input_data": {
+                  "__typename": "User",
+                  "id": "u1"
+                },
+                "input": {
+                  "body": {
+                    "query": "query($representations: [_Any!]!){_entities(representations: $representations){... on User {__typename favoriteProduct {upc __typename}}}}",
+                    "variables": {
+                      "representations": [
+                        {
+                          "__typename": "User",
+                          "id": "u1"
+                        }
+                      ]
+                    }
+                  },
+                  "header": {},
+                  "method": "POST",
+                  "url": "http://products.service"
+                },
+                "output": {
+                  "data": {
+                    "_entities": [
+                      {
+                        "__typename": "User",
+                        "favoriteProduct": {
+                          "__typename": "Product",
+                          "upc": "1"
+                        }
+                      }
+                    ]
+                  },
+                  "extensions": {
+                    "trace": {
+                      "request": {
+                        "method": "POST",
+                        "url": "http://products.service",
+                        "headers": {
+                          "Accept": [
+                            "application/json"
+                          ],
+                          "Accept-Encoding": [
+                            "gzip",
+                            "deflate"
+                          ],
+                          "Content-Type": [
+                            "application/json"
+                          ]
+                        }
+                      },
+                      "response": {
+                        "status_code": 200,
+                        "status": "200 OK",
+                        "headers": {
+                          "Content-Length": [
+                            "99"
+                          ],
+                          "Content-Type": [
+                            "application/json"
+                          ]
+                        },
+                        "body_size": 99
+                      }
+                    }
+                  }
+                },
+                "single_flight_used": true,
+                "single_flight_shared_response": false,
+                "load_skipped": false
+              }
+            }
+          },
+          {
+            "kind": "Single",
+            "fetch": {
+              "kind": "Entity",
+              "path": "me.favoriteProduct",
+              "source_id": "1",
+              "source_name": "1",
+              "trace": {
+                "raw_input_data": {
+                  "__typename": "Product",
+                  "upc": "1"
+                },
+                "input": {
+                  "body": {
+                    "query": "query($representations: [_Any!]!){_entities(representations: $representations){... on Product {__typename stock}}}",
+                    "variables": {
+                      "representations": [
+                        {
+                          "__typename": "Product",
+                          "upc": "1"
+                        }
+                      ]
+                    }
+                  },
+                  "header": {},
+                  "method": "POST",
+                  "url": "http://inventory.service"
+                },
+                "output": {
+                  "data": {
+                    "_entities": [
+                      {
+                        "__typename": "Product",
+                        "stock": 5
+                      }
+                    ]
+                  },
+                  "extensions": {
+                    "trace": {
+                      "request": {
+                        "method": "POST",
+                        "url": "http://inventory.service",
+                        "headers": {
+                          "Accept": [
+                            "application/json"
+                          ],
+                          "Accept-Encoding": [
+                            "gzip",
+                            "deflate"
+                          ],
+                          "Content-Type": [
+                            "application/json"
+                          ]
+                        }
+                      },
+                      "response": {
+                        "status_code": 200,
+                        "status": "200 OK",
+                        "headers": {
+                          "Content-Length": [
+                            "59"
+                          ],
+                          "Content-Type": [
+                            "application/json"
+                          ]
+                        },
+                        "body_size": 59
+                      }
+                    }
+                  }
+                },
+                "single_flight_used": true,
+                "single_flight_shared_response": false,
+                "load_skipped": false,
+                "cache": {
+                  "decision": "Fetch",
+                  "hit": false,
+                  "items": [
+                    {
+                      "keys": [
+                        "inventory:22ec9a28afcdd0bf"
+                      ],
+                      "hit": false,
+                      "write_reason": "refresh"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}`, firstBody)
+
+		// The second request is a FULL L2 hit: the inventory fetch is skipped
+		// (no input/output in its trace) and the cache section records the hit.
+		secondBody := normalizedTraceBody(t, subgraphs, ExecuteTraced(t, executionEngine, query, controller))
+		assert.Equal(t, `{
+  "data": {
+    "me": {
+      "favoriteProduct": {
+        "upc": "1",
+        "stock": 5
+      }
+    }
+  },
+  "extensions": {
+    "trace": {
+      "version": "1",
+      "info": {
+        "trace_start_time": "",
+        "trace_start_unix": 0,
+        "parse_stats": {
+          "duration_nanoseconds": 0,
+          "duration_pretty": "",
+          "duration_since_start_nanoseconds": 0,
+          "duration_since_start_pretty": ""
+        },
+        "normalize_stats": {
+          "duration_nanoseconds": 0,
+          "duration_pretty": "",
+          "duration_since_start_nanoseconds": 0,
+          "duration_since_start_pretty": ""
+        },
+        "validate_stats": {
+          "duration_nanoseconds": 0,
+          "duration_pretty": "",
+          "duration_since_start_nanoseconds": 0,
+          "duration_since_start_pretty": ""
+        },
+        "planner_stats": {
+          "duration_nanoseconds": 5,
+          "duration_pretty": "5ns",
+          "duration_since_start_nanoseconds": 20,
+          "duration_since_start_pretty": "20ns"
+        }
+      },
+      "fetches": {
+        "kind": "Sequence",
+        "children": [
+          {
+            "kind": "Single",
+            "fetch": {
+              "kind": "Single",
+              "path": "",
+              "source_id": "3",
+              "source_name": "3",
+              "trace": {
+                "raw_input_data": {},
+                "input": {
+                  "body": {
+                    "query": "{me {__typename id}}"
+                  },
+                  "header": {},
+                  "method": "POST",
+                  "url": "http://users.service"
+                },
+                "output": {
+                  "data": {
+                    "me": {
+                      "__typename": "User",
+                      "id": "u1"
+                    }
+                  },
+                  "extensions": {
+                    "trace": {
+                      "request": {
+                        "method": "POST",
+                        "url": "http://users.service",
+                        "headers": {
+                          "Accept": [
+                            "application/json"
+                          ],
+                          "Accept-Encoding": [
+                            "gzip",
+                            "deflate"
+                          ],
+                          "Content-Type": [
+                            "application/json"
+                          ]
+                        }
+                      },
+                      "response": {
+                        "status_code": 200,
+                        "status": "200 OK",
+                        "headers": {
+                          "Content-Length": [
+                            "47"
+                          ],
+                          "Content-Type": [
+                            "application/json"
+                          ]
+                        },
+                        "body_size": 47
+                      }
+                    }
+                  }
+                },
+                "single_flight_used": true,
+                "single_flight_shared_response": false,
+                "load_skipped": false
+              }
+            }
+          },
+          {
+            "kind": "Single",
+            "fetch": {
+              "kind": "Entity",
+              "path": "me",
+              "source_id": "0",
+              "source_name": "0",
+              "trace": {
+                "raw_input_data": {
+                  "__typename": "User",
+                  "id": "u1"
+                },
+                "input": {
+                  "body": {
+                    "query": "query($representations: [_Any!]!){_entities(representations: $representations){... on User {__typename favoriteProduct {upc __typename}}}}",
+                    "variables": {
+                      "representations": [
+                        {
+                          "__typename": "User",
+                          "id": "u1"
+                        }
+                      ]
+                    }
+                  },
+                  "header": {},
+                  "method": "POST",
+                  "url": "http://products.service"
+                },
+                "output": {
+                  "data": {
+                    "_entities": [
+                      {
+                        "__typename": "User",
+                        "favoriteProduct": {
+                          "__typename": "Product",
+                          "upc": "1"
+                        }
+                      }
+                    ]
+                  },
+                  "extensions": {
+                    "trace": {
+                      "request": {
+                        "method": "POST",
+                        "url": "http://products.service",
+                        "headers": {
+                          "Accept": [
+                            "application/json"
+                          ],
+                          "Accept-Encoding": [
+                            "gzip",
+                            "deflate"
+                          ],
+                          "Content-Type": [
+                            "application/json"
+                          ]
+                        }
+                      },
+                      "response": {
+                        "status_code": 200,
+                        "status": "200 OK",
+                        "headers": {
+                          "Content-Length": [
+                            "99"
+                          ],
+                          "Content-Type": [
+                            "application/json"
+                          ]
+                        },
+                        "body_size": 99
+                      }
+                    }
+                  }
+                },
+                "single_flight_used": true,
+                "single_flight_shared_response": false,
+                "load_skipped": false
+              }
+            }
+          },
+          {
+            "kind": "Single",
+            "fetch": {
+              "kind": "Entity",
+              "path": "me.favoriteProduct",
+              "source_id": "1",
+              "source_name": "1",
+              "trace": {
+                "raw_input_data": {
+                  "__typename": "Product",
+                  "upc": "1"
+                },
+                "single_flight_used": false,
+                "single_flight_shared_response": false,
+                "load_skipped": true,
+                "cache": {
+                  "decision": "SkipFullHit",
+                  "hit": true,
+                  "items": [
+                    {
+                      "keys": [
+                        "inventory:22ec9a28afcdd0bf"
+                      ],
+                      "served_from": "l2",
+                      "hit": true,
+                      "remaining_ttl_nanoseconds": -1
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}`, secondBody)
+		assert.Equal(t, int64(1), inventory.Requests())
+	})
+
+	t.Run("L1 hit within one request", func(t *testing.T) {
+		store := cachetesting.NewFakeStore()
+		controller := cache.NewController(cachetesting.StoreAdapter{Store: store}, cache.NewTraceObserver())
+		// The dependency-ordered deal -> product(sku) -> reviews(upc) ->
+		// product(upc) chain: fetch B is served from L1 within the request
+		// (its canned response is TAMPERED so network use fails loudly).
+		query := `{ deal(id: "d1") { product { name reviews { product { name } } } } }`
+		deals := Respond(`{"data":{"deal":{"__typename":"Deal","id":"d1","product":{"__typename":"Product","sku":"S1"}}}}`)
+		reviews := Respond(`{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","product":{"__typename":"Product","upc":"1"}}]}]}}`)
+		products := Rules(
+			Rule(`"sku":"S1"`, `{"data":{"_entities":[{"__typename":"Product","name":"Table","upc":"1"}]}}`),
+			Rule(`"upc":"1"`, `{"data":{"_entities":[{"__typename":"Product","name":"NETWORK-MUST-NOT-SERVE"}]}}`),
+		)
+		subgraphs := Subgraphs{"deals": deals, "reviews": reviews, "products": products}
+		executionEngine := NewEngine(t, productL1Caching(0), subgraphs)
+
+		// The key hashes are deterministic (xxhash64 of the canonical key
+		// preimage), so the WHOLE cache sections pin as literals: fetch A is a
+		// plain miss+refresh (its sku-derived key; the upc candidate pending),
+		// fetch B is the in-request L1 hit under the upc-derived key.
+		body := normalizedTraceBody(t, subgraphs, ExecuteTraced(t, executionEngine, query, controller))
+		assert.Equal(t, `{
+  "data": {
+    "deal": {
+      "product": {
+        "name": "Table",
+        "reviews": [
+          {
+            "product": {
+              "name": "Table"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "extensions": {
+    "trace": {
+      "version": "1",
+      "info": {
+        "trace_start_time": "",
+        "trace_start_unix": 0,
+        "parse_stats": {
+          "duration_nanoseconds": 0,
+          "duration_pretty": "",
+          "duration_since_start_nanoseconds": 0,
+          "duration_since_start_pretty": ""
+        },
+        "normalize_stats": {
+          "duration_nanoseconds": 0,
+          "duration_pretty": "",
+          "duration_since_start_nanoseconds": 0,
+          "duration_since_start_pretty": ""
+        },
+        "validate_stats": {
+          "duration_nanoseconds": 0,
+          "duration_pretty": "",
+          "duration_since_start_nanoseconds": 0,
+          "duration_since_start_pretty": ""
+        },
+        "planner_stats": {
+          "duration_nanoseconds": 5,
+          "duration_pretty": "5ns",
+          "duration_since_start_nanoseconds": 20,
+          "duration_since_start_pretty": "20ns"
+        }
+      },
+      "fetches": {
+        "kind": "Sequence",
+        "children": [
+          {
+            "kind": "Single",
+            "fetch": {
+              "kind": "Single",
+              "path": "",
+              "source_id": "4",
+              "source_name": "4",
+              "trace": {
+                "raw_input_data": {},
+                "input": {
+                  "body": {
+                    "query": "query($a: ID!){deal(id: $a){product {__typename sku}}}",
+                    "variables": {
+                      "a": "d1"
+                    }
+                  },
+                  "header": {},
+                  "method": "POST",
+                  "url": "http://deals.service"
+                },
+                "output": {
+                  "data": {
+                    "deal": {
+                      "__typename": "Deal",
+                      "id": "d1",
+                      "product": {
+                        "__typename": "Product",
+                        "sku": "S1"
+                      }
+                    }
+                  },
+                  "extensions": {
+                    "trace": {
+                      "request": {
+                        "method": "POST",
+                        "url": "http://deals.service",
+                        "headers": {
+                          "Accept": [
+                            "application/json"
+                          ],
+                          "Accept-Encoding": [
+                            "gzip",
+                            "deflate"
+                          ],
+                          "Content-Type": [
+                            "application/json"
+                          ]
+                        }
+                      },
+                      "response": {
+                        "status_code": 200,
+                        "status": "200 OK",
+                        "headers": {
+                          "Content-Length": [
+                            "95"
+                          ],
+                          "Content-Type": [
+                            "application/json"
+                          ]
+                        },
+                        "body_size": 95
+                      }
+                    }
+                  }
+                },
+                "single_flight_used": true,
+                "single_flight_shared_response": false,
+                "load_skipped": false
+              }
+            }
+          },
+          {
+            "kind": "Single",
+            "fetch": {
+              "kind": "Entity",
+              "path": "deal.product",
+              "source_id": "0",
+              "source_name": "0",
+              "trace": {
+                "raw_input_data": {
+                  "__typename": "Product",
+                  "sku": "S1"
+                },
+                "input": {
+                  "body": {
+                    "query": "query($representations: [_Any!]!){_entities(representations: $representations){... on Product {__typename name upc}}}",
+                    "variables": {
+                      "representations": [
+                        {
+                          "__typename": "Product",
+                          "sku": "S1"
+                        }
+                      ]
+                    }
+                  },
+                  "header": {},
+                  "method": "POST",
+                  "url": "http://products.service"
+                },
+                "output": {
+                  "data": {
+                    "_entities": [
+                      {
+                        "__typename": "Product",
+                        "name": "Table",
+                        "upc": "1"
+                      }
+                    ]
+                  },
+                  "extensions": {
+                    "trace": {
+                      "request": {
+                        "method": "POST",
+                        "url": "http://products.service",
+                        "headers": {
+                          "Accept": [
+                            "application/json"
+                          ],
+                          "Accept-Encoding": [
+                            "gzip",
+                            "deflate"
+                          ],
+                          "Content-Type": [
+                            "application/json"
+                          ]
+                        }
+                      },
+                      "response": {
+                        "status_code": 200,
+                        "status": "200 OK",
+                        "headers": {
+                          "Content-Length": [
+                            "74"
+                          ],
+                          "Content-Type": [
+                            "application/json"
+                          ]
+                        },
+                        "body_size": 74
+                      }
+                    }
+                  }
+                },
+                "single_flight_used": true,
+                "single_flight_shared_response": false,
+                "load_skipped": false,
+                "cache": {
+                  "decision": "Fetch",
+                  "hit": false,
+                  "items": [
+                    {
+                      "keys": [
+                        "entities:f58e5d95ce10e65e"
+                      ],
+                      "hit": false,
+                      "write_reason": "refresh",
+                      "pending_candidates": 1
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "Single",
+            "fetch": {
+              "kind": "Entity",
+              "path": "deal.product",
+              "source_id": "2",
+              "source_name": "2",
+              "trace": {
+                "raw_input_data": {
+                  "__typename": "Product",
+                  "sku": "S1",
+                  "name": "Table",
+                  "upc": "1"
+                },
+                "input": {
+                  "body": {
+                    "query": "query($representations: [_Any!]!){_entities(representations: $representations){... on Product {__typename reviews {product {__typename upc}}}}}",
+                    "variables": {
+                      "representations": [
+                        {
+                          "__typename": "Product",
+                          "upc": "1"
+                        }
+                      ]
+                    }
+                  },
+                  "header": {},
+                  "method": "POST",
+                  "url": "http://reviews.service"
+                },
+                "output": {
+                  "data": {
+                    "_entities": [
+                      {
+                        "__typename": "Product",
+                        "reviews": [
+                          {
+                            "__typename": "Review",
+                            "product": {
+                              "__typename": "Product",
+                              "upc": "1"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "extensions": {
+                    "trace": {
+                      "request": {
+                        "method": "POST",
+                        "url": "http://reviews.service",
+                        "headers": {
+                          "Accept": [
+                            "application/json"
+                          ],
+                          "Accept-Encoding": [
+                            "gzip",
+                            "deflate"
+                          ],
+                          "Content-Type": [
+                            "application/json"
+                          ]
+                        }
+                      },
+                      "response": {
+                        "status_code": 200,
+                        "status": "200 OK",
+                        "headers": {
+                          "Content-Length": [
+                            "130"
+                          ],
+                          "Content-Type": [
+                            "application/json"
+                          ]
+                        },
+                        "body_size": 130
+                      }
+                    }
+                  }
+                },
+                "single_flight_used": true,
+                "single_flight_shared_response": false,
+                "load_skipped": false
+              }
+            }
+          },
+          {
+            "kind": "Single",
+            "fetch": {
+              "kind": "BatchEntity",
+              "path": "deal.product.reviews.@.product",
+              "source_id": "0",
+              "source_name": "0",
+              "trace": {
+                "raw_input_data": {
+                  "__typename": "Product",
+                  "upc": "1"
+                },
+                "single_flight_used": false,
+                "single_flight_shared_response": false,
+                "load_skipped": true,
+                "cache": {
+                  "decision": "SkipFullHit",
+                  "hit": true,
+                  "items": [
+                    {
+                      "keys": [
+                        "entities:153cc511c85713fb"
+                      ],
+                      "served_from": "l1",
+                      "hit": true,
+                      "pending_candidates": 1
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}`, body)
+	})
+
+	t.Run("shadow compare", func(t *testing.T) {
+		store := cachetesting.NewFakeStore()
+		controller := cache.NewController(cachetesting.StoreAdapter{Store: store}, cache.NewTraceObserver())
+		query := `{ me { favoriteProduct { upc stock } } }`
+		users := Respond(`{"data":{"me":{"__typename":"User","id":"u1"}}}`)
+		products := Respond(`{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`)
+		inventory := Respond(`{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`)
+		subgraphs := Subgraphs{"users": users, "products": products, "inventory": inventory}
+		executionEngine := NewEngine(t, inventoryShadowCaching(), subgraphs)
+
+		primeBody := Execute(t, executionEngine, query, controller)
+		assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"upc":"1","stock":5}}}}`, primeBody)
+
+		secondBody := normalizedTraceBody(t, subgraphs, ExecuteTraced(t, executionEngine, query, controller))
+		assert.Equal(t, `{
+  "data": {
+    "me": {
+      "favoriteProduct": {
+        "upc": "1",
+        "stock": 5
+      }
+    }
+  },
+  "extensions": {
+    "trace": {
+      "version": "1",
+      "info": {
+        "trace_start_time": "",
+        "trace_start_unix": 0,
+        "parse_stats": {
+          "duration_nanoseconds": 0,
+          "duration_pretty": "",
+          "duration_since_start_nanoseconds": 0,
+          "duration_since_start_pretty": ""
+        },
+        "normalize_stats": {
+          "duration_nanoseconds": 0,
+          "duration_pretty": "",
+          "duration_since_start_nanoseconds": 0,
+          "duration_since_start_pretty": ""
+        },
+        "validate_stats": {
+          "duration_nanoseconds": 0,
+          "duration_pretty": "",
+          "duration_since_start_nanoseconds": 0,
+          "duration_since_start_pretty": ""
+        },
+        "planner_stats": {
+          "duration_nanoseconds": 5,
+          "duration_pretty": "5ns",
+          "duration_since_start_nanoseconds": 20,
+          "duration_since_start_pretty": "20ns"
+        }
+      },
+      "fetches": {
+        "kind": "Sequence",
+        "children": [
+          {
+            "kind": "Single",
+            "fetch": {
+              "kind": "Single",
+              "path": "",
+              "source_id": "3",
+              "source_name": "3",
+              "trace": {
+                "raw_input_data": {},
+                "input": {
+                  "body": {
+                    "query": "{me {__typename id}}"
+                  },
+                  "header": {},
+                  "method": "POST",
+                  "url": "http://users.service"
+                },
+                "output": {
+                  "data": {
+                    "me": {
+                      "__typename": "User",
+                      "id": "u1"
+                    }
+                  },
+                  "extensions": {
+                    "trace": {
+                      "request": {
+                        "method": "POST",
+                        "url": "http://users.service",
+                        "headers": {
+                          "Accept": [
+                            "application/json"
+                          ],
+                          "Accept-Encoding": [
+                            "gzip",
+                            "deflate"
+                          ],
+                          "Content-Type": [
+                            "application/json"
+                          ]
+                        }
+                      },
+                      "response": {
+                        "status_code": 200,
+                        "status": "200 OK",
+                        "headers": {
+                          "Content-Length": [
+                            "47"
+                          ],
+                          "Content-Type": [
+                            "application/json"
+                          ]
+                        },
+                        "body_size": 47
+                      }
+                    }
+                  }
+                },
+                "single_flight_used": true,
+                "single_flight_shared_response": false,
+                "load_skipped": false
+              }
+            }
+          },
+          {
+            "kind": "Single",
+            "fetch": {
+              "kind": "Entity",
+              "path": "me",
+              "source_id": "0",
+              "source_name": "0",
+              "trace": {
+                "raw_input_data": {
+                  "__typename": "User",
+                  "id": "u1"
+                },
+                "input": {
+                  "body": {
+                    "query": "query($representations: [_Any!]!){_entities(representations: $representations){... on User {__typename favoriteProduct {upc __typename}}}}",
+                    "variables": {
+                      "representations": [
+                        {
+                          "__typename": "User",
+                          "id": "u1"
+                        }
+                      ]
+                    }
+                  },
+                  "header": {},
+                  "method": "POST",
+                  "url": "http://products.service"
+                },
+                "output": {
+                  "data": {
+                    "_entities": [
+                      {
+                        "__typename": "User",
+                        "favoriteProduct": {
+                          "__typename": "Product",
+                          "upc": "1"
+                        }
+                      }
+                    ]
+                  },
+                  "extensions": {
+                    "trace": {
+                      "request": {
+                        "method": "POST",
+                        "url": "http://products.service",
+                        "headers": {
+                          "Accept": [
+                            "application/json"
+                          ],
+                          "Accept-Encoding": [
+                            "gzip",
+                            "deflate"
+                          ],
+                          "Content-Type": [
+                            "application/json"
+                          ]
+                        }
+                      },
+                      "response": {
+                        "status_code": 200,
+                        "status": "200 OK",
+                        "headers": {
+                          "Content-Length": [
+                            "99"
+                          ],
+                          "Content-Type": [
+                            "application/json"
+                          ]
+                        },
+                        "body_size": 99
+                      }
+                    }
+                  }
+                },
+                "single_flight_used": true,
+                "single_flight_shared_response": false,
+                "load_skipped": false
+              }
+            }
+          },
+          {
+            "kind": "Single",
+            "fetch": {
+              "kind": "Entity",
+              "path": "me.favoriteProduct",
+              "source_id": "1",
+              "source_name": "1",
+              "trace": {
+                "raw_input_data": {
+                  "__typename": "Product",
+                  "upc": "1"
+                },
+                "input": {
+                  "body": {
+                    "query": "query($representations: [_Any!]!){_entities(representations: $representations){... on Product {__typename stock}}}",
+                    "variables": {
+                      "representations": [
+                        {
+                          "__typename": "Product",
+                          "upc": "1"
+                        }
+                      ]
+                    }
+                  },
+                  "header": {},
+                  "method": "POST",
+                  "url": "http://inventory.service"
+                },
+                "output": {
+                  "data": {
+                    "_entities": [
+                      {
+                        "__typename": "Product",
+                        "stock": 5
+                      }
+                    ]
+                  },
+                  "extensions": {
+                    "trace": {
+                      "request": {
+                        "method": "POST",
+                        "url": "http://inventory.service",
+                        "headers": {
+                          "Accept": [
+                            "application/json"
+                          ],
+                          "Accept-Encoding": [
+                            "gzip",
+                            "deflate"
+                          ],
+                          "Content-Type": [
+                            "application/json"
+                          ]
+                        }
+                      },
+                      "response": {
+                        "status_code": 200,
+                        "status": "200 OK",
+                        "headers": {
+                          "Content-Length": [
+                            "59"
+                          ],
+                          "Content-Type": [
+                            "application/json"
+                          ]
+                        },
+                        "body_size": 59
+                      }
+                    }
+                  }
+                },
+                "single_flight_used": true,
+                "single_flight_shared_response": false,
+                "load_skipped": false,
+                "cache": {
+                  "decision": "FetchShadow",
+                  "hit": false,
+                  "shadow": true,
+                  "items": [
+                    {
+                      "keys": [
+                        "entities:153cc511c85713fb"
+                      ],
+                      "hit": false,
+                      "write_reason": "refresh"
+                    }
+                  ],
+                  "shadow_compares": [
+                    {
+                      "key": "entities:153cc511c85713fb",
+                      "is_fresh": true,
+                      "cache_age_nanoseconds": -1
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}`, secondBody)
+		// Shadow mode never serves from cache: BOTH requests hit inventory.
+		assert.Equal(t, int64(2), inventory.Requests())
+	})
+
+	t.Run("partial batch", func(t *testing.T) {
+		store := cachetesting.NewFakeStore()
+		controller := cache.NewController(cachetesting.StoreAdapter{Store: store}, cache.NewTraceObserver())
+		// The products double routes by the rendered first-argument variable;
+		// the reviews double by the representations: the priming run sends upc
+		// "1", the partial batch afterwards sends ONLY the missing upc "2".
+		products := Rules(
+			Rule(`"variables":{"a":1}`, `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`),
+			Rule(`"variables":{"a":2}`, `{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"}]}}`),
+		)
+		reviews := Rules(
+			Rule(`"upc":"1"`, `{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","body":"great table"}]}]}}`),
+			Rule(`"upc":"2"`, `{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","body":"sturdy chair"}]}]}}`),
+		)
+		subgraphs := Subgraphs{"products": products, "reviews": reviews}
+		executionEngine := NewEngine(t, reviewsPartialCaching(), subgraphs)
+
+		primeBody := Execute(t, executionEngine, `{ products(first: 1) { upc reviews { body } } }`, controller)
+		assert.Equal(t, `{"data":{"products":[{"upc":"1","reviews":[{"body":"great table"}]}]}}`, primeBody)
+
+		// One partial fetch: bucket 1 (upc "1") served from L2 under the primed
+		// key, bucket 2 (upc "2") fetched over the reduced batch and refreshed.
+		body := normalizedTraceBody(t, subgraphs, ExecuteTraced(t, executionEngine, `{ products(first: 2) { upc reviews { body } } }`, controller))
+		assert.Equal(t, `{
+  "data": {
+    "products": [
+      {
+        "upc": "1",
+        "reviews": [
+          {
+            "body": "great table"
+          }
+        ]
+      },
+      {
+        "upc": "2",
+        "reviews": [
+          {
+            "body": "sturdy chair"
+          }
+        ]
+      }
+    ]
+  },
+  "extensions": {
+    "trace": {
+      "version": "1",
+      "info": {
+        "trace_start_time": "",
+        "trace_start_unix": 0,
+        "parse_stats": {
+          "duration_nanoseconds": 0,
+          "duration_pretty": "",
+          "duration_since_start_nanoseconds": 0,
+          "duration_since_start_pretty": ""
+        },
+        "normalize_stats": {
+          "duration_nanoseconds": 0,
+          "duration_pretty": "",
+          "duration_since_start_nanoseconds": 0,
+          "duration_since_start_pretty": ""
+        },
+        "validate_stats": {
+          "duration_nanoseconds": 0,
+          "duration_pretty": "",
+          "duration_since_start_nanoseconds": 0,
+          "duration_since_start_pretty": ""
+        },
+        "planner_stats": {
+          "duration_nanoseconds": 5,
+          "duration_pretty": "5ns",
+          "duration_since_start_nanoseconds": 20,
+          "duration_since_start_pretty": "20ns"
+        }
+      },
+      "fetches": {
+        "kind": "Sequence",
+        "children": [
+          {
+            "kind": "Single",
+            "fetch": {
+              "kind": "Single",
+              "path": "",
+              "source_id": "0",
+              "source_name": "0",
+              "trace": {
+                "raw_input_data": {},
+                "input": {
+                  "body": {
+                    "query": "query($a: Int){products(first: $a){upc __typename}}",
+                    "variables": {
+                      "a": 2
+                    }
+                  },
+                  "header": {},
+                  "method": "POST",
+                  "url": "http://products.service"
+                },
+                "output": {
+                  "data": {
+                    "products": [
+                      {
+                        "__typename": "Product",
+                        "upc": "1"
+                      },
+                      {
+                        "__typename": "Product",
+                        "upc": "2"
+                      }
+                    ]
+                  },
+                  "extensions": {
+                    "trace": {
+                      "request": {
+                        "method": "POST",
+                        "url": "http://products.service",
+                        "headers": {
+                          "Accept": [
+                            "application/json"
+                          ],
+                          "Accept-Encoding": [
+                            "gzip",
+                            "deflate"
+                          ],
+                          "Content-Type": [
+                            "application/json"
+                          ]
+                        }
+                      },
+                      "response": {
+                        "status_code": 200,
+                        "status": "200 OK",
+                        "headers": {
+                          "Content-Length": [
+                            "93"
+                          ],
+                          "Content-Type": [
+                            "application/json"
+                          ]
+                        },
+                        "body_size": 93
+                      }
+                    }
+                  }
+                },
+                "single_flight_used": true,
+                "single_flight_shared_response": false,
+                "load_skipped": false
+              }
+            }
+          },
+          {
+            "kind": "Single",
+            "fetch": {
+              "kind": "BatchEntity",
+              "path": "products",
+              "source_id": "2",
+              "source_name": "2",
+              "trace": {
+                "raw_input_data": [
+                  {
+                    "__typename": "Product",
+                    "upc": "1"
+                  },
+                  {
+                    "__typename": "Product",
+                    "upc": "2"
+                  }
+                ],
+                "input": {
+                  "body": {
+                    "query": "query($representations: [_Any!]!){_entities(representations: $representations){... on Product {__typename reviews {body}}}}",
+                    "variables": {
+                      "representations": [
+                        {
+                          "__typename": "Product",
+                          "upc": "2"
+                        }
+                      ]
+                    }
+                  },
+                  "header": {},
+                  "method": "POST",
+                  "url": "http://reviews.service"
+                },
+                "output": {
+                  "data": {
+                    "_entities": [
+                      {
+                        "__typename": "Product",
+                        "reviews": [
+                          {
+                            "__typename": "Review",
+                            "body": "sturdy chair"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "extensions": {
+                    "trace": {
+                      "request": {
+                        "method": "POST",
+                        "url": "http://reviews.service",
+                        "headers": {
+                          "Accept": [
+                            "application/json"
+                          ],
+                          "Accept-Encoding": [
+                            "gzip",
+                            "deflate"
+                          ],
+                          "Content-Type": [
+                            "application/json"
+                          ]
+                        }
+                      },
+                      "response": {
+                        "status_code": 200,
+                        "status": "200 OK",
+                        "headers": {
+                          "Content-Length": [
+                            "107"
+                          ],
+                          "Content-Type": [
+                            "application/json"
+                          ]
+                        },
+                        "body_size": 107
+                      }
+                    }
+                  }
+                },
+                "single_flight_used": true,
+                "single_flight_shared_response": false,
+                "load_skipped": false,
+                "cache": {
+                  "decision": "FetchPartial",
+                  "hit": false,
+                  "items": [
+                    {
+                      "keys": [
+                        "reviews:aa052522cb64dff0"
+                      ],
+                      "served_from": "l2",
+                      "hit": true,
+                      "remaining_ttl_nanoseconds": -1
+                    },
+                    {
+                      "keys": [
+                        "reviews:258590a53d3c528e"
+                      ],
+                      "hit": false,
+                      "write_reason": "refresh"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}`, body)
+	})
+
+	t.Run("regression: tracing off leaves fetch traces nil", func(t *testing.T) {
 		store := cachetesting.NewFakeStore()
 		query := `{ me { favoriteProduct { upc stock } } }`
 		caching := map[string]cacheconfig.CachingConfiguration{
 			"inventory": {Entities: []cacheconfig.EntityCachePolicy{{TypeName: "Product", CacheName: "inventory", TTL: time.Minute}}},
 		}
-		responses := map[string]string{
-			"users":                        `{"data":{"me":{"__typename":"User","id":"u1"}}}`,
-			"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
-			"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
-		}
+		users := Respond(`{"data":{"me":{"__typename":"User","id":"u1"}}}`)
+		products := Respond(`{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`)
+		inventory := Respond(`{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`)
+		executionEngine := NewEngine(t, caching, Subgraphs{"users": users, "products": products, "inventory": inventory})
 
-		first := Plan(t, query, caching, responses)
-		firstBody := resolveTraced(t, first.Response, store)
-		assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"upc":"1","stock":5}}}}`, firstBody)
-		assert.Equal(t, `=== path "" ===
-{
-  "raw_input_data": {},
-  "input": {
-    "body": {
-      "query": "{me {__typename id}}"
-    },
-    "header": {},
-    "method": "POST",
-    "url": "http://users.service"
-  },
-  "output": {
-    "data": {
-      "me": {
-        "__typename": "User",
-        "id": "u1"
-      }
-    }
-  },
-  "duration_since_start_pretty": "0s",
-  "duration_load_pretty": "0s",
-  "single_flight_used": true,
-  "single_flight_shared_response": false,
-  "load_skipped": false,
-  "load_stats": {
-    "get_conn": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "host_port": ""
-    },
-    "got_conn": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "reused": false,
-      "was_idle": false,
-      "idle_time_nanoseconds": 0,
-      "idle_time_pretty": ""
-    },
-    "got_first_response_byte": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "dns_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "host": ""
-    },
-    "dns_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "connect_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "network": "",
-      "addr": ""
-    },
-    "connect_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "network": "",
-      "addr": ""
-    },
-    "tls_handshake_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "tls_handshake_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "wrote_headers": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "wrote_request": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    }
-  }
-}
-=== path "me" ===
-{
-  "raw_input_data": {
-    "__typename": "User",
-    "id": "u1"
-  },
-  "input": {
-    "body": {
-      "query": "query($representations: [_Any!]!){_entities(representations: $representations){... on User {__typename favoriteProduct {upc __typename}}}}",
-      "variables": {
-        "representations": [
-          {
-            "__typename": "User",
-            "id": "u1"
-          }
-        ]
-      }
-    },
-    "header": {},
-    "method": "POST",
-    "url": "http://products.service"
-  },
-  "output": {
-    "data": {
-      "_entities": [
-        {
-          "__typename": "User",
-          "favoriteProduct": {
-            "__typename": "Product",
-            "upc": "1"
-          }
-        }
-      ]
-    }
-  },
-  "duration_since_start_pretty": "0s",
-  "duration_load_pretty": "0s",
-  "single_flight_used": true,
-  "single_flight_shared_response": false,
-  "load_skipped": false,
-  "load_stats": {
-    "get_conn": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "host_port": ""
-    },
-    "got_conn": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "reused": false,
-      "was_idle": false,
-      "idle_time_nanoseconds": 0,
-      "idle_time_pretty": ""
-    },
-    "got_first_response_byte": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "dns_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "host": ""
-    },
-    "dns_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "connect_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "network": "",
-      "addr": ""
-    },
-    "connect_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "network": "",
-      "addr": ""
-    },
-    "tls_handshake_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "tls_handshake_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "wrote_headers": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "wrote_request": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    }
-  }
-}
-=== path "me.favoriteProduct" ===
-{
-  "raw_input_data": {
-    "__typename": "Product",
-    "upc": "1"
-  },
-  "input": {
-    "body": {
-      "query": "query($representations: [_Any!]!){_entities(representations: $representations){... on Product {__typename stock}}}",
-      "variables": {
-        "representations": [
-          {
-            "__typename": "Product",
-            "upc": "1"
-          }
-        ]
-      }
-    },
-    "header": {},
-    "method": "POST",
-    "url": "http://inventory.service"
-  },
-  "output": {
-    "data": {
-      "_entities": [
-        {
-          "__typename": "Product",
-          "stock": 5
-        }
-      ]
-    }
-  },
-  "duration_since_start_pretty": "0s",
-  "duration_load_pretty": "0s",
-  "single_flight_used": true,
-  "single_flight_shared_response": false,
-  "load_skipped": false,
-  "load_stats": {
-    "get_conn": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "host_port": ""
-    },
-    "got_conn": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "reused": false,
-      "was_idle": false,
-      "idle_time_nanoseconds": 0,
-      "idle_time_pretty": ""
-    },
-    "got_first_response_byte": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "dns_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "host": ""
-    },
-    "dns_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "connect_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "network": "",
-      "addr": ""
-    },
-    "connect_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "network": "",
-      "addr": ""
-    },
-    "tls_handshake_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "tls_handshake_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "wrote_headers": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "wrote_request": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    }
-  },
-  "cache": {
-    "decision": "Fetch",
-    "hit": false,
-    "items": [
-      {
-        "keys": [
-          "inventory:22ec9a28afcdd0bf"
-        ],
-        "hit": false,
-        "write_reason": "refresh"
-      }
-    ]
-  }
-}
-`, fullTraces(t, first.Response.Fetches))
-
-		second := Plan(t, query, caching, responses)
-		secondBody := resolveTraced(t, second.Response, store)
-		assert.Equal(t, firstBody, secondBody)
-		assert.Equal(t, `=== path "" ===
-{
-  "raw_input_data": {},
-  "input": {
-    "body": {
-      "query": "{me {__typename id}}"
-    },
-    "header": {},
-    "method": "POST",
-    "url": "http://users.service"
-  },
-  "output": {
-    "data": {
-      "me": {
-        "__typename": "User",
-        "id": "u1"
-      }
-    }
-  },
-  "duration_since_start_pretty": "0s",
-  "duration_load_pretty": "0s",
-  "single_flight_used": true,
-  "single_flight_shared_response": false,
-  "load_skipped": false,
-  "load_stats": {
-    "get_conn": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "host_port": ""
-    },
-    "got_conn": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "reused": false,
-      "was_idle": false,
-      "idle_time_nanoseconds": 0,
-      "idle_time_pretty": ""
-    },
-    "got_first_response_byte": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "dns_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "host": ""
-    },
-    "dns_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "connect_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "network": "",
-      "addr": ""
-    },
-    "connect_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "network": "",
-      "addr": ""
-    },
-    "tls_handshake_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "tls_handshake_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "wrote_headers": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "wrote_request": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    }
-  }
-}
-=== path "me" ===
-{
-  "raw_input_data": {
-    "__typename": "User",
-    "id": "u1"
-  },
-  "input": {
-    "body": {
-      "query": "query($representations: [_Any!]!){_entities(representations: $representations){... on User {__typename favoriteProduct {upc __typename}}}}",
-      "variables": {
-        "representations": [
-          {
-            "__typename": "User",
-            "id": "u1"
-          }
-        ]
-      }
-    },
-    "header": {},
-    "method": "POST",
-    "url": "http://products.service"
-  },
-  "output": {
-    "data": {
-      "_entities": [
-        {
-          "__typename": "User",
-          "favoriteProduct": {
-            "__typename": "Product",
-            "upc": "1"
-          }
-        }
-      ]
-    }
-  },
-  "duration_since_start_pretty": "0s",
-  "duration_load_pretty": "0s",
-  "single_flight_used": true,
-  "single_flight_shared_response": false,
-  "load_skipped": false,
-  "load_stats": {
-    "get_conn": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "host_port": ""
-    },
-    "got_conn": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "reused": false,
-      "was_idle": false,
-      "idle_time_nanoseconds": 0,
-      "idle_time_pretty": ""
-    },
-    "got_first_response_byte": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "dns_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "host": ""
-    },
-    "dns_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "connect_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "network": "",
-      "addr": ""
-    },
-    "connect_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "network": "",
-      "addr": ""
-    },
-    "tls_handshake_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "tls_handshake_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "wrote_headers": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "wrote_request": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    }
-  }
-}
-=== path "me.favoriteProduct" ===
-{
-  "raw_input_data": {
-    "__typename": "Product",
-    "upc": "1"
-  },
-  "single_flight_used": false,
-  "single_flight_shared_response": false,
-  "load_skipped": true,
-  "cache": {
-    "decision": "SkipFullHit",
-    "hit": true,
-    "items": [
-      {
-        "keys": [
-          "inventory:22ec9a28afcdd0bf"
-        ],
-        "served_from": "l2",
-        "hit": true,
-        "remaining_ttl_nanoseconds": -1
-      }
-    ]
-  }
-}
-`, fullTraces(t, second.Response.Fetches))
-	})
-
-	t.Run("L1 hit within one request", func(t *testing.T) {
-		store := cachetesting.NewFakeStore()
-		// The dependency-ordered deal -> product(sku) -> reviews(upc) ->
-		// product(upc) chain: fetch B is served from L1 within the request
-		// (its canned response is TAMPERED so network use fails loudly).
-		query := `{ deal(id: "d1") { product { name reviews { product { name } } } } }`
-		responses := map[string]string{
-			"deals":                 `{"data":{"deal":{"__typename":"Deal","id":"d1","product":{"__typename":"Product","sku":"S1"}}}}`,
-			"products:deal.product": `{"data":{"_entities":[{"__typename":"Product","name":"Table","upc":"1"}]}}`,
-			"reviews":               `{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","product":{"__typename":"Product","upc":"1"}}]}]}}`,
-			"products:deal.product.reviews.@.product": `{"data":{"_entities":[{"__typename":"Product","name":"NETWORK-MUST-NOT-SERVE"}]}}`,
-		}
-		result := Plan(t, query, productL1Caching(0), responses)
-		body := resolveTraced(t, result.Response, store)
-		assert.Equal(t, `{"data":{"deal":{"product":{"name":"Table","reviews":[{"product":{"name":"Table"}}]}}}}`, body)
-		// The key hashes are deterministic (xxhash64 of the canonical key
-		// preimage), so the WHOLE cache sections pin as literals: fetch A is a
-		// plain miss+refresh (its sku-derived key; the upc candidate pending),
-		// fetch B is the in-request L1 hit under the upc-derived key.
-		assert.Equal(t, `=== path "" ===
-{
-  "raw_input_data": {},
-  "input": {
-    "body": {
-      "query": "query($a: ID!){deal(id: $a){product {__typename sku}}}",
-      "variables": {
-        "a": null
-      }
-    },
-    "header": {},
-    "method": "POST",
-    "undefined": [
-      "a"
-    ],
-    "url": "http://deals.service"
-  },
-  "output": {
-    "data": {
-      "deal": {
-        "__typename": "Deal",
-        "id": "d1",
-        "product": {
-          "__typename": "Product",
-          "sku": "S1"
-        }
-      }
-    }
-  },
-  "duration_since_start_pretty": "0s",
-  "duration_load_pretty": "0s",
-  "single_flight_used": true,
-  "single_flight_shared_response": false,
-  "load_skipped": false,
-  "load_stats": {
-    "get_conn": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "host_port": ""
-    },
-    "got_conn": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "reused": false,
-      "was_idle": false,
-      "idle_time_nanoseconds": 0,
-      "idle_time_pretty": ""
-    },
-    "got_first_response_byte": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "dns_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "host": ""
-    },
-    "dns_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "connect_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "network": "",
-      "addr": ""
-    },
-    "connect_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "network": "",
-      "addr": ""
-    },
-    "tls_handshake_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "tls_handshake_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "wrote_headers": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "wrote_request": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    }
-  }
-}
-=== path "deal.product" ===
-{
-  "raw_input_data": {
-    "__typename": "Product",
-    "sku": "S1"
-  },
-  "input": {
-    "body": {
-      "query": "query($representations: [_Any!]!){_entities(representations: $representations){... on Product {__typename name upc}}}",
-      "variables": {
-        "representations": [
-          {
-            "__typename": "Product",
-            "sku": "S1"
-          }
-        ]
-      }
-    },
-    "header": {},
-    "method": "POST",
-    "url": "http://products.service"
-  },
-  "output": {
-    "data": {
-      "_entities": [
-        {
-          "__typename": "Product",
-          "name": "Table",
-          "upc": "1"
-        }
-      ]
-    }
-  },
-  "duration_since_start_pretty": "0s",
-  "duration_load_pretty": "0s",
-  "single_flight_used": true,
-  "single_flight_shared_response": false,
-  "load_skipped": false,
-  "load_stats": {
-    "get_conn": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "host_port": ""
-    },
-    "got_conn": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "reused": false,
-      "was_idle": false,
-      "idle_time_nanoseconds": 0,
-      "idle_time_pretty": ""
-    },
-    "got_first_response_byte": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "dns_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "host": ""
-    },
-    "dns_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "connect_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "network": "",
-      "addr": ""
-    },
-    "connect_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "network": "",
-      "addr": ""
-    },
-    "tls_handshake_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "tls_handshake_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "wrote_headers": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "wrote_request": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    }
-  },
-  "cache": {
-    "decision": "Fetch",
-    "hit": false,
-    "items": [
-      {
-        "keys": [
-          "entities:f58e5d95ce10e65e"
-        ],
-        "hit": false,
-        "write_reason": "refresh",
-        "pending_candidates": 1
-      }
-    ]
-  }
-}
-=== path "deal.product" ===
-{
-  "raw_input_data": {
-    "__typename": "Product",
-    "sku": "S1",
-    "name": "Table",
-    "upc": "1"
-  },
-  "input": {
-    "body": {
-      "query": "query($representations: [_Any!]!){_entities(representations: $representations){... on Product {__typename reviews {product {__typename upc}}}}}",
-      "variables": {
-        "representations": [
-          {
-            "__typename": "Product",
-            "upc": "1"
-          }
-        ]
-      }
-    },
-    "header": {},
-    "method": "POST",
-    "url": "http://reviews.service"
-  },
-  "output": {
-    "data": {
-      "_entities": [
-        {
-          "__typename": "Product",
-          "reviews": [
-            {
-              "__typename": "Review",
-              "product": {
-                "__typename": "Product",
-                "upc": "1"
-              }
-            }
-          ]
-        }
-      ]
-    }
-  },
-  "duration_since_start_pretty": "0s",
-  "duration_load_pretty": "0s",
-  "single_flight_used": true,
-  "single_flight_shared_response": false,
-  "load_skipped": false,
-  "load_stats": {
-    "get_conn": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "host_port": ""
-    },
-    "got_conn": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "reused": false,
-      "was_idle": false,
-      "idle_time_nanoseconds": 0,
-      "idle_time_pretty": ""
-    },
-    "got_first_response_byte": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "dns_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "host": ""
-    },
-    "dns_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "connect_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "network": "",
-      "addr": ""
-    },
-    "connect_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "network": "",
-      "addr": ""
-    },
-    "tls_handshake_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "tls_handshake_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "wrote_headers": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "wrote_request": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    }
-  }
-}
-=== path "deal.product.reviews.@.product" ===
-{
-  "raw_input_data": {
-    "__typename": "Product",
-    "upc": "1"
-  },
-  "single_flight_used": false,
-  "single_flight_shared_response": false,
-  "load_skipped": true,
-  "cache": {
-    "decision": "SkipFullHit",
-    "hit": true,
-    "items": [
-      {
-        "keys": [
-          "entities:153cc511c85713fb"
-        ],
-        "served_from": "l1",
-        "hit": true,
-        "pending_candidates": 1
-      }
-    ]
-  }
-}
-`, fullTraces(t, result.Response.Fetches))
-	})
-
-	t.Run("shadow compare", func(t *testing.T) {
-		store := cachetesting.NewFakeStore()
-		query := `{ me { favoriteProduct { upc stock } } }`
-		responses := map[string]string{
-			"users":                        `{"data":{"me":{"__typename":"User","id":"u1"}}}`,
-			"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
-			"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
-		}
-		prime := Plan(t, query, inventoryShadowCaching(), responses)
-		resolveTraced(t, prime.Response, store)
-		second := Plan(t, query, inventoryShadowCaching(), responses)
-		secondBody := resolveTraced(t, second.Response, store)
-		assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"upc":"1","stock":5}}}}`, secondBody)
-		assert.Equal(t, `=== path "" ===
-{
-  "raw_input_data": {},
-  "input": {
-    "body": {
-      "query": "{me {__typename id}}"
-    },
-    "header": {},
-    "method": "POST",
-    "url": "http://users.service"
-  },
-  "output": {
-    "data": {
-      "me": {
-        "__typename": "User",
-        "id": "u1"
-      }
-    }
-  },
-  "duration_since_start_pretty": "0s",
-  "duration_load_pretty": "0s",
-  "single_flight_used": true,
-  "single_flight_shared_response": false,
-  "load_skipped": false,
-  "load_stats": {
-    "get_conn": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "host_port": ""
-    },
-    "got_conn": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "reused": false,
-      "was_idle": false,
-      "idle_time_nanoseconds": 0,
-      "idle_time_pretty": ""
-    },
-    "got_first_response_byte": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "dns_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "host": ""
-    },
-    "dns_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "connect_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "network": "",
-      "addr": ""
-    },
-    "connect_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "network": "",
-      "addr": ""
-    },
-    "tls_handshake_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "tls_handshake_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "wrote_headers": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "wrote_request": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    }
-  }
-}
-=== path "me" ===
-{
-  "raw_input_data": {
-    "__typename": "User",
-    "id": "u1"
-  },
-  "input": {
-    "body": {
-      "query": "query($representations: [_Any!]!){_entities(representations: $representations){... on User {__typename favoriteProduct {upc __typename}}}}",
-      "variables": {
-        "representations": [
-          {
-            "__typename": "User",
-            "id": "u1"
-          }
-        ]
-      }
-    },
-    "header": {},
-    "method": "POST",
-    "url": "http://products.service"
-  },
-  "output": {
-    "data": {
-      "_entities": [
-        {
-          "__typename": "User",
-          "favoriteProduct": {
-            "__typename": "Product",
-            "upc": "1"
-          }
-        }
-      ]
-    }
-  },
-  "duration_since_start_pretty": "0s",
-  "duration_load_pretty": "0s",
-  "single_flight_used": true,
-  "single_flight_shared_response": false,
-  "load_skipped": false,
-  "load_stats": {
-    "get_conn": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "host_port": ""
-    },
-    "got_conn": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "reused": false,
-      "was_idle": false,
-      "idle_time_nanoseconds": 0,
-      "idle_time_pretty": ""
-    },
-    "got_first_response_byte": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "dns_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "host": ""
-    },
-    "dns_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "connect_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "network": "",
-      "addr": ""
-    },
-    "connect_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "network": "",
-      "addr": ""
-    },
-    "tls_handshake_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "tls_handshake_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "wrote_headers": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "wrote_request": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    }
-  }
-}
-=== path "me.favoriteProduct" ===
-{
-  "raw_input_data": {
-    "__typename": "Product",
-    "upc": "1"
-  },
-  "input": {
-    "body": {
-      "query": "query($representations: [_Any!]!){_entities(representations: $representations){... on Product {__typename stock}}}",
-      "variables": {
-        "representations": [
-          {
-            "__typename": "Product",
-            "upc": "1"
-          }
-        ]
-      }
-    },
-    "header": {},
-    "method": "POST",
-    "url": "http://inventory.service"
-  },
-  "output": {
-    "data": {
-      "_entities": [
-        {
-          "__typename": "Product",
-          "stock": 5
-        }
-      ]
-    }
-  },
-  "duration_since_start_pretty": "0s",
-  "duration_load_pretty": "0s",
-  "single_flight_used": true,
-  "single_flight_shared_response": false,
-  "load_skipped": false,
-  "load_stats": {
-    "get_conn": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "host_port": ""
-    },
-    "got_conn": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "reused": false,
-      "was_idle": false,
-      "idle_time_nanoseconds": 0,
-      "idle_time_pretty": ""
-    },
-    "got_first_response_byte": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "dns_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "host": ""
-    },
-    "dns_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "connect_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "network": "",
-      "addr": ""
-    },
-    "connect_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "network": "",
-      "addr": ""
-    },
-    "tls_handshake_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "tls_handshake_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "wrote_headers": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "wrote_request": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    }
-  },
-  "cache": {
-    "decision": "FetchShadow",
-    "hit": false,
-    "shadow": true,
-    "items": [
-      {
-        "keys": [
-          "entities:153cc511c85713fb"
-        ],
-        "hit": false,
-        "write_reason": "refresh"
-      }
-    ],
-    "shadow_compares": [
-      {
-        "key": "entities:153cc511c85713fb",
-        "is_fresh": true,
-        "cache_age_nanoseconds": -1
-      }
-    ]
-  }
-}
-`, fullTraces(t, second.Response.Fetches))
-	})
-
-	t.Run("partial batch", func(t *testing.T) {
-		store := cachetesting.NewFakeStore()
-		prime := Plan(t, `{ products(first: 1) { upc reviews { body } } }`, reviewsPartialCaching(), map[string]string{
-			"products": `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`,
-			"reviews":  `{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","body":"great table"}]}]}}`,
-		})
-		resolveTraced(t, prime.Response, store)
-
-		second := Plan(t, `{ products(first: 2) { upc reviews { body } } }`, reviewsPartialCaching(), map[string]string{
-			"products": `{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"}]}}`,
-			"reviews":  `{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","body":"sturdy chair"}]}]}}`,
-		})
-		body := resolveTraced(t, second.Response, store)
-		assert.Equal(t,
-			`{"data":{"products":[{"upc":"1","reviews":[{"body":"great table"}]},{"upc":"2","reviews":[{"body":"sturdy chair"}]}]}}`,
-			body)
-		// One partial fetch: bucket 1 (upc "1") served from L2 under the primed
-		// key, bucket 2 (upc "2") fetched over the reduced batch and refreshed.
-		assert.Equal(t, `=== path "" ===
-{
-  "raw_input_data": {},
-  "input": {
-    "body": {
-      "query": "query($a: Int){products(first: $a){upc __typename}}",
-      "variables": {
-        "a": null
-      }
-    },
-    "header": {},
-    "method": "POST",
-    "undefined": [
-      "a"
-    ],
-    "url": "http://products.service"
-  },
-  "output": {
-    "data": {
-      "products": [
-        {
-          "__typename": "Product",
-          "upc": "1"
-        },
-        {
-          "__typename": "Product",
-          "upc": "2"
-        }
-      ]
-    }
-  },
-  "duration_since_start_pretty": "0s",
-  "duration_load_pretty": "0s",
-  "single_flight_used": true,
-  "single_flight_shared_response": false,
-  "load_skipped": false,
-  "load_stats": {
-    "get_conn": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "host_port": ""
-    },
-    "got_conn": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "reused": false,
-      "was_idle": false,
-      "idle_time_nanoseconds": 0,
-      "idle_time_pretty": ""
-    },
-    "got_first_response_byte": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "dns_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "host": ""
-    },
-    "dns_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "connect_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "network": "",
-      "addr": ""
-    },
-    "connect_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "network": "",
-      "addr": ""
-    },
-    "tls_handshake_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "tls_handshake_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "wrote_headers": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "wrote_request": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    }
-  }
-}
-=== path "products" ===
-{
-  "raw_input_data": [
-    {
-      "__typename": "Product",
-      "upc": "1"
-    },
-    {
-      "__typename": "Product",
-      "upc": "2"
-    }
-  ],
-  "input": {
-    "body": {
-      "query": "query($representations: [_Any!]!){_entities(representations: $representations){... on Product {__typename reviews {body}}}}",
-      "variables": {
-        "representations": [
-          {
-            "__typename": "Product",
-            "upc": "2"
-          }
-        ]
-      }
-    },
-    "header": {},
-    "method": "POST",
-    "url": "http://reviews.service"
-  },
-  "output": {
-    "data": {
-      "_entities": [
-        {
-          "__typename": "Product",
-          "reviews": [
-            {
-              "__typename": "Review",
-              "body": "sturdy chair"
-            }
-          ]
-        }
-      ]
-    }
-  },
-  "duration_since_start_pretty": "0s",
-  "duration_load_pretty": "0s",
-  "single_flight_used": true,
-  "single_flight_shared_response": false,
-  "load_skipped": false,
-  "load_stats": {
-    "get_conn": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "host_port": ""
-    },
-    "got_conn": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "reused": false,
-      "was_idle": false,
-      "idle_time_nanoseconds": 0,
-      "idle_time_pretty": ""
-    },
-    "got_first_response_byte": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "dns_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "host": ""
-    },
-    "dns_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "connect_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "network": "",
-      "addr": ""
-    },
-    "connect_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": "",
-      "network": "",
-      "addr": ""
-    },
-    "tls_handshake_start": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "tls_handshake_done": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "wrote_headers": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    },
-    "wrote_request": {
-      "duration_since_start_nanoseconds": 0,
-      "duration_since_start_pretty": ""
-    }
-  },
-  "cache": {
-    "decision": "FetchPartial",
-    "hit": false,
-    "items": [
-      {
-        "keys": [
-          "reviews:aa052522cb64dff0"
-        ],
-        "served_from": "l2",
-        "hit": true,
-        "remaining_ttl_nanoseconds": -1
-      },
-      {
-        "keys": [
-          "reviews:258590a53d3c528e"
-        ],
-        "hit": false,
-        "write_reason": "refresh"
-      }
-    ]
-  }
-}
-`, fullTraces(t, second.Response.Fetches))
-	})
-
-	t.Run("regression: tracing off leaves fetch traces nil", func(t *testing.T) {
-		store := cachetesting.NewFakeStore()
-		result := Plan(t, `{ me { favoriteProduct { upc stock } } }`, map[string]cacheconfig.CachingConfiguration{
-			"inventory": {Entities: []cacheconfig.EntityCachePolicy{{TypeName: "Product", CacheName: "inventory", TTL: time.Minute}}},
-		}, map[string]string{
-			"users":                        `{"data":{"me":{"__typename":"User","id":"u1"}}}`,
-			"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
-			"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
-		})
-		body := ResolveResponse(t, result.Response, cachetesting.NewRealishCache(store, nil))
+		// Tracing OFF: the response is the bare data — no extensions, no trace.
+		body := Execute(t, executionEngine, query, cachetesting.NewRealishCache(store, nil))
 		assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"upc":"1","stock":5}}}}`, body)
-		assert.Empty(t, fullTraces(t, result.Response.Fetches))
 	})
 }

--- a/execution/cachingtesting/art_e2e_test.go
+++ b/execution/cachingtesting/art_e2e_test.go
@@ -106,9 +106,19 @@ func TestARTCacheTraceEndToEnd(t *testing.T) {
 
 	t.Run("L1 hit within one request", func(t *testing.T) {
 		store := cachetesting.NewFakeStore()
-		result := Plan(t, l1ChainQuery, productL1Caching(0), l1ChainResponses())
+		// The dependency-ordered deal -> product(sku) -> reviews(upc) ->
+		// product(upc) chain: fetch B is served from L1 within the request
+		// (its canned response is TAMPERED so network use fails loudly).
+		query := `{ deal(id: "d1") { product { name reviews { product { name } } } } }`
+		responses := map[string]string{
+			"deals":                 `{"data":{"deal":{"__typename":"Deal","id":"d1","product":{"__typename":"Product","sku":"S1"}}}}`,
+			"products:deal.product": `{"data":{"_entities":[{"__typename":"Product","name":"Table","upc":"1"}]}}`,
+			"reviews":               `{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","product":{"__typename":"Product","upc":"1"}}]}]}}`,
+			"products:deal.product.reviews.@.product": `{"data":{"_entities":[{"__typename":"Product","name":"NETWORK-MUST-NOT-SERVE"}]}}`,
+		}
+		result := Plan(t, query, productL1Caching(0), responses)
 		body := resolveTraced(t, result.Response, store)
-		assert.Equal(t, l1ChainExpected, body)
+		assert.Equal(t, `{"data":{"deal":{"product":{"name":"Table","reviews":[{"product":{"name":"Table"}}]}}}}`, body)
 		// The key hashes are deterministic (xxhash64 of the canonical key
 		// preimage), so the WHOLE cache sections pin as literals: fetch A is a
 		// plain miss+refresh (its sku-derived key; the upc candidate pending),

--- a/execution/cachingtesting/art_e2e_test.go
+++ b/execution/cachingtesting/art_e2e_test.go
@@ -3,6 +3,7 @@ package cachingtesting
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,39 +26,57 @@ func resolveTraced(t *testing.T, resp *resolve.GraphQLResponse, store *cachetest
 	return resolveWithContext(t, ctx, resp)
 }
 
-// cacheTraces walks the fetch tree and renders every attached CacheTrace as
-// canonical JSON (TTL/age nanos normalized to -1 when positive: real-clock
-// values; exactness is pinned by the synctest observer unit rows).
-func cacheTraces(t *testing.T, node *resolve.FetchTreeNode) []string {
+// fullTraces renders EVERY fetch's COMPLETE ART trace as path-labeled,
+// indented JSON — the whole DataSourceLoadTrace, cache section included — with
+// the real-clock fields normalized: durations zeroed, TTL and cache-age nanos
+// set to -1 when positive (their exact values are pinned by the synctest
+// observer unit rows).
+func fullTraces(t *testing.T, node *resolve.FetchTreeNode) string {
 	t.Helper()
-	if node == nil {
-		return nil
-	}
-	var out []string
-	if node.Item != nil && node.Item.Fetch != nil {
-		if trace := loadTraceOf(node.Item.Fetch); trace != nil && trace.CacheTrace != nil {
-			normalized := *trace.CacheTrace
-			normalized.Items = append([]resolve.CacheItemTrace(nil), trace.CacheTrace.Items...)
-			for i := range normalized.Items {
-				if normalized.Items[i].RemainingTTLNano > 0 {
-					normalized.Items[i].RemainingTTLNano = -1
+	var b strings.Builder
+	var walk func(node *resolve.FetchTreeNode)
+	walk = func(node *resolve.FetchTreeNode) {
+		if node == nil {
+			return
+		}
+		if node.Item != nil && node.Item.Fetch != nil {
+			if trace := loadTraceOf(node.Item.Fetch); trace != nil {
+				normalized := *trace
+				normalized.DurationSinceStartNano = 0
+				normalized.DurationLoadNano = 0
+				if normalized.DurationSinceStartPretty != "" {
+					normalized.DurationSinceStartPretty = "0s"
 				}
-			}
-			normalized.ShadowCompares = append([]resolve.CacheShadowCompareTrace(nil), trace.CacheTrace.ShadowCompares...)
-			for i := range normalized.ShadowCompares {
-				if normalized.ShadowCompares[i].CacheAgeNano > 0 {
-					normalized.ShadowCompares[i].CacheAgeNano = -1
+				if normalized.DurationLoadPretty != "" {
+					normalized.DurationLoadPretty = "0s"
 				}
+				if trace.CacheTrace != nil {
+					cacheTrace := *trace.CacheTrace
+					cacheTrace.Items = append([]resolve.CacheItemTrace(nil), trace.CacheTrace.Items...)
+					for i := range cacheTrace.Items {
+						if cacheTrace.Items[i].RemainingTTLNano > 0 {
+							cacheTrace.Items[i].RemainingTTLNano = -1
+						}
+					}
+					cacheTrace.ShadowCompares = append([]resolve.CacheShadowCompareTrace(nil), trace.CacheTrace.ShadowCompares...)
+					for i := range cacheTrace.ShadowCompares {
+						if cacheTrace.ShadowCompares[i].CacheAgeNano > 0 {
+							cacheTrace.ShadowCompares[i].CacheAgeNano = -1
+						}
+					}
+					normalized.CacheTrace = &cacheTrace
+				}
+				raw, err := json.MarshalIndent(&normalized, "", "  ")
+				require.NoError(t, err)
+				fmt.Fprintf(&b, "=== path %q ===\n%s\n", node.Item.ResponsePath, raw)
 			}
-			raw, err := json.Marshal(&normalized)
-			require.NoError(t, err)
-			out = append(out, fmt.Sprintf("path:%q %s", node.Item.ResponsePath, raw))
+		}
+		for _, child := range node.ChildNodes {
+			walk(child)
 		}
 	}
-	for _, child := range node.ChildNodes {
-		out = append(out, cacheTraces(t, child)...)
-	}
-	return out
+	walk(node)
+	return b.String()
 }
 
 func loadTraceOf(fetch resolve.Fetch) *resolve.DataSourceLoadTrace {
@@ -91,17 +110,499 @@ func TestARTCacheTraceEndToEnd(t *testing.T) {
 		first := Plan(t, query, caching, responses)
 		firstBody := resolveTraced(t, first.Response, store)
 		assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"upc":"1","stock":5}}}}`, firstBody)
-		key := store.Ops()[0].Key
-		assert.Equal(t, []string{
-			`path:"me.favoriteProduct" {"decision":"Fetch","hit":false,"items":[{"keys":["` + key + `"],"hit":false,"write_reason":"refresh"}]}`,
-		}, cacheTraces(t, first.Response.Fetches))
+		assert.Equal(t, `=== path "" ===
+{
+  "raw_input_data": {},
+  "input": {
+    "body": {
+      "query": "{me {__typename id}}"
+    },
+    "header": {},
+    "method": "POST",
+    "url": "http://users.service"
+  },
+  "output": {
+    "data": {
+      "me": {
+        "__typename": "User",
+        "id": "u1"
+      }
+    }
+  },
+  "duration_since_start_pretty": "0s",
+  "duration_load_pretty": "0s",
+  "single_flight_used": true,
+  "single_flight_shared_response": false,
+  "load_skipped": false,
+  "load_stats": {
+    "get_conn": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "host_port": ""
+    },
+    "got_conn": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "reused": false,
+      "was_idle": false,
+      "idle_time_nanoseconds": 0,
+      "idle_time_pretty": ""
+    },
+    "got_first_response_byte": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "dns_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "host": ""
+    },
+    "dns_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "connect_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "network": "",
+      "addr": ""
+    },
+    "connect_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "network": "",
+      "addr": ""
+    },
+    "tls_handshake_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "tls_handshake_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "wrote_headers": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "wrote_request": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    }
+  }
+}
+=== path "me" ===
+{
+  "raw_input_data": {
+    "__typename": "User",
+    "id": "u1"
+  },
+  "input": {
+    "body": {
+      "query": "query($representations: [_Any!]!){_entities(representations: $representations){... on User {__typename favoriteProduct {upc __typename}}}}",
+      "variables": {
+        "representations": [
+          {
+            "__typename": "User",
+            "id": "u1"
+          }
+        ]
+      }
+    },
+    "header": {},
+    "method": "POST",
+    "url": "http://products.service"
+  },
+  "output": {
+    "data": {
+      "_entities": [
+        {
+          "__typename": "User",
+          "favoriteProduct": {
+            "__typename": "Product",
+            "upc": "1"
+          }
+        }
+      ]
+    }
+  },
+  "duration_since_start_pretty": "0s",
+  "duration_load_pretty": "0s",
+  "single_flight_used": true,
+  "single_flight_shared_response": false,
+  "load_skipped": false,
+  "load_stats": {
+    "get_conn": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "host_port": ""
+    },
+    "got_conn": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "reused": false,
+      "was_idle": false,
+      "idle_time_nanoseconds": 0,
+      "idle_time_pretty": ""
+    },
+    "got_first_response_byte": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "dns_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "host": ""
+    },
+    "dns_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "connect_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "network": "",
+      "addr": ""
+    },
+    "connect_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "network": "",
+      "addr": ""
+    },
+    "tls_handshake_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "tls_handshake_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "wrote_headers": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "wrote_request": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    }
+  }
+}
+=== path "me.favoriteProduct" ===
+{
+  "raw_input_data": {
+    "__typename": "Product",
+    "upc": "1"
+  },
+  "input": {
+    "body": {
+      "query": "query($representations: [_Any!]!){_entities(representations: $representations){... on Product {__typename stock}}}",
+      "variables": {
+        "representations": [
+          {
+            "__typename": "Product",
+            "upc": "1"
+          }
+        ]
+      }
+    },
+    "header": {},
+    "method": "POST",
+    "url": "http://inventory.service"
+  },
+  "output": {
+    "data": {
+      "_entities": [
+        {
+          "__typename": "Product",
+          "stock": 5
+        }
+      ]
+    }
+  },
+  "duration_since_start_pretty": "0s",
+  "duration_load_pretty": "0s",
+  "single_flight_used": true,
+  "single_flight_shared_response": false,
+  "load_skipped": false,
+  "load_stats": {
+    "get_conn": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "host_port": ""
+    },
+    "got_conn": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "reused": false,
+      "was_idle": false,
+      "idle_time_nanoseconds": 0,
+      "idle_time_pretty": ""
+    },
+    "got_first_response_byte": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "dns_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "host": ""
+    },
+    "dns_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "connect_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "network": "",
+      "addr": ""
+    },
+    "connect_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "network": "",
+      "addr": ""
+    },
+    "tls_handshake_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "tls_handshake_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "wrote_headers": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "wrote_request": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    }
+  },
+  "cache": {
+    "decision": "Fetch",
+    "hit": false,
+    "items": [
+      {
+        "keys": [
+          "inventory:22ec9a28afcdd0bf"
+        ],
+        "hit": false,
+        "write_reason": "refresh"
+      }
+    ]
+  }
+}
+`, fullTraces(t, first.Response.Fetches))
 
 		second := Plan(t, query, caching, responses)
 		secondBody := resolveTraced(t, second.Response, store)
 		assert.Equal(t, firstBody, secondBody)
-		assert.Equal(t, []string{
-			`path:"me.favoriteProduct" {"decision":"SkipFullHit","hit":true,"items":[{"keys":["` + key + `"],"served_from":"l2","hit":true,"remaining_ttl_nanoseconds":-1}]}`,
-		}, cacheTraces(t, second.Response.Fetches))
+		assert.Equal(t, `=== path "" ===
+{
+  "raw_input_data": {},
+  "input": {
+    "body": {
+      "query": "{me {__typename id}}"
+    },
+    "header": {},
+    "method": "POST",
+    "url": "http://users.service"
+  },
+  "output": {
+    "data": {
+      "me": {
+        "__typename": "User",
+        "id": "u1"
+      }
+    }
+  },
+  "duration_since_start_pretty": "0s",
+  "duration_load_pretty": "0s",
+  "single_flight_used": true,
+  "single_flight_shared_response": false,
+  "load_skipped": false,
+  "load_stats": {
+    "get_conn": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "host_port": ""
+    },
+    "got_conn": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "reused": false,
+      "was_idle": false,
+      "idle_time_nanoseconds": 0,
+      "idle_time_pretty": ""
+    },
+    "got_first_response_byte": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "dns_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "host": ""
+    },
+    "dns_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "connect_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "network": "",
+      "addr": ""
+    },
+    "connect_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "network": "",
+      "addr": ""
+    },
+    "tls_handshake_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "tls_handshake_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "wrote_headers": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "wrote_request": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    }
+  }
+}
+=== path "me" ===
+{
+  "raw_input_data": {
+    "__typename": "User",
+    "id": "u1"
+  },
+  "input": {
+    "body": {
+      "query": "query($representations: [_Any!]!){_entities(representations: $representations){... on User {__typename favoriteProduct {upc __typename}}}}",
+      "variables": {
+        "representations": [
+          {
+            "__typename": "User",
+            "id": "u1"
+          }
+        ]
+      }
+    },
+    "header": {},
+    "method": "POST",
+    "url": "http://products.service"
+  },
+  "output": {
+    "data": {
+      "_entities": [
+        {
+          "__typename": "User",
+          "favoriteProduct": {
+            "__typename": "Product",
+            "upc": "1"
+          }
+        }
+      ]
+    }
+  },
+  "duration_since_start_pretty": "0s",
+  "duration_load_pretty": "0s",
+  "single_flight_used": true,
+  "single_flight_shared_response": false,
+  "load_skipped": false,
+  "load_stats": {
+    "get_conn": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "host_port": ""
+    },
+    "got_conn": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "reused": false,
+      "was_idle": false,
+      "idle_time_nanoseconds": 0,
+      "idle_time_pretty": ""
+    },
+    "got_first_response_byte": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "dns_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "host": ""
+    },
+    "dns_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "connect_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "network": "",
+      "addr": ""
+    },
+    "connect_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "network": "",
+      "addr": ""
+    },
+    "tls_handshake_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "tls_handshake_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "wrote_headers": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "wrote_request": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    }
+  }
+}
+=== path "me.favoriteProduct" ===
+{
+  "raw_input_data": {
+    "__typename": "Product",
+    "upc": "1"
+  },
+  "single_flight_used": false,
+  "single_flight_shared_response": false,
+  "load_skipped": true,
+  "cache": {
+    "decision": "SkipFullHit",
+    "hit": true,
+    "items": [
+      {
+        "keys": [
+          "inventory:22ec9a28afcdd0bf"
+        ],
+        "served_from": "l2",
+        "hit": true,
+        "remaining_ttl_nanoseconds": -1
+      }
+    ]
+  }
+}
+`, fullTraces(t, second.Response.Fetches))
 	})
 
 	t.Run("L1 hit within one request", func(t *testing.T) {
@@ -123,10 +624,335 @@ func TestARTCacheTraceEndToEnd(t *testing.T) {
 		// preimage), so the WHOLE cache sections pin as literals: fetch A is a
 		// plain miss+refresh (its sku-derived key; the upc candidate pending),
 		// fetch B is the in-request L1 hit under the upc-derived key.
-		assert.Equal(t, []string{
-			`path:"deal.product" {"decision":"Fetch","hit":false,"items":[{"keys":["entities:f58e5d95ce10e65e"],"hit":false,"write_reason":"refresh","pending_candidates":1}]}`,
-			`path:"deal.product.reviews.@.product" {"decision":"SkipFullHit","hit":true,"items":[{"keys":["entities:153cc511c85713fb"],"served_from":"l1","hit":true,"pending_candidates":1}]}`,
-		}, cacheTraces(t, result.Response.Fetches))
+		assert.Equal(t, `=== path "" ===
+{
+  "raw_input_data": {},
+  "input": {
+    "body": {
+      "query": "query($a: ID!){deal(id: $a){product {__typename sku}}}",
+      "variables": {
+        "a": null
+      }
+    },
+    "header": {},
+    "method": "POST",
+    "undefined": [
+      "a"
+    ],
+    "url": "http://deals.service"
+  },
+  "output": {
+    "data": {
+      "deal": {
+        "__typename": "Deal",
+        "id": "d1",
+        "product": {
+          "__typename": "Product",
+          "sku": "S1"
+        }
+      }
+    }
+  },
+  "duration_since_start_pretty": "0s",
+  "duration_load_pretty": "0s",
+  "single_flight_used": true,
+  "single_flight_shared_response": false,
+  "load_skipped": false,
+  "load_stats": {
+    "get_conn": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "host_port": ""
+    },
+    "got_conn": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "reused": false,
+      "was_idle": false,
+      "idle_time_nanoseconds": 0,
+      "idle_time_pretty": ""
+    },
+    "got_first_response_byte": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "dns_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "host": ""
+    },
+    "dns_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "connect_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "network": "",
+      "addr": ""
+    },
+    "connect_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "network": "",
+      "addr": ""
+    },
+    "tls_handshake_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "tls_handshake_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "wrote_headers": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "wrote_request": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    }
+  }
+}
+=== path "deal.product" ===
+{
+  "raw_input_data": {
+    "__typename": "Product",
+    "sku": "S1"
+  },
+  "input": {
+    "body": {
+      "query": "query($representations: [_Any!]!){_entities(representations: $representations){... on Product {__typename name upc}}}",
+      "variables": {
+        "representations": [
+          {
+            "__typename": "Product",
+            "sku": "S1"
+          }
+        ]
+      }
+    },
+    "header": {},
+    "method": "POST",
+    "url": "http://products.service"
+  },
+  "output": {
+    "data": {
+      "_entities": [
+        {
+          "__typename": "Product",
+          "name": "Table",
+          "upc": "1"
+        }
+      ]
+    }
+  },
+  "duration_since_start_pretty": "0s",
+  "duration_load_pretty": "0s",
+  "single_flight_used": true,
+  "single_flight_shared_response": false,
+  "load_skipped": false,
+  "load_stats": {
+    "get_conn": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "host_port": ""
+    },
+    "got_conn": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "reused": false,
+      "was_idle": false,
+      "idle_time_nanoseconds": 0,
+      "idle_time_pretty": ""
+    },
+    "got_first_response_byte": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "dns_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "host": ""
+    },
+    "dns_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "connect_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "network": "",
+      "addr": ""
+    },
+    "connect_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "network": "",
+      "addr": ""
+    },
+    "tls_handshake_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "tls_handshake_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "wrote_headers": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "wrote_request": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    }
+  },
+  "cache": {
+    "decision": "Fetch",
+    "hit": false,
+    "items": [
+      {
+        "keys": [
+          "entities:f58e5d95ce10e65e"
+        ],
+        "hit": false,
+        "write_reason": "refresh",
+        "pending_candidates": 1
+      }
+    ]
+  }
+}
+=== path "deal.product" ===
+{
+  "raw_input_data": {
+    "__typename": "Product",
+    "sku": "S1",
+    "name": "Table",
+    "upc": "1"
+  },
+  "input": {
+    "body": {
+      "query": "query($representations: [_Any!]!){_entities(representations: $representations){... on Product {__typename reviews {product {__typename upc}}}}}",
+      "variables": {
+        "representations": [
+          {
+            "__typename": "Product",
+            "upc": "1"
+          }
+        ]
+      }
+    },
+    "header": {},
+    "method": "POST",
+    "url": "http://reviews.service"
+  },
+  "output": {
+    "data": {
+      "_entities": [
+        {
+          "__typename": "Product",
+          "reviews": [
+            {
+              "__typename": "Review",
+              "product": {
+                "__typename": "Product",
+                "upc": "1"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "duration_since_start_pretty": "0s",
+  "duration_load_pretty": "0s",
+  "single_flight_used": true,
+  "single_flight_shared_response": false,
+  "load_skipped": false,
+  "load_stats": {
+    "get_conn": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "host_port": ""
+    },
+    "got_conn": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "reused": false,
+      "was_idle": false,
+      "idle_time_nanoseconds": 0,
+      "idle_time_pretty": ""
+    },
+    "got_first_response_byte": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "dns_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "host": ""
+    },
+    "dns_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "connect_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "network": "",
+      "addr": ""
+    },
+    "connect_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "network": "",
+      "addr": ""
+    },
+    "tls_handshake_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "tls_handshake_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "wrote_headers": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "wrote_request": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    }
+  }
+}
+=== path "deal.product.reviews.@.product" ===
+{
+  "raw_input_data": {
+    "__typename": "Product",
+    "upc": "1"
+  },
+  "single_flight_used": false,
+  "single_flight_shared_response": false,
+  "load_skipped": true,
+  "cache": {
+    "decision": "SkipFullHit",
+    "hit": true,
+    "items": [
+      {
+        "keys": [
+          "entities:153cc511c85713fb"
+        ],
+        "served_from": "l1",
+        "hit": true,
+        "pending_candidates": 1
+      }
+    ]
+  }
+}
+`, fullTraces(t, result.Response.Fetches))
 	})
 
 	t.Run("shadow compare", func(t *testing.T) {
@@ -139,14 +965,303 @@ func TestARTCacheTraceEndToEnd(t *testing.T) {
 		}
 		prime := Plan(t, query, inventoryShadowCaching(), responses)
 		resolveTraced(t, prime.Response, store)
-		key := store.Ops()[0].Key
-
 		second := Plan(t, query, inventoryShadowCaching(), responses)
 		secondBody := resolveTraced(t, second.Response, store)
 		assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"upc":"1","stock":5}}}}`, secondBody)
-		assert.Equal(t, []string{
-			`path:"me.favoriteProduct" {"decision":"FetchShadow","hit":false,"shadow":true,"items":[{"keys":["` + key + `"],"hit":false,"write_reason":"refresh"}],"shadow_compares":[{"key":"` + key + `","is_fresh":true,"cache_age_nanoseconds":-1}]}`,
-		}, cacheTraces(t, second.Response.Fetches))
+		assert.Equal(t, `=== path "" ===
+{
+  "raw_input_data": {},
+  "input": {
+    "body": {
+      "query": "{me {__typename id}}"
+    },
+    "header": {},
+    "method": "POST",
+    "url": "http://users.service"
+  },
+  "output": {
+    "data": {
+      "me": {
+        "__typename": "User",
+        "id": "u1"
+      }
+    }
+  },
+  "duration_since_start_pretty": "0s",
+  "duration_load_pretty": "0s",
+  "single_flight_used": true,
+  "single_flight_shared_response": false,
+  "load_skipped": false,
+  "load_stats": {
+    "get_conn": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "host_port": ""
+    },
+    "got_conn": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "reused": false,
+      "was_idle": false,
+      "idle_time_nanoseconds": 0,
+      "idle_time_pretty": ""
+    },
+    "got_first_response_byte": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "dns_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "host": ""
+    },
+    "dns_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "connect_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "network": "",
+      "addr": ""
+    },
+    "connect_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "network": "",
+      "addr": ""
+    },
+    "tls_handshake_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "tls_handshake_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "wrote_headers": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "wrote_request": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    }
+  }
+}
+=== path "me" ===
+{
+  "raw_input_data": {
+    "__typename": "User",
+    "id": "u1"
+  },
+  "input": {
+    "body": {
+      "query": "query($representations: [_Any!]!){_entities(representations: $representations){... on User {__typename favoriteProduct {upc __typename}}}}",
+      "variables": {
+        "representations": [
+          {
+            "__typename": "User",
+            "id": "u1"
+          }
+        ]
+      }
+    },
+    "header": {},
+    "method": "POST",
+    "url": "http://products.service"
+  },
+  "output": {
+    "data": {
+      "_entities": [
+        {
+          "__typename": "User",
+          "favoriteProduct": {
+            "__typename": "Product",
+            "upc": "1"
+          }
+        }
+      ]
+    }
+  },
+  "duration_since_start_pretty": "0s",
+  "duration_load_pretty": "0s",
+  "single_flight_used": true,
+  "single_flight_shared_response": false,
+  "load_skipped": false,
+  "load_stats": {
+    "get_conn": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "host_port": ""
+    },
+    "got_conn": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "reused": false,
+      "was_idle": false,
+      "idle_time_nanoseconds": 0,
+      "idle_time_pretty": ""
+    },
+    "got_first_response_byte": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "dns_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "host": ""
+    },
+    "dns_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "connect_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "network": "",
+      "addr": ""
+    },
+    "connect_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "network": "",
+      "addr": ""
+    },
+    "tls_handshake_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "tls_handshake_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "wrote_headers": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "wrote_request": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    }
+  }
+}
+=== path "me.favoriteProduct" ===
+{
+  "raw_input_data": {
+    "__typename": "Product",
+    "upc": "1"
+  },
+  "input": {
+    "body": {
+      "query": "query($representations: [_Any!]!){_entities(representations: $representations){... on Product {__typename stock}}}",
+      "variables": {
+        "representations": [
+          {
+            "__typename": "Product",
+            "upc": "1"
+          }
+        ]
+      }
+    },
+    "header": {},
+    "method": "POST",
+    "url": "http://inventory.service"
+  },
+  "output": {
+    "data": {
+      "_entities": [
+        {
+          "__typename": "Product",
+          "stock": 5
+        }
+      ]
+    }
+  },
+  "duration_since_start_pretty": "0s",
+  "duration_load_pretty": "0s",
+  "single_flight_used": true,
+  "single_flight_shared_response": false,
+  "load_skipped": false,
+  "load_stats": {
+    "get_conn": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "host_port": ""
+    },
+    "got_conn": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "reused": false,
+      "was_idle": false,
+      "idle_time_nanoseconds": 0,
+      "idle_time_pretty": ""
+    },
+    "got_first_response_byte": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "dns_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "host": ""
+    },
+    "dns_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "connect_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "network": "",
+      "addr": ""
+    },
+    "connect_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "network": "",
+      "addr": ""
+    },
+    "tls_handshake_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "tls_handshake_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "wrote_headers": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "wrote_request": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    }
+  },
+  "cache": {
+    "decision": "FetchShadow",
+    "hit": false,
+    "shadow": true,
+    "items": [
+      {
+        "keys": [
+          "entities:153cc511c85713fb"
+        ],
+        "hit": false,
+        "write_reason": "refresh"
+      }
+    ],
+    "shadow_compares": [
+      {
+        "key": "entities:153cc511c85713fb",
+        "is_fresh": true,
+        "cache_age_nanoseconds": -1
+      }
+    ]
+  }
+}
+`, fullTraces(t, second.Response.Fetches))
 	})
 
 	t.Run("partial batch", func(t *testing.T) {
@@ -167,9 +1282,226 @@ func TestARTCacheTraceEndToEnd(t *testing.T) {
 			body)
 		// One partial fetch: bucket 1 (upc "1") served from L2 under the primed
 		// key, bucket 2 (upc "2") fetched over the reduced batch and refreshed.
-		assert.Equal(t, []string{
-			`path:"products" {"decision":"FetchPartial","hit":false,"items":[{"keys":["reviews:aa052522cb64dff0"],"served_from":"l2","hit":true,"remaining_ttl_nanoseconds":-1},{"keys":["reviews:258590a53d3c528e"],"hit":false,"write_reason":"refresh"}]}`,
-		}, cacheTraces(t, second.Response.Fetches))
+		assert.Equal(t, `=== path "" ===
+{
+  "raw_input_data": {},
+  "input": {
+    "body": {
+      "query": "query($a: Int){products(first: $a){upc __typename}}",
+      "variables": {
+        "a": null
+      }
+    },
+    "header": {},
+    "method": "POST",
+    "undefined": [
+      "a"
+    ],
+    "url": "http://products.service"
+  },
+  "output": {
+    "data": {
+      "products": [
+        {
+          "__typename": "Product",
+          "upc": "1"
+        },
+        {
+          "__typename": "Product",
+          "upc": "2"
+        }
+      ]
+    }
+  },
+  "duration_since_start_pretty": "0s",
+  "duration_load_pretty": "0s",
+  "single_flight_used": true,
+  "single_flight_shared_response": false,
+  "load_skipped": false,
+  "load_stats": {
+    "get_conn": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "host_port": ""
+    },
+    "got_conn": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "reused": false,
+      "was_idle": false,
+      "idle_time_nanoseconds": 0,
+      "idle_time_pretty": ""
+    },
+    "got_first_response_byte": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "dns_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "host": ""
+    },
+    "dns_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "connect_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "network": "",
+      "addr": ""
+    },
+    "connect_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "network": "",
+      "addr": ""
+    },
+    "tls_handshake_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "tls_handshake_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "wrote_headers": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "wrote_request": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    }
+  }
+}
+=== path "products" ===
+{
+  "raw_input_data": [
+    {
+      "__typename": "Product",
+      "upc": "1"
+    },
+    {
+      "__typename": "Product",
+      "upc": "2"
+    }
+  ],
+  "input": {
+    "body": {
+      "query": "query($representations: [_Any!]!){_entities(representations: $representations){... on Product {__typename reviews {body}}}}",
+      "variables": {
+        "representations": [
+          {
+            "__typename": "Product",
+            "upc": "2"
+          }
+        ]
+      }
+    },
+    "header": {},
+    "method": "POST",
+    "url": "http://reviews.service"
+  },
+  "output": {
+    "data": {
+      "_entities": [
+        {
+          "__typename": "Product",
+          "reviews": [
+            {
+              "__typename": "Review",
+              "body": "sturdy chair"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "duration_since_start_pretty": "0s",
+  "duration_load_pretty": "0s",
+  "single_flight_used": true,
+  "single_flight_shared_response": false,
+  "load_skipped": false,
+  "load_stats": {
+    "get_conn": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "host_port": ""
+    },
+    "got_conn": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "reused": false,
+      "was_idle": false,
+      "idle_time_nanoseconds": 0,
+      "idle_time_pretty": ""
+    },
+    "got_first_response_byte": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "dns_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "host": ""
+    },
+    "dns_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "connect_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "network": "",
+      "addr": ""
+    },
+    "connect_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": "",
+      "network": "",
+      "addr": ""
+    },
+    "tls_handshake_start": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "tls_handshake_done": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "wrote_headers": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    },
+    "wrote_request": {
+      "duration_since_start_nanoseconds": 0,
+      "duration_since_start_pretty": ""
+    }
+  },
+  "cache": {
+    "decision": "FetchPartial",
+    "hit": false,
+    "items": [
+      {
+        "keys": [
+          "reviews:aa052522cb64dff0"
+        ],
+        "served_from": "l2",
+        "hit": true,
+        "remaining_ttl_nanoseconds": -1
+      },
+      {
+        "keys": [
+          "reviews:258590a53d3c528e"
+        ],
+        "hit": false,
+        "write_reason": "refresh"
+      }
+    ]
+  }
+}
+`, fullTraces(t, second.Response.Fetches))
 	})
 
 	t.Run("regression: tracing off leaves fetch traces nil", func(t *testing.T) {
@@ -183,6 +1515,6 @@ func TestARTCacheTraceEndToEnd(t *testing.T) {
 		})
 		body := ResolveResponse(t, result.Response, cachetesting.NewRealishCache(store, nil))
 		assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"upc":"1","stock":5}}}}`, body)
-		assert.Empty(t, cacheTraces(t, result.Response.Fetches))
+		assert.Empty(t, fullTraces(t, result.Response.Fetches))
 	})
 }

--- a/execution/cachingtesting/art_e2e_test.go
+++ b/execution/cachingtesting/art_e2e_test.go
@@ -1,0 +1,175 @@
+package cachingtesting
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/cache"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/cache/cachetesting"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// resolveTraced resolves with ART enabled and the production TraceObserver
+// composed into the controller, returning the response body.
+func resolveTraced(t *testing.T, resp *resolve.GraphQLResponse, store *cachetesting.FakeStore) string {
+	t.Helper()
+	ctx := resolve.NewContext(t.Context())
+	ctx.TracingOptions.Enable = true
+	ctx.SetCacheController(cache.NewController(cachetesting.StoreAdapter{Store: store}, cache.NewTraceObserver()))
+	return resolveWithContext(t, ctx, resp)
+}
+
+// cacheTraces walks the fetch tree and renders every attached CacheTrace as
+// canonical JSON (TTL/age nanos normalized to -1 when positive: real-clock
+// values; exactness is pinned by the synctest observer unit rows).
+func cacheTraces(t *testing.T, node *resolve.FetchTreeNode) []string {
+	t.Helper()
+	if node == nil {
+		return nil
+	}
+	var out []string
+	if node.Item != nil && node.Item.Fetch != nil {
+		if trace := loadTraceOf(node.Item.Fetch); trace != nil && trace.CacheTrace != nil {
+			normalized := *trace.CacheTrace
+			normalized.Items = append([]resolve.CacheItemTrace(nil), trace.CacheTrace.Items...)
+			for i := range normalized.Items {
+				if normalized.Items[i].RemainingTTLNano > 0 {
+					normalized.Items[i].RemainingTTLNano = -1
+				}
+			}
+			normalized.ShadowCompares = append([]resolve.CacheShadowCompareTrace(nil), trace.CacheTrace.ShadowCompares...)
+			for i := range normalized.ShadowCompares {
+				if normalized.ShadowCompares[i].CacheAgeNano > 0 {
+					normalized.ShadowCompares[i].CacheAgeNano = -1
+				}
+			}
+			raw, err := json.Marshal(&normalized)
+			require.NoError(t, err)
+			out = append(out, fmt.Sprintf("path:%q %s", node.Item.ResponsePath, raw))
+		}
+	}
+	for _, child := range node.ChildNodes {
+		out = append(out, cacheTraces(t, child)...)
+	}
+	return out
+}
+
+func loadTraceOf(fetch resolve.Fetch) *resolve.DataSourceLoadTrace {
+	switch f := fetch.(type) {
+	case *resolve.SingleFetch:
+		return f.Trace
+	case *resolve.EntityFetch:
+		return f.Trace
+	case *resolve.BatchEntityFetch:
+		return f.Trace
+	default:
+		return nil
+	}
+}
+
+// TestARTCacheTraceEndToEnd asserts the COMPLETE cache sections of the ART
+// trace for the representative scenarios.
+func TestARTCacheTraceEndToEnd(t *testing.T) {
+	t.Run("L2 miss then hit", func(t *testing.T) {
+		store := cachetesting.NewFakeStore()
+		query := `{ me { favoriteProduct { upc stock } } }`
+		caching := map[string]cacheconfig.CachingConfiguration{
+			"inventory": {Entities: []cacheconfig.EntityCachePolicy{{TypeName: "Product", CacheName: "inventory", TTL: time.Minute}}},
+		}
+		responses := map[string]string{
+			"users":                        `{"data":{"me":{"__typename":"User","id":"u1"}}}`,
+			"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
+			"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
+		}
+
+		first := Plan(t, query, caching, responses)
+		firstBody := resolveTraced(t, first.Response, store)
+		assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"upc":"1","stock":5}}}}`, firstBody)
+		key := store.Ops()[0].Key
+		assert.Equal(t, []string{
+			`path:"me.favoriteProduct" {"decision":"Fetch","hit":false,"items":[{"keys":["` + key + `"],"hit":false,"write_reason":"refresh"}]}`,
+		}, cacheTraces(t, first.Response.Fetches))
+
+		second := Plan(t, query, caching, responses)
+		secondBody := resolveTraced(t, second.Response, store)
+		assert.Equal(t, firstBody, secondBody)
+		assert.Equal(t, []string{
+			`path:"me.favoriteProduct" {"decision":"SkipFullHit","hit":true,"items":[{"keys":["` + key + `"],"served_from":"l2","hit":true,"remaining_ttl_nanoseconds":-1}]}`,
+		}, cacheTraces(t, second.Response.Fetches))
+	})
+
+	t.Run("L1 hit within one request", func(t *testing.T) {
+		store := cachetesting.NewFakeStore()
+		result := Plan(t, l1ChainQuery, productL1Caching(0), l1ChainResponses())
+		body := resolveTraced(t, result.Response, store)
+		assert.Equal(t, l1ChainExpected, body)
+		traces := cacheTraces(t, result.Response.Fetches)
+		require.Len(t, traces, 2)
+		assert.Contains(t, traces[0], `path:"deal.product" {"decision":"Fetch","hit":false`)
+		assert.Contains(t, traces[1], `"decision":"SkipFullHit","hit":true,"items":[{"keys":["`)
+		assert.Contains(t, traces[1], `"served_from":"l1","hit":true,"pending_candidates":1}]`)
+	})
+
+	t.Run("shadow compare", func(t *testing.T) {
+		store := cachetesting.NewFakeStore()
+		query := `{ me { favoriteProduct { upc stock } } }`
+		responses := map[string]string{
+			"users":                        `{"data":{"me":{"__typename":"User","id":"u1"}}}`,
+			"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
+			"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
+		}
+		prime := Plan(t, query, inventoryShadowCaching(), responses)
+		resolveTraced(t, prime.Response, store)
+		key := store.Ops()[0].Key
+
+		second := Plan(t, query, inventoryShadowCaching(), responses)
+		secondBody := resolveTraced(t, second.Response, store)
+		assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"upc":"1","stock":5}}}}`, secondBody)
+		assert.Equal(t, []string{
+			`path:"me.favoriteProduct" {"decision":"FetchShadow","hit":false,"shadow":true,"items":[{"keys":["` + key + `"],"hit":false,"write_reason":"refresh"}],"shadow_compares":[{"key":"` + key + `","is_fresh":true,"cache_age_nanoseconds":-1}]}`,
+		}, cacheTraces(t, second.Response.Fetches))
+	})
+
+	t.Run("partial batch", func(t *testing.T) {
+		store := cachetesting.NewFakeStore()
+		prime := Plan(t, `{ products(first: 1) { upc reviews { body } } }`, reviewsPartialCaching(), map[string]string{
+			"products": `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`,
+			"reviews":  `{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","body":"great table"}]}]}}`,
+		})
+		resolveTraced(t, prime.Response, store)
+
+		second := Plan(t, `{ products(first: 2) { upc reviews { body } } }`, reviewsPartialCaching(), map[string]string{
+			"products": `{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"}]}}`,
+			"reviews":  `{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","body":"sturdy chair"}]}]}}`,
+		})
+		body := resolveTraced(t, second.Response, store)
+		assert.Equal(t,
+			`{"data":{"products":[{"upc":"1","reviews":[{"body":"great table"}]},{"upc":"2","reviews":[{"body":"sturdy chair"}]}]}}`,
+			body)
+		traces := cacheTraces(t, second.Response.Fetches)
+		require.Len(t, traces, 1)
+		assert.Contains(t, traces[0], `"decision":"FetchPartial","hit":false`)
+		assert.Contains(t, traces[0], `"served_from":"l2","hit":true,"remaining_ttl_nanoseconds":-1`)
+		assert.Contains(t, traces[0], `"hit":false,"write_reason":"refresh"`)
+	})
+
+	t.Run("regression: tracing off leaves fetch traces nil", func(t *testing.T) {
+		store := cachetesting.NewFakeStore()
+		result := Plan(t, `{ me { favoriteProduct { upc stock } } }`, map[string]cacheconfig.CachingConfiguration{
+			"inventory": {Entities: []cacheconfig.EntityCachePolicy{{TypeName: "Product", CacheName: "inventory", TTL: time.Minute}}},
+		}, map[string]string{
+			"users":                        `{"data":{"me":{"__typename":"User","id":"u1"}}}`,
+			"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
+			"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
+		})
+		body := ResolveResponse(t, result.Response, cachetesting.NewRealishCache(store, nil))
+		assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"upc":"1","stock":5}}}}`, body)
+		assert.Empty(t, cacheTraces(t, result.Response.Fetches))
+	})
+}

--- a/execution/cachingtesting/batch_e2e_test.go
+++ b/execution/cachingtesting/batch_e2e_test.go
@@ -1,0 +1,104 @@
+package cachingtesting
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/cache/cachetesting"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
+)
+
+// reviewsEntityCaching enables entity caching for the reviews subgraph's
+// Product (the batch entity fetch under products).
+func reviewsEntityCaching() map[string]cacheconfig.CachingConfiguration {
+	return map[string]cacheconfig.CachingConfiguration{
+		"reviews": {
+			Entities: []cacheconfig.EntityCachePolicy{
+				{TypeName: "Product", CacheName: "entities", TTL: time.Minute},
+			},
+		},
+	}
+}
+
+const batchQuery = `{ products(first: 2) { upc reviews { body } } }`
+
+func batchResponses(products, entities string) map[string]string {
+	return map[string]string{
+		"products": products,
+		"reviews":  entities,
+	}
+}
+
+// TestBatchEntityL2EndToEnd: request 1 populates one entry PER entity from the
+// batch response; request 2 is a full-batch hit with ZERO network to reviews.
+func TestBatchEntityL2EndToEnd(t *testing.T) {
+	store := cachetesting.NewFakeStore()
+	products := `{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"}]}}`
+	entities := `{"data":{"_entities":[{"__typename":"Product","reviews":[{"body":"Solid"}]},{"__typename":"Product","reviews":[{"body":"Wobbly"}]}]}}`
+	expected := `{"data":{"products":[{"upc":"1","reviews":[{"body":"Solid"}]},{"upc":"2","reviews":[{"body":"Wobbly"}]}]}}`
+
+	first := Plan(t, batchQuery, reviewsEntityCaching(), batchResponses(products, entities))
+	firstBody := ResolveResponse(t, first.Response, cachetesting.NewRealishCache(store, nil))
+	assert.Equal(t, expected, firstBody)
+	assert.Equal(t, int64(1), first.LoadCount("reviews", "products"))
+
+	firstOps := store.Ops()
+	require.Len(t, firstOps, 4)
+	key1, key2 := firstOps[0].Key, firstOps[1].Key
+	assert.NotEqual(t, key1, key2)
+	assert.Equal(t, []cachetesting.StoreOp{
+		{Kind: "Get", Key: key1},
+		{Kind: "Get", Key: key2},
+		{Kind: "Set", Key: key1, Value: `{"__typename":"Product","reviews":[{"body":"Solid"}]}`, TTL: time.Minute},
+		{Kind: "Set", Key: key2, Value: `{"__typename":"Product","reviews":[{"body":"Wobbly"}]}`, TTL: time.Minute},
+	}, firstOps)
+
+	second := Plan(t, batchQuery, reviewsEntityCaching(), batchResponses(products, entities))
+	secondBody := ResolveResponse(t, second.Response, cachetesting.NewRealishCache(store, nil))
+	assert.Equal(t, expected, secondBody)
+	assert.Equal(t, int64(0), second.LoadCount("reviews", "products"))
+	assert.Equal(t, []cachetesting.StoreOp{
+		{Kind: "Get", Key: key1},
+		{Kind: "Get", Key: key2},
+		{Kind: "Set", Key: key1, Value: `{"__typename":"Product","reviews":[{"body":"Solid"}]}`, TTL: time.Minute},
+		{Kind: "Set", Key: key2, Value: `{"__typename":"Product","reviews":[{"body":"Wobbly"}]}`, TTL: time.Minute},
+		{Kind: "Get", Key: key1},
+		{Kind: "Get", Key: key2},
+	}, store.Ops())
+}
+
+// TestBatchEntityMixedRun: only ONE of two entities is primed; the batch must
+// fully refetch (no partial serving in this task), produce the correct
+// response, and write entries for ALL entities afterwards.
+func TestBatchEntityMixedRun(t *testing.T) {
+	store := cachetesting.NewFakeStore()
+
+	// Prime ONLY upc 1 through a single-product run.
+	prime := Plan(t, `{ products(first: 1) { upc reviews { body } } }`, reviewsEntityCaching(), batchResponses(
+		`{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`,
+		`{"data":{"_entities":[{"__typename":"Product","reviews":[{"body":"Solid"}]}]}}`,
+	))
+	ResolveResponse(t, prime.Response, cachetesting.NewRealishCache(store, nil))
+	require.Equal(t, int64(1), prime.LoadCount("reviews", "products"))
+
+	// The mixed batch (upc 1 primed, upc 3 not) refetches EVERYTHING.
+	mixed := Plan(t, batchQuery, reviewsEntityCaching(), batchResponses(
+		`{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"3"}]}}`,
+		`{"data":{"_entities":[{"__typename":"Product","reviews":[{"body":"Solid"}]},{"__typename":"Product","reviews":[{"body":"New"}]}]}}`,
+	))
+	mixedBody := ResolveResponse(t, mixed.Response, cachetesting.NewRealishCache(store, nil))
+	assert.Equal(t, `{"data":{"products":[{"upc":"1","reviews":[{"body":"Solid"}]},{"upc":"3","reviews":[{"body":"New"}]}]}}`, mixedBody)
+	assert.Equal(t, int64(1), mixed.LoadCount("reviews", "products"))
+
+	// Afterwards BOTH entities are cached: a repeat of the mixed batch hits.
+	repeat := Plan(t, batchQuery, reviewsEntityCaching(), batchResponses(
+		`{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"3"}]}}`,
+		``,
+	))
+	repeatBody := ResolveResponse(t, repeat.Response, cachetesting.NewRealishCache(store, nil))
+	assert.Equal(t, `{"data":{"products":[{"upc":"1","reviews":[{"body":"Solid"}]},{"upc":"3","reviews":[{"body":"New"}]}]}}`, repeatBody)
+	assert.Equal(t, int64(0), repeat.LoadCount("reviews", "products"))
+}

--- a/execution/cachingtesting/batch_e2e_test.go
+++ b/execution/cachingtesting/batch_e2e_test.go
@@ -23,24 +23,18 @@ func reviewsEntityCaching() map[string]cacheconfig.CachingConfiguration {
 	}
 }
 
-const batchQuery = `{ products(first: 2) { upc reviews { body } } }`
-
-func batchResponses(products, entities string) map[string]string {
-	return map[string]string{
-		"products": products,
-		"reviews":  entities,
-	}
-}
-
 // TestBatchEntityL2EndToEnd: request 1 populates one entry PER entity from the
 // batch response; request 2 is a full-batch hit with ZERO network to reviews.
 func TestBatchEntityL2EndToEnd(t *testing.T) {
 	store := cachetesting.NewFakeStore()
-	products := `{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"}]}}`
-	entities := `{"data":{"_entities":[{"__typename":"Product","reviews":[{"body":"Solid"}]},{"__typename":"Product","reviews":[{"body":"Wobbly"}]}]}}`
+	query := `{ products(first: 2) { upc reviews { body } } }`
+	responses := map[string]string{
+		"products": `{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"}]}}`,
+		"reviews":  `{"data":{"_entities":[{"__typename":"Product","reviews":[{"body":"Solid"}]},{"__typename":"Product","reviews":[{"body":"Wobbly"}]}]}}`,
+	}
 	expected := `{"data":{"products":[{"upc":"1","reviews":[{"body":"Solid"}]},{"upc":"2","reviews":[{"body":"Wobbly"}]}]}}`
 
-	first := Plan(t, batchQuery, reviewsEntityCaching(), batchResponses(products, entities))
+	first := Plan(t, query, reviewsEntityCaching(), responses)
 	firstBody := ResolveResponse(t, first.Response, cachetesting.NewRealishCache(store, nil))
 	assert.Equal(t, expected, firstBody)
 	assert.Equal(t, int64(1), first.LoadCount("reviews", "products"))
@@ -56,7 +50,7 @@ func TestBatchEntityL2EndToEnd(t *testing.T) {
 		{Kind: "Set", Key: key2, Value: `{"__typename":"Product","reviews":[{"body":"Wobbly"}]}`, TTL: time.Minute},
 	}, firstOps)
 
-	second := Plan(t, batchQuery, reviewsEntityCaching(), batchResponses(products, entities))
+	second := Plan(t, query, reviewsEntityCaching(), responses)
 	secondBody := ResolveResponse(t, second.Response, cachetesting.NewRealishCache(store, nil))
 	assert.Equal(t, expected, secondBody)
 	assert.Equal(t, int64(0), second.LoadCount("reviews", "products"))
@@ -77,27 +71,28 @@ func TestBatchEntityMixedRun(t *testing.T) {
 	store := cachetesting.NewFakeStore()
 
 	// Prime ONLY upc 1 through a single-product run.
-	prime := Plan(t, `{ products(first: 1) { upc reviews { body } } }`, reviewsEntityCaching(), batchResponses(
-		`{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`,
-		`{"data":{"_entities":[{"__typename":"Product","reviews":[{"body":"Solid"}]}]}}`,
-	))
+	prime := Plan(t, `{ products(first: 1) { upc reviews { body } } }`, reviewsEntityCaching(), map[string]string{
+		"products": `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`,
+		"reviews":  `{"data":{"_entities":[{"__typename":"Product","reviews":[{"body":"Solid"}]}]}}`,
+	})
 	ResolveResponse(t, prime.Response, cachetesting.NewRealishCache(store, nil))
 	require.Equal(t, int64(1), prime.LoadCount("reviews", "products"))
 
 	// The mixed batch (upc 1 primed, upc 3 not) refetches EVERYTHING.
-	mixed := Plan(t, batchQuery, reviewsEntityCaching(), batchResponses(
-		`{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"3"}]}}`,
-		`{"data":{"_entities":[{"__typename":"Product","reviews":[{"body":"Solid"}]},{"__typename":"Product","reviews":[{"body":"New"}]}]}}`,
-	))
+	query := `{ products(first: 2) { upc reviews { body } } }`
+	mixed := Plan(t, query, reviewsEntityCaching(), map[string]string{
+		"products": `{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"3"}]}}`,
+		"reviews":  `{"data":{"_entities":[{"__typename":"Product","reviews":[{"body":"Solid"}]},{"__typename":"Product","reviews":[{"body":"New"}]}]}}`,
+	})
 	mixedBody := ResolveResponse(t, mixed.Response, cachetesting.NewRealishCache(store, nil))
 	assert.Equal(t, `{"data":{"products":[{"upc":"1","reviews":[{"body":"Solid"}]},{"upc":"3","reviews":[{"body":"New"}]}]}}`, mixedBody)
 	assert.Equal(t, int64(1), mixed.LoadCount("reviews", "products"))
 
 	// Afterwards BOTH entities are cached: a repeat of the mixed batch hits.
-	repeat := Plan(t, batchQuery, reviewsEntityCaching(), batchResponses(
-		`{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"3"}]}}`,
-		``,
-	))
+	repeat := Plan(t, query, reviewsEntityCaching(), map[string]string{
+		"products": `{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"3"}]}}`,
+		"reviews":  ``,
+	})
 	repeatBody := ResolveResponse(t, repeat.Response, cachetesting.NewRealishCache(store, nil))
 	assert.Equal(t, `{"data":{"products":[{"upc":"1","reviews":[{"body":"Solid"}]},{"upc":"3","reviews":[{"body":"New"}]}]}}`, repeatBody)
 	assert.Equal(t, int64(0), repeat.LoadCount("reviews", "products"))

--- a/execution/cachingtesting/batch_e2e_test.go
+++ b/execution/cachingtesting/batch_e2e_test.go
@@ -25,19 +25,19 @@ func reviewsEntityCaching() map[string]cacheconfig.CachingConfiguration {
 
 // TestBatchEntityL2EndToEnd: request 1 populates one entry PER entity from the
 // batch response; request 2 is a full-batch hit with ZERO network to reviews.
+// Runs through the REAL ExecutionEngine over HTTP subgraph doubles.
 func TestBatchEntityL2EndToEnd(t *testing.T) {
 	store := cachetesting.NewFakeStore()
+	controller := cachetesting.NewRealishCache(store, nil)
 	query := `{ products(first: 2) { upc reviews { body } } }`
-	responses := map[string]string{
-		"products": `{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"}]}}`,
-		"reviews":  `{"data":{"_entities":[{"__typename":"Product","reviews":[{"body":"Solid"}]},{"__typename":"Product","reviews":[{"body":"Wobbly"}]}]}}`,
-	}
+	products := Respond(`{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"}]}}`)
+	reviews := Respond(`{"data":{"_entities":[{"__typename":"Product","reviews":[{"body":"Solid"}]},{"__typename":"Product","reviews":[{"body":"Wobbly"}]}]}}`)
+	executionEngine := NewEngine(t, reviewsEntityCaching(), Subgraphs{"products": products, "reviews": reviews})
 	expected := `{"data":{"products":[{"upc":"1","reviews":[{"body":"Solid"}]},{"upc":"2","reviews":[{"body":"Wobbly"}]}]}}`
 
-	first := Plan(t, query, reviewsEntityCaching(), responses)
-	firstBody := ResolveResponse(t, first.Response, cachetesting.NewRealishCache(store, nil))
+	firstBody := Execute(t, executionEngine, query, controller)
 	assert.Equal(t, expected, firstBody)
-	assert.Equal(t, int64(1), first.LoadCount("reviews", "products"))
+	assert.Equal(t, int64(1), reviews.Requests())
 
 	firstOps := store.Ops()
 	require.Len(t, firstOps, 4)
@@ -50,13 +50,12 @@ func TestBatchEntityL2EndToEnd(t *testing.T) {
 		{Kind: "Set", Key: key2, Value: `{"__typename":"Product","reviews":[{"body":"Wobbly"}]}`, TTL: time.Minute},
 	}, firstOps)
 
-	// Request 2's ops assert in isolation.
+	// Request 2's ops assert in isolation: a full-batch hit — the reviews
+	// upstream is NOT hit again, and exactly one Get per entity, no writes.
 	store.ResetOps()
-	second := Plan(t, query, reviewsEntityCaching(), responses)
-	secondBody := ResolveResponse(t, second.Response, cachetesting.NewRealishCache(store, nil))
+	secondBody := Execute(t, executionEngine, query, controller)
 	assert.Equal(t, expected, secondBody)
-	assert.Equal(t, int64(0), second.LoadCount("reviews", "products"))
-	// The full-batch hit performs exactly one Get per entity — no writes.
+	assert.Equal(t, int64(1), reviews.Requests())
 	assert.Equal(t, []cachetesting.StoreOp{
 		{Kind: "Get", Key: key1},
 		{Kind: "Get", Key: key2},
@@ -68,31 +67,35 @@ func TestBatchEntityL2EndToEnd(t *testing.T) {
 // response, and write entries for ALL entities afterwards.
 func TestBatchEntityMixedRun(t *testing.T) {
 	store := cachetesting.NewFakeStore()
+	controller := cachetesting.NewRealishCache(store, nil)
+
+	// The subgraph doubles route by REQUEST BODY: the one-product request
+	// primes upc 1; the two-product request returns both entities. The reviews
+	// double distinguishes the batches by their representations.
+	products := Rules(
+		Rule(`"variables":{"a":1}`, `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`),
+		Rule(`"variables":{"a":2}`, `{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"3"}]}}`),
+	)
+	reviews := Rules(
+		Rule(`{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"3"}`, `{"data":{"_entities":[{"__typename":"Product","reviews":[{"body":"Solid"}]},{"__typename":"Product","reviews":[{"body":"New"}]}]}}`),
+		Rule(`"upc":"1"`, `{"data":{"_entities":[{"__typename":"Product","reviews":[{"body":"Solid"}]}]}}`),
+	)
+	executionEngine := NewEngine(t, reviewsEntityCaching(), Subgraphs{"products": products, "reviews": reviews})
 
 	// Prime ONLY upc 1 through a single-product run.
-	prime := Plan(t, `{ products(first: 1) { upc reviews { body } } }`, reviewsEntityCaching(), map[string]string{
-		"products": `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`,
-		"reviews":  `{"data":{"_entities":[{"__typename":"Product","reviews":[{"body":"Solid"}]}]}}`,
-	})
-	ResolveResponse(t, prime.Response, cachetesting.NewRealishCache(store, nil))
-	require.Equal(t, int64(1), prime.LoadCount("reviews", "products"))
+	primeBody := Execute(t, executionEngine, `{ products(first: 1) { upc reviews { body } } }`, controller)
+	assert.Equal(t, `{"data":{"products":[{"upc":"1","reviews":[{"body":"Solid"}]}]}}`, primeBody)
+	require.Equal(t, int64(1), reviews.Requests())
 
 	// The mixed batch (upc 1 primed, upc 3 not) refetches EVERYTHING.
 	query := `{ products(first: 2) { upc reviews { body } } }`
-	mixed := Plan(t, query, reviewsEntityCaching(), map[string]string{
-		"products": `{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"3"}]}}`,
-		"reviews":  `{"data":{"_entities":[{"__typename":"Product","reviews":[{"body":"Solid"}]},{"__typename":"Product","reviews":[{"body":"New"}]}]}}`,
-	})
-	mixedBody := ResolveResponse(t, mixed.Response, cachetesting.NewRealishCache(store, nil))
+	mixedBody := Execute(t, executionEngine, query, controller)
 	assert.Equal(t, `{"data":{"products":[{"upc":"1","reviews":[{"body":"Solid"}]},{"upc":"3","reviews":[{"body":"New"}]}]}}`, mixedBody)
-	assert.Equal(t, int64(1), mixed.LoadCount("reviews", "products"))
+	assert.Equal(t, int64(2), reviews.Requests())
 
-	// Afterwards BOTH entities are cached: a repeat of the mixed batch hits.
-	repeat := Plan(t, query, reviewsEntityCaching(), map[string]string{
-		"products": `{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"3"}]}}`,
-		"reviews":  ``,
-	})
-	repeatBody := ResolveResponse(t, repeat.Response, cachetesting.NewRealishCache(store, nil))
+	// Afterwards BOTH entities are cached: a repeat of the mixed batch hits
+	// with no further reviews request.
+	repeatBody := Execute(t, executionEngine, query, controller)
 	assert.Equal(t, `{"data":{"products":[{"upc":"1","reviews":[{"body":"Solid"}]},{"upc":"3","reviews":[{"body":"New"}]}]}}`, repeatBody)
-	assert.Equal(t, int64(0), repeat.LoadCount("reviews", "products"))
+	assert.Equal(t, int64(2), reviews.Requests())
 }

--- a/execution/cachingtesting/batch_e2e_test.go
+++ b/execution/cachingtesting/batch_e2e_test.go
@@ -50,15 +50,14 @@ func TestBatchEntityL2EndToEnd(t *testing.T) {
 		{Kind: "Set", Key: key2, Value: `{"__typename":"Product","reviews":[{"body":"Wobbly"}]}`, TTL: time.Minute},
 	}, firstOps)
 
+	// Request 2's ops assert in isolation.
+	store.ResetOps()
 	second := Plan(t, query, reviewsEntityCaching(), responses)
 	secondBody := ResolveResponse(t, second.Response, cachetesting.NewRealishCache(store, nil))
 	assert.Equal(t, expected, secondBody)
 	assert.Equal(t, int64(0), second.LoadCount("reviews", "products"))
+	// The full-batch hit performs exactly one Get per entity — no writes.
 	assert.Equal(t, []cachetesting.StoreOp{
-		{Kind: "Get", Key: key1},
-		{Kind: "Get", Key: key2},
-		{Kind: "Set", Key: key1, Value: `{"__typename":"Product","reviews":[{"body":"Solid"}]}`, TTL: time.Minute},
-		{Kind: "Set", Key: key2, Value: `{"__typename":"Product","reviews":[{"body":"Wobbly"}]}`, TTL: time.Minute},
 		{Kind: "Get", Key: key1},
 		{Kind: "Get", Key: key2},
 	}, store.Ops())

--- a/execution/cachingtesting/cachingtesting.go
+++ b/execution/cachingtesting/cachingtesting.go
@@ -12,9 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"slices"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -188,72 +186,6 @@ func ResolveResponse(tb testing.TB, resp *resolve.GraphQLResponse, controller re
 	_, err := r.ResolveGraphQLResponse(ctx, resp, nil, &buf)
 	require.NoError(tb, err)
 	return buf.String()
-}
-
-// deferFrameWriter captures each flushed incremental frame as one COMPLETE
-// payload string (safe for concurrent Write/Flush from group goroutines).
-type deferFrameWriter struct {
-	mu       sync.Mutex
-	buf      bytes.Buffer
-	frames   []string
-	complete bool
-	// Flushed (optional) receives one signal per flushed frame, so tests can
-	// gate on frame progress with pure channel synchronization (no polling,
-	// no latency). Buffer it generously; Flush blocks on a full channel.
-	Flushed chan struct{}
-}
-
-func (w *deferFrameWriter) Write(p []byte) (int, error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	return w.buf.Write(p)
-}
-
-func (w *deferFrameWriter) Flush() error {
-	w.mu.Lock()
-	w.frames = append(w.frames, w.buf.String())
-	w.buf.Reset()
-	w.mu.Unlock()
-	if w.Flushed != nil {
-		w.Flushed <- struct{}{}
-	}
-	return nil
-}
-
-func (w *deferFrameWriter) Complete() {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	w.complete = true
-}
-
-// Frames returns the flushed frames so far (usable mid-resolve for gating).
-func (w *deferFrameWriter) Frames() []string {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	return slices.Clone(w.frames)
-}
-
-// ResolveDeferResponse resolves a deferred response end to end and returns
-// every flushed incremental frame as a complete string.
-func ResolveDeferResponse(tb testing.TB, resp *resolve.GraphQLDeferResponse, controller resolve.CacheController) []string {
-	tb.Helper()
-	writer := &deferFrameWriter{}
-	ResolveDeferResponseWith(tb, resp, controller, writer)
-	return writer.frames
-}
-
-// ResolveDeferResponseWith is ResolveDeferResponse with a caller-owned writer,
-// for tests that gate on frames mid-resolve.
-func ResolveDeferResponseWith(tb testing.TB, resp *resolve.GraphQLDeferResponse, controller resolve.CacheController, writer *deferFrameWriter) {
-	tb.Helper()
-	ctx := resolve.NewContext(tb.Context())
-	if controller != nil {
-		ctx.SetCacheController(controller)
-	}
-	r := resolve.New(tb.Context(), resolve.ResolverOptions{MaxConcurrency: 16})
-	_, err := r.ResolveGraphQLDeferResponse(ctx, resp, writer)
-	require.NoError(tb, err)
-	require.True(tb, writer.complete)
 }
 
 // PrettyPlan renders the ENTIRE execution plan as one engine-pretty-printed

--- a/execution/cachingtesting/cachingtesting.go
+++ b/execution/cachingtesting/cachingtesting.go
@@ -42,6 +42,9 @@ type PlanResult struct {
 	DeferResponse *resolve.GraphQLDeferResponse
 	Fakes         *cachetesting.FakeRegistry
 
+	// tb lets the name-keyed accessors fail fast on typo'd subgraph names
+	// instead of silently reading empty registry state.
+	tb testing.TB
 	// nameToID translates subgraph names to the ID-named datasources of the
 	// factory-built configuration, so tests can keep using subgraph names.
 	nameToID map[string]string
@@ -53,14 +56,14 @@ func (p PlanResult) Inputs(name, path string) []string {
 	return p.Fakes.Inputs(p.datasourceID(name), path)
 }
 
-// datasourceID resolves a subgraph name to its datasource ID, falling back to
-// the literal name (consistent with LoadCount — a typo'd name can then never
-// silently register an unusable gate or fetch path).
+// datasourceID resolves a subgraph name to its datasource ID; an unknown name
+// fails the test immediately, so a typo can never make a LoadCount/Inputs
+// assertion pass vacuously or register an unusable gate.
 func (p PlanResult) datasourceID(name string) string {
-	if id, ok := p.nameToID[name]; ok {
-		return id
-	}
-	return name
+	p.tb.Helper()
+	id, ok := p.nameToID[name]
+	require.True(p.tb, ok, "unknown subgraph name %q", name)
+	return id
 }
 
 // Gate attaches gate channels to the fake datasource for the given SUBGRAPH
@@ -81,11 +84,7 @@ func (p PlanResult) Gate(name, path string, gate cachetesting.DataSourceGate) {
 // LoadCount returns how often the fake datasource for the given SUBGRAPH NAME
 // loaded at the given response path.
 func (r PlanResult) LoadCount(subgraphName, path string) int64 {
-	id, ok := r.nameToID[subgraphName]
-	if !ok {
-		id = subgraphName
-	}
-	return r.Fakes.LoadCount(id, path)
+	return r.Fakes.LoadCount(r.datasourceID(subgraphName), path)
 }
 
 // Plan runs the real planner + postprocess over query against the committed
@@ -153,7 +152,8 @@ func Plan(tb testing.TB, query string, caching map[string]cacheconfig.CachingCon
 	postprocess.NewProcessor(processorOptions...).Process(raw)
 
 	result := PlanResult{
-		Fakes:    cachetesting.NewFakeRegistry(translateResponseKeys(responses, nameToID)),
+		Fakes:    cachetesting.NewFakeRegistry(translateResponseKeys(tb, responses, nameToID)),
+		tb:       tb,
 		nameToID: nameToID,
 	}
 	switch p := raw.(type) {
@@ -321,20 +321,28 @@ func subgraphNameToDatasourceID(rc *nodev1.RouterConfig) map[string]string {
 
 // translateResponseKeys rewrites subgraph-name response keys ("products",
 // "products:path") to the datasource-ID keys FakeRegistry matches on at
-// runtime; unknown prefixes (e.g. "*") pass through unchanged.
-func translateResponseKeys(responses map[string]string, nameToID map[string]string) map[string]string {
+// runtime; unknown prefixes (e.g. "*") pass through unchanged. Two source keys
+// landing on the same registry key (a subgraph name AND its raw datasource ID)
+// fail the test instead of letting map iteration pick a winner.
+func translateResponseKeys(tb testing.TB, responses map[string]string, nameToID map[string]string) map[string]string {
+	tb.Helper()
 	out := make(map[string]string, len(responses))
+	translated := make(map[string]string, len(responses))
 	for key, value := range responses {
 		name, path, hasPath := strings.Cut(key, ":")
+		outKey := key
 		if id, ok := nameToID[name]; ok {
 			if hasPath {
-				out[id+":"+path] = value
+				outKey = id + ":" + path
 			} else {
-				out[id] = value
+				outKey = id
 			}
-			continue
 		}
-		out[key] = value
+		if prev, collides := translated[outKey]; collides {
+			tb.Fatalf("response keys %q and %q both translate to %q", prev, key, outKey)
+		}
+		translated[outKey] = key
+		out[outKey] = value
 	}
 	return out
 }

--- a/execution/cachingtesting/cachingtesting.go
+++ b/execution/cachingtesting/cachingtesting.go
@@ -1,0 +1,211 @@
+// Package cachingtesting is the plan-driven caching test harness: it loads the
+// committed wgc-composed config.json of the dedicated caching subgraphs, runs
+// the REAL v2 planner and postprocess over a query (with caching wired exactly
+// as the engine Configuration wires it), and swaps every fetch's transport for
+// an in-process fake. Tests then drive the public resolve entry points and
+// assert complete responses — no hand-written plans, no golden files.
+package cachingtesting
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	nodev1 "github.com/wundergraph/cosmo/router/gen/proto/wg/cosmo/node/v1"
+
+	"github.com/wundergraph/graphql-go-tools/execution/engine"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astnormalization"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astparser"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/asttransform"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astvalidation"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/cache/cachetesting"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/postprocess"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/operationreport"
+)
+
+// PlanResult is the harness output: the postprocessed response (and defer
+// response for defer plans) with all datasources swapped for fakes.
+type PlanResult struct {
+	Response      *resolve.GraphQLResponse
+	DeferResponse *resolve.GraphQLDeferResponse
+	Fakes         *cachetesting.FakeRegistry
+}
+
+// Plan runs the real planner + postprocess over query against the committed
+// caching fixture config. caching is keyed by SUBGRAPH NAME (translated to
+// datasource IDs internally); nil/empty leaves caching fully unconfigured (the
+// no-op baseline). responses feed the fake datasources and may also be keyed
+// by subgraph name (or name:responsePath, responsePath, "*").
+func Plan(tb testing.TB, query string, caching map[string]cacheconfig.CachingConfiguration, responses map[string]string) PlanResult {
+	tb.Helper()
+
+	rc := routerConfig(tb)
+	factory := engine.NewFederationEngineConfigFactory(tb.Context())
+	conf, err := factory.BuildEngineConfiguration(rc)
+	require.NoError(tb, err)
+	cfg := conf.PlannerConfig()
+
+	def, parseReport := astparser.ParseGraphqlDocumentString(rc.EngineConfig.GraphqlSchema)
+	require.False(tb, parseReport.HasErrors(), "parse schema: %v", parseReport)
+	require.NoError(tb, asttransform.MergeDefinitionWithBaseSchema(&def))
+	op, parseReport := astparser.ParseGraphqlDocumentString(query)
+	require.False(tb, parseReport.HasErrors(), "parse query: %v", parseReport)
+
+	norm := astnormalization.NewWithOpts(
+		astnormalization.WithExtractVariables(),
+		astnormalization.WithInlineFragmentSpreads(),
+		astnormalization.WithRemoveFragmentDefinitions(),
+		astnormalization.WithRemoveUnusedVariables(),
+		astnormalization.WithEnableDefer(),
+	)
+	var report operationreport.Report
+	norm.NormalizeOperation(&op, &def, &report)
+	astvalidation.DefaultOperationValidator().Validate(&op, &def, &report)
+	require.False(tb, report.HasErrors(), "normalize/validate: %s", report.Error())
+
+	nameToID := subgraphNameToDatasourceID(rc)
+
+	// Wire caching exactly as NewExecutionEngine does for SetCaching: providers
+	// + federation keyed by datasource ID, FetchInfo force-enabled.
+	var processorOptions []postprocess.ProcessorOption
+	if len(caching) > 0 {
+		providers := make(map[string]cacheconfig.CacheConfigProvider, len(caching))
+		for name, cachingCfg := range caching {
+			id, ok := nameToID[name]
+			require.True(tb, ok, "caching configured for unknown subgraph %q", name)
+			providers[id] = &cachingCfg
+		}
+		federation := make(map[string]plan.FederationMetaData, len(providers))
+		for _, ds := range cfg.DataSources {
+			if _, ok := providers[ds.Id()]; ok {
+				federation[ds.Id()] = ds.FederationConfiguration()
+			}
+		}
+		cfg.CacheConfigProviders = providers
+		cfg.DisableIncludeInfo = false
+		processorOptions = append(processorOptions, postprocess.EnableCaching(providers, federation, &def))
+	}
+
+	planner, err := plan.NewPlanner(cfg)
+	require.NoError(tb, err)
+	// Query plans are always included so tests can make full-value plan-shape
+	// assertions on the rendered fetch trees (instead of golden files).
+	raw := planner.Plan(&op, &def, "", &report, plan.IncludeQueryPlanInResponse())
+	require.False(tb, report.HasErrors(), "plan: %s", report.Error())
+
+	postprocess.NewProcessor(processorOptions...).Process(raw)
+
+	result := PlanResult{
+		Fakes: cachetesting.NewFakeRegistry(translateResponseKeys(responses, nameToID)),
+	}
+	switch p := raw.(type) {
+	case *plan.SynchronousResponsePlan:
+		result.Response = p.Response
+	case *plan.DeferResponsePlan:
+		result.Response = p.Response.Response
+		result.DeferResponse = p.Response
+	default:
+		tb.Fatalf("unsupported plan type %T", raw)
+	}
+
+	cachetesting.SwapDataSources(result.Response.Fetches, result.Fakes)
+	for _, group := range DeferGroups(result.DeferResponse) {
+		cachetesting.SwapDataSources(group.Fetches, result.Fakes)
+	}
+	return result
+}
+
+// ResolveResponse drives the PUBLIC sync entry point over a harness plan with
+// the given cache controller (nil = caching off) and returns the complete
+// response body.
+func ResolveResponse(tb testing.TB, resp *resolve.GraphQLResponse, controller resolve.CacheController) string {
+	tb.Helper()
+
+	ctx := resolve.NewContext(tb.Context())
+	if controller != nil {
+		ctx.SetCacheController(controller)
+	}
+	var buf bytes.Buffer
+	r := resolve.New(tb.Context(), resolve.ResolverOptions{MaxConcurrency: 16})
+	_, err := r.ResolveGraphQLResponse(ctx, resp, nil, &buf)
+	require.NoError(tb, err)
+	return buf.String()
+}
+
+// DeferGroups flattens a defer response's groups (the extracted Defers list
+// plus the built DeferTree) so tests can reach every deferred fetch tree.
+func DeferGroups(resp *resolve.GraphQLDeferResponse) []*resolve.DeferFetchGroup {
+	if resp == nil {
+		return nil
+	}
+	groups := append([]*resolve.DeferFetchGroup(nil), resp.Defers...)
+	return appendDeferTreeGroups(groups, resp.DeferTree)
+}
+
+func appendDeferTreeGroups(groups []*resolve.DeferFetchGroup, node *resolve.DeferTreeNode) []*resolve.DeferFetchGroup {
+	if node == nil {
+		return groups
+	}
+	if node.Item != nil {
+		groups = append(groups, node.Item)
+	}
+	for _, child := range node.ChildNodes {
+		groups = appendDeferTreeGroups(groups, child)
+	}
+	return groups
+}
+
+// routerConfig loads the committed wgc-composed config.json next to this file,
+// so the harness works from any test package in the execution module.
+func routerConfig(tb testing.TB) *nodev1.RouterConfig {
+	tb.Helper()
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(tb, ok, "cannot locate cachingtesting package dir")
+	data, err := os.ReadFile(filepath.Join(filepath.Dir(thisFile), "config.json"))
+	require.NoError(tb, err)
+
+	var rc nodev1.RouterConfig
+	require.NoError(tb, protojson.Unmarshal(data, &rc))
+	return &rc
+}
+
+// subgraphNameToDatasourceID maps subgraph names to the datasource IDs the
+// factory-built planner configuration uses (the router config keeps them in
+// its subgraph list).
+func subgraphNameToDatasourceID(rc *nodev1.RouterConfig) map[string]string {
+	out := make(map[string]string, len(rc.Subgraphs))
+	for _, sg := range rc.Subgraphs {
+		out[sg.Name] = sg.Id
+	}
+	return out
+}
+
+// translateResponseKeys rewrites subgraph-name response keys ("products",
+// "products:path") to the datasource-ID keys FakeRegistry matches on at
+// runtime; unknown prefixes (e.g. "*") pass through unchanged.
+func translateResponseKeys(responses map[string]string, nameToID map[string]string) map[string]string {
+	out := make(map[string]string, len(responses))
+	for key, value := range responses {
+		name, path, hasPath := strings.Cut(key, ":")
+		if id, ok := nameToID[name]; ok {
+			if hasPath {
+				out[id+":"+path] = value
+			} else {
+				out[id] = value
+			}
+			continue
+		}
+		out[key] = value
+	}
+	return out
+}

--- a/execution/cachingtesting/cachingtesting.go
+++ b/execution/cachingtesting/cachingtesting.go
@@ -46,6 +46,12 @@ type PlanResult struct {
 	nameToID map[string]string
 }
 
+// Inputs returns the exact input bytes every load of the fake datasource for
+// the given SUBGRAPH NAME + fetch path received, in order.
+func (p PlanResult) Inputs(name, path string) []string {
+	return p.Fakes.Inputs(p.nameToID[name], path)
+}
+
 // Gate attaches gate channels to the fake datasource for the given SUBGRAPH
 // NAME + fetch path, re-swapping the trees so the gate takes effect.
 func (p PlanResult) Gate(name, path string, gate cachetesting.DataSourceGate) {

--- a/execution/cachingtesting/cachingtesting.go
+++ b/execution/cachingtesting/cachingtesting.go
@@ -8,6 +8,7 @@ package cachingtesting
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -253,6 +254,20 @@ func ResolveDeferResponseWith(tb testing.TB, resp *resolve.GraphQLDeferResponse,
 	_, err := r.ResolveGraphQLDeferResponse(ctx, resp, writer)
 	require.NoError(tb, err)
 	require.True(tb, writer.complete)
+}
+
+// PrettyPlan renders the ENTIRE execution plan as one engine-pretty-printed
+// string — the initial tree plus every defer group, each cached fetch carrying
+// its cache config line — so plan tests assert the complete plan at once and
+// read top to bottom.
+func PrettyPlan(result PlanResult) string {
+	var b strings.Builder
+	b.WriteString(result.Response.Fetches.QueryPlan().PrettyPrint())
+	for _, group := range DeferGroups(result.DeferResponse) {
+		fmt.Fprintf(&b, "Deferred (id: %d) ", group.DeferID)
+		b.WriteString(group.Fetches.QueryPlan().PrettyPrint())
+	}
+	return b.String()
 }
 
 // DeferGroups flattens a defer response's groups (the extracted Defers list

--- a/execution/cachingtesting/cachingtesting.go
+++ b/execution/cachingtesting/cachingtesting.go
@@ -38,6 +38,20 @@ type PlanResult struct {
 	Response      *resolve.GraphQLResponse
 	DeferResponse *resolve.GraphQLDeferResponse
 	Fakes         *cachetesting.FakeRegistry
+
+	// nameToID translates subgraph names to the ID-named datasources of the
+	// factory-built configuration, so tests can keep using subgraph names.
+	nameToID map[string]string
+}
+
+// LoadCount returns how often the fake datasource for the given SUBGRAPH NAME
+// loaded at the given response path.
+func (r PlanResult) LoadCount(subgraphName, path string) int64 {
+	id, ok := r.nameToID[subgraphName]
+	if !ok {
+		id = subgraphName
+	}
+	return r.Fakes.LoadCount(id, path)
 }
 
 // Plan runs the real planner + postprocess over query against the committed
@@ -105,7 +119,8 @@ func Plan(tb testing.TB, query string, caching map[string]cacheconfig.CachingCon
 	postprocess.NewProcessor(processorOptions...).Process(raw)
 
 	result := PlanResult{
-		Fakes: cachetesting.NewFakeRegistry(translateResponseKeys(responses, nameToID)),
+		Fakes:    cachetesting.NewFakeRegistry(translateResponseKeys(responses, nameToID)),
+		nameToID: nameToID,
 	}
 	switch p := raw.(type) {
 	case *plan.SynchronousResponsePlan:

--- a/execution/cachingtesting/cachingtesting.go
+++ b/execution/cachingtesting/cachingtesting.go
@@ -11,7 +11,9 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -42,6 +44,21 @@ type PlanResult struct {
 	// nameToID translates subgraph names to the ID-named datasources of the
 	// factory-built configuration, so tests can keep using subgraph names.
 	nameToID map[string]string
+}
+
+// Gate attaches gate channels to the fake datasource for the given SUBGRAPH
+// NAME + fetch path, re-swapping the trees so the gate takes effect.
+func (p PlanResult) Gate(name, path string, gate cachetesting.DataSourceGate) {
+	p.Fakes.SetGate(p.nameToID[name], path, gate)
+	if p.Response != nil {
+		cachetesting.SwapDataSources(p.Response.Fetches, p.Fakes)
+	}
+	if p.DeferResponse != nil {
+		cachetesting.SwapDataSources(p.DeferResponse.Response.Fetches, p.Fakes)
+		for _, g := range DeferGroups(p.DeferResponse) {
+			cachetesting.SwapDataSources(g.Fetches, p.Fakes)
+		}
+	}
 }
 
 // LoadCount returns how often the fake datasource for the given SUBGRAPH NAME
@@ -154,6 +171,72 @@ func ResolveResponse(tb testing.TB, resp *resolve.GraphQLResponse, controller re
 	_, err := r.ResolveGraphQLResponse(ctx, resp, nil, &buf)
 	require.NoError(tb, err)
 	return buf.String()
+}
+
+// deferFrameWriter captures each flushed incremental frame as one COMPLETE
+// payload string (safe for concurrent Write/Flush from group goroutines).
+type deferFrameWriter struct {
+	mu       sync.Mutex
+	buf      bytes.Buffer
+	frames   []string
+	complete bool
+	// Flushed (optional) receives one signal per flushed frame, so tests can
+	// gate on frame progress with pure channel synchronization (no polling,
+	// no latency). Buffer it generously; Flush blocks on a full channel.
+	Flushed chan struct{}
+}
+
+func (w *deferFrameWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
+func (w *deferFrameWriter) Flush() error {
+	w.mu.Lock()
+	w.frames = append(w.frames, w.buf.String())
+	w.buf.Reset()
+	w.mu.Unlock()
+	if w.Flushed != nil {
+		w.Flushed <- struct{}{}
+	}
+	return nil
+}
+
+func (w *deferFrameWriter) Complete() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.complete = true
+}
+
+// Frames returns the flushed frames so far (usable mid-resolve for gating).
+func (w *deferFrameWriter) Frames() []string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return slices.Clone(w.frames)
+}
+
+// ResolveDeferResponse resolves a deferred response end to end and returns
+// every flushed incremental frame as a complete string.
+func ResolveDeferResponse(tb testing.TB, resp *resolve.GraphQLDeferResponse, controller resolve.CacheController) []string {
+	tb.Helper()
+	writer := &deferFrameWriter{}
+	ResolveDeferResponseWith(tb, resp, controller, writer)
+	return writer.frames
+}
+
+// ResolveDeferResponseWith is ResolveDeferResponse with a caller-owned writer,
+// for tests that gate on frames mid-resolve.
+func ResolveDeferResponseWith(tb testing.TB, resp *resolve.GraphQLDeferResponse, controller resolve.CacheController, writer *deferFrameWriter) {
+	tb.Helper()
+	ctx := resolve.NewContext(tb.Context())
+	if controller != nil {
+		ctx.SetCacheController(controller)
+	}
+	r := resolve.New(tb.Context(), resolve.ResolverOptions{MaxConcurrency: 16})
+	_, err := r.ResolveGraphQLDeferResponse(ctx, resp, writer)
+	require.NoError(tb, err)
+	require.True(tb, writer.complete)
 }
 
 // DeferGroups flattens a defer response's groups (the extracted Defers list

--- a/execution/cachingtesting/cachingtesting.go
+++ b/execution/cachingtesting/cachingtesting.go
@@ -49,13 +49,23 @@ type PlanResult struct {
 // Inputs returns the exact input bytes every load of the fake datasource for
 // the given SUBGRAPH NAME + fetch path received, in order.
 func (p PlanResult) Inputs(name, path string) []string {
-	return p.Fakes.Inputs(p.nameToID[name], path)
+	return p.Fakes.Inputs(p.datasourceID(name), path)
+}
+
+// datasourceID resolves a subgraph name to its datasource ID, falling back to
+// the literal name (consistent with LoadCount — a typo'd name can then never
+// silently register an unusable gate or fetch path).
+func (p PlanResult) datasourceID(name string) string {
+	if id, ok := p.nameToID[name]; ok {
+		return id
+	}
+	return name
 }
 
 // Gate attaches gate channels to the fake datasource for the given SUBGRAPH
 // NAME + fetch path, re-swapping the trees so the gate takes effect.
 func (p PlanResult) Gate(name, path string, gate cachetesting.DataSourceGate) {
-	p.Fakes.SetGate(p.nameToID[name], path, gate)
+	p.Fakes.SetGate(p.datasourceID(name), path, gate)
 	if p.Response != nil {
 		cachetesting.SwapDataSources(p.Response.Fetches, p.Fakes)
 	}

--- a/execution/cachingtesting/cachingtesting_test.go
+++ b/execution/cachingtesting/cachingtesting_test.go
@@ -10,81 +10,72 @@ import (
 )
 
 // TestNoOpBaseline is the Phase 0 exit proof (appendix row A1 shape): with
-// caching unconfigured, the resolved response is byte-identical whether or not
-// a runtime controller is set, and the controller is never consulted.
+// caching unconfigured, the response is byte-identical whether or not a
+// runtime controller is set, and the controller is never consulted.
 func TestNoOpBaseline(t *testing.T) {
 	query := `{ products(first: 2) { upc name } }`
-	responses := map[string]string{
-		"products": `{"data":{"products":[{"__typename":"Product","upc":"1","name":"Table"},{"__typename":"Product","upc":"2","name":"Chair"}]}}`,
-	}
+	products := Respond(`{"data":{"products":[{"__typename":"Product","upc":"1","name":"Table"},{"__typename":"Product","upc":"2","name":"Chair"}]}}`)
+	executionEngine := NewEngine(t, nil, Subgraphs{"products": products})
 	expected := `{"data":{"products":[{"upc":"1","name":"Table"},{"upc":"2","name":"Chair"}]}}`
 
-	baseline := Plan(t, query, nil, responses)
-	baselineBody := ResolveResponse(t, baseline.Response, nil)
+	baselineBody := Execute(t, executionEngine, query, nil)
 	assert.Equal(t, expected, baselineBody)
 
 	controller := cachetesting.NewRecordingController(nil)
-	withController := Plan(t, query, nil, responses)
-	withControllerBody := ResolveResponse(t, withController.Response, controller)
+	withControllerBody := Execute(t, executionEngine, query, controller)
 	assert.Equal(t, expected, withControllerBody)
 	assert.Equal(t, baselineBody, withControllerBody)
 	assert.Equal(t, int64(0), controller.Begins())
 	assert.Empty(t, controller.Calls())
 }
 
-// TestFixtureSmoke plans and resolves one representative operation per fixture
-// shape through the harness with canned responses, asserting the COMPLETE
+// TestFixtureSmoke executes one representative operation per fixture shape
+// through the real engine over subgraph doubles, asserting the COMPLETE
 // response body.
 func TestFixtureSmoke(t *testing.T) {
 	t.Run("multi-key entity via second key set", func(t *testing.T) {
-		result := Plan(t, `{ productBySku(sku: "S1") { upc sku name price } }`, nil, map[string]string{
-			"products": `{"data":{"productBySku":{"__typename":"Product","upc":"1","sku":"S1","name":"Table","price":100}}}`,
-		})
-		body := ResolveResponse(t, result.Response, nil)
+		products := Respond(`{"data":{"productBySku":{"__typename":"Product","upc":"1","sku":"S1","name":"Table","price":100}}}`)
+		executionEngine := NewEngine(t, nil, Subgraphs{"products": products})
+		body := Execute(t, executionEngine, `{ productBySku(sku: "S1") { upc sku name price } }`, nil)
 		assert.Equal(t, `{"data":{"productBySku":{"upc":"1","sku":"S1","name":"Table","price":100}}}`, body)
 	})
 
 	t.Run("by-key root field", func(t *testing.T) {
-		result := Plan(t, `{ product(upc: "1") { name } }`, nil, map[string]string{
-			"products": `{"data":{"product":{"__typename":"Product","name":"Table"}}}`,
-		})
-		body := ResolveResponse(t, result.Response, nil)
+		products := Respond(`{"data":{"product":{"__typename":"Product","name":"Table"}}}`)
+		executionEngine := NewEngine(t, nil, Subgraphs{"products": products})
+		body := Execute(t, executionEngine, `{ product(upc: "1") { name } }`, nil)
 		assert.Equal(t, `{"data":{"product":{"name":"Table"}}}`, body)
 	})
 
 	t.Run("nested cross-subgraph entities", func(t *testing.T) {
-		result := Plan(t, `{ me { username favoriteProduct { name stock warehouse { location } } } }`, nil, map[string]string{
-			"users":                        `{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`,
-			"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1","name":"Table"}}]}}`,
-			"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5,"warehouse":{"location":"Berlin"}}]}}`,
-		})
-		body := ResolveResponse(t, result.Response, nil)
+		users := Respond(`{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`)
+		products := Respond(`{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1","name":"Table"}}]}}`)
+		inventory := Respond(`{"data":{"_entities":[{"__typename":"Product","stock":5,"warehouse":{"location":"Berlin"}}]}}`)
+		executionEngine := NewEngine(t, nil, Subgraphs{"users": users, "products": products, "inventory": inventory})
+		body := Execute(t, executionEngine, `{ me { username favoriteProduct { name stock warehouse { location } } } }`, nil)
 		assert.Equal(t, `{"data":{"me":{"username":"jens","favoriteProduct":{"name":"Table","stock":5,"warehouse":{"location":"Berlin"}}}}}`, body)
 	})
 
 	t.Run("batch entity reviews", func(t *testing.T) {
-		result := Plan(t, `{ products(first: 2) { upc reviews { body } } }`, nil, map[string]string{
-			"products": `{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"}]}}`,
-			"reviews":  `{"data":{"_entities":[{"__typename":"Product","reviews":[{"body":"Solid"}]},{"__typename":"Product","reviews":[{"body":"Wobbly"}]}]}}`,
-		})
-		body := ResolveResponse(t, result.Response, nil)
+		products := Respond(`{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"}]}}`)
+		reviews := Respond(`{"data":{"_entities":[{"__typename":"Product","reviews":[{"body":"Solid"}]},{"__typename":"Product","reviews":[{"body":"Wobbly"}]}]}}`)
+		executionEngine := NewEngine(t, nil, Subgraphs{"products": products, "reviews": reviews})
+		body := Execute(t, executionEngine, `{ products(first: 2) { upc reviews { body } } }`, nil)
 		assert.Equal(t, `{"data":{"products":[{"upc":"1","reviews":[{"body":"Solid"}]},{"upc":"2","reviews":[{"body":"Wobbly"}]}]}}`, body)
 	})
 
 	t.Run("sibling root fields on one datasource", func(t *testing.T) {
-		result := Plan(t, `{ products(first: 1) { upc } promotions { upc } }`, nil, map[string]string{
-			"products": `{"data":{"products":[{"__typename":"Product","upc":"1"}],"promotions":[{"__typename":"Product","upc":"9"}]}}`,
-		})
-		body := ResolveResponse(t, result.Response, nil)
+		products := Respond(`{"data":{"products":[{"__typename":"Product","upc":"1"}],"promotions":[{"__typename":"Product","upc":"9"}]}}`)
+		executionEngine := NewEngine(t, nil, Subgraphs{"products": products})
+		body := Execute(t, executionEngine, `{ products(first: 1) { upc } promotions { upc } }`, nil)
 		assert.Equal(t, `{"data":{"products":[{"upc":"1"}],"promotions":[{"upc":"9"}]}}`, body)
 	})
 
 	t.Run("mixed ttl siblings across subgraphs", func(t *testing.T) {
-		result := Plan(t, `{ product(upc: "1") { name stock } }`, nil, map[string]string{
-			"products":          `{"data":{"product":{"__typename":"Product","name":"Table","upc":"1"}}}`,
-			"inventory:product": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
-		})
-		body := ResolveResponse(t, result.Response, nil)
+		products := Respond(`{"data":{"product":{"__typename":"Product","name":"Table","upc":"1"}}}`)
+		inventory := Respond(`{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`)
+		executionEngine := NewEngine(t, nil, Subgraphs{"products": products, "inventory": inventory})
+		body := Execute(t, executionEngine, `{ product(upc: "1") { name stock } }`, nil)
 		assert.Equal(t, `{"data":{"product":{"name":"Table","stock":5}}}`, body)
 	})
 }
@@ -93,6 +84,8 @@ func TestFixtureSmoke(t *testing.T) {
 // request's inventory entity fetch provides a STRICT SUPERSET (stock +
 // warehouse) of the deferred inventory entity fetch in a later group (stock
 // only), so cross-defer-group L1 serving is provable (task 18 rows N1/N2/M3).
+// Stays on the Plan harness: its whole point is the deferred group's PLANNED
+// fetch shape, which no client-visible response can express.
 func TestDeferSupersetShape(t *testing.T) {
 	query := `
 		query {

--- a/execution/cachingtesting/cachingtesting_test.go
+++ b/execution/cachingtesting/cachingtesting_test.go
@@ -1,0 +1,138 @@
+package cachingtesting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/cache/cachetesting"
+)
+
+// TestNoOpBaseline is the Phase 0 exit proof (appendix row A1 shape): with
+// caching unconfigured, the resolved response is byte-identical whether or not
+// a runtime controller is set, and the controller is never consulted.
+func TestNoOpBaseline(t *testing.T) {
+	query := `{ products(first: 2) { upc name } }`
+	responses := map[string]string{
+		"products": `{"data":{"products":[{"__typename":"Product","upc":"1","name":"Table"},{"__typename":"Product","upc":"2","name":"Chair"}]}}`,
+	}
+	expected := `{"data":{"products":[{"upc":"1","name":"Table"},{"upc":"2","name":"Chair"}]}}`
+
+	baseline := Plan(t, query, nil, responses)
+	baselineBody := ResolveResponse(t, baseline.Response, nil)
+	assert.Equal(t, expected, baselineBody)
+
+	controller := cachetesting.NewRecordingController(nil)
+	withController := Plan(t, query, nil, responses)
+	withControllerBody := ResolveResponse(t, withController.Response, controller)
+	assert.Equal(t, expected, withControllerBody)
+	assert.Equal(t, baselineBody, withControllerBody)
+	assert.Equal(t, int64(0), controller.Begins())
+	assert.Empty(t, controller.Calls())
+}
+
+// TestFixtureSmoke plans and resolves one representative operation per fixture
+// shape through the harness with canned responses, asserting the COMPLETE
+// response body.
+func TestFixtureSmoke(t *testing.T) {
+	t.Run("multi-key entity via second key set", func(t *testing.T) {
+		result := Plan(t, `{ productBySku(sku: "S1") { upc sku name price } }`, nil, map[string]string{
+			"products": `{"data":{"productBySku":{"__typename":"Product","upc":"1","sku":"S1","name":"Table","price":100}}}`,
+		})
+		body := ResolveResponse(t, result.Response, nil)
+		assert.Equal(t, `{"data":{"productBySku":{"upc":"1","sku":"S1","name":"Table","price":100}}}`, body)
+	})
+
+	t.Run("by-key root field", func(t *testing.T) {
+		result := Plan(t, `{ product(upc: "1") { name } }`, nil, map[string]string{
+			"products": `{"data":{"product":{"__typename":"Product","name":"Table"}}}`,
+		})
+		body := ResolveResponse(t, result.Response, nil)
+		assert.Equal(t, `{"data":{"product":{"name":"Table"}}}`, body)
+	})
+
+	t.Run("nested cross-subgraph entities", func(t *testing.T) {
+		result := Plan(t, `{ me { username favoriteProduct { name stock warehouse { location } } } }`, nil, map[string]string{
+			"users":                        `{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`,
+			"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1","name":"Table"}}]}}`,
+			"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5,"warehouse":{"location":"Berlin"}}]}}`,
+		})
+		body := ResolveResponse(t, result.Response, nil)
+		assert.Equal(t, `{"data":{"me":{"username":"jens","favoriteProduct":{"name":"Table","stock":5,"warehouse":{"location":"Berlin"}}}}}`, body)
+	})
+
+	t.Run("batch entity reviews", func(t *testing.T) {
+		result := Plan(t, `{ products(first: 2) { upc reviews { body } } }`, nil, map[string]string{
+			"products": `{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"}]}}`,
+			"reviews":  `{"data":{"_entities":[{"__typename":"Product","reviews":[{"body":"Solid"}]},{"__typename":"Product","reviews":[{"body":"Wobbly"}]}]}}`,
+		})
+		body := ResolveResponse(t, result.Response, nil)
+		assert.Equal(t, `{"data":{"products":[{"upc":"1","reviews":[{"body":"Solid"}]},{"upc":"2","reviews":[{"body":"Wobbly"}]}]}}`, body)
+	})
+
+	t.Run("sibling root fields on one datasource", func(t *testing.T) {
+		result := Plan(t, `{ products(first: 1) { upc } promotions { upc } }`, nil, map[string]string{
+			"products": `{"data":{"products":[{"__typename":"Product","upc":"1"}],"promotions":[{"__typename":"Product","upc":"9"}]}}`,
+		})
+		body := ResolveResponse(t, result.Response, nil)
+		assert.Equal(t, `{"data":{"products":[{"upc":"1"}],"promotions":[{"upc":"9"}]}}`, body)
+	})
+
+	t.Run("mixed ttl siblings across subgraphs", func(t *testing.T) {
+		result := Plan(t, `{ product(upc: "1") { name stock } }`, nil, map[string]string{
+			"products":          `{"data":{"product":{"__typename":"Product","name":"Table","upc":"1"}}}`,
+			"inventory:product": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
+		})
+		body := ResolveResponse(t, result.Response, nil)
+		assert.Equal(t, `{"data":{"product":{"name":"Table","stock":5}}}`, body)
+	})
+}
+
+// TestDeferSupersetShape closes the first-pass fixture gap: the initial
+// request's inventory entity fetch provides a STRICT SUPERSET (stock +
+// warehouse) of the deferred inventory entity fetch in a later group (stock
+// only), so cross-defer-group L1 serving is provable (task 18 rows N1/N2/M3).
+func TestDeferSupersetShape(t *testing.T) {
+	query := `
+		query {
+			me { favoriteProduct { upc stock warehouse { id location } } }
+			products(first: 1) {
+				upc
+				... @defer { stock }
+			}
+		}`
+	result := Plan(t, query, nil, nil)
+	require.NotNil(t, result.DeferResponse, "expected a defer plan")
+
+	groups := DeferGroups(result.DeferResponse)
+	require.NotEmpty(t, groups, "expected at least one defer group")
+
+	rendered := make([]string, 0, len(groups))
+	for _, group := range groups {
+		require.NotNil(t, group.Fetches)
+		rendered = append(rendered, group.Fetches.QueryPlan().PrettyPrint())
+	}
+	// The deferred group holds ONLY the inventory (service "1") entity fetch
+	// selecting stock — a strict subset of the initial inventory fetch's
+	// {stock warehouse{id location}} for the same entity type.
+	assert.Equal(t, []string{`QueryPlan {
+  Fetch(service: "1") {
+    {
+      fragment Key on Product {
+          __typename
+          upc
+      }
+    } =>
+    {
+        _entities(representations: $representations){
+            ... on Product {
+                __typename
+                stock
+            }
+        }
+    }
+  }
+}
+`}, rendered)
+}

--- a/execution/cachingtesting/compose.sh
+++ b/execution/cachingtesting/compose.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Composing caching test subgraphs"
+
+npx -y wgc@latest router compose -i graph.yaml -o config.json
+
+echo "Formatting config"
+jq . config.json > config.json.tmp
+mv config.json.tmp config.json

--- a/execution/cachingtesting/config.json
+++ b/execution/cachingtesting/config.json
@@ -1,0 +1,350 @@
+{
+  "engineConfig": {
+    "defaultFlushInterval": "500",
+    "datasourceConfigurations": [
+      {
+        "kind": "GRAPHQL",
+        "rootNodes": [
+          {
+            "typeName": "Query",
+            "fieldNames": [
+              "products",
+              "promotions",
+              "product",
+              "productBySku"
+            ]
+          },
+          {
+            "typeName": "Product",
+            "fieldNames": [
+              "upc",
+              "sku",
+              "name",
+              "price"
+            ]
+          },
+          {
+            "typeName": "User",
+            "fieldNames": [
+              "id",
+              "favoriteProduct"
+            ]
+          }
+        ],
+        "overrideFieldPathFromAlias": true,
+        "customGraphql": {
+          "fetch": {
+            "url": {
+              "staticVariableContent": "http://products.service"
+            },
+            "method": "POST",
+            "body": {},
+            "baseUrl": {},
+            "path": {}
+          },
+          "subscription": {
+            "enabled": true,
+            "url": {
+              "staticVariableContent": "http://products.service"
+            },
+            "protocol": "GRAPHQL_SUBSCRIPTION_PROTOCOL_WS",
+            "websocketSubprotocol": "GRAPHQL_WEBSOCKET_SUBPROTOCOL_AUTO"
+          },
+          "federation": {
+            "enabled": true,
+            "serviceSdl": "extend type Query {\n    products(first: Int = 5): [Product!]!\n    promotions: [Product!]!\n    product(upc: String!): Product\n    productBySku(sku: String!): Product\n}\ntype Product @key(fields: \"upc\") @key(fields: \"sku\") {\n    upc: String!\n    sku: String!\n    name: String!\n    price: Int!\n}\nextend type User @key(fields: \"id\") {\n    id: ID! @external\n    favoriteProduct: Product\n}\n"
+          },
+          "upstreamSchema": {
+            "key": "0a7b3af7e196634fc2cabac28cac3901c52d849a"
+          }
+        },
+        "requestTimeoutSeconds": "10",
+        "id": "0",
+        "keys": [
+          {
+            "typeName": "Product",
+            "selectionSet": "upc"
+          },
+          {
+            "typeName": "Product",
+            "selectionSet": "sku"
+          },
+          {
+            "typeName": "User",
+            "selectionSet": "id"
+          }
+        ]
+      },
+      {
+        "kind": "GRAPHQL",
+        "rootNodes": [
+          {
+            "typeName": "Product",
+            "fieldNames": [
+              "upc",
+              "stock",
+              "warehouse"
+            ]
+          }
+        ],
+        "childNodes": [
+          {
+            "typeName": "Warehouse",
+            "fieldNames": [
+              "id",
+              "location"
+            ]
+          }
+        ],
+        "overrideFieldPathFromAlias": true,
+        "customGraphql": {
+          "fetch": {
+            "url": {
+              "staticVariableContent": "http://inventory.service"
+            },
+            "method": "POST",
+            "body": {},
+            "baseUrl": {},
+            "path": {}
+          },
+          "subscription": {
+            "enabled": true,
+            "url": {
+              "staticVariableContent": "http://inventory.service"
+            },
+            "protocol": "GRAPHQL_SUBSCRIPTION_PROTOCOL_WS",
+            "websocketSubprotocol": "GRAPHQL_WEBSOCKET_SUBPROTOCOL_AUTO"
+          },
+          "federation": {
+            "enabled": true,
+            "serviceSdl": "extend type Product @key(fields: \"upc\") {\n    upc: String! @external\n    stock: Int!\n    warehouse: Warehouse!\n}\ntype Warehouse {\n    id: ID!\n    location: String!\n}\n"
+          },
+          "upstreamSchema": {
+            "key": "57520dc45820c952beab17280b3b150cd0706171"
+          }
+        },
+        "requestTimeoutSeconds": "10",
+        "id": "1",
+        "keys": [
+          {
+            "typeName": "Product",
+            "selectionSet": "upc"
+          }
+        ]
+      },
+      {
+        "kind": "GRAPHQL",
+        "rootNodes": [
+          {
+            "typeName": "Query",
+            "fieldNames": [
+              "latestReviews"
+            ]
+          },
+          {
+            "typeName": "User",
+            "fieldNames": [
+              "id",
+              "reviews"
+            ]
+          },
+          {
+            "typeName": "Product",
+            "fieldNames": [
+              "upc",
+              "reviews"
+            ]
+          }
+        ],
+        "childNodes": [
+          {
+            "typeName": "Review",
+            "fieldNames": [
+              "id",
+              "body",
+              "author",
+              "product"
+            ]
+          }
+        ],
+        "overrideFieldPathFromAlias": true,
+        "customGraphql": {
+          "fetch": {
+            "url": {
+              "staticVariableContent": "http://reviews.service"
+            },
+            "method": "POST",
+            "body": {},
+            "baseUrl": {},
+            "path": {}
+          },
+          "subscription": {
+            "enabled": true,
+            "url": {
+              "staticVariableContent": "http://reviews.service"
+            },
+            "protocol": "GRAPHQL_SUBSCRIPTION_PROTOCOL_WS",
+            "websocketSubprotocol": "GRAPHQL_WEBSOCKET_SUBPROTOCOL_AUTO"
+          },
+          "federation": {
+            "enabled": true,
+            "serviceSdl": "extend type Query {\n    latestReviews(first: Int = 5): [Review!]!\n}\ntype Review {\n    id: ID!\n    body: String!\n    author: User!\n    product: Product!\n}\nextend type User @key(fields: \"id\") {\n    id: ID! @external\n    reviews: [Review!]!\n}\nextend type Product @key(fields: \"upc\") {\n    upc: String! @external\n    reviews: [Review!]!\n}\n"
+          },
+          "upstreamSchema": {
+            "key": "4fc9aa6ca3d426ce5bf140e4a624f93e69310501"
+          }
+        },
+        "requestTimeoutSeconds": "10",
+        "id": "2",
+        "keys": [
+          {
+            "typeName": "User",
+            "selectionSet": "id"
+          },
+          {
+            "typeName": "Product",
+            "selectionSet": "upc"
+          }
+        ]
+      },
+      {
+        "kind": "GRAPHQL",
+        "rootNodes": [
+          {
+            "typeName": "Query",
+            "fieldNames": [
+              "me",
+              "user"
+            ]
+          },
+          {
+            "typeName": "User",
+            "fieldNames": [
+              "id",
+              "username"
+            ]
+          }
+        ],
+        "overrideFieldPathFromAlias": true,
+        "customGraphql": {
+          "fetch": {
+            "url": {
+              "staticVariableContent": "http://users.service"
+            },
+            "method": "POST",
+            "body": {},
+            "baseUrl": {},
+            "path": {}
+          },
+          "subscription": {
+            "enabled": true,
+            "url": {
+              "staticVariableContent": "http://users.service"
+            },
+            "protocol": "GRAPHQL_SUBSCRIPTION_PROTOCOL_WS",
+            "websocketSubprotocol": "GRAPHQL_WEBSOCKET_SUBPROTOCOL_AUTO"
+          },
+          "federation": {
+            "enabled": true,
+            "serviceSdl": "extend type Query {\n    me: User\n    user(id: ID!): User\n}\ntype User @key(fields: \"id\") {\n    id: ID!\n    username: String!\n}\n"
+          },
+          "upstreamSchema": {
+            "key": "68714e916ae5c46b1ca8cbbfeabafcd03f78ff1d"
+          }
+        },
+        "requestTimeoutSeconds": "10",
+        "id": "3",
+        "keys": [
+          {
+            "typeName": "User",
+            "selectionSet": "id"
+          }
+        ]
+      }
+    ],
+    "fieldConfigurations": [
+      {
+        "typeName": "Query",
+        "fieldName": "products",
+        "argumentsConfiguration": [
+          {
+            "name": "first",
+            "sourceType": "FIELD_ARGUMENT"
+          }
+        ]
+      },
+      {
+        "typeName": "Query",
+        "fieldName": "product",
+        "argumentsConfiguration": [
+          {
+            "name": "upc",
+            "sourceType": "FIELD_ARGUMENT"
+          }
+        ]
+      },
+      {
+        "typeName": "Query",
+        "fieldName": "productBySku",
+        "argumentsConfiguration": [
+          {
+            "name": "sku",
+            "sourceType": "FIELD_ARGUMENT"
+          }
+        ]
+      },
+      {
+        "typeName": "Query",
+        "fieldName": "latestReviews",
+        "argumentsConfiguration": [
+          {
+            "name": "first",
+            "sourceType": "FIELD_ARGUMENT"
+          }
+        ]
+      },
+      {
+        "typeName": "Query",
+        "fieldName": "user",
+        "argumentsConfiguration": [
+          {
+            "name": "id",
+            "sourceType": "FIELD_ARGUMENT"
+          }
+        ]
+      }
+    ],
+    "graphqlSchema": "schema {\n  query: Query\n}\n\ntype Query {\n  products(first: Int = 5): [Product!]!\n  promotions: [Product!]!\n  product(upc: String!): Product\n  productBySku(sku: String!): Product\n  latestReviews(first: Int = 5): [Review!]!\n  me: User\n  user(id: ID!): User\n}\n\ntype Product {\n  upc: String!\n  sku: String!\n  name: String!\n  price: Int!\n  stock: Int!\n  warehouse: Warehouse!\n  reviews: [Review!]!\n}\n\ntype User {\n  id: ID!\n  favoriteProduct: Product\n  reviews: [Review!]!\n  username: String!\n}\n\ntype Warehouse {\n  id: ID!\n  location: String!\n}\n\ntype Review {\n  id: ID!\n  body: String!\n  author: User!\n  product: Product!\n}",
+    "stringStorage": {
+      "0a7b3af7e196634fc2cabac28cac3901c52d849a": "schema {\n  query: Query\n}\n\ndirective @external on FIELD_DEFINITION | OBJECT\n\ndirective @key(fields: openfed__FieldSet!, resolvable: Boolean = true) repeatable on INTERFACE | OBJECT\n\ntype Product @key(fields: \"upc\") @key(fields: \"sku\") {\n  name: String!\n  price: Int!\n  sku: String!\n  upc: String!\n}\n\ntype Query {\n  product(upc: String!): Product\n  productBySku(sku: String!): Product\n  products(first: Int = 5): [Product!]!\n  promotions: [Product!]!\n}\n\ntype User @key(fields: \"id\") {\n  favoriteProduct: Product\n  id: ID! @external\n}\n\nscalar openfed__FieldSet",
+      "57520dc45820c952beab17280b3b150cd0706171": "directive @external on FIELD_DEFINITION | OBJECT\n\ndirective @key(fields: openfed__FieldSet!, resolvable: Boolean = true) repeatable on INTERFACE | OBJECT\n\ntype Product @key(fields: \"upc\") {\n  stock: Int!\n  upc: String! @external\n  warehouse: Warehouse!\n}\n\ntype Warehouse {\n  id: ID!\n  location: String!\n}\n\nscalar openfed__FieldSet",
+      "4fc9aa6ca3d426ce5bf140e4a624f93e69310501": "schema {\n  query: Query\n}\n\ndirective @external on FIELD_DEFINITION | OBJECT\n\ndirective @key(fields: openfed__FieldSet!, resolvable: Boolean = true) repeatable on INTERFACE | OBJECT\n\ntype Product @key(fields: \"upc\") {\n  reviews: [Review!]!\n  upc: String! @external\n}\n\ntype Query {\n  latestReviews(first: Int = 5): [Review!]!\n}\n\ntype Review {\n  author: User!\n  body: String!\n  id: ID!\n  product: Product!\n}\n\ntype User @key(fields: \"id\") {\n  id: ID! @external\n  reviews: [Review!]!\n}\n\nscalar openfed__FieldSet",
+      "68714e916ae5c46b1ca8cbbfeabafcd03f78ff1d": "schema {\n  query: Query\n}\n\ndirective @key(fields: openfed__FieldSet!, resolvable: Boolean = true) repeatable on INTERFACE | OBJECT\n\ntype Query {\n  me: User\n  user(id: ID!): User\n}\n\ntype User @key(fields: \"id\") {\n  id: ID!\n  username: String!\n}\n\nscalar openfed__FieldSet"
+    }
+  },
+  "version": "00000000-0000-0000-0000-000000000000",
+  "subgraphs": [
+    {
+      "id": "0",
+      "name": "products",
+      "routingUrl": "http://products.service"
+    },
+    {
+      "id": "1",
+      "name": "inventory",
+      "routingUrl": "http://inventory.service"
+    },
+    {
+      "id": "2",
+      "name": "reviews",
+      "routingUrl": "http://reviews.service"
+    },
+    {
+      "id": "3",
+      "name": "users",
+      "routingUrl": "http://users.service"
+    }
+  ],
+  "featureFlagConfigs": {},
+  "compatibilityVersion": "1:0.62.2"
+}

--- a/execution/cachingtesting/config.json
+++ b/execution/cachingtesting/config.json
@@ -83,6 +83,7 @@
             "fieldNames": [
               "upc",
               "stock",
+              "stockHistory",
               "warehouse"
             ]
           }
@@ -117,10 +118,10 @@
           },
           "federation": {
             "enabled": true,
-            "serviceSdl": "extend type Product @key(fields: \"upc\") {\n    upc: String! @external\n    stock: Int!\n    warehouse: Warehouse!\n}\ntype Warehouse {\n    id: ID!\n    location: String!\n}\n"
+            "serviceSdl": "extend type Product @key(fields: \"upc\") {\n    upc: String! @external\n    stock: Int!\n    stockHistory(days: Int!): [Int!]!\n    warehouse: Warehouse!\n}\ntype Warehouse {\n    id: ID!\n    location: String!\n}\n"
           },
           "upstreamSchema": {
-            "key": "57520dc45820c952beab17280b3b150cd0706171"
+            "key": "98e3da6ea5aef066a1f9661511e7c7e3993d4c4a"
           }
         },
         "requestTimeoutSeconds": "10",
@@ -384,12 +385,22 @@
             "sourceType": "FIELD_ARGUMENT"
           }
         ]
+      },
+      {
+        "typeName": "Product",
+        "fieldName": "stockHistory",
+        "argumentsConfiguration": [
+          {
+            "name": "days",
+            "sourceType": "FIELD_ARGUMENT"
+          }
+        ]
       }
     ],
-    "graphqlSchema": "schema {\n  query: Query\n}\n\ntype Query {\n  products(first: Int = 5): [Product!]!\n  promotions: [Product!]!\n  product(upc: String!): Product\n  productBySku(sku: String!): Product\n  latestReviews(first: Int = 5): [Review!]!\n  featuredReview: Review\n  me: User\n  user(id: ID!): User\n  deal(id: ID!): Deal\n}\n\ntype Product {\n  upc: String!\n  sku: String!\n  name: String!\n  price: Int!\n  stock: Int!\n  warehouse: Warehouse!\n  reviews: [Review!]!\n}\n\ntype User {\n  id: ID!\n  favoriteProduct: Product\n  reviews: [Review!]!\n  username: String!\n}\n\ntype Warehouse {\n  id: ID!\n  location: String!\n}\n\ntype Review {\n  id: ID!\n  body: String!\n  author: User!\n  product: Product!\n}\n\ntype Deal {\n  id: ID!\n  product: Product!\n}",
+    "graphqlSchema": "schema {\n  query: Query\n}\n\ntype Query {\n  products(first: Int = 5): [Product!]!\n  promotions: [Product!]!\n  product(upc: String!): Product\n  productBySku(sku: String!): Product\n  latestReviews(first: Int = 5): [Review!]!\n  featuredReview: Review\n  me: User\n  user(id: ID!): User\n  deal(id: ID!): Deal\n}\n\ntype Product {\n  upc: String!\n  sku: String!\n  name: String!\n  price: Int!\n  stock: Int!\n  stockHistory(days: Int!): [Int!]!\n  warehouse: Warehouse!\n  reviews: [Review!]!\n}\n\ntype User {\n  id: ID!\n  favoriteProduct: Product\n  reviews: [Review!]!\n  username: String!\n}\n\ntype Warehouse {\n  id: ID!\n  location: String!\n}\n\ntype Review {\n  id: ID!\n  body: String!\n  author: User!\n  product: Product!\n}\n\ntype Deal {\n  id: ID!\n  product: Product!\n}",
     "stringStorage": {
       "0a7b3af7e196634fc2cabac28cac3901c52d849a": "schema {\n  query: Query\n}\n\ndirective @external on FIELD_DEFINITION | OBJECT\n\ndirective @key(fields: openfed__FieldSet!, resolvable: Boolean = true) repeatable on INTERFACE | OBJECT\n\ntype Product @key(fields: \"upc\") @key(fields: \"sku\") {\n  name: String!\n  price: Int!\n  sku: String!\n  upc: String!\n}\n\ntype Query {\n  product(upc: String!): Product\n  productBySku(sku: String!): Product\n  products(first: Int = 5): [Product!]!\n  promotions: [Product!]!\n}\n\ntype User @key(fields: \"id\") {\n  favoriteProduct: Product\n  id: ID! @external\n}\n\nscalar openfed__FieldSet",
-      "57520dc45820c952beab17280b3b150cd0706171": "directive @external on FIELD_DEFINITION | OBJECT\n\ndirective @key(fields: openfed__FieldSet!, resolvable: Boolean = true) repeatable on INTERFACE | OBJECT\n\ntype Product @key(fields: \"upc\") {\n  stock: Int!\n  upc: String! @external\n  warehouse: Warehouse!\n}\n\ntype Warehouse {\n  id: ID!\n  location: String!\n}\n\nscalar openfed__FieldSet",
+      "98e3da6ea5aef066a1f9661511e7c7e3993d4c4a": "directive @external on FIELD_DEFINITION | OBJECT\n\ndirective @key(fields: openfed__FieldSet!, resolvable: Boolean = true) repeatable on INTERFACE | OBJECT\n\ntype Product @key(fields: \"upc\") {\n  stock: Int!\n  stockHistory(days: Int!): [Int!]!\n  upc: String! @external\n  warehouse: Warehouse!\n}\n\ntype Warehouse {\n  id: ID!\n  location: String!\n}\n\nscalar openfed__FieldSet",
       "dd2fde369ba0ba0bda2edd5296fa2dc9ea3e988b": "schema {\n  query: Query\n}\n\ndirective @external on FIELD_DEFINITION | OBJECT\n\ndirective @key(fields: openfed__FieldSet!, resolvable: Boolean = true) repeatable on INTERFACE | OBJECT\n\ntype Product @key(fields: \"upc\") {\n  reviews: [Review!]!\n  upc: String! @external\n}\n\ntype Query {\n  featuredReview: Review\n  latestReviews(first: Int = 5): [Review!]!\n}\n\ntype Review {\n  author: User!\n  body: String!\n  id: ID!\n  product: Product!\n}\n\ntype User @key(fields: \"id\") {\n  id: ID! @external\n  reviews: [Review!]!\n}\n\nscalar openfed__FieldSet",
       "68714e916ae5c46b1ca8cbbfeabafcd03f78ff1d": "schema {\n  query: Query\n}\n\ndirective @key(fields: openfed__FieldSet!, resolvable: Boolean = true) repeatable on INTERFACE | OBJECT\n\ntype Query {\n  me: User\n  user(id: ID!): User\n}\n\ntype User @key(fields: \"id\") {\n  id: ID!\n  username: String!\n}\n\nscalar openfed__FieldSet",
       "7984b56f4b7be0a83fbf0fd0dd3a3416f1a3bd3d": "schema {\n  query: Query\n}\n\ndirective @external on FIELD_DEFINITION | OBJECT\n\ndirective @key(fields: openfed__FieldSet!, resolvable: Boolean = true) repeatable on INTERFACE | OBJECT\n\ntype Deal {\n  id: ID!\n  product: Product!\n}\n\ntype Product @key(fields: \"sku\") {\n  sku: String! @external\n}\n\ntype Query {\n  deal(id: ID!): Deal\n}\n\nscalar openfed__FieldSet"

--- a/execution/cachingtesting/config.json
+++ b/execution/cachingtesting/config.json
@@ -138,7 +138,8 @@
           {
             "typeName": "Query",
             "fieldNames": [
-              "latestReviews"
+              "latestReviews",
+              "featuredReview"
             ]
           },
           {
@@ -188,10 +189,10 @@
           },
           "federation": {
             "enabled": true,
-            "serviceSdl": "extend type Query {\n    latestReviews(first: Int = 5): [Review!]!\n}\ntype Review {\n    id: ID!\n    body: String!\n    author: User!\n    product: Product!\n}\nextend type User @key(fields: \"id\") {\n    id: ID! @external\n    reviews: [Review!]!\n}\nextend type Product @key(fields: \"upc\") {\n    upc: String! @external\n    reviews: [Review!]!\n}\n"
+            "serviceSdl": "extend type Query {\n    latestReviews(first: Int = 5): [Review!]!\n    featuredReview: Review\n}\ntype Review {\n    id: ID!\n    body: String!\n    author: User!\n    product: Product!\n}\nextend type User @key(fields: \"id\") {\n    id: ID! @external\n    reviews: [Review!]!\n}\nextend type Product @key(fields: \"upc\") {\n    upc: String! @external\n    reviews: [Review!]!\n}\n"
           },
           "upstreamSchema": {
-            "key": "4fc9aa6ca3d426ce5bf140e4a624f93e69310501"
+            "key": "dd2fde369ba0ba0bda2edd5296fa2dc9ea3e988b"
           }
         },
         "requestTimeoutSeconds": "10",
@@ -260,6 +261,67 @@
             "selectionSet": "id"
           }
         ]
+      },
+      {
+        "kind": "GRAPHQL",
+        "rootNodes": [
+          {
+            "typeName": "Query",
+            "fieldNames": [
+              "deal"
+            ]
+          },
+          {
+            "typeName": "Product",
+            "fieldNames": [
+              "sku"
+            ]
+          }
+        ],
+        "childNodes": [
+          {
+            "typeName": "Deal",
+            "fieldNames": [
+              "id",
+              "product"
+            ]
+          }
+        ],
+        "overrideFieldPathFromAlias": true,
+        "customGraphql": {
+          "fetch": {
+            "url": {
+              "staticVariableContent": "http://deals.service"
+            },
+            "method": "POST",
+            "body": {},
+            "baseUrl": {},
+            "path": {}
+          },
+          "subscription": {
+            "enabled": true,
+            "url": {
+              "staticVariableContent": "http://deals.service"
+            },
+            "protocol": "GRAPHQL_SUBSCRIPTION_PROTOCOL_WS",
+            "websocketSubprotocol": "GRAPHQL_WEBSOCKET_SUBPROTOCOL_AUTO"
+          },
+          "federation": {
+            "enabled": true,
+            "serviceSdl": "extend type Query {\n    deal(id: ID!): Deal\n}\ntype Deal {\n    id: ID!\n    product: Product!\n}\nextend type Product @key(fields: \"sku\") {\n    sku: String! @external\n}\n"
+          },
+          "upstreamSchema": {
+            "key": "7984b56f4b7be0a83fbf0fd0dd3a3416f1a3bd3d"
+          }
+        },
+        "requestTimeoutSeconds": "10",
+        "id": "4",
+        "keys": [
+          {
+            "typeName": "Product",
+            "selectionSet": "sku"
+          }
+        ]
       }
     ],
     "fieldConfigurations": [
@@ -312,14 +374,25 @@
             "sourceType": "FIELD_ARGUMENT"
           }
         ]
+      },
+      {
+        "typeName": "Query",
+        "fieldName": "deal",
+        "argumentsConfiguration": [
+          {
+            "name": "id",
+            "sourceType": "FIELD_ARGUMENT"
+          }
+        ]
       }
     ],
-    "graphqlSchema": "schema {\n  query: Query\n}\n\ntype Query {\n  products(first: Int = 5): [Product!]!\n  promotions: [Product!]!\n  product(upc: String!): Product\n  productBySku(sku: String!): Product\n  latestReviews(first: Int = 5): [Review!]!\n  me: User\n  user(id: ID!): User\n}\n\ntype Product {\n  upc: String!\n  sku: String!\n  name: String!\n  price: Int!\n  stock: Int!\n  warehouse: Warehouse!\n  reviews: [Review!]!\n}\n\ntype User {\n  id: ID!\n  favoriteProduct: Product\n  reviews: [Review!]!\n  username: String!\n}\n\ntype Warehouse {\n  id: ID!\n  location: String!\n}\n\ntype Review {\n  id: ID!\n  body: String!\n  author: User!\n  product: Product!\n}",
+    "graphqlSchema": "schema {\n  query: Query\n}\n\ntype Query {\n  products(first: Int = 5): [Product!]!\n  promotions: [Product!]!\n  product(upc: String!): Product\n  productBySku(sku: String!): Product\n  latestReviews(first: Int = 5): [Review!]!\n  featuredReview: Review\n  me: User\n  user(id: ID!): User\n  deal(id: ID!): Deal\n}\n\ntype Product {\n  upc: String!\n  sku: String!\n  name: String!\n  price: Int!\n  stock: Int!\n  warehouse: Warehouse!\n  reviews: [Review!]!\n}\n\ntype User {\n  id: ID!\n  favoriteProduct: Product\n  reviews: [Review!]!\n  username: String!\n}\n\ntype Warehouse {\n  id: ID!\n  location: String!\n}\n\ntype Review {\n  id: ID!\n  body: String!\n  author: User!\n  product: Product!\n}\n\ntype Deal {\n  id: ID!\n  product: Product!\n}",
     "stringStorage": {
       "0a7b3af7e196634fc2cabac28cac3901c52d849a": "schema {\n  query: Query\n}\n\ndirective @external on FIELD_DEFINITION | OBJECT\n\ndirective @key(fields: openfed__FieldSet!, resolvable: Boolean = true) repeatable on INTERFACE | OBJECT\n\ntype Product @key(fields: \"upc\") @key(fields: \"sku\") {\n  name: String!\n  price: Int!\n  sku: String!\n  upc: String!\n}\n\ntype Query {\n  product(upc: String!): Product\n  productBySku(sku: String!): Product\n  products(first: Int = 5): [Product!]!\n  promotions: [Product!]!\n}\n\ntype User @key(fields: \"id\") {\n  favoriteProduct: Product\n  id: ID! @external\n}\n\nscalar openfed__FieldSet",
       "57520dc45820c952beab17280b3b150cd0706171": "directive @external on FIELD_DEFINITION | OBJECT\n\ndirective @key(fields: openfed__FieldSet!, resolvable: Boolean = true) repeatable on INTERFACE | OBJECT\n\ntype Product @key(fields: \"upc\") {\n  stock: Int!\n  upc: String! @external\n  warehouse: Warehouse!\n}\n\ntype Warehouse {\n  id: ID!\n  location: String!\n}\n\nscalar openfed__FieldSet",
-      "4fc9aa6ca3d426ce5bf140e4a624f93e69310501": "schema {\n  query: Query\n}\n\ndirective @external on FIELD_DEFINITION | OBJECT\n\ndirective @key(fields: openfed__FieldSet!, resolvable: Boolean = true) repeatable on INTERFACE | OBJECT\n\ntype Product @key(fields: \"upc\") {\n  reviews: [Review!]!\n  upc: String! @external\n}\n\ntype Query {\n  latestReviews(first: Int = 5): [Review!]!\n}\n\ntype Review {\n  author: User!\n  body: String!\n  id: ID!\n  product: Product!\n}\n\ntype User @key(fields: \"id\") {\n  id: ID! @external\n  reviews: [Review!]!\n}\n\nscalar openfed__FieldSet",
-      "68714e916ae5c46b1ca8cbbfeabafcd03f78ff1d": "schema {\n  query: Query\n}\n\ndirective @key(fields: openfed__FieldSet!, resolvable: Boolean = true) repeatable on INTERFACE | OBJECT\n\ntype Query {\n  me: User\n  user(id: ID!): User\n}\n\ntype User @key(fields: \"id\") {\n  id: ID!\n  username: String!\n}\n\nscalar openfed__FieldSet"
+      "dd2fde369ba0ba0bda2edd5296fa2dc9ea3e988b": "schema {\n  query: Query\n}\n\ndirective @external on FIELD_DEFINITION | OBJECT\n\ndirective @key(fields: openfed__FieldSet!, resolvable: Boolean = true) repeatable on INTERFACE | OBJECT\n\ntype Product @key(fields: \"upc\") {\n  reviews: [Review!]!\n  upc: String! @external\n}\n\ntype Query {\n  featuredReview: Review\n  latestReviews(first: Int = 5): [Review!]!\n}\n\ntype Review {\n  author: User!\n  body: String!\n  id: ID!\n  product: Product!\n}\n\ntype User @key(fields: \"id\") {\n  id: ID! @external\n  reviews: [Review!]!\n}\n\nscalar openfed__FieldSet",
+      "68714e916ae5c46b1ca8cbbfeabafcd03f78ff1d": "schema {\n  query: Query\n}\n\ndirective @key(fields: openfed__FieldSet!, resolvable: Boolean = true) repeatable on INTERFACE | OBJECT\n\ntype Query {\n  me: User\n  user(id: ID!): User\n}\n\ntype User @key(fields: \"id\") {\n  id: ID!\n  username: String!\n}\n\nscalar openfed__FieldSet",
+      "7984b56f4b7be0a83fbf0fd0dd3a3416f1a3bd3d": "schema {\n  query: Query\n}\n\ndirective @external on FIELD_DEFINITION | OBJECT\n\ndirective @key(fields: openfed__FieldSet!, resolvable: Boolean = true) repeatable on INTERFACE | OBJECT\n\ntype Deal {\n  id: ID!\n  product: Product!\n}\n\ntype Product @key(fields: \"sku\") {\n  sku: String! @external\n}\n\ntype Query {\n  deal(id: ID!): Deal\n}\n\nscalar openfed__FieldSet"
     }
   },
   "version": "00000000-0000-0000-0000-000000000000",
@@ -343,6 +416,11 @@
       "id": "3",
       "name": "users",
       "routingUrl": "http://users.service"
+    },
+    {
+      "id": "4",
+      "name": "deals",
+      "routingUrl": "http://deals.service"
     }
   ],
   "featureFlagConfigs": {},

--- a/execution/cachingtesting/defer_l1_e2e_test.go
+++ b/execution/cachingtesting/defer_l1_e2e_test.go
@@ -46,17 +46,90 @@ func TestDeferL1CrossGroupServing(t *testing.T) {
 	// The reviewer-guidance plan inspection: the initial tree really carries a
 	// configured inventory fetch (the superset provider) and the DEFER GROUP
 	// really carries a configured same-entity fetch — L1 kept on BOTH.
-	assert.Equal(t, []string{
-		`path:"" cache:<nil> ttl:0s dependsOn:[]`,
-		`path:"" cache:<nil> ttl:0s dependsOn:[]`,
-		`path:"me" cache:<nil> ttl:0s dependsOn:[0]`,
-		`path:"me.favoriteProduct" cache:inventory ttl:0s dependsOn:[3]`,
-	}, renderFetchIsolation(result.Response.Fetches))
-	groups := DeferGroups(result.DeferResponse)
-	require.Len(t, groups, 1)
-	assert.Equal(t, []string{
-		`path:"products" cache:inventory ttl:0s dependsOn:[1]`,
-	}, renderFetchIsolation(groups[0].Fetches))
+	assert.Equal(t, `QueryPlan {
+  Sequence {
+    Parallel {
+      Fetch(service: "3") {
+        {
+            me {
+                __typename
+                id
+            }
+        }
+      }
+      Fetch(service: "0") {
+        {
+            products(first: $a){
+                upc
+                __typename
+            }
+        }
+      }
+    }
+    Fetch(service: "0") {
+      {
+        fragment Key on User {
+            __typename
+            id
+        }
+      } =>
+      {
+          _entities(representations: $representations){
+              ... on User {
+                  __typename
+                  favoriteProduct {
+                      upc
+                      __typename
+                  }
+              }
+          }
+      }
+    }
+    Flatten(path: "me.favoriteProduct") {
+      Fetch(service: "1") {
+        {
+          fragment Key on Product {
+              __typename
+              upc
+          }
+        } =>
+        Cache: {l1:true l2:false cacheName:inventory ttl:0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:Entity type:Product field: candidates:1 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}
+        {
+            _entities(representations: $representations){
+                ... on Product {
+                    __typename
+                    stock
+                    warehouse {
+                        id
+                        location
+                    }
+                }
+            }
+        }
+      }
+    }
+  }
+}
+Deferred (id: 1) QueryPlan {
+  Fetch(service: "1") {
+    {
+      fragment Key on Product {
+          __typename
+          upc
+      }
+    } =>
+    Cache: {l1:true l2:false cacheName:inventory ttl:0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:Entity type:Product field: candidates:1 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}
+    {
+        _entities(representations: $representations){
+            ... on Product {
+                __typename
+                stock
+            }
+        }
+    }
+  }
+}
+`, PrettyPlan(result))
 
 	store := cachetesting.NewFakeStore()
 	controller := &countingController{inner: cachetesting.NewRealishCache(store, nil)}
@@ -86,18 +159,90 @@ func TestDeferL1GroupToLaterGroup(t *testing.T) {
 	}
 	result := Plan(t, query, inventoryL1Caching(0), responses)
 
-	// Plan inspection: the OUTER group's inventory fetch is the provider; the
-	// NESTED group (parent = outer) carries the same-entity consumer, kept L1
-	// although NO dependency edge links it to the provider.
+	// Plan inspection: the OUTER group's inventory fetch (id 1) is the
+	// provider; the NESTED group (id 2, parent = outer) carries the
+	// same-entity consumer, kept L1 although NO dependency edge links it to
+	// the provider.
+	assert.Equal(t, `QueryPlan {
+  Fetch(service: "0") {
+    {
+        products(first: $a){
+            upc
+            __typename
+        }
+    }
+  }
+}
+Deferred (id: 1) QueryPlan {
+  Fetch(service: "1") {
+    {
+      fragment Key on Product {
+          __typename
+          upc
+      }
+    } =>
+    Cache: {l1:true l2:false cacheName:inventory ttl:0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:Entity type:Product field: candidates:1 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}
+    {
+        _entities(representations: $representations){
+            ... on Product {
+                __typename
+                stock
+                warehouse {
+                    id
+                    location
+                }
+            }
+        }
+    }
+  }
+}
+Deferred (id: 2) QueryPlan {
+  Sequence {
+    Fetch(service: "2") {
+      {
+        fragment Key on Product {
+            __typename
+            upc
+        }
+      } =>
+      {
+          _entities(representations: $representations){
+              ... on Product {
+                  __typename
+                  reviews {
+                      product {
+                          __typename
+                          upc
+                      }
+                  }
+              }
+          }
+      }
+    }
+    Flatten(path: "products.@.reviews.@.product") {
+      Fetch(service: "1") {
+        {
+          fragment Key on Product {
+              __typename
+              upc
+          }
+        } =>
+        Cache: {l1:true l2:false cacheName:inventory ttl:0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:Entity type:Product field: candidates:1 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}
+        {
+            _entities(representations: $representations){
+                ... on Product {
+                    __typename
+                    stock
+                }
+            }
+        }
+      }
+    }
+  }
+}
+`, PrettyPlan(result))
 	groups := DeferGroups(result.DeferResponse)
 	require.Len(t, groups, 2)
-	assert.Equal(t, []string{
-		`path:"products" cache:inventory ttl:0s dependsOn:[0]`,
-	}, renderFetchIsolation(groups[0].Fetches))
-	assert.Equal(t, []string{
-		`path:"products" cache:<nil> ttl:0s dependsOn:[0]`,
-		`path:"products.@.reviews.@.product" cache:inventory ttl:0s dependsOn:[2]`,
-	}, renderFetchIsolation(groups[1].Fetches))
 	assert.Equal(t, 1, result.DeferResponse.DeferDescriptors[groups[1].DeferID].ParentID)
 
 	store := cachetesting.NewFakeStore()

--- a/execution/cachingtesting/defer_l1_e2e_test.go
+++ b/execution/cachingtesting/defer_l1_e2e_test.go
@@ -1,0 +1,299 @@
+package cachingtesting
+
+import (
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/cache/cachetesting"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// inventoryL1Caching enables the inventory Product policy (ttl 0 = L1-only).
+func inventoryL1Caching(ttl time.Duration) map[string]cacheconfig.CachingConfiguration {
+	return map[string]cacheconfig.CachingConfiguration{
+		"inventory": {
+			Entities: []cacheconfig.EntityCachePolicy{
+				{TypeName: "Product", CacheName: "inventory", TTL: ttl},
+			},
+		},
+	}
+}
+
+// TestDeferL1CrossGroupServing (N1 + M3): an entity cached by the INITIAL
+// fetch serves a same-entity DEFERRED fetch in a later group — the deferred
+// group's subgraph is never hit, both frames are complete, and the per-group
+// loaders share ONE L1 through the by-reference Context (one BeginRequest).
+func TestDeferL1CrossGroupServing(t *testing.T) {
+	query := `{ me { favoriteProduct { upc stock warehouse { id location } } } products(first: 1) { upc ... @defer { stock } } }`
+	responses := map[string]string{
+		"users":                        `{"data":{"me":{"__typename":"User","id":"u1"}}}`,
+		"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
+		"products":                     `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`,
+		"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5,"warehouse":{"__typename":"Warehouse","id":"w1","location":"Berlin"}}]}}`,
+		// TAMPERED: if the deferred group ever touches the network, the frame
+		// shows 999 and the assertion fails loudly.
+		"inventory:products": `{"data":{"_entities":[{"__typename":"Product","stock":999}]}}`,
+	}
+	result := Plan(t, query, inventoryL1Caching(0), responses)
+
+	// The reviewer-guidance plan inspection: the initial tree really carries a
+	// configured inventory fetch (the superset provider) and the DEFER GROUP
+	// really carries a configured same-entity fetch — L1 kept on BOTH.
+	assert.Equal(t, []string{
+		`path:"" cache:<nil> ttl:0s dependsOn:[]`,
+		`path:"" cache:<nil> ttl:0s dependsOn:[]`,
+		`path:"me" cache:<nil> ttl:0s dependsOn:[0]`,
+		`path:"me.favoriteProduct" cache:inventory ttl:0s dependsOn:[3]`,
+	}, renderFetchIsolation(result.Response.Fetches))
+	groups := DeferGroups(result.DeferResponse)
+	require.Len(t, groups, 1)
+	assert.Equal(t, []string{
+		`path:"products" cache:inventory ttl:0s dependsOn:[1]`,
+	}, renderFetchIsolation(groups[0].Fetches))
+
+	store := cachetesting.NewFakeStore()
+	controller := &countingController{inner: cachetesting.NewRealishCache(store, nil)}
+	frames := ResolveDeferResponse(t, result.DeferResponse, controller)
+	assert.Equal(t, []string{
+		`{"data":{"me":{"favoriteProduct":{"upc":"1","stock":5,"warehouse":{"id":"w1","location":"Berlin"}}},"products":[{"upc":"1"}]},"pending":[{"id":"1","path":["products"]}],"hasNext":true}`,
+		`{"incremental":[{"data":{"stock":5},"id":"1","subPath":[0]}],"completed":[{"id":"1"}],"hasNext":false}`,
+	}, frames)
+	// The deferred subgraph was NEVER hit; L1-only means zero store traffic.
+	assert.Equal(t, int64(0), result.LoadCount("inventory", "products"))
+	assert.Empty(t, store.Ops())
+	// M3: one BeginRequest — every group's loader worked on the same L1.
+	assert.Equal(t, int64(1), controller.begins.Load())
+}
+
+// TestDeferL1GroupToLaterGroup (N2): a DEFERRED fetch populates L1 that a
+// LATER (nested) group is served from — ordering comes purely from the
+// defer-group ancestry (no dependency edge links the two inventory fetches).
+func TestDeferL1GroupToLaterGroup(t *testing.T) {
+	query := `{ products(first: 1) { upc ... @defer { stock warehouse { id location } ... @defer { reviews { product { stock } } } } } }`
+	responses := map[string]string{
+		"products":           `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`,
+		"inventory:products": `{"data":{"_entities":[{"__typename":"Product","stock":5,"warehouse":{"__typename":"Warehouse","id":"w1","location":"Berlin"}}]}}`,
+		"reviews":            `{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","product":{"__typename":"Product","upc":"1"}}]}]}}`,
+		// TAMPERED: the nested group's inventory fetch must never fire.
+		"inventory:products.@.reviews.@.product": `{"data":{"_entities":[{"__typename":"Product","stock":999}]}}`,
+	}
+	result := Plan(t, query, inventoryL1Caching(0), responses)
+
+	// Plan inspection: the OUTER group's inventory fetch is the provider; the
+	// NESTED group (parent = outer) carries the same-entity consumer, kept L1
+	// although NO dependency edge links it to the provider.
+	groups := DeferGroups(result.DeferResponse)
+	require.Len(t, groups, 2)
+	assert.Equal(t, []string{
+		`path:"products" cache:inventory ttl:0s dependsOn:[0]`,
+	}, renderFetchIsolation(groups[0].Fetches))
+	assert.Equal(t, []string{
+		`path:"products" cache:<nil> ttl:0s dependsOn:[0]`,
+		`path:"products.@.reviews.@.product" cache:inventory ttl:0s dependsOn:[2]`,
+	}, renderFetchIsolation(groups[1].Fetches))
+	assert.Equal(t, 1, result.DeferResponse.DeferDescriptors[groups[1].DeferID].ParentID)
+
+	store := cachetesting.NewFakeStore()
+	frames := ResolveDeferResponse(t, result.DeferResponse, cachetesting.NewRealishCache(store, nil))
+	assert.Equal(t, []string{
+		`{"data":{"products":[{"upc":"1"}]},"pending":[{"id":"1","path":["products"]}],"hasNext":true}`,
+		`{"incremental":[{"data":{"stock":5,"warehouse":{"id":"w1","location":"Berlin"}},"id":"1","subPath":[0]}],"completed":[{"id":"1"}],"pending":[{"id":"2","path":["products"]}],"hasNext":true}`,
+		`{"incremental":[{"data":{"reviews":[{"product":{"stock":5}}]},"id":"2","subPath":[0]}],"completed":[{"id":"2"}],"hasNext":false}`,
+	}, frames)
+	assert.Equal(t, int64(0), result.LoadCount("inventory", "products.@.reviews.@.product"))
+	assert.Empty(t, store.Ops())
+}
+
+// endCountingController wraps a controller and counts EndRequest calls on the
+// request caches it hands out.
+type endCountingController struct {
+	inner resolve.CacheController
+	ends  atomic.Int64
+}
+
+func (c *endCountingController) BeginRequest(ctx *resolve.Context) resolve.RequestCache {
+	return &endCountingCache{inner: c.inner.BeginRequest(ctx), ends: &c.ends}
+}
+
+type endCountingCache struct {
+	inner resolve.RequestCache
+	ends  *atomic.Int64
+}
+
+func (c *endCountingCache) PrepareFetch(in resolve.PrepareFetchInput) (resolve.Decision, *resolve.FetchCacheHandle) {
+	return c.inner.PrepareFetch(in)
+}
+
+func (c *endCountingCache) OnFetchSkipped(h *resolve.FetchCacheHandle, in resolve.MergeInput) error {
+	return c.inner.OnFetchSkipped(h, in)
+}
+
+func (c *endCountingCache) OnFetchResult(h *resolve.FetchCacheHandle, in resolve.MergeInput) error {
+	return c.inner.OnFetchResult(h, in)
+}
+
+func (c *endCountingCache) EndRequest() {
+	c.ends.Add(1)
+	c.inner.EndRequest()
+}
+
+// TestDeferSingleFlush (N3): exactly ONE EndRequest after ALL groups, and the
+// L2 flush carries the deferred writes from the initial fetch AND the group —
+// every Set sits AFTER every Get in the op log.
+func TestDeferSingleFlush(t *testing.T) {
+	// The deferred selection is NOT covered by the initial fetch, so the group
+	// genuinely fetches and owes an L2 write.
+	query := `{ me { favoriteProduct { upc stock } } products(first: 1) { upc ... @defer { warehouse { id location } } } }`
+	responses := map[string]string{
+		"users":                        `{"data":{"me":{"__typename":"User","id":"u1"}}}`,
+		"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
+		"products":                     `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`,
+		"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
+		"inventory:products":           `{"data":{"_entities":[{"__typename":"Product","warehouse":{"__typename":"Warehouse","id":"w1","location":"Berlin"}}]}}`,
+	}
+	result := Plan(t, query, inventoryL1Caching(time.Minute), responses)
+	store := cachetesting.NewFakeStore()
+	controller := &endCountingController{inner: cachetesting.NewRealishCache(store, nil)}
+	frames := ResolveDeferResponse(t, result.DeferResponse, controller)
+	require.Len(t, frames, 2)
+	assert.Equal(t, int64(1), controller.ends.Load())
+
+	ops := store.Ops()
+	require.Len(t, ops, 4)
+	// Both lookups (initial + deferred group) precede BOTH writes: the single
+	// request-end flush carries the initial fetch's write and the group's.
+	assert.Equal(t, "Get", ops[0].Kind)
+	assert.Equal(t, "Get", ops[1].Kind)
+	assert.Equal(t, "Set", ops[2].Kind)
+	assert.Equal(t, "Set", ops[3].Kind)
+	values := []string{ops[2].Value, ops[3].Value}
+	assert.Contains(t, values, `{"__typename":"Product","stock":5}`)
+	assert.Contains(t, values, `{"__typename":"Product","warehouse":{"__typename":"Warehouse","id":"w1","location":"Berlin"}}`)
+}
+
+// TestDeferSkipDoesNotReorderFrames (N4): a SkipFullHit on one sibling group
+// flushes its frame while the OTHER sibling is still gated on its subgraph —
+// the skip neither waits for nor reorders the fetching sibling.
+func TestDeferSkipDoesNotReorderFrames(t *testing.T) {
+	query := `{ me { favoriteProduct { upc stock } } products(first: 1) { upc ... @defer { stock } ... @defer { warehouse { id } } } }`
+	responses := map[string]string{
+		"users":                        `{"data":{"me":{"__typename":"User","id":"u1"}}}`,
+		"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
+		"products":                     `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`,
+		"products:products":            `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`,
+		"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
+		// Only the warehouse group LOADS (the stock group is L1-served and
+		// never reaches its gated datasource).
+		"inventory:products": `{"data":{"_entities":[{"__typename":"Product","warehouse":{"__typename":"Warehouse","id":"w1"}}]}}`,
+	}
+	result := Plan(t, query, inventoryL1Caching(0), responses)
+
+	arrived := make(chan string, 4)
+	release := make(chan struct{})
+	result.Gate("inventory", "products", cachetesting.DataSourceGate{Arrived: arrived, Release: release})
+
+	writer := &deferFrameWriter{Flushed: make(chan struct{}, 8)}
+	done := make(chan error, 1)
+	ctx := resolve.NewContext(t.Context())
+	ctx.SetCacheController(cachetesting.NewRealishCache(cachetesting.NewFakeStore(), nil))
+	r := resolve.New(t.Context(), resolve.ResolverOptions{MaxConcurrency: 16})
+	go func() {
+		_, err := r.ResolveGraphQLDeferResponse(ctx, result.DeferResponse, writer)
+		done <- err
+	}()
+
+	// Pure channel ordering, no latency: the gated group's fetch is IN FLIGHT
+	// (blocked on the gate) ...
+	<-arrived
+	// ... and the initial frame plus the L1-served sibling's frame still flush
+	// without waiting for it.
+	<-writer.Flushed
+	<-writer.Flushed
+	framesBeforeRelease := writer.Frames()
+	require.Len(t, framesBeforeRelease, 2)
+	assert.Contains(t, framesBeforeRelease[1], `"data":{"stock":5}`)
+
+	close(release)
+	require.NoError(t, <-done)
+	<-writer.Flushed
+	frames := writer.Frames()
+	require.Len(t, frames, 3)
+	assert.Contains(t, frames[2], `"data":{"warehouse":{"id":"w1"}}`)
+	assert.True(t, strings.HasSuffix(frames[2], `"hasNext":false}`))
+}
+
+// erroringResultCache fails OnFetchResult when the fresh response contains
+// the marker, leaving every other hook untouched.
+type erroringResultController struct {
+	inner  resolve.CacheController
+	marker string
+}
+
+func (c *erroringResultController) BeginRequest(ctx *resolve.Context) resolve.RequestCache {
+	return &erroringResultCache{inner: c.inner.BeginRequest(ctx), marker: c.marker}
+}
+
+type erroringResultCache struct {
+	inner  resolve.RequestCache
+	marker string
+}
+
+func (c *erroringResultCache) PrepareFetch(in resolve.PrepareFetchInput) (resolve.Decision, *resolve.FetchCacheHandle) {
+	return c.inner.PrepareFetch(in)
+}
+
+func (c *erroringResultCache) OnFetchSkipped(h *resolve.FetchCacheHandle, in resolve.MergeInput) error {
+	return c.inner.OnFetchSkipped(h, in)
+}
+
+func (c *erroringResultCache) OnFetchResult(h *resolve.FetchCacheHandle, in resolve.MergeInput) error {
+	if in.ResponseData != nil && strings.Contains(string(in.ResponseData.MarshalTo(nil)), c.marker) {
+		return errFromHook
+	}
+	return c.inner.OnFetchResult(h, in)
+}
+
+func (c *erroringResultCache) EndRequest() {
+	c.inner.EndRequest()
+}
+
+var errFromHook = errors.New("cache hook failed")
+
+// TestDeferHookErrorIsolation (M5): one group's cache-hook error surfaces in
+// THAT group's outcome; the sibling group's frame is complete and unaffected.
+func TestDeferHookErrorIsolation(t *testing.T) {
+	query := `{ me { favoriteProduct { upc ... @defer { stock } } } products(first: 1) { upc ... @defer { warehouse { id } } } }`
+	responses := map[string]string{
+		"users":                        `{"data":{"me":{"__typename":"User","id":"u1"}}}`,
+		"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
+		"products":                     `{"data":{"products":[{"__typename":"Product","upc":"2"}]}}`,
+		"products:products":            `{"data":{"products":[{"__typename":"Product","upc":"2"}]}}`,
+		"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
+		"inventory:products":           `{"data":{"_entities":[{"__typename":"Product","warehouse":{"__typename":"Warehouse","id":"w1"}}]}}`,
+	}
+	result := Plan(t, query, inventoryL1Caching(time.Minute), responses)
+	controller := &erroringResultController{
+		inner:  cachetesting.NewRealishCache(cachetesting.NewFakeStore(), nil),
+		marker: "warehouse",
+	}
+	frames := ResolveDeferResponse(t, result.DeferResponse, controller)
+	require.Len(t, frames, 3)
+	assert.Equal(t,
+		`{"data":{"me":{"favoriteProduct":{"upc":"1"}},"products":[{"upc":"2"}]},"pending":[{"id":"1","path":["me","favoriteProduct"]},{"id":"2","path":["products"]}],"hasNext":true}`,
+		frames[0])
+	// One frame carries the erroring group's hook failure; the OTHER carries
+	// the sibling's complete data — unaffected. (Parallel siblings flush in
+	// either order; match by content.)
+	joined := strings.Join(frames[1:], " ")
+	assert.Contains(t, joined, `"errors":[{"message":"cache hook failed"}]`)
+	assert.Contains(t, joined, `"data":{"stock":5}`)
+	assert.NotContains(t, joined, `"warehouse"`)
+	assert.True(t, strings.HasSuffix(frames[2], `"hasNext":false}`))
+}

--- a/execution/cachingtesting/defer_l1_e2e_test.go
+++ b/execution/cachingtesting/defer_l1_e2e_test.go
@@ -209,20 +209,39 @@ func TestDeferSkipDoesNotReorderFrames(t *testing.T) {
 		done <- err
 	}()
 
-	// Pure channel ordering, no latency: the gated group's fetch is IN FLIGHT
-	// (blocked on the gate) ...
-	<-arrived
+	// Pure channel ordering, no latency dependence: every receive carries a
+	// failsafe timeout so a resolver regression fails the test instead of
+	// hanging it (the timeout can only fire on regression, never orders).
+	waitFor := func(what string, ch <-chan struct{}) {
+		t.Helper()
+		select {
+		case <-ch:
+		case <-time.After(30 * time.Second):
+			t.Fatalf("timed out waiting for %s", what)
+		}
+	}
+	// The gated group's fetch is IN FLIGHT (blocked on the gate) ...
+	select {
+	case <-arrived:
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for the gated inventory fetch to arrive")
+	}
 	// ... and the initial frame plus the L1-served sibling's frame still flush
 	// without waiting for it.
-	<-writer.Flushed
-	<-writer.Flushed
+	waitFor("the initial frame flush", writer.Flushed)
+	waitFor("the L1-served sibling's frame flush", writer.Flushed)
 	framesBeforeRelease := writer.Frames()
 	require.Len(t, framesBeforeRelease, 2)
 	assert.Contains(t, framesBeforeRelease[1], `"data":{"stock":5}`)
 
 	close(release)
-	require.NoError(t, <-done)
-	<-writer.Flushed
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for the defer resolve to complete")
+	}
+	waitFor("the gated sibling's frame flush", writer.Flushed)
 	frames := writer.Frames()
 	require.Len(t, frames, 3)
 	assert.Contains(t, frames[2], `"data":{"warehouse":{"id":"w1"}}`)

--- a/execution/cachingtesting/defer_l1_e2e_test.go
+++ b/execution/cachingtesting/defer_l1_e2e_test.go
@@ -1,6 +1,7 @@
 package cachingtesting
 
 import (
+	"context"
 	"errors"
 	"slices"
 	"strings"
@@ -11,6 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/wundergraph/graphql-go-tools/execution/engine"
+	"github.com/wundergraph/graphql-go-tools/execution/graphql"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/cache/cachetesting"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
@@ -27,120 +30,56 @@ func inventoryL1Caching(ttl time.Duration) map[string]cacheconfig.CachingConfigu
 	}
 }
 
+// executeDeferOnFlush is ExecuteDefer with a per-flushed-frame callback (called
+// with all frames flushed so far), so tests can close subgraph gates off
+// deterministic frame progress instead of latency.
+func executeDeferOnFlush(tb testing.TB, executionEngine *engine.ExecutionEngine, query string, controller resolve.CacheController, onFlush func(frames []string)) []string {
+	tb.Helper()
+	var frames []string
+	writer := graphql.NewEngineResultWriter()
+	writer.SetFlushCallback(func(data []byte) {
+		frames = append(frames, string(data))
+		onFlush(frames)
+	})
+	require.NoError(tb, executionEngine.Execute(context.Background(), &graphql.Request{Query: query}, &writer, engine.WithCacheController(controller)))
+	if writer.Len() > 0 {
+		frames = append(frames, writer.String())
+	}
+	return frames
+}
+
 // TestDeferL1CrossGroupServing (N1 + M3): an entity cached by the INITIAL
 // fetch serves a same-entity DEFERRED fetch in a later group — the deferred
 // group's subgraph is never hit, both frames are complete, and the per-group
 // loaders share ONE L1 through the by-reference Context (one BeginRequest).
 func TestDeferL1CrossGroupServing(t *testing.T) {
 	query := `{ me { favoriteProduct { upc stock warehouse { id location } } } products(first: 1) { upc ... @defer { stock } } }`
-	responses := map[string]string{
-		"users":                        `{"data":{"me":{"__typename":"User","id":"u1"}}}`,
-		"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
-		"products":                     `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`,
-		"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5,"warehouse":{"__typename":"Warehouse","id":"w1","location":"Berlin"}}]}}`,
-		// TAMPERED: if the deferred group ever touches the network, the frame
-		// shows 999 and the assertion fails loudly.
-		"inventory:products": `{"data":{"_entities":[{"__typename":"Product","stock":999}]}}`,
-	}
-	result := Plan(t, query, inventoryL1Caching(0), responses)
-
-	// The reviewer-guidance plan inspection: the initial tree really carries a
-	// configured inventory fetch (the superset provider) and the DEFER GROUP
-	// really carries a configured same-entity fetch — L1 kept on BOTH.
-	assert.Equal(t, `QueryPlan {
-  Sequence {
-    Parallel {
-      Fetch(service: "3") {
-        {
-            me {
-                __typename
-                id
-            }
-        }
-      }
-      Fetch(service: "0") {
-        {
-            products(first: $a){
-                upc
-                __typename
-            }
-        }
-      }
-    }
-    Fetch(service: "0") {
-      {
-        fragment Key on User {
-            __typename
-            id
-        }
-      } =>
-      {
-          _entities(representations: $representations){
-              ... on User {
-                  __typename
-                  favoriteProduct {
-                      upc
-                      __typename
-                  }
-              }
-          }
-      }
-    }
-    Flatten(path: "me.favoriteProduct") {
-      Fetch(service: "1") {
-        {
-          fragment Key on Product {
-              __typename
-              upc
-          }
-        } =>
-        Cache: {l1:true l2:false cacheName:inventory ttl:0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:Entity type:Product field: candidates:1 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}
-        {
-            _entities(representations: $representations){
-                ... on Product {
-                    __typename
-                    stock
-                    warehouse {
-                        id
-                        location
-                    }
-                }
-            }
-        }
-      }
-    }
-  }
-}
-Deferred (id: 1) QueryPlan {
-  Fetch(service: "1") {
-    {
-      fragment Key on Product {
-          __typename
-          upc
-      }
-    } =>
-    Cache: {l1:true l2:false cacheName:inventory ttl:0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:Entity type:Product field: candidates:1 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}
-    {
-        _entities(representations: $representations){
-            ... on Product {
-                __typename
-                stock
-            }
-        }
-    }
-  }
-}
-`, PrettyPlan(result))
+	users := Respond(`{"data":{"me":{"__typename":"User","id":"u1"}}}`)
+	products := Rules(
+		Rule(`_entities`, `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`),
+		Rule(`products(first: $a)`, `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`),
+	)
+	// TAMPERED fallback: the deferred group's stock-only request misses the
+	// warehouse rule, so if it ever touches the network the frame shows 999
+	// and the assertion fails loudly.
+	tampered := Rule(``, `{"data":{"_entities":[{"__typename":"Product","stock":999}]}}`)
+	inventory := Rules(
+		Rule(`warehouse`, `{"data":{"_entities":[{"__typename":"Product","stock":5,"warehouse":{"__typename":"Warehouse","id":"w1","location":"Berlin"}}]}}`),
+		tampered,
+	)
+	executionEngine := NewEngine(t, inventoryL1Caching(0), Subgraphs{"users": users, "products": products, "inventory": inventory})
 
 	store := cachetesting.NewFakeStore()
 	controller := &countingController{inner: cachetesting.NewRealishCache(store, nil)}
-	frames := ResolveDeferResponse(t, result.DeferResponse, controller)
+	frames := ExecuteDefer(t, executionEngine, query, controller)
 	assert.Equal(t, []string{
 		`{"data":{"me":{"favoriteProduct":{"upc":"1","stock":5,"warehouse":{"id":"w1","location":"Berlin"}}},"products":[{"upc":"1"}]},"pending":[{"id":"1","path":["products"]}],"hasNext":true}`,
 		`{"incremental":[{"data":{"stock":5},"id":"1","subPath":[0]}],"completed":[{"id":"1"}],"hasNext":false}`,
 	}, frames)
-	// The deferred subgraph was NEVER hit; L1-only means zero store traffic.
-	assert.Equal(t, int64(0), result.LoadCount("inventory", "products"))
+	// The deferred group NEVER hit the network: inventory saw exactly the one
+	// initial superset fetch; L1-only means zero store traffic.
+	assert.Equal(t, int64(0), tampered.Count.Load())
+	assert.Equal(t, int64(1), inventory.Requests())
 	assert.Empty(t, store.Ops())
 	// M3: one BeginRequest — every group's loader worked on the same L1.
 	assert.Equal(t, int64(1), controller.begins.Load())
@@ -151,109 +90,28 @@ Deferred (id: 1) QueryPlan {
 // defer-group ancestry (no dependency edge links the two inventory fetches).
 func TestDeferL1GroupToLaterGroup(t *testing.T) {
 	query := `{ products(first: 1) { upc ... @defer { stock warehouse { id location } ... @defer { reviews { product { stock } } } } } }`
-	responses := map[string]string{
-		"products":           `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`,
-		"inventory:products": `{"data":{"_entities":[{"__typename":"Product","stock":5,"warehouse":{"__typename":"Warehouse","id":"w1","location":"Berlin"}}]}}`,
-		"reviews":            `{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","product":{"__typename":"Product","upc":"1"}}]}]}}`,
-		// TAMPERED: the nested group's inventory fetch must never fire.
-		"inventory:products.@.reviews.@.product": `{"data":{"_entities":[{"__typename":"Product","stock":999}]}}`,
-	}
-	result := Plan(t, query, inventoryL1Caching(0), responses)
-
-	// Plan inspection: the OUTER group's inventory fetch (id 1) is the
-	// provider; the NESTED group (id 2, parent = outer) carries the
-	// same-entity consumer, kept L1 although NO dependency edge links it to
-	// the provider.
-	assert.Equal(t, `QueryPlan {
-  Fetch(service: "0") {
-    {
-        products(first: $a){
-            upc
-            __typename
-        }
-    }
-  }
-}
-Deferred (id: 1) QueryPlan {
-  Fetch(service: "1") {
-    {
-      fragment Key on Product {
-          __typename
-          upc
-      }
-    } =>
-    Cache: {l1:true l2:false cacheName:inventory ttl:0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:Entity type:Product field: candidates:1 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}
-    {
-        _entities(representations: $representations){
-            ... on Product {
-                __typename
-                stock
-                warehouse {
-                    id
-                    location
-                }
-            }
-        }
-    }
-  }
-}
-Deferred (id: 2) QueryPlan {
-  Sequence {
-    Fetch(service: "2") {
-      {
-        fragment Key on Product {
-            __typename
-            upc
-        }
-      } =>
-      {
-          _entities(representations: $representations){
-              ... on Product {
-                  __typename
-                  reviews {
-                      product {
-                          __typename
-                          upc
-                      }
-                  }
-              }
-          }
-      }
-    }
-    Flatten(path: "products.@.reviews.@.product") {
-      Fetch(service: "1") {
-        {
-          fragment Key on Product {
-              __typename
-              upc
-          }
-        } =>
-        Cache: {l1:true l2:false cacheName:inventory ttl:0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:Entity type:Product field: candidates:1 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}
-        {
-            _entities(representations: $representations){
-                ... on Product {
-                    __typename
-                    stock
-                }
-            }
-        }
-      }
-    }
-  }
-}
-`, PrettyPlan(result))
-	groups := DeferGroups(result.DeferResponse)
-	require.Len(t, groups, 2)
-	assert.Equal(t, 1, result.DeferResponse.DeferDescriptors[groups[1].DeferID].ParentID)
+	products := Respond(`{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`)
+	// TAMPERED fallback: the nested group's stock-only inventory fetch must
+	// never fire.
+	tampered := Rule(``, `{"data":{"_entities":[{"__typename":"Product","stock":999}]}}`)
+	inventory := Rules(
+		Rule(`warehouse`, `{"data":{"_entities":[{"__typename":"Product","stock":5,"warehouse":{"__typename":"Warehouse","id":"w1","location":"Berlin"}}]}}`),
+		tampered,
+	)
+	reviews := Respond(`{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","product":{"__typename":"Product","upc":"1"}}]}]}}`)
+	executionEngine := NewEngine(t, inventoryL1Caching(0), Subgraphs{"products": products, "inventory": inventory, "reviews": reviews})
 
 	store := cachetesting.NewFakeStore()
-	frames := ResolveDeferResponse(t, result.DeferResponse, cachetesting.NewRealishCache(store, nil))
+	frames := ExecuteDefer(t, executionEngine, query, cachetesting.NewRealishCache(store, nil))
 	assert.Equal(t, []string{
 		`{"data":{"products":[{"upc":"1"}]},"pending":[{"id":"1","path":["products"]}],"hasNext":true}`,
 		`{"incremental":[{"data":{"stock":5,"warehouse":{"id":"w1","location":"Berlin"}},"id":"1","subPath":[0]}],"completed":[{"id":"1"}],"pending":[{"id":"2","path":["products"]}],"hasNext":true}`,
 		`{"incremental":[{"data":{"reviews":[{"product":{"stock":5}}]},"id":"2","subPath":[0]}],"completed":[{"id":"2"}],"hasNext":false}`,
 	}, frames)
-	assert.Equal(t, int64(0), result.LoadCount("inventory", "products.@.reviews.@.product"))
+	// The nested group NEVER hit the network: inventory saw exactly the OUTER
+	// group's superset fetch; L1-only means zero store traffic.
+	assert.Equal(t, int64(0), tampered.Count.Load())
+	assert.Equal(t, int64(1), inventory.Requests())
 	assert.Empty(t, store.Ops())
 }
 
@@ -297,18 +155,24 @@ func TestDeferSingleFlush(t *testing.T) {
 	// The deferred selection is NOT covered by the initial fetch, so the group
 	// genuinely fetches and owes an L2 write.
 	query := `{ me { favoriteProduct { upc stock } } products(first: 1) { upc ... @defer { warehouse { id location } } } }`
-	responses := map[string]string{
-		"users":                        `{"data":{"me":{"__typename":"User","id":"u1"}}}`,
-		"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
-		"products":                     `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`,
-		"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
-		"inventory:products":           `{"data":{"_entities":[{"__typename":"Product","warehouse":{"__typename":"Warehouse","id":"w1","location":"Berlin"}}]}}`,
-	}
-	result := Plan(t, query, inventoryL1Caching(time.Minute), responses)
+	users := Respond(`{"data":{"me":{"__typename":"User","id":"u1"}}}`)
+	products := Rules(
+		Rule(`_entities`, `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`),
+		Rule(`products(first: $a)`, `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`),
+	)
+	inventory := Rules(
+		Rule(`stock`, `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`),
+		Rule(`warehouse`, `{"data":{"_entities":[{"__typename":"Product","warehouse":{"__typename":"Warehouse","id":"w1","location":"Berlin"}}]}}`),
+	)
+	executionEngine := NewEngine(t, inventoryL1Caching(time.Minute), Subgraphs{"users": users, "products": products, "inventory": inventory})
+
 	store := cachetesting.NewFakeStore()
 	controller := &endCountingController{inner: cachetesting.NewRealishCache(store, nil)}
-	frames := ResolveDeferResponse(t, result.DeferResponse, controller)
-	require.Len(t, frames, 2)
+	frames := ExecuteDefer(t, executionEngine, query, controller)
+	assert.Equal(t, []string{
+		`{"data":{"me":{"favoriteProduct":{"upc":"1","stock":5}},"products":[{"upc":"1"}]},"pending":[{"id":"1","path":["products"]}],"hasNext":true}`,
+		`{"incremental":[{"data":{"warehouse":{"id":"w1","location":"Berlin"}},"id":"1","subPath":[0]}],"completed":[{"id":"1"}],"hasNext":false}`,
+	}, frames)
 	assert.Equal(t, int64(1), controller.ends.Load())
 
 	ops := store.Ops()
@@ -331,70 +195,43 @@ func TestDeferSingleFlush(t *testing.T) {
 // the skip neither waits for nor reorders the fetching sibling.
 func TestDeferSkipDoesNotReorderFrames(t *testing.T) {
 	query := `{ me { favoriteProduct { upc stock } } products(first: 1) { upc ... @defer { stock } ... @defer { warehouse { id } } } }`
-	responses := map[string]string{
-		"users":                        `{"data":{"me":{"__typename":"User","id":"u1"}}}`,
-		"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
-		"products":                     `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`,
-		"products:products":            `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`,
-		"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
-		// Only the warehouse group LOADS (the stock group is L1-served and
-		// never reaches its gated datasource).
-		"inventory:products": `{"data":{"_entities":[{"__typename":"Product","warehouse":{"__typename":"Warehouse","id":"w1"}}]}}`,
-	}
-	result := Plan(t, query, inventoryL1Caching(0), responses)
-
-	arrived := make(chan string, 4)
+	users := Respond(`{"data":{"me":{"__typename":"User","id":"u1"}}}`)
+	products := Rules(
+		Rule(`_entities`, `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`),
+		Rule(`products(first: $a)`, `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`),
+	)
+	// Only the warehouse group LOADS (the stock group is L1-served); its HTTP
+	// response stays gated until `release` closes.
 	release := make(chan struct{})
-	result.Gate("inventory", "products", cachetesting.DataSourceGate{Arrived: arrived, Release: release})
+	gated := &SubgraphRule{
+		Match:    `warehouse`,
+		Response: `{"data":{"_entities":[{"__typename":"Product","warehouse":{"__typename":"Warehouse","id":"w1"}}]}}`,
+		Gate:     release,
+	}
+	stockRule := Rule(`stock`, `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`)
+	inventory := Rules(gated, stockRule)
+	executionEngine := NewEngine(t, inventoryL1Caching(0), Subgraphs{"users": users, "products": products, "inventory": inventory})
 
-	writer := &deferFrameWriter{Flushed: make(chan struct{}, 8)}
-	done := make(chan error, 1)
-	ctx := resolve.NewContext(t.Context())
-	ctx.SetCacheController(cachetesting.NewRealishCache(cachetesting.NewFakeStore(), nil))
-	r := resolve.New(t.Context(), resolve.ResolverOptions{MaxConcurrency: 16})
-	go func() {
-		_, err := r.ResolveGraphQLDeferResponse(ctx, result.DeferResponse, writer)
-		done <- err
-	}()
-
-	// Pure channel ordering, no latency dependence: every receive carries a
-	// failsafe timeout so a resolver regression fails the test instead of
-	// hanging it (the timeout can only fire on regression, never orders).
-	waitFor := func(what string, ch <-chan struct{}) {
-		t.Helper()
-		select {
-		case <-ch:
-		case <-time.After(30 * time.Second):
-			t.Fatalf("timed out waiting for %s", what)
+	// Pure gate ordering, no latency dependence: the gated sibling's frame can
+	// only flush after `release` closes, and `release` closes only once BOTH
+	// earlier frames (initial + the L1-served skip sibling's) have flushed — so
+	// the skip demonstrably did not wait for the gated fetch, and the full
+	// frame order is deterministic.
+	frames := executeDeferOnFlush(t, executionEngine, query, cachetesting.NewRealishCache(cachetesting.NewFakeStore(), nil), func(frames []string) {
+		if len(frames) == 2 {
+			close(release)
 		}
-	}
-	// The gated group's fetch is IN FLIGHT (blocked on the gate) ...
-	select {
-	case <-arrived:
-	case <-time.After(30 * time.Second):
-		t.Fatal("timed out waiting for the gated inventory fetch to arrive")
-	}
-	// ... and the initial frame plus the L1-served sibling's frame still flush
-	// without waiting for it.
-	waitFor("the initial frame flush", writer.Flushed)
-	waitFor("the L1-served sibling's frame flush", writer.Flushed)
-	framesBeforeRelease := writer.Frames()
-	require.Equal(t, []string{
+	})
+	assert.Equal(t, []string{
 		`{"data":{"me":{"favoriteProduct":{"upc":"1","stock":5}},"products":[{"upc":"1"}]},"pending":[{"id":"1","path":["products"]},{"id":"2","path":["products"]}],"hasNext":true}`,
 		`{"incremental":[{"data":{"stock":5},"id":"1","subPath":[0]}],"completed":[{"id":"1"}],"hasNext":true}`,
-	}, framesBeforeRelease)
-
-	close(release)
-	select {
-	case err := <-done:
-		require.NoError(t, err)
-	case <-time.After(30 * time.Second):
-		t.Fatal("timed out waiting for the defer resolve to complete")
-	}
-	waitFor("the gated sibling's frame flush", writer.Flushed)
-	frames := writer.Frames()
-	require.Len(t, frames, 3)
-	assert.Equal(t, `{"incremental":[{"data":{"warehouse":{"id":"w1"}},"id":"2","subPath":[0]}],"completed":[{"id":"2"}],"hasNext":false}`, frames[2])
+		`{"incremental":[{"data":{"warehouse":{"id":"w1"}},"id":"2","subPath":[0]}],"completed":[{"id":"2"}],"hasNext":false}`,
+	}, frames)
+	// The skip group never touched the network: inventory saw exactly the
+	// initial stock fetch and the gated warehouse fetch.
+	assert.Equal(t, int64(1), stockRule.Count.Load())
+	assert.Equal(t, int64(1), gated.Count.Load())
+	assert.Equal(t, int64(2), inventory.Requests())
 }
 
 // erroringResultCache fails OnFetchResult when the fresh response contains
@@ -438,61 +275,40 @@ var errFromHook = errors.New("cache hook failed")
 // THAT group's outcome; the sibling group's frame is complete and unaffected.
 func TestDeferHookErrorIsolation(t *testing.T) {
 	query := `{ me { favoriteProduct { upc ... @defer { stock } } } products(first: 1) { upc ... @defer { warehouse { id } } } }`
-	responses := map[string]string{
-		"users":                        `{"data":{"me":{"__typename":"User","id":"u1"}}}`,
-		"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
-		"products":                     `{"data":{"products":[{"__typename":"Product","upc":"2"}]}}`,
-		"products:products":            `{"data":{"products":[{"__typename":"Product","upc":"2"}]}}`,
-		"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
-		"inventory:products":           `{"data":{"_entities":[{"__typename":"Product","warehouse":{"__typename":"Warehouse","id":"w1"}}]}}`,
+	users := Respond(`{"data":{"me":{"__typename":"User","id":"u1"}}}`)
+	products := Rules(
+		Rule(`_entities`, `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`),
+		Rule(`products(first: $a)`, `{"data":{"products":[{"__typename":"Product","upc":"2"}]}}`),
+	)
+	// Parallel sibling groups flush in either order — gate the ERRORING group's
+	// subgraph fetch until the healthy sibling's frame has flushed, so the frame
+	// order is gate-deterministic and every frame can be pinned in full.
+	release := make(chan struct{})
+	gated := &SubgraphRule{
+		Match:    `warehouse`,
+		Response: `{"data":{"_entities":[{"__typename":"Product","warehouse":{"__typename":"Warehouse","id":"w1"}}]}}`,
+		Gate:     release,
 	}
-	result := Plan(t, query, inventoryL1Caching(time.Minute), responses)
+	inventory := Rules(
+		gated,
+		Rule(`stock`, `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`),
+	)
+	executionEngine := NewEngine(t, inventoryL1Caching(time.Minute), Subgraphs{"users": users, "products": products, "inventory": inventory})
+
 	controller := &erroringResultController{
 		inner:  cachetesting.NewRealishCache(cachetesting.NewFakeStore(), nil),
 		marker: "warehouse",
 	}
-
-	// Parallel sibling groups flush in either order — gate the ERRORING group's
-	// subgraph fetch until the healthy sibling's frame has flushed, so the frame
-	// order is channel-deterministic and every frame can be pinned in full.
-	arrived := make(chan string, 4)
-	release := make(chan struct{})
-	result.Gate("inventory", "products", cachetesting.DataSourceGate{Arrived: arrived, Release: release})
-
-	writer := &deferFrameWriter{Flushed: make(chan struct{}, 8)}
-	done := make(chan error, 1)
-	ctx := resolve.NewContext(t.Context())
-	ctx.SetCacheController(controller)
-	r := resolve.New(t.Context(), resolve.ResolverOptions{MaxConcurrency: 16})
-	go func() {
-		_, err := r.ResolveGraphQLDeferResponse(ctx, result.DeferResponse, writer)
-		done <- err
-	}()
-
-	waitFor := func(what string, ch <-chan struct{}) {
-		t.Helper()
-		select {
-		case <-ch:
-		case <-time.After(30 * time.Second):
-			t.Fatalf("timed out waiting for %s", what)
+	frames := executeDeferOnFlush(t, executionEngine, query, controller, func(frames []string) {
+		if len(frames) == 2 {
+			close(release)
 		}
-	}
-	waitFor("the initial frame flush", writer.Flushed)
-	waitFor("the healthy sibling's frame flush", writer.Flushed)
-	close(release)
-	select {
-	case err := <-done:
-		require.NoError(t, err)
-	case <-time.After(30 * time.Second):
-		t.Fatal("timed out waiting for the defer resolve to complete")
-	}
-	waitFor("the erroring group's frame flush", writer.Flushed)
-
+	})
 	// The erroring group's frame carries ONLY the hook failure (no warehouse
 	// data); the sibling's frame is complete and unaffected.
 	assert.Equal(t, []string{
 		`{"data":{"me":{"favoriteProduct":{"upc":"1"}},"products":[{"upc":"2"}]},"pending":[{"id":"1","path":["me","favoriteProduct"]},{"id":"2","path":["products"]}],"hasNext":true}`,
 		`{"incremental":[{"data":{"stock":5},"id":"1"}],"completed":[{"id":"1"}],"hasNext":true}`,
 		`{"completed":[{"id":"2","errors":[{"message":"cache hook failed"}]}],"hasNext":false}`,
-	}, writer.Frames())
+	}, frames)
 }

--- a/execution/cachingtesting/defer_l1_e2e_test.go
+++ b/execution/cachingtesting/defer_l1_e2e_test.go
@@ -2,6 +2,7 @@ package cachingtesting
 
 import (
 	"errors"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -314,13 +315,15 @@ func TestDeferSingleFlush(t *testing.T) {
 	require.Len(t, ops, 4)
 	// Both lookups (initial + deferred group) precede BOTH writes: the single
 	// request-end flush carries the initial fetch's write and the group's.
-	assert.Equal(t, "Get", ops[0].Kind)
-	assert.Equal(t, "Get", ops[1].Kind)
-	assert.Equal(t, "Set", ops[2].Kind)
-	assert.Equal(t, "Set", ops[3].Kind)
+	assert.Equal(t, []string{"Get", "Get", "Set", "Set"}, []string{ops[0].Kind, ops[1].Kind, ops[2].Kind, ops[3].Kind})
+	// The two flush writes drain a map, so their order is free — sort, then
+	// pin the complete value set.
 	values := []string{ops[2].Value, ops[3].Value}
-	assert.Contains(t, values, `{"__typename":"Product","stock":5}`)
-	assert.Contains(t, values, `{"__typename":"Product","warehouse":{"__typename":"Warehouse","id":"w1","location":"Berlin"}}`)
+	slices.Sort(values)
+	assert.Equal(t, []string{
+		`{"__typename":"Product","stock":5}`,
+		`{"__typename":"Product","warehouse":{"__typename":"Warehouse","id":"w1","location":"Berlin"}}`,
+	}, values)
 }
 
 // TestDeferSkipDoesNotReorderFrames (N4): a SkipFullHit on one sibling group
@@ -376,8 +379,10 @@ func TestDeferSkipDoesNotReorderFrames(t *testing.T) {
 	waitFor("the initial frame flush", writer.Flushed)
 	waitFor("the L1-served sibling's frame flush", writer.Flushed)
 	framesBeforeRelease := writer.Frames()
-	require.Len(t, framesBeforeRelease, 2)
-	assert.Contains(t, framesBeforeRelease[1], `"data":{"stock":5}`)
+	require.Equal(t, []string{
+		`{"data":{"me":{"favoriteProduct":{"upc":"1","stock":5}},"products":[{"upc":"1"}]},"pending":[{"id":"1","path":["products"]},{"id":"2","path":["products"]}],"hasNext":true}`,
+		`{"incremental":[{"data":{"stock":5},"id":"1","subPath":[0]}],"completed":[{"id":"1"}],"hasNext":true}`,
+	}, framesBeforeRelease)
 
 	close(release)
 	select {
@@ -389,8 +394,7 @@ func TestDeferSkipDoesNotReorderFrames(t *testing.T) {
 	waitFor("the gated sibling's frame flush", writer.Flushed)
 	frames := writer.Frames()
 	require.Len(t, frames, 3)
-	assert.Contains(t, frames[2], `"data":{"warehouse":{"id":"w1"}}`)
-	assert.True(t, strings.HasSuffix(frames[2], `"hasNext":false}`))
+	assert.Equal(t, `{"incremental":[{"data":{"warehouse":{"id":"w1"}},"id":"2","subPath":[0]}],"completed":[{"id":"2"}],"hasNext":false}`, frames[2])
 }
 
 // erroringResultCache fails OnFetchResult when the fresh response contains
@@ -447,17 +451,48 @@ func TestDeferHookErrorIsolation(t *testing.T) {
 		inner:  cachetesting.NewRealishCache(cachetesting.NewFakeStore(), nil),
 		marker: "warehouse",
 	}
-	frames := ResolveDeferResponse(t, result.DeferResponse, controller)
-	require.Len(t, frames, 3)
-	assert.Equal(t,
+
+	// Parallel sibling groups flush in either order — gate the ERRORING group's
+	// subgraph fetch until the healthy sibling's frame has flushed, so the frame
+	// order is channel-deterministic and every frame can be pinned in full.
+	arrived := make(chan string, 4)
+	release := make(chan struct{})
+	result.Gate("inventory", "products", cachetesting.DataSourceGate{Arrived: arrived, Release: release})
+
+	writer := &deferFrameWriter{Flushed: make(chan struct{}, 8)}
+	done := make(chan error, 1)
+	ctx := resolve.NewContext(t.Context())
+	ctx.SetCacheController(controller)
+	r := resolve.New(t.Context(), resolve.ResolverOptions{MaxConcurrency: 16})
+	go func() {
+		_, err := r.ResolveGraphQLDeferResponse(ctx, result.DeferResponse, writer)
+		done <- err
+	}()
+
+	waitFor := func(what string, ch <-chan struct{}) {
+		t.Helper()
+		select {
+		case <-ch:
+		case <-time.After(30 * time.Second):
+			t.Fatalf("timed out waiting for %s", what)
+		}
+	}
+	waitFor("the initial frame flush", writer.Flushed)
+	waitFor("the healthy sibling's frame flush", writer.Flushed)
+	close(release)
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for the defer resolve to complete")
+	}
+	waitFor("the erroring group's frame flush", writer.Flushed)
+
+	// The erroring group's frame carries ONLY the hook failure (no warehouse
+	// data); the sibling's frame is complete and unaffected.
+	assert.Equal(t, []string{
 		`{"data":{"me":{"favoriteProduct":{"upc":"1"}},"products":[{"upc":"2"}]},"pending":[{"id":"1","path":["me","favoriteProduct"]},{"id":"2","path":["products"]}],"hasNext":true}`,
-		frames[0])
-	// One frame carries the erroring group's hook failure; the OTHER carries
-	// the sibling's complete data — unaffected. (Parallel siblings flush in
-	// either order; match by content.)
-	joined := strings.Join(frames[1:], " ")
-	assert.Contains(t, joined, `"errors":[{"message":"cache hook failed"}]`)
-	assert.Contains(t, joined, `"data":{"stock":5}`)
-	assert.NotContains(t, joined, `"warehouse"`)
-	assert.True(t, strings.HasSuffix(frames[2], `"hasNext":false}`))
+		`{"incremental":[{"data":{"stock":5},"id":"1"}],"completed":[{"id":"1"}],"hasNext":true}`,
+		`{"completed":[{"id":"2","errors":[{"message":"cache hook failed"}]}],"hasNext":false}`,
+	}, writer.Frames())
 }

--- a/execution/cachingtesting/enginetesting.go
+++ b/execution/cachingtesting/enginetesting.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -29,10 +30,13 @@ import (
 
 // SubgraphRule routes one canned response: the first rule whose Match
 // substring appears in the incoming request body wins (empty Match matches
-// everything). Count records how many requests the rule served.
+// everything). Count records how many requests the rule served. A non-nil
+// Gate blocks the RESPONSE (after the request is recorded) until the channel
+// is closed — the deterministic ordering handle for defer-group tests.
 type SubgraphRule struct {
 	Match    string
 	Response string
+	Gate     <-chan struct{}
 	Count    atomic.Int64
 }
 
@@ -92,6 +96,9 @@ func (s *Subgraph) start(tb testing.TB, name string) {
 		for _, rule := range s.Rules {
 			if rule.Match == "" || strings.Contains(string(body), rule.Match) {
 				rule.Count.Add(1)
+				if rule.Gate != nil {
+					<-rule.Gate
+				}
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = w.Write([]byte(rule.Response))
 				return
@@ -174,4 +181,74 @@ func ExecuteWithVariables(tb testing.TB, executionEngine *engine.ExecutionEngine
 	writer := graphql.NewEngineResultWriter()
 	require.NoError(tb, executionEngine.Execute(context.Background(), request, &writer, options...))
 	return writer.String()
+}
+
+// TracedExecutionOptions are the deterministic ART options for pinned traces:
+// predictable timings, no connection-timing noise, trace in the extensions.
+func TracedExecutionOptions() engine.ExecutionOptions {
+	return engine.WithRequestTraceOptions(resolve.TraceOptions{
+		Enable:                                 true,
+		ExcludeLoadStats:                       true,
+		EnablePredictableDebugTimings:          true,
+		Debug:                                  true,
+		IncludeTraceOutputInResponseExtensions: true,
+	})
+}
+
+// ExecuteTraced runs one operation with ART enabled and returns the full body
+// including extensions.trace.
+func ExecuteTraced(tb testing.TB, executionEngine *engine.ExecutionEngine, query string, controller resolve.CacheController, options ...engine.ExecutionOptions) string {
+	tb.Helper()
+	return Execute(tb, executionEngine, query, controller, append(options, TracedExecutionOptions())...)
+}
+
+// ExecutePlanned runs one operation with the QueryPlan included in the
+// response extensions and returns the full body.
+func ExecutePlanned(tb testing.TB, executionEngine *engine.ExecutionEngine, query string, controller resolve.CacheController, options ...engine.ExecutionOptions) string {
+	tb.Helper()
+	return Execute(tb, executionEngine, query, controller, append(options, engine.WithIncludeQueryPlanInResponse())...)
+}
+
+// ExecuteDefer runs one @defer operation and returns every flushed frame in
+// delivery order.
+func ExecuteDefer(tb testing.TB, executionEngine *engine.ExecutionEngine, query string, controller resolve.CacheController, options ...engine.ExecutionOptions) []string {
+	tb.Helper()
+	if controller != nil {
+		options = append(options, engine.WithCacheController(controller))
+	}
+	var frames []string
+	writer := graphql.NewEngineResultWriter()
+	writer.SetFlushCallback(func(data []byte) {
+		frames = append(frames, string(data))
+	})
+	require.NoError(tb, executionEngine.Execute(context.Background(), &graphql.Request{Query: query}, &writer, options...))
+	if writer.Len() > 0 {
+		frames = append(frames, writer.String())
+	}
+	return frames
+}
+
+// NormalizeURLs rewrites every subgraph double's ephemeral httptest URL to the
+// stable fixture form http://<name>.service so response pins stay literal.
+func (s Subgraphs) NormalizeURLs(body string) string {
+	for name, subgraph := range s {
+		if subgraph.server != nil {
+			body = strings.ReplaceAll(body, subgraph.server.URL, "http://"+name+".service")
+		}
+	}
+	return body
+}
+
+var (
+	remainingTTLPattern = regexp.MustCompile(`"remaining_ttl_nanoseconds":[1-9][0-9]*`)
+	cacheAgePattern     = regexp.MustCompile(`"cache_age_nanoseconds":[1-9][0-9]*`)
+)
+
+// NormalizeCacheTraceClock rewrites the real-clock cache-trace fields (positive
+// remaining-TTL and cache-age nanos) to -1 so full-body pins stay literal;
+// their exact values are pinned by the synctest observer unit rows.
+func NormalizeCacheTraceClock(body string) string {
+	body = remainingTTLPattern.ReplaceAllString(body, `"remaining_ttl_nanoseconds":-1`)
+	body = cacheAgePattern.ReplaceAllString(body, `"cache_age_nanoseconds":-1`)
+	return body
 }

--- a/execution/cachingtesting/enginetesting.go
+++ b/execution/cachingtesting/enginetesting.go
@@ -1,0 +1,177 @@
+package cachingtesting
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/jensneuse/abstractlogger"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/execution/engine"
+	"github.com/wundergraph/graphql-go-tools/execution/graphql"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// The engine-based half of the harness: real ExecutionEngine over real HTTP
+// subgraph upstreams (the federation_integration_static_test.go pattern),
+// with caching wired through Configuration.SetCaching and the runtime
+// controller attached per request via engine.WithCacheController. Plan()
+// remains for PLAN-shape assertions (pretty-printed plans, ART trace
+// internals, defer frames, gated in-process ordering, benchmarks); request
+// execution goes through the engine.
+
+// SubgraphRule routes one canned response: the first rule whose Match
+// substring appears in the incoming request body wins (empty Match matches
+// everything). Count records how many requests the rule served.
+type SubgraphRule struct {
+	Match    string
+	Response string
+	Count    atomic.Int64
+}
+
+// Subgraph is one httptest upstream with routing rules and a request counter.
+type Subgraph struct {
+	Rules []*SubgraphRule
+
+	mu       sync.Mutex
+	requests []string
+	server   *httptest.Server
+	count    atomic.Int64
+}
+
+// Requests returns how many requests the subgraph received in total.
+func (s *Subgraph) Requests() int64 {
+	return s.count.Load()
+}
+
+// Bodies returns the exact request bodies received, in order.
+func (s *Subgraph) Bodies() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.requests...)
+}
+
+// Subgraphs maps subgraph NAME to its upstream double.
+type Subgraphs map[string]*Subgraph
+
+// Rules builds a Subgraph from ordered routing rules.
+func Rules(rules ...*SubgraphRule) *Subgraph {
+	return &Subgraph{Rules: rules}
+}
+
+// Respond builds a single-response Subgraph (every request gets response).
+func Respond(response string) *Subgraph {
+	return Rules(&SubgraphRule{Response: response})
+}
+
+// Rule builds one routing rule.
+func Rule(match, response string) *SubgraphRule {
+	return &SubgraphRule{Match: match, Response: response}
+}
+
+func (s *Subgraph) start(tb testing.TB, name string) {
+	tb.Helper()
+	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			tb.Errorf("subgraph %q: read body: %v", name, err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		s.count.Add(1)
+		s.mu.Lock()
+		s.requests = append(s.requests, string(body))
+		s.mu.Unlock()
+		for _, rule := range s.Rules {
+			if rule.Match == "" || strings.Contains(string(body), rule.Match) {
+				rule.Count.Add(1)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(rule.Response))
+				return
+			}
+		}
+		tb.Errorf("subgraph %q: no rule matched request body: %s", name, body)
+		http.Error(w, "no canned response", http.StatusInternalServerError)
+	}))
+	tb.Cleanup(s.server.Close)
+}
+
+// NewEngine builds a real ExecutionEngine over the committed caching fixture
+// federation, with every datasource pointed at its subgraph double and the
+// caching policies (keyed by SUBGRAPH NAME) wired through SetCaching. Every
+// configured subgraph must have a double; unconfigured doubles fail the test
+// on first use via their own rule mismatch.
+func NewEngine(tb testing.TB, caching map[string]cacheconfig.CachingConfiguration, subgraphs Subgraphs) *engine.ExecutionEngine {
+	tb.Helper()
+
+	rc := routerConfig(tb)
+	nameToID := subgraphNameToDatasourceID(rc)
+	idToName := make(map[string]string, len(nameToID))
+	for name, id := range nameToID {
+		idToName[id] = name
+	}
+
+	// Point each datasource at its double BEFORE the engine configuration is
+	// built; a subgraph without a double keeps its unreachable fixture URL, so
+	// touching it fails loudly.
+	for _, ds := range rc.EngineConfig.DatasourceConfigurations {
+		name := idToName[ds.Id]
+		subgraph, ok := subgraphs[name]
+		if !ok {
+			continue
+		}
+		subgraph.start(tb, name)
+		require.NotNil(tb, ds.CustomGraphql, "datasource %q has no graphql config", name)
+		ds.CustomGraphql.Fetch.Url.StaticVariableContent = subgraph.server.URL
+	}
+	for name := range subgraphs {
+		_, ok := nameToID[name]
+		require.True(tb, ok, "unknown subgraph name %q", name)
+	}
+
+	factory := engine.NewFederationEngineConfigFactory(tb.Context())
+	conf, err := factory.BuildEngineConfiguration(rc)
+	require.NoError(tb, err)
+
+	if len(caching) > 0 {
+		byID := make(map[string]cacheconfig.CachingConfiguration, len(caching))
+		for name, cfg := range caching {
+			id, ok := nameToID[name]
+			require.True(tb, ok, "caching configured for unknown subgraph %q", name)
+			byID[id] = cfg
+		}
+		conf.SetCaching(byID)
+	}
+
+	executionEngine, err := engine.NewExecutionEngine(tb.Context(), abstractlogger.Noop{}, conf, resolve.ResolverOptions{MaxConcurrency: 16})
+	require.NoError(tb, err)
+	return executionEngine
+}
+
+// Execute runs one operation through the engine with the given runtime cache
+// controller (nil = caching runtime off) and returns the full response body.
+func Execute(tb testing.TB, executionEngine *engine.ExecutionEngine, query string, controller resolve.CacheController, options ...engine.ExecutionOptions) string {
+	return ExecuteWithVariables(tb, executionEngine, query, "", controller, options...)
+}
+
+// ExecuteWithVariables is Execute with request variables (JSON, "" for none).
+func ExecuteWithVariables(tb testing.TB, executionEngine *engine.ExecutionEngine, query, variables string, controller resolve.CacheController, options ...engine.ExecutionOptions) string {
+	tb.Helper()
+	request := &graphql.Request{Query: query}
+	if variables != "" {
+		request.Variables = []byte(variables)
+	}
+	if controller != nil {
+		options = append(options, engine.WithCacheController(controller))
+	}
+	writer := graphql.NewEngineResultWriter()
+	require.NoError(tb, executionEngine.Execute(context.Background(), request, &writer, options...))
+	return writer.String()
+}

--- a/execution/cachingtesting/entity_config_test.go
+++ b/execution/cachingtesting/entity_config_test.go
@@ -43,13 +43,15 @@ func entityCachingFor(subgraphs ...string) map[string]cacheconfig.CachingConfigu
 
 // TestEntityCacheConfigSyncPlan pins the full per-fetch cache config over a
 // REAL sync plan: the reviews batch entity fetch is configured, the products
-// root fetch stays nil (root-field caching is task 13).
+// root fetch stays nil (root-field caching is task 13). The lone entity fetch
+// has no L1 provider/consumer pair, so optimizeL1Cache (task 16) narrows L1
+// off.
 func TestEntityCacheConfigSyncPlan(t *testing.T) {
 	result := Plan(t, `{ products(first: 2) { upc reviews { body } } }`, entityCachingFor("reviews"), nil)
 	rendered := renderFetchCacheConfigs(result.Response.Fetches)
 	assert.Equal(t, []string{
 		`path:"" cache:<nil>`,
-		`path:"products" cache:{l1:true l2:true cacheName:products ttl:1m0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:Entity type:Product field: candidates:1 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}`,
+		`path:"products" cache:{l1:false l2:true cacheName:products ttl:1m0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:Entity type:Product field: candidates:1 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}`,
 	}, rendered)
 }
 

--- a/execution/cachingtesting/entity_config_test.go
+++ b/execution/cachingtesting/entity_config_test.go
@@ -1,0 +1,99 @@
+package cachingtesting
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// renderFetchCacheConfigs walks a fetch tree and renders every fetch's cache
+// config (nil-safe) with its response path, for full-value plan-level asserts.
+func renderFetchCacheConfigs(node *resolve.FetchTreeNode) []string {
+	if node == nil {
+		return nil
+	}
+	var out []string
+	if node.Item != nil && node.Item.Fetch != nil {
+		out = append(out, fmt.Sprintf("path:%q cache:%s", node.Item.ResponsePath, node.Item.Fetch.CacheConfig().String()))
+	}
+	for _, child := range node.ChildNodes {
+		out = append(out, renderFetchCacheConfigs(child)...)
+	}
+	return out
+}
+
+func entityCachingFor(subgraphs ...string) map[string]cacheconfig.CachingConfiguration {
+	caching := make(map[string]cacheconfig.CachingConfiguration, len(subgraphs))
+	for _, name := range subgraphs {
+		caching[name] = cacheconfig.CachingConfiguration{
+			Entities: []cacheconfig.EntityCachePolicy{
+				{TypeName: "Product", CacheName: "products", TTL: time.Minute},
+			},
+		}
+	}
+	return caching
+}
+
+// TestEntityCacheConfigSyncPlan pins the full per-fetch cache config over a
+// REAL sync plan: the reviews batch entity fetch is configured, the products
+// root fetch stays nil (root-field caching is task 13).
+func TestEntityCacheConfigSyncPlan(t *testing.T) {
+	result := Plan(t, `{ products(first: 2) { upc reviews { body } } }`, entityCachingFor("reviews"), nil)
+	rendered := renderFetchCacheConfigs(result.Response.Fetches)
+	assert.Equal(t, []string{
+		`path:"" cache:<nil>`,
+		`path:"products" cache:{l1:true l2:true cacheName:products ttl:1m0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:Entity type:Product field: candidates:1 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}`,
+	}, rendered)
+}
+
+// TestEntityCacheConfigDeferPlan pins that DEFER-GROUP entity fetches carry
+// config too: the initial inventory fetch and the deferred inventory fetch are
+// both configured from the same policy.
+func TestEntityCacheConfigDeferPlan(t *testing.T) {
+	query := `
+		query {
+			me { favoriteProduct { upc stock warehouse { id location } } }
+			products(first: 1) {
+				upc
+				... @defer { stock }
+			}
+		}`
+	result := Plan(t, query, entityCachingFor("inventory"), nil)
+	require.NotNil(t, result.DeferResponse)
+
+	inventoryCfg := `{l1:true l2:true cacheName:products ttl:1m0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:Entity type:Product field: candidates:1 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}`
+
+	initial := renderFetchCacheConfigs(result.Response.Fetches)
+	assert.Equal(t, []string{
+		`path:"" cache:<nil>`,
+		`path:"" cache:<nil>`,
+		`path:"me" cache:<nil>`,
+		`path:"me.favoriteProduct" cache:` + inventoryCfg,
+	}, initial)
+
+	groups := DeferGroups(result.DeferResponse)
+	require.Len(t, groups, 1)
+	deferred := renderFetchCacheConfigs(groups[0].Fetches)
+	assert.Equal(t, []string{
+		`path:"products" cache:` + inventoryCfg,
+	}, deferred)
+}
+
+// TestEntityCacheConfigDeterminism plans the same operation twice and asserts
+// identical rendered configs.
+func TestEntityCacheConfigDeterminism(t *testing.T) {
+	query := `{ products(first: 2) { upc reviews { body } } }`
+	first := Plan(t, query, entityCachingFor("reviews", "inventory"), nil)
+	second := Plan(t, query, entityCachingFor("reviews", "inventory"), nil)
+	assert.Equal(t,
+		strings.Join(renderFetchCacheConfigs(first.Response.Fetches), "\n"),
+		strings.Join(renderFetchCacheConfigs(second.Response.Fetches), "\n"),
+	)
+}

--- a/execution/cachingtesting/entity_config_test.go
+++ b/execution/cachingtesting/entity_config_test.go
@@ -1,8 +1,6 @@
 package cachingtesting
 
 import (
-	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -10,24 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
-	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 )
-
-// renderFetchCacheConfigs walks a fetch tree and renders every fetch's cache
-// config (nil-safe) with its response path, for full-value plan-level asserts.
-func renderFetchCacheConfigs(node *resolve.FetchTreeNode) []string {
-	if node == nil {
-		return nil
-	}
-	var out []string
-	if node.Item != nil && node.Item.Fetch != nil {
-		out = append(out, fmt.Sprintf("path:%q cache:%s", node.Item.ResponsePath, node.Item.Fetch.CacheConfig().String()))
-	}
-	for _, child := range node.ChildNodes {
-		out = append(out, renderFetchCacheConfigs(child)...)
-	}
-	return out
-}
 
 func entityCachingFor(subgraphs ...string) map[string]cacheconfig.CachingConfiguration {
 	caching := make(map[string]cacheconfig.CachingConfiguration, len(subgraphs))
@@ -48,11 +29,38 @@ func entityCachingFor(subgraphs ...string) map[string]cacheconfig.CachingConfigu
 // off.
 func TestEntityCacheConfigSyncPlan(t *testing.T) {
 	result := Plan(t, `{ products(first: 2) { upc reviews { body } } }`, entityCachingFor("reviews"), nil)
-	rendered := renderFetchCacheConfigs(result.Response.Fetches)
-	assert.Equal(t, []string{
-		`path:"" cache:<nil>`,
-		`path:"products" cache:{l1:false l2:true cacheName:products ttl:1m0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:Entity type:Product field: candidates:1 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}`,
-	}, rendered)
+	assert.Equal(t, `QueryPlan {
+  Sequence {
+    Fetch(service: "0") {
+      {
+          products(first: $a){
+              upc
+              __typename
+          }
+      }
+    }
+    Fetch(service: "2") {
+      {
+        fragment Key on Product {
+            __typename
+            upc
+        }
+      } =>
+      Cache: {l1:false l2:true cacheName:products ttl:1m0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:Entity type:Product field: candidates:1 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}
+      {
+          _entities(representations: $representations){
+              ... on Product {
+                  __typename
+                  reviews {
+                      body
+                  }
+              }
+          }
+      }
+    }
+  }
+}
+`, PrettyPlan(result))
 }
 
 // TestEntityCacheConfigDeferPlan pins that DEFER-GROUP entity fetches carry
@@ -70,22 +78,90 @@ func TestEntityCacheConfigDeferPlan(t *testing.T) {
 	result := Plan(t, query, entityCachingFor("inventory"), nil)
 	require.NotNil(t, result.DeferResponse)
 
-	inventoryCfg := `{l1:true l2:true cacheName:products ttl:1m0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:Entity type:Product field: candidates:1 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}`
-
-	initial := renderFetchCacheConfigs(result.Response.Fetches)
-	assert.Equal(t, []string{
-		`path:"" cache:<nil>`,
-		`path:"" cache:<nil>`,
-		`path:"me" cache:<nil>`,
-		`path:"me.favoriteProduct" cache:` + inventoryCfg,
-	}, initial)
-
-	groups := DeferGroups(result.DeferResponse)
-	require.Len(t, groups, 1)
-	deferred := renderFetchCacheConfigs(groups[0].Fetches)
-	assert.Equal(t, []string{
-		`path:"products" cache:` + inventoryCfg,
-	}, deferred)
+	assert.Equal(t, `QueryPlan {
+  Sequence {
+    Parallel {
+      Fetch(service: "3") {
+        {
+            me {
+                __typename
+                id
+            }
+        }
+      }
+      Fetch(service: "0") {
+        {
+            products(first: $a){
+                upc
+                __typename
+            }
+        }
+      }
+    }
+    Fetch(service: "0") {
+      {
+        fragment Key on User {
+            __typename
+            id
+        }
+      } =>
+      {
+          _entities(representations: $representations){
+              ... on User {
+                  __typename
+                  favoriteProduct {
+                      upc
+                      __typename
+                  }
+              }
+          }
+      }
+    }
+    Flatten(path: "me.favoriteProduct") {
+      Fetch(service: "1") {
+        {
+          fragment Key on Product {
+              __typename
+              upc
+          }
+        } =>
+        Cache: {l1:true l2:true cacheName:products ttl:1m0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:Entity type:Product field: candidates:1 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}
+        {
+            _entities(representations: $representations){
+                ... on Product {
+                    __typename
+                    stock
+                    warehouse {
+                        id
+                        location
+                    }
+                }
+            }
+        }
+      }
+    }
+  }
+}
+Deferred (id: 1) QueryPlan {
+  Fetch(service: "1") {
+    {
+      fragment Key on Product {
+          __typename
+          upc
+      }
+    } =>
+    Cache: {l1:true l2:true cacheName:products ttl:1m0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:Entity type:Product field: candidates:1 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}
+    {
+        _entities(representations: $representations){
+            ... on Product {
+                __typename
+                stock
+            }
+        }
+    }
+  }
+}
+`, PrettyPlan(result))
 }
 
 // TestEntityCacheConfigDeterminism plans the same operation twice and asserts
@@ -94,8 +170,5 @@ func TestEntityCacheConfigDeterminism(t *testing.T) {
 	query := `{ products(first: 2) { upc reviews { body } } }`
 	first := Plan(t, query, entityCachingFor("reviews", "inventory"), nil)
 	second := Plan(t, query, entityCachingFor("reviews", "inventory"), nil)
-	assert.Equal(t,
-		strings.Join(renderFetchCacheConfigs(first.Response.Fetches), "\n"),
-		strings.Join(renderFetchCacheConfigs(second.Response.Fetches), "\n"),
-	)
+	assert.Equal(t, PrettyPlan(first), PrettyPlan(second))
 }

--- a/execution/cachingtesting/entity_config_test.go
+++ b/execution/cachingtesting/entity_config_test.go
@@ -1,12 +1,15 @@
 package cachingtesting
 
 import (
+	"bytes"
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/cache/cachetesting"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
 )
 
@@ -23,49 +26,103 @@ func entityCachingFor(subgraphs ...string) map[string]cacheconfig.CachingConfigu
 }
 
 // TestEntityCacheConfigSyncPlan pins the full per-fetch cache config over a
-// REAL sync plan: the reviews batch entity fetch is configured, the products
-// root fetch stays nil (root-field caching is task 13). The lone entity fetch
-// has no L1 provider/consumer pair, so optimizeL1Cache (task 16) narrows L1
-// off.
+// REAL sync execution: the reviews batch entity fetch is configured, the
+// products root fetch stays uncached (root-field caching is task 13). The lone
+// entity fetch has no L1 provider/consumer pair, so optimizeL1Cache (task 16)
+// narrows L1 off. Runs through the REAL ExecutionEngine with the QueryPlan in
+// the response extensions; the ENTIRE body (data + fetch tree with cache
+// configs) is pinned.
 func TestEntityCacheConfigSyncPlan(t *testing.T) {
-	result := Plan(t, `{ products(first: 2) { upc reviews { body } } }`, entityCachingFor("reviews"), nil)
-	assert.Equal(t, `QueryPlan {
-  Sequence {
-    Fetch(service: "0") {
+	controller := cachetesting.NewRealishCache(cachetesting.NewFakeStore(), nil)
+	products := Respond(`{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"}]}}`)
+	reviews := Respond(`{"data":{"_entities":[{"__typename":"Product","reviews":[{"body":"Solid"}]},{"__typename":"Product","reviews":[{"body":"Wobbly"}]}]}}`)
+	subgraphs := Subgraphs{"products": products, "reviews": reviews}
+	executionEngine := NewEngine(t, entityCachingFor("reviews"), subgraphs)
+	body := ExecutePlanned(t, executionEngine, `{ products(first: 2) { upc reviews { body } } }`, controller)
+	var buf bytes.Buffer
+	require.NoError(t, json.Indent(&buf, []byte(subgraphs.NormalizeURLs(body)), "", "  "))
+	assert.Equal(t, `{
+  "data": {
+    "products": [
       {
-          products(first: $a){
-              upc
-              __typename
+        "upc": "1",
+        "reviews": [
+          {
+            "body": "Solid"
           }
+        ]
+      },
+      {
+        "upc": "2",
+        "reviews": [
+          {
+            "body": "Wobbly"
+          }
+        ]
       }
-    }
-    Fetch(service: "2") {
-      {
-        fragment Key on Product {
-            __typename
-            upc
-        }
-      } =>
-      Cache: {l1:false l2:true cacheName:products ttl:1m0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:Entity type:Product field: candidates:1 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}
-      {
-          _entities(representations: $representations){
-              ... on Product {
-                  __typename
-                  reviews {
-                      body
+    ]
+  },
+  "extensions": {
+    "queryPlan": {
+      "version": "1",
+      "kind": "Sequence",
+      "children": [
+        {
+          "kind": "Single",
+          "fetch": {
+            "kind": "Single",
+            "subgraphName": "0",
+            "subgraphId": "0",
+            "fetchId": 0
+          }
+        },
+        {
+          "kind": "Single",
+          "fetch": {
+            "kind": "BatchEntity",
+            "path": "products",
+            "subgraphName": "2",
+            "subgraphId": "2",
+            "fetchId": 1,
+            "dependsOnFetchIds": [
+              0
+            ],
+            "dependencies": [
+              {
+                "coordinate": {
+                  "typeName": "Product",
+                  "fieldName": "reviews"
+                },
+                "isUserRequested": true,
+                "dependsOn": [
+                  {
+                    "fetchId": 0,
+                    "subgraph": "0",
+                    "coordinate": {
+                      "typeName": "Product",
+                      "fieldName": "upc"
+                    },
+                    "isKey": true,
+                    "isRequires": false
                   }
+                ]
               }
+            ],
+            "cache": "{l1:false l2:true cacheName:products ttl:1m0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:Entity type:Product field: candidates:1 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}"
           }
-      }
+        }
+      ]
     }
   }
-}
-`, PrettyPlan(result))
+}`, buf.String())
 }
 
 // TestEntityCacheConfigDeferPlan pins that DEFER-GROUP entity fetches carry
 // config too: the initial inventory fetch and the deferred inventory fetch are
-// both configured from the same policy.
+// both configured from the same policy. This is a planner-level test that pins
+// plan-internal state not visible in a client response: the queryPlan response
+// extension only covers the synchronous fetch tree, so the deferred group's
+// fetch (and its cache config) can only be asserted on the Plan() result.
 func TestEntityCacheConfigDeferPlan(t *testing.T) {
 	query := `
 		query {
@@ -164,11 +221,23 @@ Deferred (id: 1) QueryPlan {
 `, PrettyPlan(result))
 }
 
-// TestEntityCacheConfigDeterminism plans the same operation twice and asserts
-// identical rendered configs.
+// TestEntityCacheConfigDeterminism executes the same operation through TWO
+// independent engines (one engine would serve the repeat from its execution
+// plan cache) and asserts the two full response bodies — data plus the
+// queryPlan extension with its rendered cache configs — are byte-identical.
 func TestEntityCacheConfigDeterminism(t *testing.T) {
 	query := `{ products(first: 2) { upc reviews { body } } }`
-	first := Plan(t, query, entityCachingFor("reviews", "inventory"), nil)
-	second := Plan(t, query, entityCachingFor("reviews", "inventory"), nil)
-	assert.Equal(t, PrettyPlan(first), PrettyPlan(second))
+
+	run := func(t *testing.T) string {
+		controller := cachetesting.NewRealishCache(cachetesting.NewFakeStore(), nil)
+		products := Respond(`{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"}]}}`)
+		reviews := Respond(`{"data":{"_entities":[{"__typename":"Product","reviews":[{"body":"Solid"}]},{"__typename":"Product","reviews":[{"body":"Wobbly"}]}]}}`)
+		subgraphs := Subgraphs{"products": products, "reviews": reviews}
+		executionEngine := NewEngine(t, entityCachingFor("reviews", "inventory"), subgraphs)
+		return subgraphs.NormalizeURLs(ExecutePlanned(t, executionEngine, query, controller))
+	}
+
+	first := run(t)
+	second := run(t)
+	assert.Equal(t, first, second)
 }

--- a/execution/cachingtesting/entity_l2_test.go
+++ b/execution/cachingtesting/entity_l2_test.go
@@ -96,7 +96,9 @@ func TestEntityL2EndToEnd(t *testing.T) {
 	}, firstOps)
 
 	// Request 2: L2 hit; the inventory datasource never loads; LoaderHooks do
-	// not fire for the skipped fetch.
+	// not fire for the skipped fetch. The op log resets so request 2's ops
+	// assert in isolation.
+	store.ResetOps()
 	second := Plan(t, query, inventoryCaching(), responses)
 	hooks := &recordingLoaderHooks{}
 	secondController := &countingController{inner: cachetesting.NewRealishCache(store, nil)}
@@ -110,11 +112,9 @@ func TestEntityL2EndToEnd(t *testing.T) {
 	assert.Equal(t, int64(1), second.LoadCount("products", "me"))
 	assert.Equal(t, int64(0), second.LoadCount("inventory", "me.favoriteProduct"))
 	assert.Equal(t, int64(1), secondController.begins.Load())
-	// Read key == write key (key fidelity): request 2's single extra op is a
-	// Get under the SAME key request 1 wrote.
+	// Read key == write key (key fidelity): request 2's ONLY op is a Get
+	// under the SAME key request 1 wrote.
 	assert.Equal(t, []cachetesting.StoreOp{
-		{Kind: "Get", Key: key},
-		{Kind: "Set", Key: key, Value: `{"__typename":"Product","stock":5}`, TTL: time.Minute},
 		{Kind: "Get", Key: key},
 	}, store.Ops())
 

--- a/execution/cachingtesting/entity_l2_test.go
+++ b/execution/cachingtesting/entity_l2_test.go
@@ -27,19 +27,6 @@ func inventoryCaching() map[string]cacheconfig.CachingConfiguration {
 	}
 }
 
-const (
-	entityL2Query    = `{ me { username favoriteProduct { upc stock } } }`
-	entityL2Expected = `{"data":{"me":{"username":"jens","favoriteProduct":{"upc":"1","stock":5}}}}`
-)
-
-func entityL2Responses() map[string]string {
-	return map[string]string{
-		"users":                        `{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`,
-		"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
-		"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
-	}
-}
-
 // countingController wraps a controller to count BeginRequest calls (B rows).
 type countingController struct {
 	inner  resolve.CacheController
@@ -78,13 +65,20 @@ func (h *recordingLoaderHooks) OnFinished(ctx context.Context, ds resolve.DataSo
 // LoaderHooks contract (not fired for the skipped fetch, C7) ride along.
 func TestEntityL2EndToEnd(t *testing.T) {
 	store := cachetesting.NewFakeStore()
+	query := `{ me { username favoriteProduct { upc stock } } }`
+	responses := map[string]string{
+		"users":                        `{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`,
+		"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
+		"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
+	}
+	expected := `{"data":{"me":{"username":"jens","favoriteProduct":{"upc":"1","stock":5}}}}`
 
 	// Request 1: miss + write-through.
-	first := Plan(t, entityL2Query, inventoryCaching(), entityL2Responses())
+	first := Plan(t, query, inventoryCaching(), responses)
 	firstObserver := &cachetesting.RecordingObserver{}
 	firstController := &countingController{inner: cachetesting.NewRealishCache(store, firstObserver)}
 	firstBody := ResolveResponse(t, first.Response, firstController)
-	assert.Equal(t, entityL2Expected, firstBody)
+	assert.Equal(t, expected, firstBody)
 	assert.Equal(t, int64(1), first.LoadCount("users", ""))
 	assert.Equal(t, int64(1), first.LoadCount("products", "me"))
 	assert.Equal(t, int64(1), first.LoadCount("inventory", "me.favoriteProduct"))
@@ -103,7 +97,7 @@ func TestEntityL2EndToEnd(t *testing.T) {
 
 	// Request 2: L2 hit; the inventory datasource never loads; LoaderHooks do
 	// not fire for the skipped fetch.
-	second := Plan(t, entityL2Query, inventoryCaching(), entityL2Responses())
+	second := Plan(t, query, inventoryCaching(), responses)
 	hooks := &recordingLoaderHooks{}
 	secondController := &countingController{inner: cachetesting.NewRealishCache(store, nil)}
 	ctx := resolve.NewContext(t.Context())
@@ -111,7 +105,7 @@ func TestEntityL2EndToEnd(t *testing.T) {
 	ctx.SetEngineLoaderHooks(hooks)
 	secondBody := resolveWithContext(t, ctx, second.Response)
 
-	assert.Equal(t, entityL2Expected, secondBody)
+	assert.Equal(t, expected, secondBody)
 	assert.Equal(t, int64(1), second.LoadCount("users", ""))
 	assert.Equal(t, int64(1), second.LoadCount("products", "me"))
 	assert.Equal(t, int64(0), second.LoadCount("inventory", "me.favoriteProduct"))
@@ -164,9 +158,13 @@ func TestEntityL2DispatchRows(t *testing.T) {
 		controller := cachetesting.NewRecordingController(map[string]cachetesting.ScriptedDecision{
 			"me.favoriteProduct": {Decision: resolve.DecisionFetch, Handle: handle},
 		})
-		result := Plan(t, entityL2Query, inventoryCaching(), entityL2Responses())
+		result := Plan(t, `{ me { username favoriteProduct { upc stock } } }`, inventoryCaching(), map[string]string{
+			"users":                        `{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`,
+			"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
+			"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
+		})
 		body := ResolveResponse(t, result.Response, controller)
-		assert.Equal(t, entityL2Expected, body)
+		assert.Equal(t, `{"data":{"me":{"username":"jens","favoriteProduct":{"upc":"1","stock":5}}}}`, body)
 
 		calls := controller.Calls()
 		require.Len(t, calls, 3) // Prepare + Result + End
@@ -180,14 +178,20 @@ func TestEntityL2DispatchRows(t *testing.T) {
 	})
 
 	t.Run("[C3/C6] SkipFullHit skips the network with NO spurious error", func(t *testing.T) {
-		result := Plan(t, entityL2Query, inventoryCaching(), entityL2Responses())
+		query := `{ me { username favoriteProduct { upc stock } } }`
+		responses := map[string]string{
+			"users":                        `{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`,
+			"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
+			"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
+		}
+		result := Plan(t, query, inventoryCaching(), responses)
 		// A real full hit: seed the store through a first request, then replay.
 		store := cachetesting.NewFakeStore()
-		warmup := Plan(t, entityL2Query, inventoryCaching(), entityL2Responses())
+		warmup := Plan(t, query, inventoryCaching(), responses)
 		ResolveResponse(t, warmup.Response, cachetesting.NewRealishCache(store, nil))
 
 		body := ResolveResponse(t, result.Response, cachetesting.NewRealishCache(store, nil))
-		assert.Equal(t, entityL2Expected, body)
+		assert.Equal(t, `{"data":{"me":{"username":"jens","favoriteProduct":{"upc":"1","stock":5}}}}`, body)
 		assert.Equal(t, int64(0), result.LoadCount("inventory", "me.favoriteProduct"))
 	})
 
@@ -198,7 +202,11 @@ func TestEntityL2DispatchRows(t *testing.T) {
 		fake.SetError("me.favoriteProduct", "Result", errors.New("cache write exploded"))
 		controller := cachetesting.NewFakeCacheController(fake)
 
-		result := Plan(t, entityL2Query, inventoryCaching(), entityL2Responses())
+		result := Plan(t, `{ me { username favoriteProduct { upc stock } } }`, inventoryCaching(), map[string]string{
+			"users":                        `{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`,
+			"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
+			"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
+		})
 		ctx := resolve.NewContext(t.Context())
 		ctx.SetCacheController(controller)
 		var buf writerBuffer

--- a/execution/cachingtesting/entity_l2_test.go
+++ b/execution/cachingtesting/entity_l2_test.go
@@ -1,6 +1,7 @@
 package cachingtesting
 
 import (
+	"context"
 	"errors"
 	"sync/atomic"
 	"testing"
@@ -9,6 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/wundergraph/graphql-go-tools/execution/engine"
+	"github.com/wundergraph/graphql-go-tools/execution/graphql"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/cache/cachetesting"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
@@ -94,74 +97,86 @@ func TestEntityL2EndToEnd(t *testing.T) {
 	}, store.Ops())
 }
 
-// resolveWithContext drives the public sync entry point with a caller-built
-// Context (for hook/controller combinations the plain helper cannot express).
-func resolveWithContext(t *testing.T, ctx *resolve.Context, resp *resolve.GraphQLResponse) string {
-	t.Helper()
-	var buf writerBuffer
-	r := resolve.New(t.Context(), resolve.ResolverOptions{MaxConcurrency: 16})
-	_, err := r.ResolveGraphQLResponse(ctx, resp, nil, &buf)
-	require.NoError(t, err)
-	return buf.String()
-}
-
-type writerBuffer struct {
-	data []byte
-}
-
-func (w *writerBuffer) Write(p []byte) (int, error) {
-	w.data = append(w.data, p...)
-	return len(p), nil
-}
-
-func (w *writerBuffer) String() string {
-	return string(w.data)
-}
-
-// TestEntityL2DispatchRows covers the C dispatch/lifecycle rows with the
-// recording fake: decisions route to the right merge hook, the handle keeps
-// pointer identity from prepare to merge (C8), and hook errors propagate (O).
+// TestEntityL2DispatchRows covers the C dispatch/lifecycle rows through the
+// REAL ExecutionEngine: decisions route to the right merge hook, the handle
+// keeps pointer identity from prepare to merge (C8), and hook errors
+// propagate (O).
 func TestEntityL2DispatchRows(t *testing.T) {
 	t.Run("[C] DecisionFetch dispatches to OnFetchResult with handle identity", func(t *testing.T) {
 		handle := &resolve.FetchCacheHandle{Decision: resolve.DecisionFetch}
 		controller := cachetesting.NewRecordingController(map[string]cachetesting.ScriptedDecision{
 			"me.favoriteProduct": {Decision: resolve.DecisionFetch, Handle: handle},
 		})
-		result := Plan(t, `{ me { username favoriteProduct { upc stock } } }`, inventoryCaching(), map[string]string{
-			"users":                        `{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`,
-			"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
-			"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
-		})
-		body := ResolveResponse(t, result.Response, controller)
+		users := Respond(`{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`)
+		products := Respond(`{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`)
+		inventory := Respond(`{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`)
+		subgraphs := Subgraphs{"users": users, "products": products, "inventory": inventory}
+		executionEngine := NewEngine(t, inventoryCaching(), subgraphs)
+
+		body := Execute(t, executionEngine, `{ me { username favoriteProduct { upc stock } } }`, controller)
 		assert.Equal(t, `{"data":{"me":{"username":"jens","favoriteProduct":{"upc":"1","stock":5}}}}`, body)
 
+		// Only the cached inventory fetch hits the hooks: Prepare + Result + End.
+		// InputBytes carries the double's ephemeral URL; normalize it so the pin
+		// stays literal. EmptyEntity is the loader's RAW signal (entity fetch
+		// whose data._entities is a non-null array); the controller only treats
+		// it as a negative result when ResponseData is also null.
 		calls := controller.Calls()
-		require.Len(t, calls, 3) // Prepare + Result + End
-		assert.Equal(t, "Prepare", calls[0].Op)
-		assert.Equal(t, "me.favoriteProduct", calls[0].FetchPath)
-		assert.Equal(t, "Result", calls[1].Op)
-		assert.Equal(t, `{"__typename":"Product","stock":5}`, calls[1].ResponseData)
-		assert.Equal(t, "End", calls[2].Op)
+		for i := range calls {
+			calls[i].InputBytes = subgraphs.NormalizeURLs(calls[i].InputBytes)
+		}
+		assert.Equal(t, []cachetesting.Call{
+			{
+				Op:         "Prepare",
+				FetchPath:  "me.favoriteProduct",
+				Items:      1,
+				InputBytes: `{"method":"POST","url":"http://inventory.service","header":{},"body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){... on Product {__typename stock}}}","variables":{"representations":[{"__typename":"Product","upc":"1"}]}}}`,
+				Decision:   resolve.DecisionFetch,
+			},
+			{
+				Op:           "Result",
+				FetchPath:    "me.favoriteProduct",
+				Items:        1,
+				ResponseData: `{"__typename":"Product","stock":5}`,
+				EmptyEntity:  true,
+				StatusCode:   200,
+			},
+			{Op: "End"},
+		}, calls)
 		assert.Equal(t, []*resolve.FetchCacheHandle{handle}, controller.ResultHandles())
 		assert.Equal(t, int64(1), controller.Begins())
 	})
 
 	t.Run("[C3/C6] SkipFullHit skips the network with NO spurious error", func(t *testing.T) {
-		query := `{ me { username favoriteProduct { upc stock } } }`
-		responses := map[string]string{
-			"users":                        `{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`,
-			"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
-			"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
-		}
-		result := Plan(t, query, inventoryCaching(), responses)
-		// A real full hit: seed the store through a first request, then replay.
 		store := cachetesting.NewFakeStore()
-		warmup := Plan(t, query, inventoryCaching(), responses)
-		ResolveResponse(t, warmup.Response, cachetesting.NewRealishCache(store, nil))
+		controller := cachetesting.NewRealishCache(store, nil)
+		query := `{ me { username favoriteProduct { upc stock } } }`
+		users := Respond(`{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`)
+		products := Respond(`{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`)
+		inventory := Respond(`{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`)
+		executionEngine := NewEngine(t, inventoryCaching(), Subgraphs{"users": users, "products": products, "inventory": inventory})
+		expected := `{"data":{"me":{"username":"jens","favoriteProduct":{"upc":"1","stock":5}}}}`
 
-		body := ResolveResponse(t, result.Response, cachetesting.NewRealishCache(store, nil))
-		assert.Equal(t, `{"data":{"me":{"username":"jens","favoriteProduct":{"upc":"1","stock":5}}}}`, body)
-		assert.Equal(t, int64(0), result.LoadCount("inventory", "me.favoriteProduct"))
+		// A real full hit: seed the store through a first request, then replay.
+		warmupBody := Execute(t, executionEngine, query, controller)
+		assert.Equal(t, expected, warmupBody)
+		warmupOps := store.Ops()
+		require.Len(t, warmupOps, 2)
+		key := warmupOps[0].Key
+		assert.Equal(t, []cachetesting.StoreOp{
+			{Kind: "Get", Key: key},
+			{Kind: "Set", Key: key, Value: `{"__typename":"Product","stock":5}`, TTL: time.Minute},
+		}, warmupOps)
+
+		// The replay resolves cleanly (Execute fails the test on any resolver
+		// error) with ZERO further network to inventory: a single Get, no writes.
+		store.ResetOps()
+		body := Execute(t, executionEngine, query, controller)
+		assert.Equal(t, expected, body)
+		assert.Equal(t, int64(1), inventory.Requests())
+		assert.Equal(t, []cachetesting.StoreOp{
+			{Kind: "Get", Key: key},
+		}, store.Ops())
 	})
 
 	t.Run("[O] merge-hook errors propagate to the caller", func(t *testing.T) {
@@ -171,16 +186,14 @@ func TestEntityL2DispatchRows(t *testing.T) {
 		fake.SetError("me.favoriteProduct", "Result", errors.New("cache write exploded"))
 		controller := cachetesting.NewFakeCacheController(fake)
 
-		result := Plan(t, `{ me { username favoriteProduct { upc stock } } }`, inventoryCaching(), map[string]string{
-			"users":                        `{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`,
-			"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
-			"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
-		})
-		ctx := resolve.NewContext(t.Context())
-		ctx.SetCacheController(controller)
-		var buf writerBuffer
-		r := resolve.New(t.Context(), resolve.ResolverOptions{MaxConcurrency: 16})
-		_, err := r.ResolveGraphQLResponse(ctx, result.Response, nil, &buf)
+		users := Respond(`{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`)
+		products := Respond(`{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`)
+		inventory := Respond(`{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`)
+		executionEngine := NewEngine(t, inventoryCaching(), Subgraphs{"users": users, "products": products, "inventory": inventory})
+
+		// Execute requires success, so drive the engine directly for the error.
+		writer := graphql.NewEngineResultWriter()
+		err := executionEngine.Execute(context.Background(), &graphql.Request{Query: `{ me { username favoriteProduct { upc stock } } }`}, &writer, engine.WithCacheController(controller))
 		require.EqualError(t, err, "cache write exploded")
 	})
 }

--- a/execution/cachingtesting/entity_l2_test.go
+++ b/execution/cachingtesting/entity_l2_test.go
@@ -1,9 +1,7 @@
 package cachingtesting
 
 import (
-	"context"
 	"errors"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -38,50 +36,30 @@ func (c *countingController) BeginRequest(ctx *resolve.Context) resolve.RequestC
 	return c.inner.BeginRequest(ctx)
 }
 
-// recordingLoaderHooks records which datasources fired OnLoad/OnFinished (C7).
-type recordingLoaderHooks struct {
-	mu       sync.Mutex
-	loads    []string
-	finishes []string
-}
-
-func (h *recordingLoaderHooks) OnLoad(ctx context.Context, ds resolve.DataSourceInfo) context.Context {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	h.loads = append(h.loads, ds.Name)
-	return ctx
-}
-
-func (h *recordingLoaderHooks) OnFinished(ctx context.Context, ds resolve.DataSourceInfo, info *resolve.ResponseInfo) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	h.finishes = append(h.finishes, ds.Name)
-}
-
 // TestEntityL2EndToEnd is the end-to-end L2 entity hit: request 1 misses and
-// writes at request end; request 2 serves from L2 with the gated datasource
+// writes at request end; request 2 serves from L2 with the subgraph double
 // proving ZERO network for the cached fetch; complete responses asserted; the
-// lifecycle counts (lazy single BeginRequest, single EndRequest) and the
-// LoaderHooks contract (not fired for the skipped fetch, C7) ride along.
+// lifecycle counts (lazy single BeginRequest, single EndRequest) ride along.
+// Runs through the REAL ExecutionEngine; the engine exposes no execution
+// option for loader hooks, so the C7 LoaderHooks contract (no hooks for the
+// skipped fetch) stays pinned by the resolve-level suites.
 func TestEntityL2EndToEnd(t *testing.T) {
 	store := cachetesting.NewFakeStore()
 	query := `{ me { username favoriteProduct { upc stock } } }`
-	responses := map[string]string{
-		"users":                        `{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`,
-		"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
-		"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
-	}
+	users := Respond(`{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`)
+	products := Respond(`{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`)
+	inventory := Respond(`{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`)
+	executionEngine := NewEngine(t, inventoryCaching(), Subgraphs{"users": users, "products": products, "inventory": inventory})
 	expected := `{"data":{"me":{"username":"jens","favoriteProduct":{"upc":"1","stock":5}}}}`
 
 	// Request 1: miss + write-through.
-	first := Plan(t, query, inventoryCaching(), responses)
 	firstObserver := &cachetesting.RecordingObserver{}
 	firstController := &countingController{inner: cachetesting.NewRealishCache(store, firstObserver)}
-	firstBody := ResolveResponse(t, first.Response, firstController)
+	firstBody := Execute(t, executionEngine, query, firstController)
 	assert.Equal(t, expected, firstBody)
-	assert.Equal(t, int64(1), first.LoadCount("users", ""))
-	assert.Equal(t, int64(1), first.LoadCount("products", "me"))
-	assert.Equal(t, int64(1), first.LoadCount("inventory", "me.favoriteProduct"))
+	assert.Equal(t, int64(1), users.Requests())
+	assert.Equal(t, int64(1), products.Requests())
+	assert.Equal(t, int64(1), inventory.Requests())
 	assert.Equal(t, int64(1), firstController.begins.Load())
 	firstBegins, firstEnds := firstObserver.Counts()
 	assert.Equal(t, 1, firstBegins)
@@ -95,34 +73,25 @@ func TestEntityL2EndToEnd(t *testing.T) {
 		{Kind: "Set", Key: key, Value: `{"__typename":"Product","stock":5}`, TTL: time.Minute},
 	}, firstOps)
 
-	// Request 2: L2 hit; the inventory datasource never loads; LoaderHooks do
-	// not fire for the skipped fetch. The op log resets so request 2's ops
-	// assert in isolation.
+	// Request 2: L2 hit; the inventory subgraph is never hit again. The op log
+	// resets so request 2's ops assert in isolation; a fresh controller keeps
+	// the BeginRequest count per-request.
 	store.ResetOps()
-	second := Plan(t, query, inventoryCaching(), responses)
-	hooks := &recordingLoaderHooks{}
 	secondController := &countingController{inner: cachetesting.NewRealishCache(store, nil)}
-	ctx := resolve.NewContext(t.Context())
-	ctx.SetCacheController(secondController)
-	ctx.SetEngineLoaderHooks(hooks)
-	secondBody := resolveWithContext(t, ctx, second.Response)
+	secondBody := Execute(t, executionEngine, query, secondController)
 
 	assert.Equal(t, expected, secondBody)
-	assert.Equal(t, int64(1), second.LoadCount("users", ""))
-	assert.Equal(t, int64(1), second.LoadCount("products", "me"))
-	assert.Equal(t, int64(0), second.LoadCount("inventory", "me.favoriteProduct"))
+	// The uncached subgraphs fetched again (counts accumulate across the two
+	// requests through the one engine); inventory stayed at ONE.
+	assert.Equal(t, int64(2), users.Requests())
+	assert.Equal(t, int64(2), products.Requests())
+	assert.Equal(t, int64(1), inventory.Requests())
 	assert.Equal(t, int64(1), secondController.begins.Load())
 	// Read key == write key (key fidelity): request 2's ONLY op is a Get
 	// under the SAME key request 1 wrote.
 	assert.Equal(t, []cachetesting.StoreOp{
 		{Kind: "Get", Key: key},
 	}, store.Ops())
-
-	hooks.mu.Lock()
-	defer hooks.mu.Unlock()
-	// The skipped inventory fetch (datasource id/name "1") fired NO hooks.
-	assert.Equal(t, []string{"3", "0"}, hooks.loads)
-	assert.Equal(t, []string{"3", "0"}, hooks.finishes)
 }
 
 // resolveWithContext drives the public sync entry point with a caller-built

--- a/execution/cachingtesting/entity_l2_test.go
+++ b/execution/cachingtesting/entity_l2_test.go
@@ -1,0 +1,209 @@
+package cachingtesting
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/cache/cachetesting"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// inventoryCaching enables entity caching for the inventory subgraph's Product.
+func inventoryCaching() map[string]cacheconfig.CachingConfiguration {
+	return map[string]cacheconfig.CachingConfiguration{
+		"inventory": {
+			Entities: []cacheconfig.EntityCachePolicy{
+				{TypeName: "Product", CacheName: "entities", TTL: time.Minute},
+			},
+		},
+	}
+}
+
+const (
+	entityL2Query    = `{ me { username favoriteProduct { upc stock } } }`
+	entityL2Expected = `{"data":{"me":{"username":"jens","favoriteProduct":{"upc":"1","stock":5}}}}`
+)
+
+func entityL2Responses() map[string]string {
+	return map[string]string{
+		"users":                        `{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`,
+		"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
+		"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
+	}
+}
+
+// countingController wraps a controller to count BeginRequest calls (B rows).
+type countingController struct {
+	inner  resolve.CacheController
+	begins atomic.Int64
+}
+
+func (c *countingController) BeginRequest(ctx *resolve.Context) resolve.RequestCache {
+	c.begins.Add(1)
+	return c.inner.BeginRequest(ctx)
+}
+
+// recordingLoaderHooks records which datasources fired OnLoad/OnFinished (C7).
+type recordingLoaderHooks struct {
+	mu       sync.Mutex
+	loads    []string
+	finishes []string
+}
+
+func (h *recordingLoaderHooks) OnLoad(ctx context.Context, ds resolve.DataSourceInfo) context.Context {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.loads = append(h.loads, ds.Name)
+	return ctx
+}
+
+func (h *recordingLoaderHooks) OnFinished(ctx context.Context, ds resolve.DataSourceInfo, info *resolve.ResponseInfo) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.finishes = append(h.finishes, ds.Name)
+}
+
+// TestEntityL2EndToEnd is the end-to-end L2 entity hit: request 1 misses and
+// writes at request end; request 2 serves from L2 with the gated datasource
+// proving ZERO network for the cached fetch; complete responses asserted; the
+// lifecycle counts (lazy single BeginRequest, single EndRequest) and the
+// LoaderHooks contract (not fired for the skipped fetch, C7) ride along.
+func TestEntityL2EndToEnd(t *testing.T) {
+	store := cachetesting.NewFakeStore()
+
+	// Request 1: miss + write-through.
+	first := Plan(t, entityL2Query, inventoryCaching(), entityL2Responses())
+	firstObserver := &cachetesting.RecordingObserver{}
+	firstController := &countingController{inner: cachetesting.NewRealishCache(store, firstObserver)}
+	firstBody := ResolveResponse(t, first.Response, firstController)
+	assert.Equal(t, entityL2Expected, firstBody)
+	assert.Equal(t, int64(1), first.LoadCount("users", ""))
+	assert.Equal(t, int64(1), first.LoadCount("products", "me"))
+	assert.Equal(t, int64(1), first.LoadCount("inventory", "me.favoriteProduct"))
+	assert.Equal(t, int64(1), firstController.begins.Load())
+	firstBegins, firstEnds := firstObserver.Counts()
+	assert.Equal(t, 1, firstBegins)
+	assert.Equal(t, 1, firstEnds)
+
+	firstOps := store.Ops()
+	require.Len(t, firstOps, 2)
+	key := firstOps[0].Key
+	assert.Equal(t, []cachetesting.StoreOp{
+		{Kind: "Get", Key: key},
+		{Kind: "Set", Key: key, Value: `{"__typename":"Product","stock":5}`, TTL: time.Minute},
+	}, firstOps)
+
+	// Request 2: L2 hit; the inventory datasource never loads; LoaderHooks do
+	// not fire for the skipped fetch.
+	second := Plan(t, entityL2Query, inventoryCaching(), entityL2Responses())
+	hooks := &recordingLoaderHooks{}
+	secondController := &countingController{inner: cachetesting.NewRealishCache(store, nil)}
+	ctx := resolve.NewContext(t.Context())
+	ctx.SetCacheController(secondController)
+	ctx.SetEngineLoaderHooks(hooks)
+	secondBody := resolveWithContext(t, ctx, second.Response)
+
+	assert.Equal(t, entityL2Expected, secondBody)
+	assert.Equal(t, int64(1), second.LoadCount("users", ""))
+	assert.Equal(t, int64(1), second.LoadCount("products", "me"))
+	assert.Equal(t, int64(0), second.LoadCount("inventory", "me.favoriteProduct"))
+	assert.Equal(t, int64(1), secondController.begins.Load())
+	// Read key == write key (key fidelity): request 2's single extra op is a
+	// Get under the SAME key request 1 wrote.
+	assert.Equal(t, []cachetesting.StoreOp{
+		{Kind: "Get", Key: key},
+		{Kind: "Set", Key: key, Value: `{"__typename":"Product","stock":5}`, TTL: time.Minute},
+		{Kind: "Get", Key: key},
+	}, store.Ops())
+
+	hooks.mu.Lock()
+	defer hooks.mu.Unlock()
+	// The skipped inventory fetch (datasource id/name "1") fired NO hooks.
+	assert.Equal(t, []string{"3", "0"}, hooks.loads)
+	assert.Equal(t, []string{"3", "0"}, hooks.finishes)
+}
+
+// resolveWithContext drives the public sync entry point with a caller-built
+// Context (for hook/controller combinations the plain helper cannot express).
+func resolveWithContext(t *testing.T, ctx *resolve.Context, resp *resolve.GraphQLResponse) string {
+	t.Helper()
+	var buf writerBuffer
+	r := resolve.New(t.Context(), resolve.ResolverOptions{MaxConcurrency: 16})
+	_, err := r.ResolveGraphQLResponse(ctx, resp, nil, &buf)
+	require.NoError(t, err)
+	return buf.String()
+}
+
+type writerBuffer struct {
+	data []byte
+}
+
+func (w *writerBuffer) Write(p []byte) (int, error) {
+	w.data = append(w.data, p...)
+	return len(p), nil
+}
+
+func (w *writerBuffer) String() string {
+	return string(w.data)
+}
+
+// TestEntityL2DispatchRows covers the C dispatch/lifecycle rows with the
+// recording fake: decisions route to the right merge hook, the handle keeps
+// pointer identity from prepare to merge (C8), and hook errors propagate (O).
+func TestEntityL2DispatchRows(t *testing.T) {
+	t.Run("[C] DecisionFetch dispatches to OnFetchResult with handle identity", func(t *testing.T) {
+		handle := &resolve.FetchCacheHandle{Decision: resolve.DecisionFetch}
+		controller := cachetesting.NewRecordingController(map[string]cachetesting.ScriptedDecision{
+			"me.favoriteProduct": {Decision: resolve.DecisionFetch, Handle: handle},
+		})
+		result := Plan(t, entityL2Query, inventoryCaching(), entityL2Responses())
+		body := ResolveResponse(t, result.Response, controller)
+		assert.Equal(t, entityL2Expected, body)
+
+		calls := controller.Calls()
+		require.Len(t, calls, 3) // Prepare + Result + End
+		assert.Equal(t, "Prepare", calls[0].Op)
+		assert.Equal(t, "me.favoriteProduct", calls[0].FetchPath)
+		assert.Equal(t, "Result", calls[1].Op)
+		assert.Equal(t, `{"__typename":"Product","stock":5}`, calls[1].ResponseData)
+		assert.Equal(t, "End", calls[2].Op)
+		assert.Equal(t, []*resolve.FetchCacheHandle{handle}, controller.ResultHandles())
+		assert.Equal(t, int64(1), controller.Begins())
+	})
+
+	t.Run("[C3/C6] SkipFullHit skips the network with NO spurious error", func(t *testing.T) {
+		result := Plan(t, entityL2Query, inventoryCaching(), entityL2Responses())
+		// A real full hit: seed the store through a first request, then replay.
+		store := cachetesting.NewFakeStore()
+		warmup := Plan(t, entityL2Query, inventoryCaching(), entityL2Responses())
+		ResolveResponse(t, warmup.Response, cachetesting.NewRealishCache(store, nil))
+
+		body := ResolveResponse(t, result.Response, cachetesting.NewRealishCache(store, nil))
+		assert.Equal(t, entityL2Expected, body)
+		assert.Equal(t, int64(0), result.LoadCount("inventory", "me.favoriteProduct"))
+	})
+
+	t.Run("[O] merge-hook errors propagate to the caller", func(t *testing.T) {
+		fake := cachetesting.NewFakeRequestCache(map[string]cachetesting.ScriptedDecision{
+			"me.favoriteProduct": {Decision: resolve.DecisionFetch, Handle: &resolve.FetchCacheHandle{Decision: resolve.DecisionFetch}},
+		})
+		fake.SetError("me.favoriteProduct", "Result", errors.New("cache write exploded"))
+		controller := cachetesting.NewFakeCacheController(fake)
+
+		result := Plan(t, entityL2Query, inventoryCaching(), entityL2Responses())
+		ctx := resolve.NewContext(t.Context())
+		ctx.SetCacheController(controller)
+		var buf writerBuffer
+		r := resolve.New(t.Context(), resolve.ResolverOptions{MaxConcurrency: 16})
+		_, err := r.ResolveGraphQLResponse(ctx, result.Response, nil, &buf)
+		require.EqualError(t, err, "cache write exploded")
+	})
+}

--- a/execution/cachingtesting/entity_reuse_e2e_test.go
+++ b/execution/cachingtesting/entity_reuse_e2e_test.go
@@ -1,0 +1,65 @@
+package cachingtesting
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/cache/cachetesting"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
+)
+
+// reuseCaching enables the products ENTITY policy plus a by-key root-field
+// policy for Query.product; rootCacheName decides whether the root field
+// shares the entity key space.
+func reuseCaching(rootCacheName string) map[string]cacheconfig.CachingConfiguration {
+	return map[string]cacheconfig.CachingConfiguration{
+		"products": {
+			Entities: []cacheconfig.EntityCachePolicy{
+				{TypeName: "Product", CacheName: "entities", TTL: time.Minute},
+			},
+			RootFields: []cacheconfig.RootFieldCachePolicy{
+				{TypeName: "Query", FieldName: "product", CacheName: rootCacheName, TTL: time.Minute},
+			},
+		},
+	}
+}
+
+// TestEntityCacheReuseEndToEnd: an entity entry primed by ANOTHER path (the
+// reviews->products entity fetch) serves the by-key root field with zero
+// network; a mismatched CacheName does NOT reuse (the constraint is enforced,
+// not accidental).
+func TestEntityCacheReuseEndToEnd(t *testing.T) {
+	store := cachetesting.NewFakeStore()
+
+	// Prime the Product entity through featuredReview.product; the fresh
+	// response carries sku, so BOTH entity keys are written (upc refresh via
+	// the representation + sku backfill).
+	prime := Plan(t, `{ featuredReview { product { name } } }`, reuseCaching("entities"), map[string]string{
+		"reviews":                         `{"data":{"featuredReview":{"__typename":"Review","product":{"__typename":"Product","upc":"1"}}}}`,
+		"products:featuredReview.product": `{"data":{"_entities":[{"__typename":"Product","name":"Table","sku":"S1"}]}}`,
+	})
+	primeBody := ResolveResponse(t, prime.Response, cachetesting.NewRealishCache(store, nil))
+	assert.Equal(t, `{"data":{"featuredReview":{"product":{"name":"Table"}}}}`, primeBody)
+	require.Len(t, store.Ops(), 3) // Get upc (miss), Set upc, Set sku
+
+	// The by-key root field is served FROM THE ENTITY ENTRY: zero products loads.
+	serveQuery := `query($upc: String!) { product(upc: $upc) { name } }`
+	serve := Plan(t, serveQuery, reuseCaching("entities"), map[string]string{
+		"products": `{"data":{"product":{"__typename":"Product","name":"Network"}}}`,
+	})
+	serveBody := resolveWithVariables(t, serve, `{"upc":"1"}`, cachetesting.NewRealishCache(store, nil))
+	assert.Equal(t, `{"data":{"product":{"name":"Table"}}}`, serveBody)
+	assert.Equal(t, int64(0), serve.LoadCount("products", ""))
+
+	// A MISMATCHED CacheName renders a different prefix: no reuse, the network
+	// answers.
+	mismatched := Plan(t, serveQuery, reuseCaching("root-fields"), map[string]string{
+		"products": `{"data":{"product":{"__typename":"Product","name":"Network"}}}`,
+	})
+	mismatchedBody := resolveWithVariables(t, mismatched, `{"upc":"1"}`, cachetesting.NewRealishCache(store, nil))
+	assert.Equal(t, `{"data":{"product":{"name":"Network"}}}`, mismatchedBody)
+	assert.Equal(t, int64(1), mismatched.LoadCount("products", ""))
+}

--- a/execution/cachingtesting/entity_reuse_e2e_test.go
+++ b/execution/cachingtesting/entity_reuse_e2e_test.go
@@ -30,36 +30,38 @@ func reuseCaching(rootCacheName string) map[string]cacheconfig.CachingConfigurat
 // TestEntityCacheReuseEndToEnd: an entity entry primed by ANOTHER path (the
 // reviews->products entity fetch) serves the by-key root field with zero
 // network; a mismatched CacheName does NOT reuse (the constraint is enforced,
-// not accidental).
+// not accidental). Two caching configurations → two engines over the SAME
+// store; the root-field canned responses are TAMPERED ("Network") so serving
+// them instead of the cached "Table" fails loudly.
 func TestEntityCacheReuseEndToEnd(t *testing.T) {
 	store := cachetesting.NewFakeStore()
+	controller := cachetesting.NewRealishCache(store, nil)
+
+	reviews := Respond(`{"data":{"featuredReview":{"__typename":"Review","product":{"__typename":"Product","upc":"1"}}}}`)
+	entityFetch := Rule(`"representations"`, `{"data":{"_entities":[{"__typename":"Product","name":"Table","sku":"S1"}]}}`)
+	rootFetch := Rule(`"product`, `{"data":{"product":{"__typename":"Product","name":"Network"}}}`)
+	products := Rules(entityFetch, rootFetch)
+	matchedEngine := NewEngine(t, reuseCaching("entities"), Subgraphs{"reviews": reviews, "products": products})
 
 	// Prime the Product entity through featuredReview.product; the fresh
 	// response carries sku, so BOTH entity keys are written (upc refresh via
 	// the representation + sku backfill).
-	prime := Plan(t, `{ featuredReview { product { name } } }`, reuseCaching("entities"), map[string]string{
-		"reviews":                         `{"data":{"featuredReview":{"__typename":"Review","product":{"__typename":"Product","upc":"1"}}}}`,
-		"products:featuredReview.product": `{"data":{"_entities":[{"__typename":"Product","name":"Table","sku":"S1"}]}}`,
-	})
-	primeBody := ResolveResponse(t, prime.Response, cachetesting.NewRealishCache(store, nil))
+	primeBody := Execute(t, matchedEngine, `{ featuredReview { product { name } } }`, controller)
 	assert.Equal(t, `{"data":{"featuredReview":{"product":{"name":"Table"}}}}`, primeBody)
 	require.Len(t, store.Ops(), 3) // Get upc (miss), Set upc, Set sku
 
-	// The by-key root field is served FROM THE ENTITY ENTRY: zero products loads.
+	// The by-key root field is served FROM THE ENTITY ENTRY: zero root-field
+	// requests to products.
 	serveQuery := `query($upc: String!) { product(upc: $upc) { name } }`
-	serve := Plan(t, serveQuery, reuseCaching("entities"), map[string]string{
-		"products": `{"data":{"product":{"__typename":"Product","name":"Network"}}}`,
-	})
-	serveBody := resolveWithVariables(t, serve, `{"upc":"1"}`, cachetesting.NewRealishCache(store, nil))
+	serveBody := ExecuteWithVariables(t, matchedEngine, serveQuery, `{"upc":"1"}`, controller)
 	assert.Equal(t, `{"data":{"product":{"name":"Table"}}}`, serveBody)
-	assert.Equal(t, int64(0), serve.LoadCount("products", ""))
+	assert.Equal(t, int64(0), rootFetch.Count.Load())
 
 	// A MISMATCHED CacheName renders a different prefix: no reuse, the network
-	// answers.
-	mismatched := Plan(t, serveQuery, reuseCaching("root-fields"), map[string]string{
-		"products": `{"data":{"product":{"__typename":"Product","name":"Network"}}}`,
-	})
-	mismatchedBody := resolveWithVariables(t, mismatched, `{"upc":"1"}`, cachetesting.NewRealishCache(store, nil))
+	// answers. This is a different caching configuration, so a second engine.
+	mismatchedProducts := Respond(`{"data":{"product":{"__typename":"Product","name":"Network"}}}`)
+	mismatchedEngine := NewEngine(t, reuseCaching("root-fields"), Subgraphs{"products": mismatchedProducts})
+	mismatchedBody := ExecuteWithVariables(t, mismatchedEngine, serveQuery, `{"upc":"1"}`, controller)
 	assert.Equal(t, `{"data":{"product":{"name":"Network"}}}`, mismatchedBody)
-	assert.Equal(t, int64(1), mismatched.LoadCount("products", ""))
+	assert.Equal(t, int64(1), mismatchedProducts.Requests())
 }

--- a/execution/cachingtesting/graph.yaml
+++ b/execution/cachingtesting/graph.yaml
@@ -1,0 +1,18 @@
+version: 1
+subgraphs:
+  - name: products
+    routing_url: http://products.service
+    schema:
+      file: subgraphs/products.graphql
+  - name: inventory
+    routing_url: http://inventory.service
+    schema:
+      file: subgraphs/inventory.graphql
+  - name: reviews
+    routing_url: http://reviews.service
+    schema:
+      file: subgraphs/reviews.graphql
+  - name: users
+    routing_url: http://users.service
+    schema:
+      file: subgraphs/users.graphql

--- a/execution/cachingtesting/graph.yaml
+++ b/execution/cachingtesting/graph.yaml
@@ -16,3 +16,7 @@ subgraphs:
     routing_url: http://users.service
     schema:
       file: subgraphs/users.graphql
+  - name: deals
+    routing_url: http://deals.service
+    schema:
+      file: subgraphs/deals.graphql

--- a/execution/cachingtesting/isolation_e2e_test.go
+++ b/execution/cachingtesting/isolation_e2e_test.go
@@ -1,7 +1,6 @@
 package cachingtesting
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -10,7 +9,6 @@ import (
 
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/cache/cachetesting"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
-	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 )
 
 // isolationCaching configures two sibling root fields on the products
@@ -26,36 +24,31 @@ func isolationCaching() map[string]cacheconfig.CachingConfiguration {
 	}
 }
 
-// renderFetchIsolation walks a fetch tree rendering path, cache name/TTL, and
-// dependency edges per fetch — the isolation shape in one string per fetch.
-func renderFetchIsolation(node *resolve.FetchTreeNode) []string {
-	if node == nil {
-		return nil
-	}
-	var out []string
-	if node.Item != nil && node.Item.Fetch != nil {
-		cfg := node.Item.Fetch.CacheConfig()
-		cacheName, ttl := "<nil>", time.Duration(0)
-		if cfg != nil {
-			cacheName, ttl = cfg.CacheName, cfg.TTL
-		}
-		out = append(out, fmt.Sprintf("path:%q cache:%s ttl:%s dependsOn:%v",
-			node.Item.ResponsePath, cacheName, ttl, node.Item.Fetch.Dependencies().DependsOnFetchIDs))
-	}
-	for _, child := range node.ChildNodes {
-		out = append(out, renderFetchIsolation(child)...)
-	}
-	return out
-}
-
 // TestRootFieldIsolationPlans covers the plan-level isolation rows.
 func TestRootFieldIsolationPlans(t *testing.T) {
 	t.Run("two cached siblings with different policies become two parallel fetches", func(t *testing.T) {
 		result := Plan(t, `{ products(first: 1) { upc } promotions { upc } }`, isolationCaching(), nil)
-		assert.Equal(t, []string{
-			`path:"" cache:products-cache ttl:1m0s dependsOn:[]`,
-			`path:"" cache:promotions-cache ttl:5m0s dependsOn:[]`,
-		}, renderFetchIsolation(result.Response.Fetches))
+		assert.Equal(t, `QueryPlan {
+  Parallel {
+    Fetch(service: "0") {
+      Cache: {l1:false l2:true cacheName:products-cache ttl:1m0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:RootField type:Query field:products candidates:0 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}
+      {
+          products(first: $a){
+              upc
+          }
+      }
+    }
+    Fetch(service: "0") {
+      Cache: {l1:false l2:true cacheName:promotions-cache ttl:5m0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:RootField type:Query field:promotions candidates:0 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}
+      {
+          promotions {
+              upc
+          }
+      }
+    }
+  }
+}
+`, PrettyPlan(result))
 	})
 
 	t.Run("cached + uncached sibling: cached isolated, uncached separate without config", func(t *testing.T) {
@@ -67,17 +60,43 @@ func TestRootFieldIsolationPlans(t *testing.T) {
 			},
 		}
 		result := Plan(t, `{ products(first: 1) { upc } promotions { upc } }`, caching, nil)
-		assert.Equal(t, []string{
-			`path:"" cache:products-cache ttl:1m0s dependsOn:[]`,
-			`path:"" cache:<nil> ttl:0s dependsOn:[]`,
-		}, renderFetchIsolation(result.Response.Fetches))
+		assert.Equal(t, `QueryPlan {
+  Parallel {
+    Fetch(service: "0") {
+      Cache: {l1:false l2:true cacheName:products-cache ttl:1m0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:RootField type:Query field:products candidates:0 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}
+      {
+          products(first: $a){
+              upc
+          }
+      }
+    }
+    Fetch(service: "0") {
+      {
+          promotions {
+              upc
+          }
+      }
+    }
+  }
+}
+`, PrettyPlan(result))
 	})
 
 	t.Run("caching off: one merged fetch, byte-identical to the pre-isolation plan", func(t *testing.T) {
 		result := Plan(t, `{ products(first: 1) { upc } promotions { upc } }`, nil, nil)
-		assert.Equal(t, []string{
-			`path:"" cache:<nil> ttl:0s dependsOn:[]`,
-		}, renderFetchIsolation(result.Response.Fetches))
+		assert.Equal(t, `QueryPlan {
+  Fetch(service: "0") {
+    {
+        products(first: $a){
+            upc
+        }
+        promotions {
+            upc
+        }
+    }
+  }
+}
+`, PrettyPlan(result))
 	})
 
 	t.Run("entity-root-node trap: a nested entity under an isolated root still merges into its subtree", func(t *testing.T) {
@@ -86,12 +105,38 @@ func TestRootFieldIsolationPlans(t *testing.T) {
 			"inventory": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
 		})
 		// TWO fetches only: the isolated products root (its own subtree intact)
-		// and the inventory entity fetch depending on it — the products
+		// and the inventory entity fetch sequenced after it — the products
 		// subtree was NOT torn apart into more fetches.
-		assert.Equal(t, []string{
-			`path:"" cache:products-cache ttl:1m0s dependsOn:[]`,
-			`path:"products" cache:<nil> ttl:0s dependsOn:[0]`,
-		}, renderFetchIsolation(result.Response.Fetches))
+		assert.Equal(t, `QueryPlan {
+  Sequence {
+    Fetch(service: "0") {
+      Cache: {l1:false l2:true cacheName:products-cache ttl:1m0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:RootField type:Query field:products candidates:0 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}
+      {
+          products(first: $a){
+              upc
+              __typename
+          }
+      }
+    }
+    Fetch(service: "1") {
+      {
+        fragment Key on Product {
+            __typename
+            upc
+        }
+      } =>
+      {
+          _entities(representations: $representations){
+              ... on Product {
+                  __typename
+                  stock
+              }
+          }
+      }
+    }
+  }
+}
+`, PrettyPlan(result))
 
 		body := ResolveResponse(t, result.Response, nil)
 		assert.Equal(t, `{"data":{"products":[{"upc":"1","stock":5}]}}`, body)
@@ -100,14 +145,36 @@ func TestRootFieldIsolationPlans(t *testing.T) {
 	t.Run("defer composition: an isolated root's deferred sub-fetch lands in its defer group", func(t *testing.T) {
 		result := Plan(t, `{ products(first: 1) { upc ... @defer { stock } } }`, isolationCaching(), nil)
 		require.NotNil(t, result.DeferResponse)
-		assert.Equal(t, []string{
-			`path:"" cache:products-cache ttl:1m0s dependsOn:[]`,
-		}, renderFetchIsolation(result.Response.Fetches))
-		groups := DeferGroups(result.DeferResponse)
-		require.Len(t, groups, 1)
-		assert.Equal(t, []string{
-			`path:"products" cache:<nil> ttl:0s dependsOn:[0]`,
-		}, renderFetchIsolation(groups[0].Fetches))
+		assert.Equal(t, `QueryPlan {
+  Fetch(service: "0") {
+    Cache: {l1:false l2:true cacheName:products-cache ttl:1m0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:RootField type:Query field:products candidates:0 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}
+    {
+        products(first: $a){
+            upc
+            __typename
+        }
+    }
+  }
+}
+Deferred (id: 1) QueryPlan {
+  Fetch(service: "1") {
+    {
+      fragment Key on Product {
+          __typename
+          upc
+      }
+    } =>
+    {
+        _entities(representations: $representations){
+            ... on Product {
+                __typename
+                stock
+            }
+        }
+    }
+  }
+}
+`, PrettyPlan(result))
 	})
 }
 

--- a/execution/cachingtesting/isolation_e2e_test.go
+++ b/execution/cachingtesting/isolation_e2e_test.go
@@ -1,0 +1,148 @@
+package cachingtesting
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/cache/cachetesting"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// isolationCaching configures two sibling root fields on the products
+// subgraph with DIFFERENT policies.
+func isolationCaching() map[string]cacheconfig.CachingConfiguration {
+	return map[string]cacheconfig.CachingConfiguration{
+		"products": {
+			RootFields: []cacheconfig.RootFieldCachePolicy{
+				{TypeName: "Query", FieldName: "products", CacheName: "products-cache", TTL: time.Minute},
+				{TypeName: "Query", FieldName: "promotions", CacheName: "promotions-cache", TTL: 5 * time.Minute},
+			},
+		},
+	}
+}
+
+// renderFetchIsolation walks a fetch tree rendering path, cache name/TTL, and
+// dependency edges per fetch — the isolation shape in one string per fetch.
+func renderFetchIsolation(node *resolve.FetchTreeNode) []string {
+	if node == nil {
+		return nil
+	}
+	var out []string
+	if node.Item != nil && node.Item.Fetch != nil {
+		cfg := node.Item.Fetch.CacheConfig()
+		cacheName, ttl := "<nil>", time.Duration(0)
+		if cfg != nil {
+			cacheName, ttl = cfg.CacheName, cfg.TTL
+		}
+		out = append(out, fmt.Sprintf("path:%q cache:%s ttl:%s dependsOn:%v",
+			node.Item.ResponsePath, cacheName, ttl, node.Item.Fetch.Dependencies().DependsOnFetchIDs))
+	}
+	for _, child := range node.ChildNodes {
+		out = append(out, renderFetchIsolation(child)...)
+	}
+	return out
+}
+
+// TestRootFieldIsolationPlans covers the plan-level isolation rows.
+func TestRootFieldIsolationPlans(t *testing.T) {
+	t.Run("two cached siblings with different policies become two parallel fetches", func(t *testing.T) {
+		result := Plan(t, `{ products(first: 1) { upc } promotions { upc } }`, isolationCaching(), nil)
+		assert.Equal(t, []string{
+			`path:"" cache:products-cache ttl:1m0s dependsOn:[]`,
+			`path:"" cache:promotions-cache ttl:5m0s dependsOn:[]`,
+		}, renderFetchIsolation(result.Response.Fetches))
+	})
+
+	t.Run("cached + uncached sibling: cached isolated, uncached separate without config", func(t *testing.T) {
+		caching := map[string]cacheconfig.CachingConfiguration{
+			"products": {
+				RootFields: []cacheconfig.RootFieldCachePolicy{
+					{TypeName: "Query", FieldName: "products", CacheName: "products-cache", TTL: time.Minute},
+				},
+			},
+		}
+		result := Plan(t, `{ products(first: 1) { upc } promotions { upc } }`, caching, nil)
+		assert.Equal(t, []string{
+			`path:"" cache:products-cache ttl:1m0s dependsOn:[]`,
+			`path:"" cache:<nil> ttl:0s dependsOn:[]`,
+		}, renderFetchIsolation(result.Response.Fetches))
+	})
+
+	t.Run("caching off: one merged fetch, byte-identical to the pre-isolation plan", func(t *testing.T) {
+		result := Plan(t, `{ products(first: 1) { upc } promotions { upc } }`, nil, nil)
+		assert.Equal(t, []string{
+			`path:"" cache:<nil> ttl:0s dependsOn:[]`,
+		}, renderFetchIsolation(result.Response.Fetches))
+	})
+
+	t.Run("entity-root-node trap: a nested entity under an isolated root still merges into its subtree", func(t *testing.T) {
+		result := Plan(t, `{ products(first: 1) { upc stock } }`, isolationCaching(), map[string]string{
+			"products":  `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`,
+			"inventory": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
+		})
+		// TWO fetches only: the isolated products root (its own subtree intact)
+		// and the inventory entity fetch depending on it — the products
+		// subtree was NOT torn apart into more fetches.
+		assert.Equal(t, []string{
+			`path:"" cache:products-cache ttl:1m0s dependsOn:[]`,
+			`path:"products" cache:<nil> ttl:0s dependsOn:[0]`,
+		}, renderFetchIsolation(result.Response.Fetches))
+
+		body := ResolveResponse(t, result.Response, nil)
+		assert.Equal(t, `{"data":{"products":[{"upc":"1","stock":5}]}}`, body)
+	})
+
+	t.Run("defer composition: an isolated root's deferred sub-fetch lands in its defer group", func(t *testing.T) {
+		result := Plan(t, `{ products(first: 1) { upc ... @defer { stock } } }`, isolationCaching(), nil)
+		require.NotNil(t, result.DeferResponse)
+		assert.Equal(t, []string{
+			`path:"" cache:products-cache ttl:1m0s dependsOn:[]`,
+		}, renderFetchIsolation(result.Response.Fetches))
+		groups := DeferGroups(result.DeferResponse)
+		require.Len(t, groups, 1)
+		assert.Equal(t, []string{
+			`path:"products" cache:<nil> ttl:0s dependsOn:[0]`,
+		}, renderFetchIsolation(groups[0].Fetches))
+	})
+}
+
+// TestRootFieldIsolationIndependentServing: the two isolated siblings cache
+// and expire INDEPENDENTLY — one entry expires (forced), the other still hits.
+func TestRootFieldIsolationIndependentServing(t *testing.T) {
+	store := cachetesting.NewFakeStore()
+	query := `{ products(first: 1) { upc } promotions { upc } }`
+	responses := map[string]string{
+		"products": `{"data":{"products":[{"__typename":"Product","upc":"1"}],"promotions":[{"__typename":"Product","upc":"9"}]}}`,
+	}
+	expected := `{"data":{"products":[{"upc":"1"}],"promotions":[{"upc":"9"}]}}`
+
+	first := Plan(t, query, isolationCaching(), responses)
+	firstBody := ResolveResponse(t, first.Response, cachetesting.NewRealishCache(store, nil))
+	assert.Equal(t, expected, firstBody)
+	// TWO isolated fetches, one per root field, both to the products DS.
+	assert.Equal(t, int64(2), first.LoadCount("products", ""))
+
+	ops := store.Ops()
+	require.Len(t, ops, 4)
+	productsKey, promotionsKey := ops[0].Key, ops[1].Key
+	assert.NotEqual(t, productsKey, promotionsKey)
+
+	// Force-expire ONLY the products entry (the store double lets tests age an
+	// entry without real sleeping; TTL expiry semantics are pinned by the
+	// synctest unit rows).
+	entry, ok := store.Get(productsKey)
+	require.True(t, ok)
+	store.Seed(productsKey, entry.Value, -time.Second)
+
+	second := Plan(t, query, isolationCaching(), responses)
+	secondBody := ResolveResponse(t, second.Response, cachetesting.NewRealishCache(store, nil))
+	assert.Equal(t, expected, secondBody)
+	// The products fetch expired and refetched; promotions still hit: exactly
+	// ONE of the two isolated fetches touched the network.
+	assert.Equal(t, int64(1), second.LoadCount("products", ""))
+}

--- a/execution/cachingtesting/isolation_e2e_test.go
+++ b/execution/cachingtesting/isolation_e2e_test.go
@@ -1,6 +1,8 @@
 package cachingtesting
 
 import (
+	"bytes"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -24,34 +26,73 @@ func isolationCaching() map[string]cacheconfig.CachingConfiguration {
 	}
 }
 
-// TestRootFieldIsolationPlans covers the plan-level isolation rows.
+// TestRootFieldIsolationPlans covers the isolation rows through the REAL
+// ExecutionEngine: each scenario executes like a client with the QueryPlan in
+// the response extensions, pinning the ENTIRE body — data plus the sync fetch
+// tree with its per-fetch cache configs.
 func TestRootFieldIsolationPlans(t *testing.T) {
 	t.Run("two cached siblings with different policies become two parallel fetches", func(t *testing.T) {
-		result := Plan(t, `{ products(first: 1) { upc } promotions { upc } }`, isolationCaching(), nil)
-		assert.Equal(t, `QueryPlan {
-  Parallel {
-    Fetch(service: "0") {
-      Cache: {l1:false l2:true cacheName:products-cache ttl:1m0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:RootField type:Query field:products candidates:0 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}
+		controller := cachetesting.NewRealishCache(cachetesting.NewFakeStore(), nil)
+		products := Rules(
+			Rule(`"variables":{"a":1}`, `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`),
+			Rule(`promotions`, `{"data":{"promotions":[{"__typename":"Product","upc":"9"}]}}`),
+		)
+		subgraphs := Subgraphs{"products": products}
+		executionEngine := NewEngine(t, isolationCaching(), subgraphs)
+		body := ExecutePlanned(t, executionEngine, `{ products(first: 1) { upc } promotions { upc } }`, controller)
+		var buf bytes.Buffer
+		require.NoError(t, json.Indent(&buf, []byte(subgraphs.NormalizeURLs(body)), "", "  "))
+		assert.Equal(t, `{
+  "data": {
+    "products": [
       {
-          products(first: $a){
-              upc
-          }
+        "upc": "1"
       }
-    }
-    Fetch(service: "0") {
-      Cache: {l1:false l2:true cacheName:promotions-cache ttl:5m0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:RootField type:Query field:promotions candidates:0 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}
+    ],
+    "promotions": [
       {
-          promotions {
-              upc
-          }
+        "upc": "9"
       }
+    ]
+  },
+  "extensions": {
+    "queryPlan": {
+      "version": "1",
+      "kind": "Sequence",
+      "children": [
+        {
+          "kind": "Parallel",
+          "children": [
+            {
+              "kind": "Single",
+              "fetch": {
+                "kind": "Single",
+                "subgraphName": "0",
+                "subgraphId": "0",
+                "fetchId": 0,
+                "cache": "{l1:false l2:true cacheName:products-cache ttl:1m0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:RootField type:Query field:products candidates:0 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}"
+              }
+            },
+            {
+              "kind": "Single",
+              "fetch": {
+                "kind": "Single",
+                "subgraphName": "0",
+                "subgraphId": "0",
+                "fetchId": 1,
+                "cache": "{l1:false l2:true cacheName:promotions-cache ttl:5m0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:RootField type:Query field:promotions candidates:0 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}"
+              }
+            }
+          ]
+        }
+      ]
     }
   }
-}
-`, PrettyPlan(result))
+}`, buf.String())
 	})
 
 	t.Run("cached + uncached sibling: cached isolated, uncached separate without config", func(t *testing.T) {
+		controller := cachetesting.NewRealishCache(cachetesting.NewFakeStore(), nil)
 		caching := map[string]cacheconfig.CachingConfiguration{
 			"products": {
 				RootFields: []cacheconfig.RootFieldCachePolicy{
@@ -59,89 +100,183 @@ func TestRootFieldIsolationPlans(t *testing.T) {
 				},
 			},
 		}
-		result := Plan(t, `{ products(first: 1) { upc } promotions { upc } }`, caching, nil)
-		assert.Equal(t, `QueryPlan {
-  Parallel {
-    Fetch(service: "0") {
-      Cache: {l1:false l2:true cacheName:products-cache ttl:1m0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:RootField type:Query field:products candidates:0 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}
+		products := Rules(
+			Rule(`"variables":{"a":1}`, `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`),
+			Rule(`promotions`, `{"data":{"promotions":[{"__typename":"Product","upc":"9"}]}}`),
+		)
+		subgraphs := Subgraphs{"products": products}
+		executionEngine := NewEngine(t, caching, subgraphs)
+		body := ExecutePlanned(t, executionEngine, `{ products(first: 1) { upc } promotions { upc } }`, controller)
+		var buf bytes.Buffer
+		require.NoError(t, json.Indent(&buf, []byte(subgraphs.NormalizeURLs(body)), "", "  "))
+		assert.Equal(t, `{
+  "data": {
+    "products": [
       {
-          products(first: $a){
-              upc
-          }
+        "upc": "1"
       }
-    }
-    Fetch(service: "0") {
+    ],
+    "promotions": [
       {
-          promotions {
-              upc
-          }
+        "upc": "9"
       }
+    ]
+  },
+  "extensions": {
+    "queryPlan": {
+      "version": "1",
+      "kind": "Sequence",
+      "children": [
+        {
+          "kind": "Parallel",
+          "children": [
+            {
+              "kind": "Single",
+              "fetch": {
+                "kind": "Single",
+                "subgraphName": "0",
+                "subgraphId": "0",
+                "fetchId": 0,
+                "cache": "{l1:false l2:true cacheName:products-cache ttl:1m0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:RootField type:Query field:products candidates:0 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}"
+              }
+            },
+            {
+              "kind": "Single",
+              "fetch": {
+                "kind": "Single",
+                "subgraphName": "0",
+                "subgraphId": "0",
+                "fetchId": 1
+              }
+            }
+          ]
+        }
+      ]
     }
   }
-}
-`, PrettyPlan(result))
+}`, buf.String())
 	})
 
-	t.Run("caching off: one merged fetch, byte-identical to the pre-isolation plan", func(t *testing.T) {
-		result := Plan(t, `{ products(first: 1) { upc } promotions { upc } }`, nil, nil)
-		assert.Equal(t, `QueryPlan {
-  Fetch(service: "0") {
-    {
-        products(first: $a){
-            upc
+	t.Run("caching off: one merged fetch, no cache config on it", func(t *testing.T) {
+		products := Respond(`{"data":{"products":[{"__typename":"Product","upc":"1"}],"promotions":[{"__typename":"Product","upc":"9"}]}}`)
+		subgraphs := Subgraphs{"products": products}
+		executionEngine := NewEngine(t, nil, subgraphs)
+		body := ExecutePlanned(t, executionEngine, `{ products(first: 1) { upc } promotions { upc } }`, nil)
+		var buf bytes.Buffer
+		require.NoError(t, json.Indent(&buf, []byte(subgraphs.NormalizeURLs(body)), "", "  "))
+		assert.Equal(t, `{
+  "data": {
+    "products": [
+      {
+        "upc": "1"
+      }
+    ],
+    "promotions": [
+      {
+        "upc": "9"
+      }
+    ]
+  },
+  "extensions": {
+    "queryPlan": {
+      "version": "1",
+      "kind": "Sequence",
+      "children": [
+        {
+          "kind": "Single",
+          "fetch": {
+            "kind": "Single",
+            "subgraphName": "0",
+            "subgraphId": "0",
+            "fetchId": 0
+          }
         }
-        promotions {
-            upc
-        }
+      ]
     }
   }
-}
-`, PrettyPlan(result))
+}`, buf.String())
 	})
 
 	t.Run("entity-root-node trap: a nested entity under an isolated root still merges into its subtree", func(t *testing.T) {
-		result := Plan(t, `{ products(first: 1) { upc stock } }`, isolationCaching(), map[string]string{
-			"products":  `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`,
-			"inventory": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
-		})
 		// TWO fetches only: the isolated products root (its own subtree intact)
 		// and the inventory entity fetch sequenced after it — the products
 		// subtree was NOT torn apart into more fetches.
-		assert.Equal(t, `QueryPlan {
-  Sequence {
-    Fetch(service: "0") {
-      Cache: {l1:false l2:true cacheName:products-cache ttl:1m0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:RootField type:Query field:products candidates:0 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}
+		controller := cachetesting.NewRealishCache(cachetesting.NewFakeStore(), nil)
+		products := Respond(`{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`)
+		inventory := Respond(`{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`)
+		subgraphs := Subgraphs{"products": products, "inventory": inventory}
+		executionEngine := NewEngine(t, isolationCaching(), subgraphs)
+		body := ExecutePlanned(t, executionEngine, `{ products(first: 1) { upc stock } }`, controller)
+		var buf bytes.Buffer
+		require.NoError(t, json.Indent(&buf, []byte(subgraphs.NormalizeURLs(body)), "", "  "))
+		assert.Equal(t, `{
+  "data": {
+    "products": [
       {
-          products(first: $a){
-              upc
-              __typename
-          }
+        "upc": "1",
+        "stock": 5
       }
-    }
-    Fetch(service: "1") {
-      {
-        fragment Key on Product {
-            __typename
-            upc
-        }
-      } =>
-      {
-          _entities(representations: $representations){
-              ... on Product {
-                  __typename
-                  stock
+    ]
+  },
+  "extensions": {
+    "queryPlan": {
+      "version": "1",
+      "kind": "Sequence",
+      "children": [
+        {
+          "kind": "Single",
+          "fetch": {
+            "kind": "Single",
+            "subgraphName": "0",
+            "subgraphId": "0",
+            "fetchId": 0,
+            "cache": "{l1:false l2:true cacheName:products-cache ttl:1m0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:RootField type:Query field:products candidates:0 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}"
+          }
+        },
+        {
+          "kind": "Single",
+          "fetch": {
+            "kind": "BatchEntity",
+            "path": "products",
+            "subgraphName": "1",
+            "subgraphId": "1",
+            "fetchId": 1,
+            "dependsOnFetchIds": [
+              0
+            ],
+            "dependencies": [
+              {
+                "coordinate": {
+                  "typeName": "Product",
+                  "fieldName": "stock"
+                },
+                "isUserRequested": true,
+                "dependsOn": [
+                  {
+                    "fetchId": 0,
+                    "subgraph": "0",
+                    "coordinate": {
+                      "typeName": "Product",
+                      "fieldName": "upc"
+                    },
+                    "isKey": true,
+                    "isRequires": false
+                  }
+                ]
               }
+            ]
           }
-      }
+        }
+      ]
     }
   }
-}
-`, PrettyPlan(result))
-
-		body := ResolveResponse(t, result.Response, nil)
-		assert.Equal(t, `{"data":{"products":[{"upc":"1","stock":5}]}}`, body)
+}`, buf.String())
 	})
 
+	// This subtest is a planner-level test that pins plan-internal state not
+	// visible in a client response: the queryPlan response extension only
+	// covers the synchronous fetch tree, so the deferred group's plan (and its
+	// fetch placement) can only be asserted on the Plan() result itself.
 	t.Run("defer composition: an isolated root's deferred sub-fetch lands in its defer group", func(t *testing.T) {
 		result := Plan(t, `{ products(first: 1) { upc ... @defer { stock } } }`, isolationCaching(), nil)
 		require.NotNil(t, result.DeferResponse)

--- a/execution/cachingtesting/isolation_e2e_test.go
+++ b/execution/cachingtesting/isolation_e2e_test.go
@@ -180,23 +180,43 @@ Deferred (id: 1) QueryPlan {
 
 // TestRootFieldIsolationIndependentServing: the two isolated siblings cache
 // and expire INDEPENDENTLY — one entry expires (forced), the other still hits.
+// Runs through the REAL ExecutionEngine: the products double routes each
+// isolated fetch by its request body, so the old per-DS load counts become
+// per-rule request counts.
 func TestRootFieldIsolationIndependentServing(t *testing.T) {
 	store := cachetesting.NewFakeStore()
+	controller := cachetesting.NewRealishCache(store, nil)
 	query := `{ products(first: 1) { upc } promotions { upc } }`
-	responses := map[string]string{
-		"products": `{"data":{"products":[{"__typename":"Product","upc":"1"}],"promotions":[{"__typename":"Product","upc":"9"}]}}`,
-	}
+	productsRule := Rule(`"variables":{"a":1}`, `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`)
+	promotionsRule := Rule(`promotions`, `{"data":{"promotions":[{"__typename":"Product","upc":"9"}]}}`)
+	products := Rules(productsRule, promotionsRule)
+	executionEngine := NewEngine(t, isolationCaching(), Subgraphs{"products": products})
 	expected := `{"data":{"products":[{"upc":"1"}],"promotions":[{"upc":"9"}]}}`
 
-	first := Plan(t, query, isolationCaching(), responses)
-	firstBody := ResolveResponse(t, first.Response, cachetesting.NewRealishCache(store, nil))
+	firstBody := Execute(t, executionEngine, query, controller)
 	assert.Equal(t, expected, firstBody)
-	// TWO isolated fetches, one per root field, both to the products DS.
-	assert.Equal(t, int64(2), first.LoadCount("products", ""))
+	// TWO isolated fetches, one per root field, both to the products double.
+	assert.Equal(t, int64(1), productsRule.Count.Load())
+	assert.Equal(t, int64(1), promotionsRule.Count.Load())
 
 	ops := store.Ops()
 	require.Len(t, ops, 4)
-	productsKey, promotionsKey := ops[0].Key, ops[1].Key
+	// The two fetches run in parallel: identify the products entry by its
+	// EXACT stored value instead of relying on op order.
+	var productsKey, promotionsKey string
+	for _, op := range ops {
+		if op.Kind != "Set" {
+			continue
+		}
+		switch op.Value {
+		case `{"products":[{"__typename":"Product","upc":"1"}]}`:
+			productsKey = op.Key
+		case `{"promotions":[{"__typename":"Product","upc":"9"}]}`:
+			promotionsKey = op.Key
+		}
+	}
+	require.NotEmpty(t, productsKey)
+	require.NotEmpty(t, promotionsKey)
 	assert.NotEqual(t, productsKey, promotionsKey)
 
 	// Force-expire ONLY the products entry (the store double lets tests age an
@@ -206,10 +226,10 @@ func TestRootFieldIsolationIndependentServing(t *testing.T) {
 	require.True(t, ok)
 	store.Seed(productsKey, entry.Value, -time.Second)
 
-	second := Plan(t, query, isolationCaching(), responses)
-	secondBody := ResolveResponse(t, second.Response, cachetesting.NewRealishCache(store, nil))
+	secondBody := Execute(t, executionEngine, query, controller)
 	assert.Equal(t, expected, secondBody)
 	// The products fetch expired and refetched; promotions still hit: exactly
-	// ONE of the two isolated fetches touched the network.
-	assert.Equal(t, int64(1), second.LoadCount("products", ""))
+	// ONE of the two isolated fetches touched the network again.
+	assert.Equal(t, int64(2), productsRule.Count.Load())
+	assert.Equal(t, int64(1), promotionsRule.Count.Load())
 }

--- a/execution/cachingtesting/l1_e2e_test.go
+++ b/execution/cachingtesting/l1_e2e_test.go
@@ -94,12 +94,23 @@ func TestL1ModeMatrixEndToEnd(t *testing.T) {
 	assert.Equal(t, "Set", ops[2].Kind)
 	assert.Equal(t, `{"__typename":"Product","name":"Table","upc":"1"}`, ops[1].Value)
 
-	// A SECOND request over a fresh plan hits L2 on fetch A and L1 on fetch B.
+	// A SECOND request over a fresh plan hits L2 on fetch A and L1 on fetch B;
+	// its ops assert in isolation.
+	bothStore.ResetOps()
 	second := Plan(t, query, productL1Caching(time.Minute), responses)
 	secondBody := ResolveResponse(t, second.Response, cachetesting.NewRealishCache(bothStore, nil))
 	assert.Equal(t, noopBody, secondBody)
 	assert.Equal(t, int64(0), second.LoadCount("products", "deal.product"))
 	assert.Equal(t, int64(0), second.LoadCount("products", "deal.product.reviews.@.product"))
+	// Exactly three ops: fetch A's sku-key Get (L2 hit), fetch B's upc-key Get
+	// (L2 hit — request 2's L1 only holds A's RENDERED key), and fetch A's
+	// pending upc candidate re-rendered from the served value (backfill Set at
+	// the request-end flush).
+	assert.Equal(t, []cachetesting.StoreOp{
+		{Kind: "Get", Key: ops[0].Key},
+		{Kind: "Get", Key: ops[2].Key},
+		{Kind: "Set", Key: ops[2].Key, Value: `{"__typename":"Product","name":"Table","upc":"1"}`, TTL: time.Minute},
+	}, bothStore.Ops())
 }
 
 // TestL1LazyInitAndParallelWrites (M1 + M2): two parallel eligible entity

--- a/execution/cachingtesting/l1_e2e_test.go
+++ b/execution/cachingtesting/l1_e2e_test.go
@@ -23,30 +23,37 @@ func productL1Caching(ttl time.Duration) map[string]cacheconfig.CachingConfigura
 	}
 }
 
+// l1ChainDoubles builds the doubles for the dependency-ordered deal ->
+// product(sku) -> reviews(upc) -> product(upc) chain: the deals root resolves
+// the product by SKU (products fetch A), the reviews hop needs UPC from A's
+// response, and each review's product resolves through a SECOND products
+// fetch B that transitively depends on A — exactly the shape optimizeL1Cache
+// keeps L1 on for. fetchBName parameterizes fetch B's canned product name so
+// tests can TAMPER it (accidental network use fails loudly).
+func l1ChainDoubles(fetchBName string) (deals, reviews *Subgraph, fetchA, fetchB *SubgraphRule) {
+	deals = Respond(`{"data":{"deal":{"__typename":"Deal","id":"d1","product":{"__typename":"Product","sku":"S1"}}}}`)
+	reviews = Respond(`{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","product":{"__typename":"Product","upc":"1"}}]}]}}`)
+	fetchA = Rule(`"sku":"S1"`, `{"data":{"_entities":[{"__typename":"Product","name":"Table","upc":"1"}]}}`)
+	fetchB = Rule(`"upc":"1"`, `{"data":{"_entities":[{"__typename":"Product","name":"`+fetchBName+`"}]}}`)
+	return deals, reviews, fetchA, fetchB
+}
+
 // TestL1InRequestReuseEndToEnd: fetch A (deal.product) populates L1 under both
 // entity keys (upc backfilled from the response); the DEPENDENT fetch B
 // (review.product, known only by upc) is served from L1 with ZERO network and
-// — the policy being L1-only — ZERO store ops for the whole request.
+// — the policy being L1-only — ZERO store ops for the whole request. Runs
+// through the REAL ExecutionEngine; the old per-path load counts become
+// per-rule request counts on the products double.
 func TestL1InRequestReuseEndToEnd(t *testing.T) {
 	store := cachetesting.NewFakeStore()
-	// The query produces a dependency-ordered same-type pair: the deals root
-	// resolves the product by SKU (products fetch A), the reviews hop needs
-	// UPC from A's response, and each review's product resolves through a
-	// SECOND products fetch B that transitively depends on A — exactly the
-	// shape optimizeL1Cache keeps L1 on for. Fetch B's canned response is
-	// TAMPERED so accidental network use fails loudly.
 	query := `{ deal(id: "d1") { product { name reviews { product { name } } } } }`
-	responses := map[string]string{
-		"deals":                 `{"data":{"deal":{"__typename":"Deal","id":"d1","product":{"__typename":"Product","sku":"S1"}}}}`,
-		"products:deal.product": `{"data":{"_entities":[{"__typename":"Product","name":"Table","upc":"1"}]}}`,
-		"reviews":               `{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","product":{"__typename":"Product","upc":"1"}}]}]}}`,
-		"products:deal.product.reviews.@.product": `{"data":{"_entities":[{"__typename":"Product","name":"NETWORK-MUST-NOT-SERVE"}]}}`,
-	}
-	result := Plan(t, query, productL1Caching(0), responses)
-	body := ResolveResponse(t, result.Response, cachetesting.NewRealishCache(store, nil))
+	deals, reviews, fetchA, fetchB := l1ChainDoubles("NETWORK-MUST-NOT-SERVE")
+	executionEngine := NewEngine(t, productL1Caching(0), Subgraphs{"deals": deals, "reviews": reviews, "products": Rules(fetchA, fetchB)})
+
+	body := Execute(t, executionEngine, query, cachetesting.NewRealishCache(store, nil))
 	assert.Equal(t, `{"data":{"deal":{"product":{"name":"Table","reviews":[{"product":{"name":"Table"}}]}}}}`, body)
-	assert.Equal(t, int64(1), result.LoadCount("products", "deal.product"))
-	assert.Equal(t, int64(0), result.LoadCount("products", "deal.product.reviews.@.product"))
+	assert.Equal(t, int64(1), fetchA.Count.Load())
+	assert.Equal(t, int64(0), fetchB.Count.Load())
 	assert.Empty(t, store.Ops())
 }
 
@@ -54,39 +61,36 @@ func TestL1InRequestReuseEndToEnd(t *testing.T) {
 // L1+L2 produces byte-identical data; the modes differ ONLY in network and
 // store traffic. Fetch B's canned response matches the cached value here (the
 // tampered variant is TestL1InRequestReuseEndToEnd's job), so byte equality
-// across modes is meaningful.
+// across modes is meaningful. Three caching configurations → three engines,
+// each over its own doubles.
 func TestL1ModeMatrixEndToEnd(t *testing.T) {
-	// The same dependency-ordered deal -> product(sku) -> reviews(upc) ->
-	// product(upc) chain as TestL1InRequestReuseEndToEnd, resolved once per
-	// mode over the SAME canned responses.
 	query := `{ deal(id: "d1") { product { name reviews { product { name } } } } }`
-	responses := map[string]string{
-		"deals":                 `{"data":{"deal":{"__typename":"Deal","id":"d1","product":{"__typename":"Product","sku":"S1"}}}}`,
-		"products:deal.product": `{"data":{"_entities":[{"__typename":"Product","name":"Table","upc":"1"}]}}`,
-		"reviews":               `{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","product":{"__typename":"Product","upc":"1"}}]}]}}`,
-		"products:deal.product.reviews.@.product": `{"data":{"_entities":[{"__typename":"Product","name":"Table"}]}}`,
-	}
+
 	// NO-OP: no caching config, no controller — the baseline bytes.
-	noop := Plan(t, query, nil, responses)
-	noopBody := ResolveResponse(t, noop.Response, nil)
+	noopDeals, noopReviews, noopA, noopB := l1ChainDoubles("Table")
+	noopEngine := NewEngine(t, nil, Subgraphs{"deals": noopDeals, "reviews": noopReviews, "products": Rules(noopA, noopB)})
+	noopBody := Execute(t, noopEngine, query, nil)
 	assert.Equal(t, `{"data":{"deal":{"product":{"name":"Table","reviews":[{"product":{"name":"Table"}}]}}}}`, noopBody)
-	assert.Equal(t, int64(1), noop.LoadCount("products", "deal.product.reviews.@.product")) // the baseline really fetches B
+	assert.Equal(t, int64(1), noopB.Count.Load()) // the baseline really fetches B
 
 	// L1-only: identical bytes, fetch B off the network, zero store traffic.
 	l1Store := cachetesting.NewFakeStore()
-	l1Only := Plan(t, query, productL1Caching(0), responses)
-	l1Body := ResolveResponse(t, l1Only.Response, cachetesting.NewRealishCache(l1Store, nil))
+	l1Deals, l1Reviews, l1A, l1B := l1ChainDoubles("Table")
+	l1Engine := NewEngine(t, productL1Caching(0), Subgraphs{"deals": l1Deals, "reviews": l1Reviews, "products": Rules(l1A, l1B)})
+	l1Body := Execute(t, l1Engine, query, cachetesting.NewRealishCache(l1Store, nil))
 	assert.Equal(t, noopBody, l1Body)
-	assert.Equal(t, int64(0), l1Only.LoadCount("products", "deal.product.reviews.@.product"))
+	assert.Equal(t, int64(0), l1B.Count.Load())
 	assert.Empty(t, l1Store.Ops())
 
 	// L1+L2: identical bytes; fetch A misses L2 once and flushes its writes;
 	// fetch B rides L1 and touches NEITHER the network NOR the store.
 	bothStore := cachetesting.NewFakeStore()
-	both := Plan(t, query, productL1Caching(time.Minute), responses)
-	bothBody := ResolveResponse(t, both.Response, cachetesting.NewRealishCache(bothStore, nil))
+	bothDeals, bothReviews, bothA, bothB := l1ChainDoubles("Table")
+	bothEngine := NewEngine(t, productL1Caching(time.Minute), Subgraphs{"deals": bothDeals, "reviews": bothReviews, "products": Rules(bothA, bothB)})
+	controller := cachetesting.NewRealishCache(bothStore, nil)
+	bothBody := Execute(t, bothEngine, query, controller)
 	assert.Equal(t, noopBody, bothBody)
-	assert.Equal(t, int64(0), both.LoadCount("products", "deal.product.reviews.@.product"))
+	assert.Equal(t, int64(0), bothB.Count.Load())
 	ops := bothStore.Ops()
 	require.Len(t, ops, 3) // Get (A's sku miss) + Set sku + Set upc backfill
 	assert.Equal(t, "Get", ops[0].Kind)
@@ -94,14 +98,13 @@ func TestL1ModeMatrixEndToEnd(t *testing.T) {
 	assert.Equal(t, "Set", ops[2].Kind)
 	assert.Equal(t, `{"__typename":"Product","name":"Table","upc":"1"}`, ops[1].Value)
 
-	// A SECOND request over a fresh plan hits L2 on fetch A and L1 on fetch B;
-	// its ops assert in isolation.
+	// A SECOND request through the same engine hits L2 on fetch A and L1 on
+	// fetch B; its ops assert in isolation.
 	bothStore.ResetOps()
-	second := Plan(t, query, productL1Caching(time.Minute), responses)
-	secondBody := ResolveResponse(t, second.Response, cachetesting.NewRealishCache(bothStore, nil))
+	secondBody := Execute(t, bothEngine, query, controller)
 	assert.Equal(t, noopBody, secondBody)
-	assert.Equal(t, int64(0), second.LoadCount("products", "deal.product"))
-	assert.Equal(t, int64(0), second.LoadCount("products", "deal.product.reviews.@.product"))
+	assert.Equal(t, int64(1), bothA.Count.Load()) // no NEW fetch A request
+	assert.Equal(t, int64(0), bothB.Count.Load())
 	// Exactly three ops: fetch A's sku-key Get (L2 hit), fetch B's upc-key Get
 	// (L2 hit — request 2's L1 only holds A's RENDERED key), and fetch A's
 	// pending upc candidate re-rendered from the served value (backfill Set at
@@ -116,6 +119,8 @@ func TestL1ModeMatrixEndToEnd(t *testing.T) {
 // TestL1LazyInitAndParallelWrites (M1 + M2): two parallel eligible entity
 // fetches trigger exactly ONE BeginRequest, and their concurrent writes to the
 // shared request cache produce an uncorrupted response (run under -race).
+// One request through the engine, so the countingController's begins count is
+// exactly this request's.
 func TestL1LazyInitAndParallelWrites(t *testing.T) {
 	store := cachetesting.NewFakeStore()
 	query := `{ me { favoriteProduct { stock } } products(first: 2) { stock } }`
@@ -126,20 +131,24 @@ func TestL1LazyInitAndParallelWrites(t *testing.T) {
 			},
 		},
 	}
-	responses := map[string]string{
-		"users":                        `{"data":{"me":{"__typename":"User","id":"u1"}}}`,
-		"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
-		"products":                     `{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"}]}}`,
-		"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
-		"inventory:products":           `{"data":{"_entities":[{"__typename":"Product","stock":5},{"__typename":"Product","stock":7}]}}`,
-	}
-	result := Plan(t, query, caching, responses)
+	users := Respond(`{"data":{"me":{"__typename":"User","id":"u1"}}}`)
+	products := Rules(
+		Rule(`"representations"`, `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`),
+		Rule(`"variables":{"a":2}`, `{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"}]}}`),
+	)
+	// The batch fetch is the only one whose representations carry upc 2, so it
+	// must be matched first; the remaining upc-1 body is the single fetch.
+	batchFetch := Rule(`"upc":"2"`, `{"data":{"_entities":[{"__typename":"Product","stock":5},{"__typename":"Product","stock":7}]}}`)
+	singleFetch := Rule(`"upc":"1"`, `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`)
+	inventory := Rules(batchFetch, singleFetch)
+	executionEngine := NewEngine(t, caching, Subgraphs{"users": users, "products": products, "inventory": inventory})
+
 	controller := &countingController{inner: cachetesting.NewRealishCache(store, nil)}
-	body := ResolveResponse(t, result.Response, controller)
+	body := Execute(t, executionEngine, query, controller)
 	assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"stock":5}},"products":[{"stock":5},{"stock":7}]}}`, body)
 	// M1: exactly one BeginRequest despite two parallel eligible fetches.
 	assert.Equal(t, int64(1), controller.begins.Load())
 	// M2: both fetches wrote (single write + batch writes) without corruption.
-	assert.Equal(t, int64(1), result.LoadCount("inventory", "me.favoriteProduct"))
-	assert.Equal(t, int64(1), result.LoadCount("inventory", "products"))
+	assert.Equal(t, int64(1), singleFetch.Count.Load())
+	assert.Equal(t, int64(1), batchFetch.Count.Load())
 }

--- a/execution/cachingtesting/l1_e2e_test.go
+++ b/execution/cachingtesting/l1_e2e_test.go
@@ -1,0 +1,134 @@
+package cachingtesting
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/cache/cachetesting"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
+)
+
+// productL1Caching enables the products Product entity policy; ttl 0 keeps the
+// config L1-only (L2 = TTL > 0), ttl > 0 enables both layers.
+func productL1Caching(ttl time.Duration) map[string]cacheconfig.CachingConfiguration {
+	return map[string]cacheconfig.CachingConfiguration{
+		"products": {
+			Entities: []cacheconfig.EntityCachePolicy{
+				{TypeName: "Product", CacheName: "entities", TTL: ttl},
+			},
+		},
+	}
+}
+
+// l1ChainQuery produces a dependency-ordered same-type pair: the deals root
+// resolves the product by SKU (products fetch A), the reviews hop needs UPC
+// from A's response, and each review's product resolves through a SECOND
+// products fetch B that transitively depends on A — exactly the shape
+// optimizeL1Cache keeps L1 on for.
+const l1ChainQuery = `{ deal(id: "d1") { product { name reviews { product { name } } } } }`
+
+func l1ChainResponses() map[string]string {
+	return map[string]string{
+		"deals":                 `{"data":{"deal":{"__typename":"Deal","id":"d1","product":{"__typename":"Product","sku":"S1"}}}}`,
+		"products:deal.product": `{"data":{"_entities":[{"__typename":"Product","name":"Table","upc":"1"}]}}`,
+		"reviews":               `{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","product":{"__typename":"Product","upc":"1"}}]}]}}`,
+		"products:deal.product.reviews.@.product": `{"data":{"_entities":[{"__typename":"Product","name":"NETWORK-MUST-NOT-SERVE"}]}}`,
+	}
+}
+
+const l1ChainExpected = `{"data":{"deal":{"product":{"name":"Table","reviews":[{"product":{"name":"Table"}}]}}}}`
+
+// TestL1InRequestReuseEndToEnd: fetch A (deal.product) populates L1 under both
+// entity keys (upc backfilled from the response); the DEPENDENT fetch B
+// (review.product, known only by upc) is served from L1 with ZERO network and
+// — the policy being L1-only — ZERO store ops for the whole request.
+func TestL1InRequestReuseEndToEnd(t *testing.T) {
+	store := cachetesting.NewFakeStore()
+	result := Plan(t, l1ChainQuery, productL1Caching(0), l1ChainResponses())
+	body := ResolveResponse(t, result.Response, cachetesting.NewRealishCache(store, nil))
+	assert.Equal(t, l1ChainExpected, body)
+	assert.Equal(t, int64(1), result.LoadCount("products", "deal.product"))
+	assert.Equal(t, int64(0), result.LoadCount("products", "deal.product.reviews.@.product"))
+	assert.Empty(t, store.Ops())
+}
+
+// TestL1ModeMatrixEndToEnd (J rows): the same operation under NO-OP / L1-only /
+// L1+L2 produces byte-identical data; the modes differ ONLY in network and
+// store traffic. Fetch B's canned response matches the cached value here (the
+// tampered variant is TestL1InRequestReuseEndToEnd's job), so byte equality
+// across modes is meaningful.
+func TestL1ModeMatrixEndToEnd(t *testing.T) {
+	matrixResponses := func() map[string]string {
+		responses := l1ChainResponses()
+		responses["products:deal.product.reviews.@.product"] = `{"data":{"_entities":[{"__typename":"Product","name":"Table"}]}}`
+		return responses
+	}
+	// NO-OP: no caching config, no controller — the baseline bytes.
+	noop := Plan(t, l1ChainQuery, nil, matrixResponses())
+	noopBody := ResolveResponse(t, noop.Response, nil)
+	assert.Equal(t, l1ChainExpected, noopBody)
+	assert.Equal(t, int64(1), noop.LoadCount("products", "deal.product.reviews.@.product")) // the baseline really fetches B
+
+	// L1-only: identical bytes, fetch B off the network, zero store traffic.
+	l1Store := cachetesting.NewFakeStore()
+	l1Only := Plan(t, l1ChainQuery, productL1Caching(0), matrixResponses())
+	l1Body := ResolveResponse(t, l1Only.Response, cachetesting.NewRealishCache(l1Store, nil))
+	assert.Equal(t, noopBody, l1Body)
+	assert.Equal(t, int64(0), l1Only.LoadCount("products", "deal.product.reviews.@.product"))
+	assert.Empty(t, l1Store.Ops())
+
+	// L1+L2: identical bytes; fetch A misses L2 once and flushes its writes;
+	// fetch B rides L1 and touches NEITHER the network NOR the store.
+	bothStore := cachetesting.NewFakeStore()
+	both := Plan(t, l1ChainQuery, productL1Caching(time.Minute), matrixResponses())
+	bothBody := ResolveResponse(t, both.Response, cachetesting.NewRealishCache(bothStore, nil))
+	assert.Equal(t, noopBody, bothBody)
+	assert.Equal(t, int64(0), both.LoadCount("products", "deal.product.reviews.@.product"))
+	ops := bothStore.Ops()
+	require.Len(t, ops, 3) // Get (A's sku miss) + Set sku + Set upc backfill
+	assert.Equal(t, "Get", ops[0].Kind)
+	assert.Equal(t, "Set", ops[1].Kind)
+	assert.Equal(t, "Set", ops[2].Kind)
+	assert.Equal(t, `{"__typename":"Product","name":"Table","upc":"1"}`, ops[1].Value)
+
+	// A SECOND request over a fresh plan hits L2 on fetch A and L1 on fetch B.
+	second := Plan(t, l1ChainQuery, productL1Caching(time.Minute), matrixResponses())
+	secondBody := ResolveResponse(t, second.Response, cachetesting.NewRealishCache(bothStore, nil))
+	assert.Equal(t, noopBody, secondBody)
+	assert.Equal(t, int64(0), second.LoadCount("products", "deal.product"))
+	assert.Equal(t, int64(0), second.LoadCount("products", "deal.product.reviews.@.product"))
+}
+
+// TestL1LazyInitAndParallelWrites (M1 + M2): two parallel eligible entity
+// fetches trigger exactly ONE BeginRequest, and their concurrent writes to the
+// shared request cache produce an uncorrupted response (run under -race).
+func TestL1LazyInitAndParallelWrites(t *testing.T) {
+	store := cachetesting.NewFakeStore()
+	query := `{ me { favoriteProduct { stock } } products(first: 2) { stock } }`
+	caching := map[string]cacheconfig.CachingConfiguration{
+		"inventory": {
+			Entities: []cacheconfig.EntityCachePolicy{
+				{TypeName: "Product", CacheName: "inventory", TTL: time.Minute},
+			},
+		},
+	}
+	responses := map[string]string{
+		"users":                        `{"data":{"me":{"__typename":"User","id":"u1"}}}`,
+		"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
+		"products":                     `{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"}]}}`,
+		"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
+		"inventory:products":           `{"data":{"_entities":[{"__typename":"Product","stock":5},{"__typename":"Product","stock":7}]}}`,
+	}
+	result := Plan(t, query, caching, responses)
+	controller := &countingController{inner: cachetesting.NewRealishCache(store, nil)}
+	body := ResolveResponse(t, result.Response, controller)
+	assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"stock":5}},"products":[{"stock":5},{"stock":7}]}}`, body)
+	// M1: exactly one BeginRequest despite two parallel eligible fetches.
+	assert.Equal(t, int64(1), controller.begins.Load())
+	// M2: both fetches wrote (single write + batch writes) without corruption.
+	assert.Equal(t, int64(1), result.LoadCount("inventory", "me.favoriteProduct"))
+	assert.Equal(t, int64(1), result.LoadCount("inventory", "products"))
+}

--- a/execution/cachingtesting/l1_e2e_test.go
+++ b/execution/cachingtesting/l1_e2e_test.go
@@ -23,33 +23,28 @@ func productL1Caching(ttl time.Duration) map[string]cacheconfig.CachingConfigura
 	}
 }
 
-// l1ChainQuery produces a dependency-ordered same-type pair: the deals root
-// resolves the product by SKU (products fetch A), the reviews hop needs UPC
-// from A's response, and each review's product resolves through a SECOND
-// products fetch B that transitively depends on A — exactly the shape
-// optimizeL1Cache keeps L1 on for.
-const l1ChainQuery = `{ deal(id: "d1") { product { name reviews { product { name } } } } }`
-
-func l1ChainResponses() map[string]string {
-	return map[string]string{
-		"deals":                 `{"data":{"deal":{"__typename":"Deal","id":"d1","product":{"__typename":"Product","sku":"S1"}}}}`,
-		"products:deal.product": `{"data":{"_entities":[{"__typename":"Product","name":"Table","upc":"1"}]}}`,
-		"reviews":               `{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","product":{"__typename":"Product","upc":"1"}}]}]}}`,
-		"products:deal.product.reviews.@.product": `{"data":{"_entities":[{"__typename":"Product","name":"NETWORK-MUST-NOT-SERVE"}]}}`,
-	}
-}
-
-const l1ChainExpected = `{"data":{"deal":{"product":{"name":"Table","reviews":[{"product":{"name":"Table"}}]}}}}`
-
 // TestL1InRequestReuseEndToEnd: fetch A (deal.product) populates L1 under both
 // entity keys (upc backfilled from the response); the DEPENDENT fetch B
 // (review.product, known only by upc) is served from L1 with ZERO network and
 // — the policy being L1-only — ZERO store ops for the whole request.
 func TestL1InRequestReuseEndToEnd(t *testing.T) {
 	store := cachetesting.NewFakeStore()
-	result := Plan(t, l1ChainQuery, productL1Caching(0), l1ChainResponses())
+	// The query produces a dependency-ordered same-type pair: the deals root
+	// resolves the product by SKU (products fetch A), the reviews hop needs
+	// UPC from A's response, and each review's product resolves through a
+	// SECOND products fetch B that transitively depends on A — exactly the
+	// shape optimizeL1Cache keeps L1 on for. Fetch B's canned response is
+	// TAMPERED so accidental network use fails loudly.
+	query := `{ deal(id: "d1") { product { name reviews { product { name } } } } }`
+	responses := map[string]string{
+		"deals":                 `{"data":{"deal":{"__typename":"Deal","id":"d1","product":{"__typename":"Product","sku":"S1"}}}}`,
+		"products:deal.product": `{"data":{"_entities":[{"__typename":"Product","name":"Table","upc":"1"}]}}`,
+		"reviews":               `{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","product":{"__typename":"Product","upc":"1"}}]}]}}`,
+		"products:deal.product.reviews.@.product": `{"data":{"_entities":[{"__typename":"Product","name":"NETWORK-MUST-NOT-SERVE"}]}}`,
+	}
+	result := Plan(t, query, productL1Caching(0), responses)
 	body := ResolveResponse(t, result.Response, cachetesting.NewRealishCache(store, nil))
-	assert.Equal(t, l1ChainExpected, body)
+	assert.Equal(t, `{"data":{"deal":{"product":{"name":"Table","reviews":[{"product":{"name":"Table"}}]}}}}`, body)
 	assert.Equal(t, int64(1), result.LoadCount("products", "deal.product"))
 	assert.Equal(t, int64(0), result.LoadCount("products", "deal.product.reviews.@.product"))
 	assert.Empty(t, store.Ops())
@@ -61,20 +56,25 @@ func TestL1InRequestReuseEndToEnd(t *testing.T) {
 // tampered variant is TestL1InRequestReuseEndToEnd's job), so byte equality
 // across modes is meaningful.
 func TestL1ModeMatrixEndToEnd(t *testing.T) {
-	matrixResponses := func() map[string]string {
-		responses := l1ChainResponses()
-		responses["products:deal.product.reviews.@.product"] = `{"data":{"_entities":[{"__typename":"Product","name":"Table"}]}}`
-		return responses
+	// The same dependency-ordered deal -> product(sku) -> reviews(upc) ->
+	// product(upc) chain as TestL1InRequestReuseEndToEnd, resolved once per
+	// mode over the SAME canned responses.
+	query := `{ deal(id: "d1") { product { name reviews { product { name } } } } }`
+	responses := map[string]string{
+		"deals":                 `{"data":{"deal":{"__typename":"Deal","id":"d1","product":{"__typename":"Product","sku":"S1"}}}}`,
+		"products:deal.product": `{"data":{"_entities":[{"__typename":"Product","name":"Table","upc":"1"}]}}`,
+		"reviews":               `{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","product":{"__typename":"Product","upc":"1"}}]}]}}`,
+		"products:deal.product.reviews.@.product": `{"data":{"_entities":[{"__typename":"Product","name":"Table"}]}}`,
 	}
 	// NO-OP: no caching config, no controller — the baseline bytes.
-	noop := Plan(t, l1ChainQuery, nil, matrixResponses())
+	noop := Plan(t, query, nil, responses)
 	noopBody := ResolveResponse(t, noop.Response, nil)
-	assert.Equal(t, l1ChainExpected, noopBody)
+	assert.Equal(t, `{"data":{"deal":{"product":{"name":"Table","reviews":[{"product":{"name":"Table"}}]}}}}`, noopBody)
 	assert.Equal(t, int64(1), noop.LoadCount("products", "deal.product.reviews.@.product")) // the baseline really fetches B
 
 	// L1-only: identical bytes, fetch B off the network, zero store traffic.
 	l1Store := cachetesting.NewFakeStore()
-	l1Only := Plan(t, l1ChainQuery, productL1Caching(0), matrixResponses())
+	l1Only := Plan(t, query, productL1Caching(0), responses)
 	l1Body := ResolveResponse(t, l1Only.Response, cachetesting.NewRealishCache(l1Store, nil))
 	assert.Equal(t, noopBody, l1Body)
 	assert.Equal(t, int64(0), l1Only.LoadCount("products", "deal.product.reviews.@.product"))
@@ -83,7 +83,7 @@ func TestL1ModeMatrixEndToEnd(t *testing.T) {
 	// L1+L2: identical bytes; fetch A misses L2 once and flushes its writes;
 	// fetch B rides L1 and touches NEITHER the network NOR the store.
 	bothStore := cachetesting.NewFakeStore()
-	both := Plan(t, l1ChainQuery, productL1Caching(time.Minute), matrixResponses())
+	both := Plan(t, query, productL1Caching(time.Minute), responses)
 	bothBody := ResolveResponse(t, both.Response, cachetesting.NewRealishCache(bothStore, nil))
 	assert.Equal(t, noopBody, bothBody)
 	assert.Equal(t, int64(0), both.LoadCount("products", "deal.product.reviews.@.product"))
@@ -95,7 +95,7 @@ func TestL1ModeMatrixEndToEnd(t *testing.T) {
 	assert.Equal(t, `{"__typename":"Product","name":"Table","upc":"1"}`, ops[1].Value)
 
 	// A SECOND request over a fresh plan hits L2 on fetch A and L1 on fetch B.
-	second := Plan(t, l1ChainQuery, productL1Caching(time.Minute), matrixResponses())
+	second := Plan(t, query, productL1Caching(time.Minute), responses)
 	secondBody := ResolveResponse(t, second.Response, cachetesting.NewRealishCache(bothStore, nil))
 	assert.Equal(t, noopBody, secondBody)
 	assert.Equal(t, int64(0), second.LoadCount("products", "deal.product"))

--- a/execution/cachingtesting/loader_bench_test.go
+++ b/execution/cachingtesting/loader_bench_test.go
@@ -1,0 +1,244 @@
+package cachingtesting
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/wundergraph/astjson"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/cache"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// benchStore is the benchmark L2 store: a plain RWMutex map with NO op
+// logging, so the measurements show the loader + cache hot paths and not the
+// test double's bookkeeping.
+type benchStore struct {
+	mu   sync.RWMutex
+	data map[string]benchEntry
+}
+
+type benchEntry struct {
+	value     []byte
+	expiresAt time.Time
+}
+
+func newBenchStore() *benchStore {
+	return &benchStore{data: make(map[string]benchEntry)}
+}
+
+func (s *benchStore) Get(key string) ([]byte, time.Duration, bool) {
+	s.mu.RLock()
+	entry, ok := s.data[key]
+	s.mu.RUnlock()
+	if !ok {
+		return nil, 0, false
+	}
+	return entry.value, time.Until(entry.expiresAt), true
+}
+
+func (s *benchStore) Set(key string, value []byte, ttl time.Duration) {
+	s.mu.Lock()
+	s.data[key] = benchEntry{value: value, expiresAt: time.Now().Add(ttl)}
+	s.mu.Unlock()
+}
+
+// discardWriter drops the rendered response (rendering cost stays included,
+// buffer growth noise does not).
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// benchResolve plans once and resolves the SAME plan per iteration — the
+// router's production mode (plans are cached and reused) — with ONE resolver
+// and one controller across iterations and a fresh Context per request.
+func benchResolve(b *testing.B, result PlanResult, controller resolve.CacheController) {
+	b.Helper()
+	r := resolve.New(context.Background(), resolve.ResolverOptions{MaxConcurrency: 1024})
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		ctx := resolve.NewContext(context.Background())
+		if controller != nil {
+			ctx.SetCacheController(controller)
+		}
+		if _, err := r.ResolveGraphQLResponse(ctx, result.Response, nil, discardWriter{}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkLoader measures the loader hot paths per fetch type, with and
+// without caching. All caching variants are steady-state HITS (primed before
+// the loop) unless named otherwise.
+func BenchmarkLoader(b *testing.B) {
+	entityQuery := `{ me { username favoriteProduct { upc stock } } }`
+	entityResponses := map[string]string{
+		"users":                        `{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`,
+		"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
+		"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
+	}
+	entityCaching := map[string]cacheconfig.CachingConfiguration{
+		"inventory": {Entities: []cacheconfig.EntityCachePolicy{{TypeName: "Product", CacheName: "inventory", TTL: time.Hour}}},
+	}
+
+	batchQuery := `{ products(first: 2) { upc reviews { body } } }`
+	batchResponses := map[string]string{
+		"products": `{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"}]}}`,
+		"reviews":  `{"data":{"_entities":[{"__typename":"Product","reviews":[{"body":"Solid"}]},{"__typename":"Product","reviews":[{"body":"Wobbly"}]}]}}`,
+	}
+	batchCaching := map[string]cacheconfig.CachingConfiguration{
+		"reviews": {Entities: []cacheconfig.EntityCachePolicy{{TypeName: "Product", CacheName: "reviews", TTL: time.Hour}}},
+	}
+	partialCaching := map[string]cacheconfig.CachingConfiguration{
+		"reviews": {Entities: []cacheconfig.EntityCachePolicy{{TypeName: "Product", CacheName: "reviews", TTL: time.Hour, EnablePartialCacheLoad: true}}},
+	}
+
+	rootFieldQuery := `query($first: Int!) { products(first: $first) { upc name } }`
+	rootFieldResponses := map[string]string{
+		"products": `{"data":{"products":[{"__typename":"Product","upc":"1","name":"Table"}]}}`,
+	}
+	rootFieldCaching := map[string]cacheconfig.CachingConfiguration{
+		"products": {RootFields: []cacheconfig.RootFieldCachePolicy{{TypeName: "Query", FieldName: "products", CacheName: "root-fields", TTL: time.Hour}}},
+	}
+
+	chainQuery := `{ deal(id: "d1") { product { name reviews { product { name } } } } }`
+	chainResponses := map[string]string{
+		"deals":                 `{"data":{"deal":{"__typename":"Deal","id":"d1","product":{"__typename":"Product","sku":"S1"}}}}`,
+		"products:deal.product": `{"data":{"_entities":[{"__typename":"Product","name":"Table","upc":"1"}]}}`,
+		"reviews":               `{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","product":{"__typename":"Product","upc":"1"}}]}]}}`,
+		"products:deal.product.reviews.@.product": `{"data":{"_entities":[{"__typename":"Product","name":"Table"}]}}`,
+	}
+	chainCaching := map[string]cacheconfig.CachingConfiguration{
+		"products": {Entities: []cacheconfig.EntityCachePolicy{{TypeName: "Product", CacheName: "entities", TTL: time.Hour}}},
+	}
+
+	prime := func(b *testing.B, result PlanResult, controller resolve.CacheController) {
+		b.Helper()
+		r := resolve.New(context.Background(), resolve.ResolverOptions{MaxConcurrency: 1024})
+		ctx := resolve.NewContext(context.Background())
+		ctx.SetCacheController(controller)
+		if _, err := r.ResolveGraphQLResponse(ctx, result.Response, nil, discardWriter{}); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.Run("entity/no-cache", func(b *testing.B) {
+		benchResolve(b, Plan(b, entityQuery, nil, entityResponses), nil)
+	})
+	b.Run("entity/l2-hit", func(b *testing.B) {
+		result := Plan(b, entityQuery, entityCaching, entityResponses)
+		controller := cache.NewController(newBenchStore(), nil)
+		prime(b, result, controller)
+		benchResolve(b, result, controller)
+	})
+	b.Run("entity/l2-miss-write", func(b *testing.B) {
+		// Every iteration misses (fresh store per loop is too heavy; instead a
+		// zero-TTL... a NEGATIVE-TTL store entry cannot be expressed, so the
+		// miss path uses a store that never returns hits).
+		result := Plan(b, entityQuery, entityCaching, entityResponses)
+		controller := cache.NewController(missStore{}, nil)
+		benchResolve(b, result, controller)
+	})
+
+	b.Run("batch/no-cache", func(b *testing.B) {
+		benchResolve(b, Plan(b, batchQuery, nil, batchResponses), nil)
+	})
+	b.Run("batch/l2-hit", func(b *testing.B) {
+		result := Plan(b, batchQuery, batchCaching, batchResponses)
+		controller := cache.NewController(newBenchStore(), nil)
+		prime(b, result, controller)
+		benchResolve(b, result, controller)
+	})
+	b.Run("batch/partial-hit", func(b *testing.B) {
+		// One of two entities primed: every iteration filters the batch and
+		// fetches the other (the canned response only matches the REDUCED
+		// request, so the partial path is proven exercised).
+		primeResult := Plan(b, `{ products(first: 1) { upc reviews { body } } }`, partialCaching, map[string]string{
+			"products": `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`,
+			"reviews":  `{"data":{"_entities":[{"__typename":"Product","reviews":[{"body":"Solid"}]}]}}`,
+		})
+		store := newBenchStore()
+		controller := cache.NewController(store, nil)
+		prime(b, primeResult, controller)
+		// Drop upc 2's entry before each run is unnecessary: it stays missing
+		// because the store primed only upc 1 and iteration writes go to upc 2
+		// AFTER the filter — delete it each iteration to keep the partial shape.
+		result := Plan(b, batchQuery, partialCaching, map[string]string{
+			"products": `{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"}]}}`,
+			"reviews":  `{"data":{"_entities":[{"__typename":"Product","reviews":[{"body":"Wobbly"}]}]}}`,
+		})
+		partial := &partialShapeStore{inner: store}
+		partialController := cache.NewController(partial, nil)
+		benchResolve(b, result, partialController)
+	})
+
+	b.Run("rootfield/no-cache", func(b *testing.B) {
+		result := Plan(b, rootFieldQuery, nil, rootFieldResponses)
+		benchResolveWithVariables(b, result, `{"first":1}`, nil)
+	})
+	b.Run("rootfield/l2-hit", func(b *testing.B) {
+		result := Plan(b, rootFieldQuery, rootFieldCaching, rootFieldResponses)
+		controller := cache.NewController(newBenchStore(), nil)
+		primeWithVariables(b, result, `{"first":1}`, controller)
+		benchResolveWithVariables(b, result, `{"first":1}`, controller)
+	})
+
+	b.Run("chain/no-cache", func(b *testing.B) {
+		benchResolve(b, Plan(b, chainQuery, nil, chainResponses), nil)
+	})
+	b.Run("chain/l1+l2-hit", func(b *testing.B) {
+		// Fetch A hits L2 per request; fetch B rides the request-lifetime L1.
+		result := Plan(b, chainQuery, chainCaching, chainResponses)
+		controller := cache.NewController(newBenchStore(), nil)
+		prime(b, result, controller)
+		benchResolve(b, result, controller)
+	})
+}
+
+// missStore never hits and swallows writes: the steady-state miss+write path
+// without unbounded map growth.
+type missStore struct{}
+
+func (missStore) Get(string) ([]byte, time.Duration, bool) { return nil, 0, false }
+func (missStore) Set(string, []byte, time.Duration)        {}
+
+// partialShapeStore serves reads from the primed inner store but drops writes,
+// so the one-of-two-primed partial shape holds for every iteration.
+type partialShapeStore struct {
+	inner *benchStore
+}
+
+func (s *partialShapeStore) Get(key string) ([]byte, time.Duration, bool) { return s.inner.Get(key) }
+func (s *partialShapeStore) Set(string, []byte, time.Duration)            {}
+
+func benchResolveWithVariables(b *testing.B, result PlanResult, variables string, controller resolve.CacheController) {
+	b.Helper()
+	r := resolve.New(context.Background(), resolve.ResolverOptions{MaxConcurrency: 1024})
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		ctx := resolve.NewContext(context.Background())
+		ctx.Variables = astjson.MustParseBytes([]byte(variables))
+		if controller != nil {
+			ctx.SetCacheController(controller)
+		}
+		if _, err := r.ResolveGraphQLResponse(ctx, result.Response, nil, discardWriter{}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func primeWithVariables(b *testing.B, result PlanResult, variables string, controller resolve.CacheController) {
+	b.Helper()
+	r := resolve.New(context.Background(), resolve.ResolverOptions{MaxConcurrency: 1024})
+	ctx := resolve.NewContext(context.Background())
+	ctx.Variables = astjson.MustParseBytes([]byte(variables))
+	ctx.SetCacheController(controller)
+	if _, err := r.ResolveGraphQLResponse(ctx, result.Response, nil, discardWriter{}); err != nil {
+		b.Fatal(err)
+	}
+}

--- a/execution/cachingtesting/loader_bench_test.go
+++ b/execution/cachingtesting/loader_bench_test.go
@@ -59,7 +59,6 @@ func benchResolve(b *testing.B, result PlanResult, controller resolve.CacheContr
 	b.Helper()
 	r := resolve.New(context.Background(), resolve.ResolverOptions{MaxConcurrency: 1024})
 	b.ReportAllocs()
-	b.ResetTimer()
 	for b.Loop() {
 		ctx := resolve.NewContext(context.Background())
 		if controller != nil {
@@ -136,9 +135,9 @@ func BenchmarkLoader(b *testing.B) {
 		benchResolve(b, result, controller)
 	})
 	b.Run("entity/l2-miss-write", func(b *testing.B) {
-		// Every iteration misses (fresh store per loop is too heavy; instead a
-		// zero-TTL... a NEGATIVE-TTL store entry cannot be expressed, so the
-		// miss path uses a store that never returns hits).
+		// Every iteration misses and writes: missStore never returns hits and
+		// swallows writes, keeping the steady-state miss+write path measurable
+		// without unbounded map growth.
 		result := Plan(b, entityQuery, entityCaching, entityResponses)
 		controller := cache.NewController(missStore{}, nil)
 		benchResolve(b, result, controller)
@@ -164,9 +163,9 @@ func BenchmarkLoader(b *testing.B) {
 		store := newBenchStore()
 		controller := cache.NewController(store, nil)
 		prime(b, primeResult, controller)
-		// Drop upc 2's entry before each run is unnecessary: it stays missing
-		// because the store primed only upc 1 and iteration writes go to upc 2
-		// AFTER the filter — delete it each iteration to keep the partial shape.
+		// partialShapeStore serves the primed upc 1 entry but drops the
+		// iteration's upc 2 write-backs, so the one-of-two-primed partial
+		// shape holds for every iteration.
 		result := Plan(b, batchQuery, partialCaching, map[string]string{
 			"products": `{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"}]}}`,
 			"reviews":  `{"data":{"_entities":[{"__typename":"Product","reviews":[{"body":"Wobbly"}]}]}}`,
@@ -219,7 +218,6 @@ func benchResolveWithVariables(b *testing.B, result PlanResult, variables string
 	b.Helper()
 	r := resolve.New(context.Background(), resolve.ResolverOptions{MaxConcurrency: 1024})
 	b.ReportAllocs()
-	b.ResetTimer()
 	for b.Loop() {
 		ctx := resolve.NewContext(context.Background())
 		ctx.Variables = astjson.MustParseBytes([]byte(variables))

--- a/execution/cachingtesting/multikey_e2e_test.go
+++ b/execution/cachingtesting/multikey_e2e_test.go
@@ -23,24 +23,25 @@ func productsEntityCaching() map[string]cacheconfig.CachingConfiguration {
 	}
 }
 
-// TestMultiKeyCrossKeyHitEndToEnd is the plan-driven cross-key row: request 1
+// TestMultiKeyCrossKeyHitEndToEnd is the engine-driven cross-key row: request 1
 // reaches Product through the upc-keyed reviews path and — because the fresh
 // response carries sku — BACKFILLS the sku key; request 2 reaches the same
 // entity through the sku-keyed deals path, renders ONLY the sku key, and is
 // served from the cache with ZERO network to products.
 func TestMultiKeyCrossKeyHitEndToEnd(t *testing.T) {
 	store := cachetesting.NewFakeStore()
+	controller := cachetesting.NewRealishCache(store, nil)
+	reviews := Respond(`{"data":{"featuredReview":{"__typename":"Review","product":{"__typename":"Product","upc":"1"}}}}`)
+	products := Respond(`{"data":{"_entities":[{"__typename":"Product","name":"Table","sku":"S1"}]}}`)
+	deals := Respond(`{"data":{"deal":{"__typename":"Deal","product":{"__typename":"Product","sku":"S1"}}}}`)
+	executionEngine := NewEngine(t, productsEntityCaching(), Subgraphs{"reviews": reviews, "products": products, "deals": deals})
 
 	// Request 1: featuredReview.product — reviews provides upc; the products
 	// entity fetch renders the upc candidate, the sku candidate is pending and
 	// backfills from the fresh response (which includes sku).
-	prime := Plan(t, `{ featuredReview { product { name } } }`, productsEntityCaching(), map[string]string{
-		"reviews":                         `{"data":{"featuredReview":{"__typename":"Review","product":{"__typename":"Product","upc":"1"}}}}`,
-		"products:featuredReview.product": `{"data":{"_entities":[{"__typename":"Product","name":"Table","sku":"S1"}]}}`,
-	})
-	primeBody := ResolveResponse(t, prime.Response, cachetesting.NewRealishCache(store, nil))
+	primeBody := Execute(t, executionEngine, `{ featuredReview { product { name } } }`, controller)
 	assert.Equal(t, `{"data":{"featuredReview":{"product":{"name":"Table"}}}}`, primeBody)
-	assert.Equal(t, int64(1), prime.LoadCount("products", "featuredReview.product"))
+	assert.Equal(t, int64(1), products.Requests())
 
 	primeOps := store.Ops()
 	require.Len(t, primeOps, 3)
@@ -57,13 +58,11 @@ func TestMultiKeyCrossKeyHitEndToEnd(t *testing.T) {
 	// renders only the sku candidate: the cross-key hit. Its ops assert in
 	// isolation.
 	store.ResetOps()
-	serve := Plan(t, `{ deal(id: "d1") { product { name } } }`, productsEntityCaching(), map[string]string{
-		"deals": `{"data":{"deal":{"__typename":"Deal","product":{"__typename":"Product","sku":"S1"}}}}`,
-	})
-	serveBody := ResolveResponse(t, serve.Response, cachetesting.NewRealishCache(store, nil))
+	serveBody := Execute(t, executionEngine, `{ deal(id: "d1") { product { name } } }`, controller)
 	assert.Equal(t, `{"data":{"deal":{"product":{"name":"Table"}}}}`, serveBody)
-	assert.Equal(t, int64(1), serve.LoadCount("deals", ""))
-	assert.Equal(t, int64(0), serve.LoadCount("products", "deal.product"))
+	assert.Equal(t, int64(1), deals.Requests())
+	// ZERO new products requests: the cross-key hit skipped the network.
+	assert.Equal(t, int64(1), products.Requests())
 
 	// The serve request performed exactly one Get, under the BACKFILLED sku key.
 	assert.Equal(t, []cachetesting.StoreOp{

--- a/execution/cachingtesting/multikey_e2e_test.go
+++ b/execution/cachingtesting/multikey_e2e_test.go
@@ -1,0 +1,73 @@
+package cachingtesting
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/cache/cachetesting"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
+)
+
+// productsEntityCaching enables entity caching for the PRODUCTS subgraph,
+// whose Product declares two @key sets (upc, sku) — the multi-key entity.
+func productsEntityCaching() map[string]cacheconfig.CachingConfiguration {
+	return map[string]cacheconfig.CachingConfiguration{
+		"products": {
+			Entities: []cacheconfig.EntityCachePolicy{
+				{TypeName: "Product", CacheName: "entities", TTL: time.Minute},
+			},
+		},
+	}
+}
+
+// TestMultiKeyCrossKeyHitEndToEnd is the plan-driven cross-key row: request 1
+// reaches Product through the upc-keyed reviews path and — because the fresh
+// response carries sku — BACKFILLS the sku key; request 2 reaches the same
+// entity through the sku-keyed deals path, renders ONLY the sku key, and is
+// served from the cache with ZERO network to products.
+func TestMultiKeyCrossKeyHitEndToEnd(t *testing.T) {
+	store := cachetesting.NewFakeStore()
+
+	// Request 1: featuredReview.product — reviews provides upc; the products
+	// entity fetch renders the upc candidate, the sku candidate is pending and
+	// backfills from the fresh response (which includes sku).
+	prime := Plan(t, `{ featuredReview { product { name } } }`, productsEntityCaching(), map[string]string{
+		"reviews":                         `{"data":{"featuredReview":{"__typename":"Review","product":{"__typename":"Product","upc":"1"}}}}`,
+		"products:featuredReview.product": `{"data":{"_entities":[{"__typename":"Product","name":"Table","sku":"S1"}]}}`,
+	})
+	primeBody := ResolveResponse(t, prime.Response, cachetesting.NewRealishCache(store, nil))
+	assert.Equal(t, `{"data":{"featuredReview":{"product":{"name":"Table"}}}}`, primeBody)
+	assert.Equal(t, int64(1), prime.LoadCount("products", "featuredReview.product"))
+
+	primeOps := store.Ops()
+	require.Len(t, primeOps, 3)
+	upcKey := primeOps[0].Key
+	skuKey := primeOps[2].Key
+	assert.Equal(t, []cachetesting.StoreOp{
+		{Kind: "Get", Key: upcKey},
+		{Kind: "Set", Key: upcKey, Value: `{"__typename":"Product","name":"Table","sku":"S1"}`, TTL: time.Minute},
+		{Kind: "Set", Key: skuKey, Value: `{"__typename":"Product","name":"Table","sku":"S1"}`, TTL: time.Minute},
+	}, primeOps)
+	assert.NotEqual(t, upcKey, skuKey)
+
+	// Request 2: deal.product — deals provides ONLY sku, so the entity fetch
+	// renders only the sku candidate: the cross-key hit.
+	serve := Plan(t, `{ deal(id: "d1") { product { name } } }`, productsEntityCaching(), map[string]string{
+		"deals": `{"data":{"deal":{"__typename":"Deal","product":{"__typename":"Product","sku":"S1"}}}}`,
+	})
+	serveBody := ResolveResponse(t, serve.Response, cachetesting.NewRealishCache(store, nil))
+	assert.Equal(t, `{"data":{"deal":{"product":{"name":"Table"}}}}`, serveBody)
+	assert.Equal(t, int64(1), serve.LoadCount("deals", ""))
+	assert.Equal(t, int64(0), serve.LoadCount("products", "deal.product"))
+
+	// The serve request added exactly one Get under the BACKFILLED sku key.
+	assert.Equal(t, []cachetesting.StoreOp{
+		{Kind: "Get", Key: upcKey},
+		{Kind: "Set", Key: upcKey, Value: `{"__typename":"Product","name":"Table","sku":"S1"}`, TTL: time.Minute},
+		{Kind: "Set", Key: skuKey, Value: `{"__typename":"Product","name":"Table","sku":"S1"}`, TTL: time.Minute},
+		{Kind: "Get", Key: skuKey},
+	}, store.Ops())
+}

--- a/execution/cachingtesting/multikey_e2e_test.go
+++ b/execution/cachingtesting/multikey_e2e_test.go
@@ -54,7 +54,9 @@ func TestMultiKeyCrossKeyHitEndToEnd(t *testing.T) {
 	assert.NotEqual(t, upcKey, skuKey)
 
 	// Request 2: deal.product — deals provides ONLY sku, so the entity fetch
-	// renders only the sku candidate: the cross-key hit.
+	// renders only the sku candidate: the cross-key hit. Its ops assert in
+	// isolation.
+	store.ResetOps()
 	serve := Plan(t, `{ deal(id: "d1") { product { name } } }`, productsEntityCaching(), map[string]string{
 		"deals": `{"data":{"deal":{"__typename":"Deal","product":{"__typename":"Product","sku":"S1"}}}}`,
 	})
@@ -63,11 +65,8 @@ func TestMultiKeyCrossKeyHitEndToEnd(t *testing.T) {
 	assert.Equal(t, int64(1), serve.LoadCount("deals", ""))
 	assert.Equal(t, int64(0), serve.LoadCount("products", "deal.product"))
 
-	// The serve request added exactly one Get under the BACKFILLED sku key.
+	// The serve request performed exactly one Get, under the BACKFILLED sku key.
 	assert.Equal(t, []cachetesting.StoreOp{
-		{Kind: "Get", Key: upcKey},
-		{Kind: "Set", Key: upcKey, Value: `{"__typename":"Product","name":"Table","sku":"S1"}`, TTL: time.Minute},
-		{Kind: "Set", Key: skuKey, Value: `{"__typename":"Product","name":"Table","sku":"S1"}`, TTL: time.Minute},
 		{Kind: "Get", Key: skuKey},
 	}, store.Ops())
 }

--- a/execution/cachingtesting/negative_e2e_test.go
+++ b/execution/cachingtesting/negative_e2e_test.go
@@ -25,18 +25,18 @@ func inventoryNegativeCaching() map[string]cacheconfig.CachingConfiguration {
 // TestNegativeCachingEndToEnd: request 1 fetches a nonexistent entity (the
 // subgraph SUCCESSFULLY returns a null entity) and writes the sentinel;
 // request 2 serves the same null response with ZERO network to inventory.
+// Runs through the REAL ExecutionEngine over HTTP subgraph doubles.
 func TestNegativeCachingEndToEnd(t *testing.T) {
 	store := cachetesting.NewFakeStore()
+	controller := cachetesting.NewRealishCache(store, nil)
 	query := `{ me { favoriteProduct { upc stock } } }`
-	responses := map[string]string{
-		"users":                        `{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`,
-		"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"404"}}]}}`,
-		"inventory:me.favoriteProduct": `{"data":{"_entities":[null]}}`,
-	}
+	users := Respond(`{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`)
+	products := Respond(`{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"404"}}]}}`)
+	inventory := Respond(`{"data":{"_entities":[null]}}`)
+	executionEngine := NewEngine(t, inventoryNegativeCaching(), Subgraphs{"users": users, "products": products, "inventory": inventory})
 
-	first := Plan(t, query, inventoryNegativeCaching(), responses)
-	firstBody := ResolveResponse(t, first.Response, cachetesting.NewRealishCache(store, nil))
-	assert.Equal(t, int64(1), first.LoadCount("inventory", "me.favoriteProduct"))
+	firstBody := Execute(t, executionEngine, query, controller)
+	assert.Equal(t, int64(1), inventory.Requests())
 
 	// The sentinel was written with the NEGATIVE TTL.
 	ops := store.Ops()
@@ -47,9 +47,9 @@ func TestNegativeCachingEndToEnd(t *testing.T) {
 		{Kind: "Set", Key: key, Value: "null", TTL: 10 * time.Second},
 	}, ops)
 
-	second := Plan(t, query, inventoryNegativeCaching(), responses)
-	secondBody := ResolveResponse(t, second.Response, cachetesting.NewRealishCache(store, nil))
-	assert.Equal(t, int64(0), second.LoadCount("inventory", "me.favoriteProduct"))
+	secondBody := Execute(t, executionEngine, query, controller)
+	// ZERO new network to inventory: the negative sentinel served.
+	assert.Equal(t, int64(1), inventory.Requests())
 
 	// The negative hit reproduces the empty-fetch response BYTE-IDENTICALLY —
 	// the same null bubble AND the same non-null error the uncached path

--- a/execution/cachingtesting/negative_e2e_test.go
+++ b/execution/cachingtesting/negative_e2e_test.go
@@ -1,0 +1,59 @@
+package cachingtesting
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/cache/cachetesting"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
+)
+
+// inventoryNegativeCaching enables entity caching with a negative TTL.
+func inventoryNegativeCaching() map[string]cacheconfig.CachingConfiguration {
+	return map[string]cacheconfig.CachingConfiguration{
+		"inventory": {
+			Entities: []cacheconfig.EntityCachePolicy{
+				{TypeName: "Product", CacheName: "entities", TTL: time.Minute, NegativeCacheTTL: 10 * time.Second},
+			},
+		},
+	}
+}
+
+// TestNegativeCachingEndToEnd: request 1 fetches a nonexistent entity (the
+// subgraph SUCCESSFULLY returns a null entity) and writes the sentinel;
+// request 2 serves the same null response with ZERO network to inventory.
+func TestNegativeCachingEndToEnd(t *testing.T) {
+	store := cachetesting.NewFakeStore()
+	query := `{ me { favoriteProduct { upc stock } } }`
+	responses := map[string]string{
+		"users":                        `{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`,
+		"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"404"}}]}}`,
+		"inventory:me.favoriteProduct": `{"data":{"_entities":[null]}}`,
+	}
+
+	first := Plan(t, query, inventoryNegativeCaching(), responses)
+	firstBody := ResolveResponse(t, first.Response, cachetesting.NewRealishCache(store, nil))
+	assert.Equal(t, int64(1), first.LoadCount("inventory", "me.favoriteProduct"))
+
+	// The sentinel was written with the NEGATIVE TTL.
+	ops := store.Ops()
+	require.Len(t, ops, 2)
+	key := ops[0].Key
+	assert.Equal(t, []cachetesting.StoreOp{
+		{Kind: "Get", Key: key},
+		{Kind: "Set", Key: key, Value: "null", TTL: 10 * time.Second},
+	}, ops)
+
+	second := Plan(t, query, inventoryNegativeCaching(), responses)
+	secondBody := ResolveResponse(t, second.Response, cachetesting.NewRealishCache(store, nil))
+	assert.Equal(t, int64(0), second.LoadCount("inventory", "me.favoriteProduct"))
+
+	// The negative hit reproduces the empty-fetch response BYTE-IDENTICALLY —
+	// the same null bubble AND the same non-null error the uncached path
+	// renders; caching never changes the response (G6 end to end).
+	assert.Equal(t, firstBody, secondBody)
+	assert.Equal(t, `{"errors":[{"message":"Cannot return null for non-nullable field 'Query.me.favoriteProduct.stock'.","path":["me","favoriteProduct","stock"]}],"data":{"me":{"favoriteProduct":null}}}`, firstBody)
+}

--- a/execution/cachingtesting/normalization_e2e_test.go
+++ b/execution/cachingtesting/normalization_e2e_test.go
@@ -39,12 +39,17 @@ func TestAliasIndependentReuseEndToEnd(t *testing.T) {
 	assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"upc":"1","inStock":5}}}}`, firstBody)
 	assert.Equal(t, int64(1), first.LoadCount("inventory", "me.favoriteProduct"))
 
-	// The STORED form is normalized to the schema name.
+	// The STORED form is normalized to the schema name; the write key equals
+	// the miss-lookup's key (read key == write key — ops[0] is the Get).
 	ops := store.Ops()
 	require.Len(t, ops, 2)
 	assert.Equal(t, cachetesting.StoreOp{
+		Kind: "Get",
+		Key:  ops[0].Key,
+	}, ops[0])
+	assert.Equal(t, cachetesting.StoreOp{
 		Kind:  "Set",
-		Key:   ops[1].Key,
+		Key:   ops[0].Key,
 		Value: `{"stock":5,"__typename":"Product"}`,
 		TTL:   time.Minute,
 	}, ops[1])

--- a/execution/cachingtesting/normalization_e2e_test.go
+++ b/execution/cachingtesting/normalization_e2e_test.go
@@ -1,0 +1,93 @@
+package cachingtesting
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/astjson"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/cache/cachetesting"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// resolveWithVariables drives the public sync entry point with request
+// variables set (argument-suffix keys derive from them).
+func resolveWithVariables(t *testing.T, result PlanResult, variables string, controller resolve.CacheController) string {
+	t.Helper()
+	ctx := resolve.NewContext(t.Context())
+	ctx.Variables = astjson.MustParseBytes([]byte(variables))
+	ctx.SetCacheController(controller)
+	return resolveWithContext(t, ctx, result.Response)
+}
+
+// TestAliasIndependentReuseEndToEnd: operation A caches the inventory entity
+// under one alias; operation B selects the same field under a DIFFERENT alias
+// and is served from the cache (zero inventory loads), each with its complete
+// response asserted.
+func TestAliasIndependentReuseEndToEnd(t *testing.T) {
+	store := cachetesting.NewFakeStore()
+
+	first := Plan(t, `{ me { favoriteProduct { upc inStock: stock } } }`, inventoryCaching(), map[string]string{
+		"users":                        `{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`,
+		"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
+		"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","inStock":5}]}}`,
+	})
+	firstBody := ResolveResponse(t, first.Response, cachetesting.NewRealishCache(store, nil))
+	assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"upc":"1","inStock":5}}}}`, firstBody)
+	assert.Equal(t, int64(1), first.LoadCount("inventory", "me.favoriteProduct"))
+
+	// The STORED form is normalized to the schema name.
+	ops := store.Ops()
+	require.Len(t, ops, 2)
+	assert.Equal(t, cachetesting.StoreOp{
+		Kind:  "Set",
+		Key:   ops[1].Key,
+		Value: `{"stock":5,"__typename":"Product"}`,
+		TTL:   time.Minute,
+	}, ops[1])
+
+	second := Plan(t, `{ me { favoriteProduct { upc availability: stock } } }`, inventoryCaching(), map[string]string{
+		"users":       `{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`,
+		"products:me": `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
+	})
+	secondBody := ResolveResponse(t, second.Response, cachetesting.NewRealishCache(store, nil))
+	assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"upc":"1","availability":5}}}}`, secondBody)
+	assert.Equal(t, int64(0), second.LoadCount("inventory", "me.favoriteProduct"))
+}
+
+// TestArgumentMismatchEndToEnd: the same entity field with DIFFERENT argument
+// values must never share a cache entry — request B misses and fetches.
+func TestArgumentMismatchEndToEnd(t *testing.T) {
+	store := cachetesting.NewFakeStore()
+
+	responsesFor := func(history string) map[string]string {
+		return map[string]string{
+			"users":                        `{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`,
+			"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
+			"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stockHistory":` + history + `}]}}`,
+		}
+	}
+
+	first := Plan(t, `query($days: Int!) { me { favoriteProduct { upc stockHistory(days: $days) } } }`,
+		inventoryCaching(), responsesFor(`[1,2,3]`))
+	firstBody := resolveWithVariables(t, first, `{"days":3}`, cachetesting.NewRealishCache(store, nil))
+	assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"upc":"1","stockHistory":[1,2,3]}}}}`, firstBody)
+	assert.Equal(t, int64(1), first.LoadCount("inventory", "me.favoriteProduct"))
+
+	// Same variables → HIT (the suffix matches).
+	sameArgs := Plan(t, `query($days: Int!) { me { favoriteProduct { upc stockHistory(days: $days) } } }`,
+		inventoryCaching(), responsesFor(`[9,9,9]`))
+	sameBody := resolveWithVariables(t, sameArgs, `{"days":3}`, cachetesting.NewRealishCache(store, nil))
+	assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"upc":"1","stockHistory":[1,2,3]}}}}`, sameBody)
+	assert.Equal(t, int64(0), sameArgs.LoadCount("inventory", "me.favoriteProduct"))
+
+	// Different variables → MISS: the fetch runs and returns the new data.
+	differentArgs := Plan(t, `query($days: Int!) { me { favoriteProduct { upc stockHistory(days: $days) } } }`,
+		inventoryCaching(), responsesFor(`[7]`))
+	differentBody := resolveWithVariables(t, differentArgs, `{"days":1}`, cachetesting.NewRealishCache(store, nil))
+	assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"upc":"1","stockHistory":[7]}}}}`, differentBody)
+	assert.Equal(t, int64(1), differentArgs.LoadCount("inventory", "me.favoriteProduct"))
+}

--- a/execution/cachingtesting/normalization_e2e_test.go
+++ b/execution/cachingtesting/normalization_e2e_test.go
@@ -7,37 +7,24 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/wundergraph/astjson"
-
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/cache/cachetesting"
-	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 )
-
-// resolveWithVariables drives the public sync entry point with request
-// variables set (argument-suffix keys derive from them).
-func resolveWithVariables(t *testing.T, result PlanResult, variables string, controller resolve.CacheController) string {
-	t.Helper()
-	ctx := resolve.NewContext(t.Context())
-	ctx.Variables = astjson.MustParseBytes([]byte(variables))
-	ctx.SetCacheController(controller)
-	return resolveWithContext(t, ctx, result.Response)
-}
 
 // TestAliasIndependentReuseEndToEnd: operation A caches the inventory entity
 // under one alias; operation B selects the same field under a DIFFERENT alias
-// and is served from the cache (zero inventory loads), each with its complete
-// response asserted.
+// and is served from the cache (zero inventory requests), each with its
+// complete response asserted. Runs through the REAL ExecutionEngine.
 func TestAliasIndependentReuseEndToEnd(t *testing.T) {
 	store := cachetesting.NewFakeStore()
+	controller := cachetesting.NewRealishCache(store, nil)
+	users := Respond(`{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`)
+	products := Respond(`{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`)
+	inventory := Respond(`{"data":{"_entities":[{"__typename":"Product","inStock":5}]}}`)
+	executionEngine := NewEngine(t, inventoryCaching(), Subgraphs{"users": users, "products": products, "inventory": inventory})
 
-	first := Plan(t, `{ me { favoriteProduct { upc inStock: stock } } }`, inventoryCaching(), map[string]string{
-		"users":                        `{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`,
-		"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
-		"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","inStock":5}]}}`,
-	})
-	firstBody := ResolveResponse(t, first.Response, cachetesting.NewRealishCache(store, nil))
+	firstBody := Execute(t, executionEngine, `{ me { favoriteProduct { upc inStock: stock } } }`, controller)
 	assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"upc":"1","inStock":5}}}}`, firstBody)
-	assert.Equal(t, int64(1), first.LoadCount("inventory", "me.favoriteProduct"))
+	assert.Equal(t, int64(1), inventory.Requests())
 
 	// The STORED form is normalized to the schema name; the write key equals
 	// the miss-lookup's key (read key == write key — ops[0] is the Get).
@@ -54,45 +41,42 @@ func TestAliasIndependentReuseEndToEnd(t *testing.T) {
 		TTL:   time.Minute,
 	}, ops[1])
 
-	second := Plan(t, `{ me { favoriteProduct { upc availability: stock } } }`, inventoryCaching(), map[string]string{
-		"users":       `{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`,
-		"products:me": `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
-	})
-	secondBody := ResolveResponse(t, second.Response, cachetesting.NewRealishCache(store, nil))
+	secondBody := Execute(t, executionEngine, `{ me { favoriteProduct { upc availability: stock } } }`, controller)
 	assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"upc":"1","availability":5}}}}`, secondBody)
-	assert.Equal(t, int64(0), second.LoadCount("inventory", "me.favoriteProduct"))
+	// Served from the cache: ZERO new inventory requests.
+	assert.Equal(t, int64(1), inventory.Requests())
 }
 
 // TestArgumentMismatchEndToEnd: the same entity field with DIFFERENT argument
 // values must never share a cache entry — request B misses and fetches.
 func TestArgumentMismatchEndToEnd(t *testing.T) {
 	store := cachetesting.NewFakeStore()
+	controller := cachetesting.NewRealishCache(store, nil)
+	users := Respond(`{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`)
+	products := Respond(`{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`)
+	// One rule per distinct argument value (the engine renames $days to $a in
+	// the rendered body): the days:3 rule serves the first request only (the
+	// repeat must be a cache hit — its count pins that); the days:1 rule
+	// proves the different-arguments miss really fetched.
+	days3 := Rule(`"a":3`, `{"data":{"_entities":[{"__typename":"Product","stockHistory":[1,2,3]}]}}`)
+	days1 := Rule(`"a":1`, `{"data":{"_entities":[{"__typename":"Product","stockHistory":[7]}]}}`)
+	inventory := Rules(days3, days1)
+	executionEngine := NewEngine(t, inventoryCaching(), Subgraphs{"users": users, "products": products, "inventory": inventory})
 
-	responsesFor := func(history string) map[string]string {
-		return map[string]string{
-			"users":                        `{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`,
-			"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
-			"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stockHistory":` + history + `}]}}`,
-		}
-	}
+	query := `query($days: Int!) { me { favoriteProduct { upc stockHistory(days: $days) } } }`
 
-	first := Plan(t, `query($days: Int!) { me { favoriteProduct { upc stockHistory(days: $days) } } }`,
-		inventoryCaching(), responsesFor(`[1,2,3]`))
-	firstBody := resolveWithVariables(t, first, `{"days":3}`, cachetesting.NewRealishCache(store, nil))
+	firstBody := ExecuteWithVariables(t, executionEngine, query, `{"days":3}`, controller)
 	assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"upc":"1","stockHistory":[1,2,3]}}}}`, firstBody)
-	assert.Equal(t, int64(1), first.LoadCount("inventory", "me.favoriteProduct"))
+	assert.Equal(t, int64(1), days3.Count.Load())
 
-	// Same variables → HIT (the suffix matches).
-	sameArgs := Plan(t, `query($days: Int!) { me { favoriteProduct { upc stockHistory(days: $days) } } }`,
-		inventoryCaching(), responsesFor(`[9,9,9]`))
-	sameBody := resolveWithVariables(t, sameArgs, `{"days":3}`, cachetesting.NewRealishCache(store, nil))
+	// Same variables → HIT (the suffix matches): no new days:3 request.
+	sameBody := ExecuteWithVariables(t, executionEngine, query, `{"days":3}`, controller)
 	assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"upc":"1","stockHistory":[1,2,3]}}}}`, sameBody)
-	assert.Equal(t, int64(0), sameArgs.LoadCount("inventory", "me.favoriteProduct"))
+	assert.Equal(t, int64(1), days3.Count.Load())
+	assert.Equal(t, int64(0), days1.Count.Load())
 
 	// Different variables → MISS: the fetch runs and returns the new data.
-	differentArgs := Plan(t, `query($days: Int!) { me { favoriteProduct { upc stockHistory(days: $days) } } }`,
-		inventoryCaching(), responsesFor(`[7]`))
-	differentBody := resolveWithVariables(t, differentArgs, `{"days":1}`, cachetesting.NewRealishCache(store, nil))
+	differentBody := ExecuteWithVariables(t, executionEngine, query, `{"days":1}`, controller)
 	assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"upc":"1","stockHistory":[7]}}}}`, differentBody)
-	assert.Equal(t, int64(1), differentArgs.LoadCount("inventory", "me.favoriteProduct"))
+	assert.Equal(t, int64(1), days1.Count.Load())
 }

--- a/execution/cachingtesting/partial_e2e_test.go
+++ b/execution/cachingtesting/partial_e2e_test.go
@@ -26,34 +26,38 @@ func reviewsPartialCaching() map[string]cacheconfig.CachingConfiguration {
 // TestPartialBatchEndToEnd: with one of two products' reviews already cached,
 // the reviews subgraph receives EXACTLY the missing representation and the
 // response is complete — cached and fetched reviews at their original
-// positions.
+// positions. Runs through the REAL ExecutionEngine; the reduced batch is
+// proven by pinning the reviews double's COMPLETE second request body.
 func TestPartialBatchEndToEnd(t *testing.T) {
 	store := cachetesting.NewFakeStore()
+	controller := cachetesting.NewRealishCache(store, nil)
+	products := Rules(
+		Rule(`"variables":{"a":1}`, `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`),
+		Rule(`"variables":{"a":2}`, `{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"}]}}`),
+	)
+	// The second rule carries ONE entity — it can only answer a REDUCED
+	// single-representation batch; the Bodies() pin below proves the reduced
+	// request is what actually went over the wire.
+	reviews := Rules(
+		Rule(`"upc":"1"`, `{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","body":"great table"}]}]}}`),
+		Rule(`"upc":"2"`, `{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","body":"sturdy chair"}]}]}}`),
+	)
+	executionEngine := NewEngine(t, reviewsPartialCaching(), Subgraphs{"products": products, "reviews": reviews})
 
 	// Prime product 1's reviews.
-	prime := Plan(t, `{ products(first: 1) { upc reviews { body } } }`, reviewsPartialCaching(), map[string]string{
-		"products": `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`,
-		"reviews":  `{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","body":"great table"}]}]}}`,
-	})
-	primeBody := ResolveResponse(t, prime.Response, cachetesting.NewRealishCache(store, nil))
+	primeBody := Execute(t, executionEngine, `{ products(first: 1) { upc reviews { body } } }`, controller)
 	assert.Equal(t, `{"data":{"products":[{"upc":"1","reviews":[{"body":"great table"}]}]}}`, primeBody)
 
-	// Two products now: product 1 covered, product 2 missing. The canned
-	// reviews response carries ONE entity — it only matches a REDUCED request;
-	// a full two-representation batch would fail the resolve loudly.
-	second := Plan(t, `{ products(first: 2) { upc reviews { body } } }`, reviewsPartialCaching(), map[string]string{
-		"products": `{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"}]}}`,
-		"reviews":  `{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","body":"sturdy chair"}]}]}}`,
-	})
-	secondBody := ResolveResponse(t, second.Response, cachetesting.NewRealishCache(store, nil))
+	// Two products now: product 1 covered, product 2 missing.
+	secondBody := Execute(t, executionEngine, `{ products(first: 2) { upc reviews { body } } }`, controller)
 	assert.Equal(t,
 		`{"data":{"products":[{"upc":"1","reviews":[{"body":"great table"}]},{"upc":"2","reviews":[{"body":"sturdy chair"}]}]}}`,
 		secondBody)
 
 	// The EXACT subgraph input: only the missing representation was sent.
-	inputs := second.Inputs("reviews", "products")
-	require.Len(t, inputs, 1)
-	assert.Equal(t, `{"method":"POST","url":"http://reviews.service","header":{},"body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){... on Product {__typename reviews {body}}}}","variables":{"representations":[{"__typename":"Product","upc":"2"}]}}}`, inputs[0])
+	bodies := reviews.Bodies()
+	require.Len(t, bodies, 2)
+	assert.Equal(t, `{"query":"query($representations: [_Any!]!){_entities(representations: $representations){... on Product {__typename reviews {body}}}}","variables":{"representations":[{"__typename":"Product","upc":"2"}]}}`, bodies[1])
 }
 
 // TestPartialExpiryEndToEnd: mixed TTLs across subgraphs — when one policy's
@@ -61,6 +65,7 @@ func TestPartialBatchEndToEnd(t *testing.T) {
 // served from cache.
 func TestPartialExpiryEndToEnd(t *testing.T) {
 	store := cachetesting.NewFakeStore()
+	controller := cachetesting.NewRealishCache(store, nil)
 	caching := map[string]cacheconfig.CachingConfiguration{
 		"reviews": {
 			Entities: []cacheconfig.EntityCachePolicy{
@@ -74,16 +79,16 @@ func TestPartialExpiryEndToEnd(t *testing.T) {
 		},
 	}
 	query := `{ products(first: 1) { upc stock reviews { body } } }`
-	responses := map[string]string{
-		"products":  `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`,
-		"inventory": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
-		"reviews":   `{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","body":"great table"}]}]}}`,
-	}
+	products := Respond(`{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`)
+	inventory := Respond(`{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`)
+	reviews := Respond(`{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","body":"great table"}]}]}}`)
+	executionEngine := NewEngine(t, caching, Subgraphs{"products": products, "inventory": inventory, "reviews": reviews})
 	expected := `{"data":{"products":[{"upc":"1","stock":5,"reviews":[{"body":"great table"}]}]}}`
 
-	first := Plan(t, query, caching, responses)
-	firstBody := ResolveResponse(t, first.Response, cachetesting.NewRealishCache(store, nil))
+	firstBody := Execute(t, executionEngine, query, controller)
 	assert.Equal(t, expected, firstBody)
+	assert.Equal(t, int64(1), inventory.Requests())
+	assert.Equal(t, int64(1), reviews.Requests())
 
 	// Age ONLY the short-TTL inventory entry past its TTL (store-double aging;
 	// the exact TTL arithmetic is pinned by the synctest unit rows).
@@ -99,11 +104,10 @@ func TestPartialExpiryEndToEnd(t *testing.T) {
 	require.True(t, ok)
 	store.Seed(inventoryKey, entry.Value, -time.Second)
 
-	second := Plan(t, query, caching, responses)
-	secondBody := ResolveResponse(t, second.Response, cachetesting.NewRealishCache(store, nil))
+	secondBody := Execute(t, executionEngine, query, controller)
 	assert.Equal(t, expected, secondBody)
 	// ONLY the expired portion hit the network: inventory refetched, reviews
 	// still served from its fresh entry.
-	assert.Equal(t, int64(1), second.LoadCount("inventory", "products"))
-	assert.Equal(t, int64(0), second.LoadCount("reviews", "products"))
+	assert.Equal(t, int64(2), inventory.Requests())
+	assert.Equal(t, int64(1), reviews.Requests())
 }

--- a/execution/cachingtesting/partial_e2e_test.go
+++ b/execution/cachingtesting/partial_e2e_test.go
@@ -53,8 +53,7 @@ func TestPartialBatchEndToEnd(t *testing.T) {
 	// The EXACT subgraph input: only the missing representation was sent.
 	inputs := second.Inputs("reviews", "products")
 	require.Len(t, inputs, 1)
-	assert.Contains(t, inputs[0], `"representations":[{"__typename":"Product","upc":"2"}]`)
-	assert.NotContains(t, inputs[0], `"upc":"1"`)
+	assert.Equal(t, `{"method":"POST","url":"http://reviews.service","header":{},"body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){... on Product {__typename reviews {body}}}}","variables":{"representations":[{"__typename":"Product","upc":"2"}]}}}`, inputs[0])
 }
 
 // TestPartialExpiryEndToEnd: mixed TTLs across subgraphs — when one policy's

--- a/execution/cachingtesting/partial_e2e_test.go
+++ b/execution/cachingtesting/partial_e2e_test.go
@@ -1,0 +1,110 @@
+package cachingtesting
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/cache/cachetesting"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
+)
+
+// reviewsPartialCaching enables partial cache loading for the Product entity
+// on the reviews subgraph.
+func reviewsPartialCaching() map[string]cacheconfig.CachingConfiguration {
+	return map[string]cacheconfig.CachingConfiguration{
+		"reviews": {
+			Entities: []cacheconfig.EntityCachePolicy{
+				{TypeName: "Product", CacheName: "reviews", TTL: time.Minute, EnablePartialCacheLoad: true},
+			},
+		},
+	}
+}
+
+// TestPartialBatchEndToEnd: with one of two products' reviews already cached,
+// the reviews subgraph receives EXACTLY the missing representation and the
+// response is complete — cached and fetched reviews at their original
+// positions.
+func TestPartialBatchEndToEnd(t *testing.T) {
+	store := cachetesting.NewFakeStore()
+
+	// Prime product 1's reviews.
+	prime := Plan(t, `{ products(first: 1) { upc reviews { body } } }`, reviewsPartialCaching(), map[string]string{
+		"products": `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`,
+		"reviews":  `{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","body":"great table"}]}]}}`,
+	})
+	primeBody := ResolveResponse(t, prime.Response, cachetesting.NewRealishCache(store, nil))
+	assert.Equal(t, `{"data":{"products":[{"upc":"1","reviews":[{"body":"great table"}]}]}}`, primeBody)
+
+	// Two products now: product 1 covered, product 2 missing. The canned
+	// reviews response carries ONE entity — it only matches a REDUCED request;
+	// a full two-representation batch would fail the resolve loudly.
+	second := Plan(t, `{ products(first: 2) { upc reviews { body } } }`, reviewsPartialCaching(), map[string]string{
+		"products": `{"data":{"products":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"}]}}`,
+		"reviews":  `{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","body":"sturdy chair"}]}]}}`,
+	})
+	secondBody := ResolveResponse(t, second.Response, cachetesting.NewRealishCache(store, nil))
+	assert.Equal(t,
+		`{"data":{"products":[{"upc":"1","reviews":[{"body":"great table"}]},{"upc":"2","reviews":[{"body":"sturdy chair"}]}]}}`,
+		secondBody)
+
+	// The EXACT subgraph input: only the missing representation was sent.
+	inputs := second.Inputs("reviews", "products")
+	require.Len(t, inputs, 1)
+	assert.Contains(t, inputs[0], `"representations":[{"__typename":"Product","upc":"2"}]`)
+	assert.NotContains(t, inputs[0], `"upc":"1"`)
+}
+
+// TestPartialExpiryEndToEnd: mixed TTLs across subgraphs — when one policy's
+// entry expires, only THAT subgraph is re-fetched; the still-fresh portion is
+// served from cache.
+func TestPartialExpiryEndToEnd(t *testing.T) {
+	store := cachetesting.NewFakeStore()
+	caching := map[string]cacheconfig.CachingConfiguration{
+		"reviews": {
+			Entities: []cacheconfig.EntityCachePolicy{
+				{TypeName: "Product", CacheName: "reviews", TTL: 5 * time.Minute},
+			},
+		},
+		"inventory": {
+			Entities: []cacheconfig.EntityCachePolicy{
+				{TypeName: "Product", CacheName: "inventory", TTL: 30 * time.Second},
+			},
+		},
+	}
+	query := `{ products(first: 1) { upc stock reviews { body } } }`
+	responses := map[string]string{
+		"products":  `{"data":{"products":[{"__typename":"Product","upc":"1"}]}}`,
+		"inventory": `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`,
+		"reviews":   `{"data":{"_entities":[{"__typename":"Product","reviews":[{"__typename":"Review","body":"great table"}]}]}}`,
+	}
+	expected := `{"data":{"products":[{"upc":"1","stock":5,"reviews":[{"body":"great table"}]}]}}`
+
+	first := Plan(t, query, caching, responses)
+	firstBody := ResolveResponse(t, first.Response, cachetesting.NewRealishCache(store, nil))
+	assert.Equal(t, expected, firstBody)
+
+	// Age ONLY the short-TTL inventory entry past its TTL (store-double aging;
+	// the exact TTL arithmetic is pinned by the synctest unit rows).
+	ops := store.Ops()
+	var inventoryKey string
+	for _, op := range ops {
+		if op.Kind == "Set" && op.TTL == 30*time.Second {
+			inventoryKey = op.Key
+		}
+	}
+	require.NotEmpty(t, inventoryKey)
+	entry, ok := store.Get(inventoryKey)
+	require.True(t, ok)
+	store.Seed(inventoryKey, entry.Value, -time.Second)
+
+	second := Plan(t, query, caching, responses)
+	secondBody := ResolveResponse(t, second.Response, cachetesting.NewRealishCache(store, nil))
+	assert.Equal(t, expected, secondBody)
+	// ONLY the expired portion hit the network: inventory refetched, reviews
+	// still served from its fresh entry.
+	assert.Equal(t, int64(1), second.LoadCount("inventory", "products"))
+	assert.Equal(t, int64(0), second.LoadCount("reviews", "products"))
+}

--- a/execution/cachingtesting/provides_data_test.go
+++ b/execution/cachingtesting/provides_data_test.go
@@ -19,6 +19,8 @@ func enableP1() map[string]cacheconfig.CachingConfiguration {
 // TestProvidesDataFidelity is the fidelity gate over REAL federation plans
 // (real fieldPlanners from the main walk, not synthetic attribution): the full
 // per-fetch ProvidesData side-table is pinned for a root + batch-entity plan.
+// This is a planner-level test that pins plan-internal state (the ProvidesData
+// resolve.Object trees) not visible in a client response.
 func TestProvidesDataFidelity(t *testing.T) {
 	result := Plan(t, `{ products(first: 2) { upc name reviews { body } } }`, enableP1(), nil)
 	pd := result.Response.CacheProvidesData()
@@ -101,7 +103,9 @@ func TestProvidesDataFidelity(t *testing.T) {
 // TestProvidesDataDeferredFetchOwnTree pins that a DEFERRED fetch gets its own
 // side-table entry (keyed per *FetchInfo, shared across the initial response
 // and all defer groups): the deferred inventory fetch's tree is exactly
-// {stock}, independent of the initial inventory fetch's larger tree.
+// {stock}, independent of the initial inventory fetch's larger tree. This is a
+// planner-level test that pins plan-internal state (the deferred fetch's
+// ProvidesData tree keyed by its *FetchInfo) not visible in a client response.
 func TestProvidesDataDeferredFetchOwnTree(t *testing.T) {
 	query := `
 		query {

--- a/execution/cachingtesting/provides_data_test.go
+++ b/execution/cachingtesting/provides_data_test.go
@@ -1,0 +1,153 @@
+package cachingtesting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// enableP1 is the minimal caching configuration that makes the P1 walk run;
+// the provider content is irrelevant to ProvidesData itself.
+func enableP1() map[string]cacheconfig.CachingConfiguration {
+	return map[string]cacheconfig.CachingConfiguration{"products": {}}
+}
+
+// TestProvidesDataFidelity is the fidelity gate over REAL federation plans
+// (real fieldPlanners from the main walk, not synthetic attribution): the full
+// per-fetch ProvidesData side-table is pinned for a root + batch-entity plan.
+func TestProvidesDataFidelity(t *testing.T) {
+	result := Plan(t, `{ products(first: 2) { upc name reviews { body } } }`, enableP1(), nil)
+	pd := result.Response.CacheProvidesData()
+	require.Len(t, pd, 2)
+
+	byDS := make(map[string]*resolve.Object, len(pd))
+	for info, obj := range pd {
+		require.NotContains(t, byDS, info.DataSourceID)
+		byDS[info.DataSourceID] = obj
+	}
+
+	assert.Equal(t, map[string]*resolve.Object{
+		// products root fetch: the full selection it returns, list-shaped.
+		"0": {
+			Fields: []*resolve.Field{
+				{
+					Name: []byte("products"),
+					Value: &resolve.Array{
+						Nullable: false,
+						Path:     []string{"products"},
+						Item: &resolve.Object{
+							Nullable: false,
+							Fields: []*resolve.Field{
+								{
+									Name: []byte("upc"),
+									Value: &resolve.Scalar{
+										Nullable: false,
+										Path:     []string{"upc"},
+									},
+								},
+								{
+									Name: []byte("name"),
+									Value: &resolve.Scalar{
+										Nullable: false,
+										Path:     []string{"name"},
+									},
+								},
+								{
+									Name: []byte("__typename"),
+									Value: &resolve.Scalar{
+										Nullable: false,
+										Path:     []string{"__typename"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		// reviews batch entity fetch: the entity-boundary reset makes its tree
+		// start at the Product entity, with the entity type condition.
+		"2": {
+			Fields: []*resolve.Field{
+				{
+					Name: []byte("reviews"),
+					Value: &resolve.Array{
+						Nullable: false,
+						Path:     []string{"reviews"},
+						Item: &resolve.Object{
+							Nullable: false,
+							Fields: []*resolve.Field{
+								{
+									Name: []byte("body"),
+									Value: &resolve.Scalar{
+										Nullable: false,
+										Path:     []string{"body"},
+									},
+								},
+							},
+						},
+					},
+					OnTypeNames: [][]byte{[]byte("Product")},
+				},
+			},
+		},
+	}, byDS)
+}
+
+// TestProvidesDataDeferredFetchOwnTree pins that a DEFERRED fetch gets its own
+// side-table entry (keyed per *FetchInfo, shared across the initial response
+// and all defer groups): the deferred inventory fetch's tree is exactly
+// {stock}, independent of the initial inventory fetch's larger tree.
+func TestProvidesDataDeferredFetchOwnTree(t *testing.T) {
+	query := `
+		query {
+			me { favoriteProduct { upc stock warehouse { id location } } }
+			products(first: 1) {
+				upc
+				... @defer { stock }
+			}
+		}`
+	result := Plan(t, query, enableP1(), nil)
+	require.NotNil(t, result.DeferResponse)
+	pd := result.Response.CacheProvidesData()
+	require.NotEmpty(t, pd)
+
+	groups := DeferGroups(result.DeferResponse)
+	require.Len(t, groups, 1)
+	deferredInfo := firstFetchInfo(t, groups[0].Fetches)
+	require.NotNil(t, deferredInfo)
+
+	assert.Equal(t, &resolve.Object{
+		Fields: []*resolve.Field{
+			{
+				Name: []byte("stock"),
+				Value: &resolve.Scalar{
+					Nullable: false,
+					Path:     []string{"stock"},
+				},
+				OnTypeNames: [][]byte{[]byte("Product")},
+			},
+		},
+	}, pd[deferredInfo])
+}
+
+// firstFetchInfo returns the FetchInfo of the first fetch item in the tree.
+func firstFetchInfo(t *testing.T, node *resolve.FetchTreeNode) *resolve.FetchInfo {
+	t.Helper()
+	if node == nil {
+		return nil
+	}
+	if node.Item != nil && node.Item.Fetch != nil {
+		return node.Item.Fetch.FetchInfo()
+	}
+	for _, child := range node.ChildNodes {
+		if info := firstFetchInfo(t, child); info != nil {
+			return info
+		}
+	}
+	return nil
+}

--- a/execution/cachingtesting/rootfield_e2e_test.go
+++ b/execution/cachingtesting/rootfield_e2e_test.go
@@ -1,0 +1,68 @@
+package cachingtesting
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/cache/cachetesting"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
+)
+
+// productsRootFieldCaching enables root-field caching for Query.products on
+// the products subgraph.
+func productsRootFieldCaching() map[string]cacheconfig.CachingConfiguration {
+	return map[string]cacheconfig.CachingConfiguration{
+		"products": {
+			RootFields: []cacheconfig.RootFieldCachePolicy{
+				{TypeName: "Query", FieldName: "products", CacheName: "root-fields", TTL: time.Minute},
+			},
+		},
+	}
+}
+
+// TestRootFieldL2EndToEnd: a cached root field is served from L2 on the second
+// request with ZERO network, and an ALIAS-VARIANT operation over the same
+// field and variables is served from the SAME entry (task 09 reuse); a
+// different-arguments operation misses.
+func TestRootFieldL2EndToEnd(t *testing.T) {
+	store := cachetesting.NewFakeStore()
+	query := `query($first: Int!) { products(first: $first) { upc name } }`
+	responses := map[string]string{
+		"products": `{"data":{"products":[{"__typename":"Product","upc":"1","name":"Table"}]}}`,
+	}
+
+	first := Plan(t, query, productsRootFieldCaching(), responses)
+	firstBody := resolveWithVariables(t, first, `{"first":1}`, cachetesting.NewRealishCache(store, nil))
+	assert.Equal(t, `{"data":{"products":[{"upc":"1","name":"Table"}]}}`, firstBody)
+	assert.Equal(t, int64(1), first.LoadCount("products", ""))
+
+	ops := store.Ops()
+	require.Len(t, ops, 2)
+	key := ops[0].Key
+	assert.Equal(t, []cachetesting.StoreOp{
+		{Kind: "Get", Key: key},
+		{Kind: "Set", Key: key, Value: `{"products":[{"__typename":"Product","upc":"1","name":"Table"}]}`, TTL: time.Minute},
+	}, ops)
+
+	// Same operation again: L2 hit, zero network.
+	second := Plan(t, query, productsRootFieldCaching(), responses)
+	secondBody := resolveWithVariables(t, second, `{"first":1}`, cachetesting.NewRealishCache(store, nil))
+	assert.Equal(t, firstBody, secondBody)
+	assert.Equal(t, int64(0), second.LoadCount("products", ""))
+
+	// ALIAS VARIANT over the same field + variables: served from the SAME entry.
+	aliasQuery := `query($first: Int!) { items: products(first: $first) { code: upc title: name } }`
+	alias := Plan(t, aliasQuery, productsRootFieldCaching(), responses)
+	aliasBody := resolveWithVariables(t, alias, `{"first":1}`, cachetesting.NewRealishCache(store, nil))
+	assert.Equal(t, `{"data":{"items":[{"code":"1","title":"Table"}]}}`, aliasBody)
+	assert.Equal(t, int64(0), alias.LoadCount("products", ""))
+
+	// Different ARGUMENTS: a different key — miss, network runs.
+	differentArgs := Plan(t, query, productsRootFieldCaching(), responses)
+	differentBody := resolveWithVariables(t, differentArgs, `{"first":5}`, cachetesting.NewRealishCache(store, nil))
+	assert.Equal(t, `{"data":{"products":[{"upc":"1","name":"Table"}]}}`, differentBody)
+	assert.Equal(t, int64(1), differentArgs.LoadCount("products", ""))
+}

--- a/execution/cachingtesting/rootfield_e2e_test.go
+++ b/execution/cachingtesting/rootfield_e2e_test.go
@@ -26,18 +26,23 @@ func productsRootFieldCaching() map[string]cacheconfig.CachingConfiguration {
 // TestRootFieldL2EndToEnd: a cached root field is served from L2 on the second
 // request with ZERO network, and an ALIAS-VARIANT operation over the same
 // field and variables is served from the SAME entry (task 09 reuse); a
-// different-arguments operation misses.
+// different-arguments operation misses. Runs through the REAL ExecutionEngine;
+// the old per-path load counts become per-rule request counts (one rule per
+// distinct argument value).
 func TestRootFieldL2EndToEnd(t *testing.T) {
 	store := cachetesting.NewFakeStore()
+	controller := cachetesting.NewRealishCache(store, nil)
 	query := `query($first: Int!) { products(first: $first) { upc name } }`
-	responses := map[string]string{
-		"products": `{"data":{"products":[{"__typename":"Product","upc":"1","name":"Table"}]}}`,
-	}
+	// The engine renames $first to $a in the rendered body: one rule per
+	// distinct argument value.
+	first1 := Rule(`"variables":{"a":1}`, `{"data":{"products":[{"__typename":"Product","upc":"1","name":"Table"}]}}`)
+	first5 := Rule(`"variables":{"a":5}`, `{"data":{"products":[{"__typename":"Product","upc":"1","name":"Table"}]}}`)
+	products := Rules(first1, first5)
+	executionEngine := NewEngine(t, productsRootFieldCaching(), Subgraphs{"products": products})
 
-	first := Plan(t, query, productsRootFieldCaching(), responses)
-	firstBody := resolveWithVariables(t, first, `{"first":1}`, cachetesting.NewRealishCache(store, nil))
+	firstBody := ExecuteWithVariables(t, executionEngine, query, `{"first":1}`, controller)
 	assert.Equal(t, `{"data":{"products":[{"upc":"1","name":"Table"}]}}`, firstBody)
-	assert.Equal(t, int64(1), first.LoadCount("products", ""))
+	assert.Equal(t, int64(1), first1.Count.Load())
 
 	ops := store.Ops()
 	require.Len(t, ops, 2)
@@ -48,21 +53,19 @@ func TestRootFieldL2EndToEnd(t *testing.T) {
 	}, ops)
 
 	// Same operation again: L2 hit, zero network.
-	second := Plan(t, query, productsRootFieldCaching(), responses)
-	secondBody := resolveWithVariables(t, second, `{"first":1}`, cachetesting.NewRealishCache(store, nil))
+	secondBody := ExecuteWithVariables(t, executionEngine, query, `{"first":1}`, controller)
 	assert.Equal(t, firstBody, secondBody)
-	assert.Equal(t, int64(0), second.LoadCount("products", ""))
+	assert.Equal(t, int64(1), first1.Count.Load())
 
 	// ALIAS VARIANT over the same field + variables: served from the SAME entry.
 	aliasQuery := `query($first: Int!) { items: products(first: $first) { code: upc title: name } }`
-	alias := Plan(t, aliasQuery, productsRootFieldCaching(), responses)
-	aliasBody := resolveWithVariables(t, alias, `{"first":1}`, cachetesting.NewRealishCache(store, nil))
+	aliasBody := ExecuteWithVariables(t, executionEngine, aliasQuery, `{"first":1}`, controller)
 	assert.Equal(t, `{"data":{"items":[{"code":"1","title":"Table"}]}}`, aliasBody)
-	assert.Equal(t, int64(0), alias.LoadCount("products", ""))
+	assert.Equal(t, int64(1), first1.Count.Load())
+	assert.Equal(t, int64(1), products.Requests())
 
 	// Different ARGUMENTS: a different key — miss, network runs.
-	differentArgs := Plan(t, query, productsRootFieldCaching(), responses)
-	differentBody := resolveWithVariables(t, differentArgs, `{"first":5}`, cachetesting.NewRealishCache(store, nil))
+	differentBody := ExecuteWithVariables(t, executionEngine, query, `{"first":5}`, controller)
 	assert.Equal(t, `{"data":{"products":[{"upc":"1","name":"Table"}]}}`, differentBody)
-	assert.Equal(t, int64(1), differentArgs.LoadCount("products", ""))
+	assert.Equal(t, int64(1), first5.Count.Load())
 }

--- a/execution/cachingtesting/shadow_e2e_test.go
+++ b/execution/cachingtesting/shadow_e2e_test.go
@@ -1,0 +1,85 @@
+package cachingtesting
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/cache/cachetesting"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
+)
+
+// inventoryShadowCaching enables entity caching in SHADOW mode.
+func inventoryShadowCaching() map[string]cacheconfig.CachingConfiguration {
+	return map[string]cacheconfig.CachingConfiguration{
+		"inventory": {
+			Entities: []cacheconfig.EntityCachePolicy{
+				{TypeName: "Product", CacheName: "entities", TTL: time.Minute, ShadowMode: true},
+			},
+		},
+	}
+}
+
+// TestShadowModeEndToEnd: the response is ALWAYS the fresh network value even
+// on an L2 hit; the shadow compare records the staleness probe.
+func TestShadowModeEndToEnd(t *testing.T) {
+	store := cachetesting.NewFakeStore()
+	query := `{ me { favoriteProduct { upc stock } } }`
+	responsesFor := func(stock string) map[string]string {
+		return map[string]string{
+			"users":                        `{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`,
+			"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
+			"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":` + stock + `}]}}`,
+		}
+	}
+
+	// Request 1: shadow MISS — plain fetch + write.
+	first := Plan(t, query, inventoryShadowCaching(), responsesFor("5"))
+	firstObserver := &cachetesting.RecordingObserver{}
+	firstBody := ResolveResponse(t, first.Response, cachetesting.NewRealishCache(store, firstObserver))
+	assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"upc":"1","stock":5}}}}`, firstBody)
+	assert.Equal(t, int64(1), first.LoadCount("inventory", "me.favoriteProduct"))
+	assert.Empty(t, firstObserver.Compares())
+
+	ops := store.Ops()
+	require.Len(t, ops, 2)
+	key := ops[0].Key
+
+	// Request 2: L2 HIT under shadow — the subgraph now says stock=7 and the
+	// response MUST show 7 (fresh served, never the cached 5); the compare
+	// records the mismatch and L2 is overwritten with the fresh value.
+	second := Plan(t, query, inventoryShadowCaching(), responsesFor("7"))
+	secondObserver := &cachetesting.RecordingObserver{}
+	secondBody := ResolveResponse(t, second.Response, cachetesting.NewRealishCache(store, secondObserver))
+	assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"upc":"1","stock":7}}}}`, secondBody)
+	assert.Equal(t, int64(1), second.LoadCount("inventory", "me.favoriteProduct"))
+	assert.Equal(t, []cachetesting.ShadowCompare{
+		{CacheKey: key, IsFresh: false},
+	}, normalizeCompareAges(secondObserver.Compares()))
+
+	entry, ok := store.Get(key)
+	require.True(t, ok)
+	assert.Equal(t, `{"__typename":"Product","stock":7}`, string(entry.Value))
+
+	// Request 3: unchanged data — the compare records IsFresh true; the
+	// response is still the network value.
+	third := Plan(t, query, inventoryShadowCaching(), responsesFor("7"))
+	thirdObserver := &cachetesting.RecordingObserver{}
+	thirdBody := ResolveResponse(t, third.Response, cachetesting.NewRealishCache(store, thirdObserver))
+	assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"upc":"1","stock":7}}}}`, thirdBody)
+	assert.Equal(t, int64(1), third.LoadCount("inventory", "me.favoriteProduct"))
+	assert.Equal(t, []cachetesting.ShadowCompare{
+		{CacheKey: key, IsFresh: true},
+	}, normalizeCompareAges(thirdObserver.Compares()))
+}
+
+// normalizeCompareAges zeroes the real-clock CacheAge before the structural
+// assert; the EXACT age is pinned by the synctest H2 unit row.
+func normalizeCompareAges(compares []cachetesting.ShadowCompare) []cachetesting.ShadowCompare {
+	for i := range compares {
+		compares[i].CacheAge = 0
+	}
+	return compares
+}

--- a/execution/cachingtesting/shadow_e2e_test.go
+++ b/execution/cachingtesting/shadow_e2e_test.go
@@ -23,24 +23,25 @@ func inventoryShadowCaching() map[string]cacheconfig.CachingConfiguration {
 }
 
 // TestShadowModeEndToEnd: the response is ALWAYS the fresh network value even
-// on an L2 hit; the shadow compare records the staleness probe.
+// on an L2 hit; the shadow compare records the staleness probe. Runs through
+// the REAL ExecutionEngine: all three requests carry the same body, so the
+// inventory double's single rule is repointed between requests (the stock the
+// subgraph currently reports), and each request builds its own controller so
+// the RecordingObserver stays per-request.
 func TestShadowModeEndToEnd(t *testing.T) {
 	store := cachetesting.NewFakeStore()
 	query := `{ me { favoriteProduct { upc stock } } }`
-	responsesFor := func(stock string) map[string]string {
-		return map[string]string{
-			"users":                        `{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`,
-			"products:me":                  `{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`,
-			"inventory:me.favoriteProduct": `{"data":{"_entities":[{"__typename":"Product","stock":` + stock + `}]}}`,
-		}
-	}
+	users := Respond(`{"data":{"me":{"__typename":"User","id":"u1","username":"jens"}}}`)
+	products := Respond(`{"data":{"_entities":[{"__typename":"User","favoriteProduct":{"__typename":"Product","upc":"1"}}]}}`)
+	inventoryRule := Rule("", `{"data":{"_entities":[{"__typename":"Product","stock":5}]}}`)
+	inventory := Rules(inventoryRule)
+	executionEngine := NewEngine(t, inventoryShadowCaching(), Subgraphs{"users": users, "products": products, "inventory": inventory})
 
 	// Request 1: shadow MISS — plain fetch + write.
-	first := Plan(t, query, inventoryShadowCaching(), responsesFor("5"))
 	firstObserver := &cachetesting.RecordingObserver{}
-	firstBody := ResolveResponse(t, first.Response, cachetesting.NewRealishCache(store, firstObserver))
+	firstBody := Execute(t, executionEngine, query, cachetesting.NewRealishCache(store, firstObserver))
 	assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"upc":"1","stock":5}}}}`, firstBody)
-	assert.Equal(t, int64(1), first.LoadCount("inventory", "me.favoriteProduct"))
+	assert.Equal(t, int64(1), inventory.Requests())
 	assert.Empty(t, firstObserver.Compares())
 
 	ops := store.Ops()
@@ -50,11 +51,12 @@ func TestShadowModeEndToEnd(t *testing.T) {
 	// Request 2: L2 HIT under shadow — the subgraph now says stock=7 and the
 	// response MUST show 7 (fresh served, never the cached 5); the compare
 	// records the mismatch and L2 is overwritten with the fresh value.
-	second := Plan(t, query, inventoryShadowCaching(), responsesFor("7"))
+	inventoryRule.Response = `{"data":{"_entities":[{"__typename":"Product","stock":7}]}}`
 	secondObserver := &cachetesting.RecordingObserver{}
-	secondBody := ResolveResponse(t, second.Response, cachetesting.NewRealishCache(store, secondObserver))
+	secondBody := Execute(t, executionEngine, query, cachetesting.NewRealishCache(store, secondObserver))
 	assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"upc":"1","stock":7}}}}`, secondBody)
-	assert.Equal(t, int64(1), second.LoadCount("inventory", "me.favoriteProduct"))
+	// Shadow mode ALWAYS fetches: the request count accumulates to 2.
+	assert.Equal(t, int64(2), inventory.Requests())
 	assert.Equal(t, []cachetesting.ShadowCompare{
 		{CacheKey: key, IsFresh: false},
 	}, normalizeCompareAges(secondObserver.Compares()))
@@ -65,11 +67,10 @@ func TestShadowModeEndToEnd(t *testing.T) {
 
 	// Request 3: unchanged data — the compare records IsFresh true; the
 	// response is still the network value.
-	third := Plan(t, query, inventoryShadowCaching(), responsesFor("7"))
 	thirdObserver := &cachetesting.RecordingObserver{}
-	thirdBody := ResolveResponse(t, third.Response, cachetesting.NewRealishCache(store, thirdObserver))
+	thirdBody := Execute(t, executionEngine, query, cachetesting.NewRealishCache(store, thirdObserver))
 	assert.Equal(t, `{"data":{"me":{"favoriteProduct":{"upc":"1","stock":7}}}}`, thirdBody)
-	assert.Equal(t, int64(1), third.LoadCount("inventory", "me.favoriteProduct"))
+	assert.Equal(t, int64(3), inventory.Requests())
 	assert.Equal(t, []cachetesting.ShadowCompare{
 		{CacheKey: key, IsFresh: true},
 	}, normalizeCompareAges(thirdObserver.Compares()))

--- a/execution/cachingtesting/subgraphs/deals.graphql
+++ b/execution/cachingtesting/subgraphs/deals.graphql
@@ -1,0 +1,10 @@
+extend type Query {
+    deal(id: ID!): Deal
+}
+type Deal {
+    id: ID!
+    product: Product!
+}
+extend type Product @key(fields: "sku") {
+    sku: String! @external
+}

--- a/execution/cachingtesting/subgraphs/inventory.graphql
+++ b/execution/cachingtesting/subgraphs/inventory.graphql
@@ -1,6 +1,7 @@
 extend type Product @key(fields: "upc") {
     upc: String! @external
     stock: Int!
+    stockHistory(days: Int!): [Int!]!
     warehouse: Warehouse!
 }
 type Warehouse {

--- a/execution/cachingtesting/subgraphs/inventory.graphql
+++ b/execution/cachingtesting/subgraphs/inventory.graphql
@@ -1,0 +1,9 @@
+extend type Product @key(fields: "upc") {
+    upc: String! @external
+    stock: Int!
+    warehouse: Warehouse!
+}
+type Warehouse {
+    id: ID!
+    location: String!
+}

--- a/execution/cachingtesting/subgraphs/products.graphql
+++ b/execution/cachingtesting/subgraphs/products.graphql
@@ -1,0 +1,16 @@
+extend type Query {
+    products(first: Int = 5): [Product!]!
+    promotions: [Product!]!
+    product(upc: String!): Product
+    productBySku(sku: String!): Product
+}
+type Product @key(fields: "upc") @key(fields: "sku") {
+    upc: String!
+    sku: String!
+    name: String!
+    price: Int!
+}
+extend type User @key(fields: "id") {
+    id: ID! @external
+    favoriteProduct: Product
+}

--- a/execution/cachingtesting/subgraphs/reviews.graphql
+++ b/execution/cachingtesting/subgraphs/reviews.graphql
@@ -1,0 +1,17 @@
+extend type Query {
+    latestReviews(first: Int = 5): [Review!]!
+}
+type Review {
+    id: ID!
+    body: String!
+    author: User!
+    product: Product!
+}
+extend type User @key(fields: "id") {
+    id: ID! @external
+    reviews: [Review!]!
+}
+extend type Product @key(fields: "upc") {
+    upc: String! @external
+    reviews: [Review!]!
+}

--- a/execution/cachingtesting/subgraphs/reviews.graphql
+++ b/execution/cachingtesting/subgraphs/reviews.graphql
@@ -1,5 +1,6 @@
 extend type Query {
     latestReviews(first: Int = 5): [Review!]!
+    featuredReview: Review
 }
 type Review {
     id: ID!

--- a/execution/cachingtesting/subgraphs/users.graphql
+++ b/execution/cachingtesting/subgraphs/users.graphql
@@ -1,0 +1,8 @@
+extend type Query {
+    me: User
+    user(id: ID!): User
+}
+type User @key(fields: "id") {
+    id: ID!
+    username: String!
+}

--- a/execution/engine/engine_caching_config_test.go
+++ b/execution/engine/engine_caching_config_test.go
@@ -1,0 +1,100 @@
+package engine
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/jensneuse/abstractlogger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/datasource/graphql_datasource"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+func newCachingTestConfiguration(t *testing.T) Configuration {
+	t.Helper()
+
+	schema := heroWithArgumentSchema(t)
+	engineConf := NewConfiguration(schema)
+	engineConf.SetDataSources([]plan.DataSource{
+		mustGraphqlDataSourceConfiguration(t,
+			"heroes-ds",
+			mustFactory(t, http.DefaultClient),
+			&plan.DataSourceMetadata{
+				RootNodes: []plan.TypeField{
+					{TypeName: "Query", FieldNames: []string{"hero", "heroDefault", "heroDefaultRequired", "heroes"}},
+				},
+			},
+			mustConfiguration(t, graphql_datasource.ConfigurationInput{
+				Fetch: &graphql_datasource.FetchConfiguration{
+					URL:    "http://localhost:8080/graphql",
+					Method: "POST",
+				},
+				SchemaConfiguration: mustSchemaConfig(t, nil, `
+					type Query {
+						hero(name: String): String
+						heroDefault(name: String = "Any"): String
+						heroDefaultRequired(name: String! = "AnyRequired"): String
+						heroes(names: [String!]!): [String!]
+					}`),
+			}),
+		),
+	})
+	return engineConf
+}
+
+// TestSetCachingWiring pins the engine entry point: SetCaching (keyed by
+// datasource ID) reaches the planner's CacheConfigProviders, force-enables
+// FetchInfo, and produces the postprocess EnableCaching option; without
+// SetCaching none of that is constructed.
+func TestSetCachingWiring(t *testing.T) {
+	t.Run("without SetCaching nothing is wired", func(t *testing.T) {
+		engineConf := newCachingTestConfiguration(t)
+		engine, err := NewExecutionEngine(context.Background(), abstractlogger.Noop{}, engineConf, resolve.ResolverOptions{MaxConcurrency: 1})
+		require.NoError(t, err)
+		assert.Nil(t, engine.config.plannerConfig.CacheConfigProviders)
+		assert.Nil(t, engine.postProcessorOptions)
+	})
+
+	t.Run("SetCaching wires planner providers, FetchInfo, and postprocess option", func(t *testing.T) {
+		engineConf := newCachingTestConfiguration(t)
+		engineConf.plannerConfig.DisableIncludeInfo = true // must be force-overridden by caching
+		engineConf.SetCaching(map[string]cacheconfig.CachingConfiguration{
+			"heroes-ds": {
+				RootFields: []cacheconfig.RootFieldCachePolicy{
+					{TypeName: "Query", FieldName: "hero", CacheName: "heroes", TTL: time.Minute},
+				},
+			},
+		})
+		engine, err := NewExecutionEngine(context.Background(), abstractlogger.Noop{}, engineConf, resolve.ResolverOptions{MaxConcurrency: 1})
+		require.NoError(t, err)
+
+		providers := engine.config.plannerConfig.CacheConfigProviders
+		require.Len(t, providers, 1)
+		policy, ok := providers["heroes-ds"].RootFieldPolicy("Query", "hero")
+		assert.True(t, ok)
+		assert.Equal(t, cacheconfig.RootFieldCachePolicy{
+			TypeName:  "Query",
+			FieldName: "hero",
+			CacheName: "heroes",
+			TTL:       time.Minute,
+		}, policy)
+
+		assert.False(t, engine.config.plannerConfig.DisableIncludeInfo)
+		assert.Len(t, engine.postProcessorOptions, 1)
+	})
+
+	t.Run("SetCaching for an unknown datasource id fails", func(t *testing.T) {
+		engineConf := newCachingTestConfiguration(t)
+		engineConf.SetCaching(map[string]cacheconfig.CachingConfiguration{
+			"no-such-ds": {},
+		})
+		_, err := NewExecutionEngine(context.Background(), abstractlogger.Noop{}, engineConf, resolve.ResolverOptions{MaxConcurrency: 1})
+		assert.EqualError(t, err, "caching configured for unknown datasource id: no-such-ds")
+	})
+}

--- a/execution/engine/engine_config.go
+++ b/execution/engine/engine_config.go
@@ -79,6 +79,13 @@ func (e *Configuration) DataSources() []plan.DataSource {
 	return e.plannerConfig.DataSources
 }
 
+// PlannerConfig returns the built planner configuration. It exists for test
+// harnesses that drive the real v2 planner directly from a composed router
+// config; production code goes through NewExecutionEngine.
+func (e *Configuration) PlannerConfig() plan.Configuration {
+	return e.plannerConfig
+}
+
 func (e *Configuration) FieldConfigurations() plan.FieldConfigurations {
 	return e.plannerConfig.Fields
 }

--- a/execution/engine/engine_config.go
+++ b/execution/engine/engine_config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/datasource/graphql_datasource"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 )
 
@@ -22,6 +23,11 @@ type Configuration struct {
 	schema                   *graphql.Schema
 	plannerConfig            plan.Configuration
 	websocketBeforeStartHook WebsocketBeforeStartHook
+
+	// caching holds the per-datasource caching policies, keyed by datasource ID
+	// (see SetCaching). NewExecutionEngine turns it into the planner's
+	// CacheConfigProviders and the postprocess EnableCaching option.
+	caching map[string]cacheconfig.CachingConfiguration
 }
 
 func NewConfiguration(schema *graphql.Schema) Configuration {
@@ -57,6 +63,16 @@ func (e *Configuration) AddFieldConfiguration(fieldConfig plan.FieldConfiguratio
 
 func (e *Configuration) SetFieldConfigurations(fieldConfigs plan.FieldConfigurations) {
 	e.plannerConfig.Fields = fieldConfigs
+}
+
+// SetCaching configures caching policies per datasource, keyed by DATASOURCE
+// ID (the same ID the datasource was created with; cache providers are matched
+// to fetches via FetchInfo.DataSourceID at plan time). It is the ONLY public
+// entry point for caching: NewExecutionEngine wires the planner's P1 walk and
+// the postprocess caching passes from it. An empty or nil map keeps caching
+// fully disabled (the planner no-op gate).
+func (e *Configuration) SetCaching(caching map[string]cacheconfig.CachingConfiguration) {
+	e.caching = caching
 }
 
 func (e *Configuration) DataSources() []plan.DataSource {

--- a/execution/engine/execution_engine.go
+++ b/execution/engine/execution_engine.go
@@ -20,6 +20,7 @@ import (
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/astvalidation"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/datasource/introspection_datasource"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/postprocess"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/operationreport"
@@ -32,10 +33,10 @@ type internalExecutionContext struct {
 	postProcessor  *postprocess.Processor
 }
 
-func newInternalExecutionContext() *internalExecutionContext {
+func newInternalExecutionContext(postProcessorOptions ...postprocess.ProcessorOption) *internalExecutionContext {
 	return &internalExecutionContext{
 		resolveContext: resolve.NewContext(context.Background()),
-		postProcessor:  postprocess.NewProcessor(),
+		postProcessor:  postprocess.NewProcessor(postProcessorOptions...),
 	}
 }
 
@@ -60,6 +61,9 @@ type ExecutionEngine struct {
 	executionPlanCache       *lru.Cache
 	apolloCompatibilityFlags apollocompatibility.Flags
 	validationOptions        []astvalidation.Option
+	// postProcessorOptions carry the caching wiring (postprocess.EnableCaching)
+	// into every per-execution postprocess.Processor; empty when caching is off.
+	postProcessorOptions []postprocess.ProcessorOption
 }
 
 type WebsocketBeforeStartHook interface {
@@ -128,6 +132,30 @@ func NewExecutionEngine(ctx context.Context, logger abstractlogger.Logger, engin
 		dsIDs[ds.Id()] = struct{}{}
 	}
 
+	var postProcessorOptions []postprocess.ProcessorOption
+	if len(engineConfig.caching) > 0 {
+		providers := make(map[string]cacheconfig.CacheConfigProvider, len(engineConfig.caching))
+		for id, caching := range engineConfig.caching {
+			if _, ok := dsIDs[id]; !ok {
+				return nil, fmt.Errorf("caching configured for unknown datasource id: %s", id)
+			}
+			providers[id] = &caching
+		}
+		federation := make(map[string]plan.FederationMetaData, len(providers))
+		for _, ds := range engineConfig.plannerConfig.DataSources {
+			if _, ok := providers[ds.Id()]; ok {
+				federation[ds.Id()] = ds.FederationConfiguration()
+			}
+		}
+		engineConfig.plannerConfig.CacheConfigProviders = providers
+		// Caching requires FetchInfo: providers are matched to fetches via
+		// FetchInfo.DataSourceID, so a DisableIncludeInfo + caching combination
+		// must never degrade to silent uncached behavior.
+		engineConfig.plannerConfig.DisableIncludeInfo = false
+		postProcessorOptions = append(postProcessorOptions,
+			postprocess.EnableCaching(providers, federation, engineConfig.schema.Document()))
+	}
+
 	var validationOpts []astvalidation.Option
 	if engineConfig.plannerConfig.RelaxSubgraphOperationFieldSelectionMergingNullability {
 		validationOpts = append(validationOpts, astvalidation.WithRelaxFieldSelectionMergingNullability())
@@ -141,7 +169,8 @@ func NewExecutionEngine(ctx context.Context, logger abstractlogger.Logger, engin
 		apolloCompatibilityFlags: apollocompatibility.Flags{
 			ReplaceInvalidVarError: resolverOptions.ResolvableOptions.ApolloCompatibilityReplaceInvalidVarError,
 		},
-		validationOptions: validationOpts,
+		validationOptions:    validationOpts,
+		postProcessorOptions: postProcessorOptions,
 	}, nil
 }
 
@@ -213,7 +242,7 @@ func (e *ExecutionEngine) Execute(ctx context.Context, operation *graphql.Reques
 		}
 	}
 
-	execContext := newInternalExecutionContext()
+	execContext := newInternalExecutionContext(e.postProcessorOptions...)
 	execContext.setContext(ctx)
 	execContext.setVariables(operation.Variables)
 	execContext.setRequest(operation.InternalRequest())

--- a/execution/engine/execution_engine.go
+++ b/execution/engine/execution_engine.go
@@ -116,6 +116,14 @@ func WithCacheController(controller resolve.CacheController) ExecutionOptions {
 	}
 }
 
+// WithIncludeQueryPlanInResponse includes the fetch tree's QueryPlan in the
+// response extensions.
+func WithIncludeQueryPlanInResponse() ExecutionOptions {
+	return func(ctx *internalExecutionContext) {
+		ctx.resolveContext.ExecutionOptions.IncludeQueryPlanInResponse = true
+	}
+}
+
 func NewExecutionEngine(ctx context.Context, logger abstractlogger.Logger, engineConfig Configuration, resolverOptions resolve.ResolverOptions) (*ExecutionEngine, error) {
 	executionPlanCache, err := lru.New(1024)
 	if err != nil {

--- a/execution/engine/execution_engine.go
+++ b/execution/engine/execution_engine.go
@@ -105,6 +105,17 @@ func WithRequestTraceOptions(options resolve.TraceOptions) ExecutionOptions {
 	}
 }
 
+// WithCacheController attaches the runtime cache controller for this
+// execution — the counterpart of Configuration.SetCaching (which wires the
+// PLAN side): the controller serves and populates the request's L1/L2 caches.
+// Without it a cache-configured plan simply fetches everything (the runtime
+// no-op).
+func WithCacheController(controller resolve.CacheController) ExecutionOptions {
+	return func(ctx *internalExecutionContext) {
+		ctx.resolveContext.SetCacheController(controller)
+	}
+}
+
 func NewExecutionEngine(ctx context.Context, logger abstractlogger.Logger, engineConfig Configuration, resolverOptions resolve.ResolverOptions) (*ExecutionEngine, error) {
 	executionPlanCache, err := lru.New(1024)
 	if err != nil {

--- a/execution/engine/testdata/complex_nesting_query_with_art.json
+++ b/execution/engine/testdata/complex_nesting_query_with_art.json
@@ -166,69 +166,9 @@
                     }
                   }
                 },
-                "duration_since_start_nanoseconds": 1,
-                "duration_since_start_pretty": "1ns",
-                "duration_load_nanoseconds": 1,
-                "duration_load_pretty": "1ns",
                 "single_flight_used": true,
                 "single_flight_shared_response": false,
-                "load_skipped": false,
-                "load_stats": {
-                  "get_conn": {
-                    "duration_since_start_nanoseconds": 1,
-                    "duration_since_start_pretty": "1ns",
-                    "host_port": ""
-                  },
-                  "got_conn": {
-                    "duration_since_start_nanoseconds": 1,
-                    "duration_since_start_pretty": "1ns",
-                    "reused": false,
-                    "was_idle": false,
-                    "idle_time_nanoseconds": 0,
-                    "idle_time_pretty": ""
-                  },
-                  "got_first_response_byte": {
-                    "duration_since_start_nanoseconds": 1,
-                    "duration_since_start_pretty": "1ns"
-                  },
-                  "dns_start": {
-                    "duration_since_start_nanoseconds": 0,
-                    "duration_since_start_pretty": "",
-                    "host": ""
-                  },
-                  "dns_done": {
-                    "duration_since_start_nanoseconds": 0,
-                    "duration_since_start_pretty": ""
-                  },
-                  "connect_start": {
-                    "duration_since_start_nanoseconds": 1,
-                    "duration_since_start_pretty": "1ns",
-                    "network": "",
-                    "addr": ""
-                  },
-                  "connect_done": {
-                    "duration_since_start_nanoseconds": 1,
-                    "duration_since_start_pretty": "1ns",
-                    "network": "",
-                    "addr": ""
-                  },
-                  "tls_handshake_start": {
-                    "duration_since_start_nanoseconds": 0,
-                    "duration_since_start_pretty": ""
-                  },
-                  "tls_handshake_done": {
-                    "duration_since_start_nanoseconds": 0,
-                    "duration_since_start_pretty": ""
-                  },
-                  "wrote_headers": {
-                    "duration_since_start_nanoseconds": 1,
-                    "duration_since_start_pretty": "1ns"
-                  },
-                  "wrote_request": {
-                    "duration_since_start_nanoseconds": 1,
-                    "duration_since_start_pretty": "1ns"
-                  }
-                }
+                "load_skipped": false
               }
             }
           },
@@ -306,69 +246,9 @@
                         }
                       }
                     },
-                    "duration_since_start_nanoseconds": 1,
-                    "duration_since_start_pretty": "1ns",
-                    "duration_load_nanoseconds": 1,
-                    "duration_load_pretty": "1ns",
                     "single_flight_used": true,
                     "single_flight_shared_response": false,
-                    "load_skipped": false,
-                    "load_stats": {
-                      "get_conn": {
-                        "duration_since_start_nanoseconds": 1,
-                        "duration_since_start_pretty": "1ns",
-                        "host_port": ""
-                      },
-                      "got_conn": {
-                        "duration_since_start_nanoseconds": 1,
-                        "duration_since_start_pretty": "1ns",
-                        "reused": false,
-                        "was_idle": false,
-                        "idle_time_nanoseconds": 0,
-                        "idle_time_pretty": ""
-                      },
-                      "got_first_response_byte": {
-                        "duration_since_start_nanoseconds": 1,
-                        "duration_since_start_pretty": "1ns"
-                      },
-                      "dns_start": {
-                        "duration_since_start_nanoseconds": 0,
-                        "duration_since_start_pretty": "",
-                        "host": ""
-                      },
-                      "dns_done": {
-                        "duration_since_start_nanoseconds": 0,
-                        "duration_since_start_pretty": ""
-                      },
-                      "connect_start": {
-                        "duration_since_start_nanoseconds": 1,
-                        "duration_since_start_pretty": "1ns",
-                        "network": "",
-                        "addr": ""
-                      },
-                      "connect_done": {
-                        "duration_since_start_nanoseconds": 1,
-                        "duration_since_start_pretty": "1ns",
-                        "network": "",
-                        "addr": ""
-                      },
-                      "tls_handshake_start": {
-                        "duration_since_start_nanoseconds": 0,
-                        "duration_since_start_pretty": ""
-                      },
-                      "tls_handshake_done": {
-                        "duration_since_start_nanoseconds": 0,
-                        "duration_since_start_pretty": ""
-                      },
-                      "wrote_headers": {
-                        "duration_since_start_nanoseconds": 1,
-                        "duration_since_start_pretty": "1ns"
-                      },
-                      "wrote_request": {
-                        "duration_since_start_nanoseconds": 1,
-                        "duration_since_start_pretty": "1ns"
-                      }
-                    }
+                    "load_skipped": false
                   }
                 }
               },
@@ -492,69 +372,9 @@
                         }
                       }
                     },
-                    "duration_since_start_nanoseconds": 1,
-                    "duration_since_start_pretty": "1ns",
-                    "duration_load_nanoseconds": 1,
-                    "duration_load_pretty": "1ns",
                     "single_flight_used": true,
                     "single_flight_shared_response": false,
-                    "load_skipped": false,
-                    "load_stats": {
-                      "get_conn": {
-                        "duration_since_start_nanoseconds": 1,
-                        "duration_since_start_pretty": "1ns",
-                        "host_port": ""
-                      },
-                      "got_conn": {
-                        "duration_since_start_nanoseconds": 1,
-                        "duration_since_start_pretty": "1ns",
-                        "reused": false,
-                        "was_idle": false,
-                        "idle_time_nanoseconds": 0,
-                        "idle_time_pretty": ""
-                      },
-                      "got_first_response_byte": {
-                        "duration_since_start_nanoseconds": 1,
-                        "duration_since_start_pretty": "1ns"
-                      },
-                      "dns_start": {
-                        "duration_since_start_nanoseconds": 0,
-                        "duration_since_start_pretty": "",
-                        "host": ""
-                      },
-                      "dns_done": {
-                        "duration_since_start_nanoseconds": 0,
-                        "duration_since_start_pretty": ""
-                      },
-                      "connect_start": {
-                        "duration_since_start_nanoseconds": 1,
-                        "duration_since_start_pretty": "1ns",
-                        "network": "",
-                        "addr": ""
-                      },
-                      "connect_done": {
-                        "duration_since_start_nanoseconds": 1,
-                        "duration_since_start_pretty": "1ns",
-                        "network": "",
-                        "addr": ""
-                      },
-                      "tls_handshake_start": {
-                        "duration_since_start_nanoseconds": 0,
-                        "duration_since_start_pretty": ""
-                      },
-                      "tls_handshake_done": {
-                        "duration_since_start_nanoseconds": 0,
-                        "duration_since_start_pretty": ""
-                      },
-                      "wrote_headers": {
-                        "duration_since_start_nanoseconds": 1,
-                        "duration_since_start_pretty": "1ns"
-                      },
-                      "wrote_request": {
-                        "duration_since_start_nanoseconds": 1,
-                        "duration_since_start_pretty": "1ns"
-                      }
-                    }
+                    "load_skipped": false
                   }
                 }
               }

--- a/execution/federationtesting/gateway/httphandler/http.go
+++ b/execution/federationtesting/gateway/httphandler/http.go
@@ -31,12 +31,14 @@ func (g *GraphQLHTTPRequestHandler) handleHTTP(w http.ResponseWriter, r *http.Re
 
 	if g.enableART {
 		tracingOpts := resolve.TraceOptions{
-			Enable:                                 true,
-			ExcludePlannerStats:                    false,
-			ExcludeRawInputData:                    false,
-			ExcludeInput:                           false,
-			ExcludeOutput:                          false,
-			ExcludeLoadStats:                       false,
+			Enable:              true,
+			ExcludePlannerStats: false,
+			ExcludeRawInputData: false,
+			ExcludeInput:        false,
+			ExcludeOutput:       false,
+			// Load stats are connection-timing noise that only bloats the ART
+			// golden files — the tests never assert on them.
+			ExcludeLoadStats:                       true,
 			EnablePredictableDebugTimings:          true,
 			Debug:                                  true,
 			IncludeTraceOutputInResponseExtensions: true,

--- a/v2/pkg/engine/cache/cache_key_builder.go
+++ b/v2/pkg/engine/cache/cache_key_builder.go
@@ -71,17 +71,135 @@ func (b *cacheKeyBuilder) buildEntitySpec(info *resolve.FetchInfo) (resolve.Cach
 	return spec, true
 }
 
-// buildRootFieldSpec builds the key spec for a root-field fetch: scope +
-// the fetch's first root-field coordinate. Root-field keys carry no @key
-// candidates (the value is whole-response scoped); entity-key mappings for
-// by-key root fields land with task 15.
+// buildRootFieldSpec builds the key spec for a root-field fetch: scope + the
+// fetch's first root-field coordinate. A BY-KEY root field — one returning an
+// entity type whose @key fields are all covered by the field's argument names
+// — additionally gets the structurally derived EntityKeyMappings (D10) and the
+// entity's FULL candidate set, so it participates in the ENTITY key space (an
+// arg-derived candidate renders at lookup; data-derived ones backfill at
+// write). Reuse then works exactly when the root-field policy shares its
+// CacheName with the entity policy (read key == write key).
 func (b *cacheKeyBuilder) buildRootFieldSpec(info *resolve.FetchInfo) (resolve.CacheKeySpec, bool) {
 	if info == nil || len(info.RootFields) == 0 {
 		return resolve.CacheKeySpec{}, false
 	}
-	return resolve.CacheKeySpec{
+	spec := resolve.CacheKeySpec{
 		Scope:     resolve.CacheScopeRootField,
 		TypeName:  info.RootFields[0].TypeName,
 		FieldName: info.RootFields[0].FieldName,
-	}, true
+	}
+	// Only a single-root-field fetch can be a by-key entity lookup.
+	if len(info.RootFields) == 1 {
+		if entityTypeName, mappings := b.deriveEntityKeyMappings(info, spec.TypeName, spec.FieldName); len(mappings) > 0 {
+			entitySpec, ok := b.buildEntitySpec(&resolve.FetchInfo{
+				DataSourceID: info.DataSourceID,
+				RootFields:   []resolve.GraphCoordinate{{TypeName: entityTypeName}},
+			})
+			if ok {
+				// The lookup item derives from ARGUMENTS and carries no
+				// __typename, so each candidate's representation gets the
+				// entity type name for the template's fallback. The nodes are
+				// freshly built per spec — setting TypeName mutates nothing
+				// shared.
+				for _, candidate := range entitySpec.Candidates {
+					candidate.Representation.TypeName = entityTypeName
+				}
+				spec.EntityKeyMappings = mappings
+				spec.Candidates = entitySpec.Candidates
+			}
+		}
+	}
+	return spec, true
+}
+
+// deriveEntityKeyMappings resolves the root field's return type from the
+// definition and, when it is an entity of the fetch's datasource, emits one
+// mapping per resolvable @key set whose EVERY key field name matches an
+// argument name of the root field (product(upc:) maps @key(upc), never
+// @key(sku)). Structural derivation only (D10): definition + federation, no
+// external mapping config. v1 CONSTRAINT: the runtime reads the argument value
+// from a request variable NAMED LIKE the key field, so reuse requires
+// arguments passed as same-named variables.
+func (b *cacheKeyBuilder) deriveEntityKeyMappings(info *resolve.FetchInfo, rootTypeName, rootFieldName string) (string, []resolve.EntityKeyMapping) {
+	if b.definition == nil {
+		return "", nil
+	}
+	fed, ok := b.federation[info.DataSourceID]
+	if !ok {
+		return "", nil
+	}
+	rootNode, ok := b.definition.Index.FirstNodeByNameStr(rootTypeName)
+	if !ok {
+		return "", nil
+	}
+	fieldDef, ok := b.definition.NodeFieldDefinitionByName(rootNode, ast.ByteSlice(rootFieldName))
+	if !ok {
+		return "", nil
+	}
+	entityTypeName := b.definition.FieldDefinitionTypeNameString(fieldDef)
+	if !fed.HasEntity(entityTypeName) {
+		return "", nil
+	}
+
+	argNames := map[string]struct{}{}
+	for _, argRef := range b.definition.NodeInputValueDefinitions(ast.Node{Kind: ast.NodeKindFieldDefinition, Ref: fieldDef}) {
+		argNames[b.definition.InputValueDefinitionNameString(argRef)] = struct{}{}
+	}
+	if len(argNames) == 0 {
+		return "", nil
+	}
+
+	keySets := fed.RequiredFieldsByKey(entityTypeName)
+	slices.SortFunc(keySets, func(a, b plan.FederationFieldConfiguration) int {
+		return strings.Compare(a.SelectionSet, b.SelectionSet)
+	})
+
+	seen := map[string]struct{}{}
+	mappings := make([]resolve.EntityKeyMapping, 0, len(keySets))
+	for _, keySet := range keySets {
+		keyFields, ok := keySelectionSetFieldNames(entityTypeName, keySet.SelectionSet)
+		if !ok {
+			continue
+		}
+		fieldMappings := make([]resolve.EntityFieldMapping, 0, len(keyFields))
+		for _, keyField := range keyFields {
+			if _, ok := argNames[keyField]; !ok {
+				// A key set with ANY field outside the argument names cannot
+				// be rendered from the arguments — skip the whole set.
+				fieldMappings = nil
+				break
+			}
+			fieldMappings = append(fieldMappings, resolve.EntityFieldMapping{
+				EntityKeyField:      keyField,
+				ArgumentPath:        []string{keyField},
+				ArgumentIsEntityKey: true,
+			})
+		}
+		if len(fieldMappings) == 0 {
+			continue
+		}
+		dedupeKey := entityTypeName + "\x00" + strings.Join(keyFields, "\x00")
+		if _, ok := seen[dedupeKey]; ok {
+			continue
+		}
+		seen[dedupeKey] = struct{}{}
+		mappings = append(mappings, resolve.EntityKeyMapping{
+			EntityTypeName: entityTypeName,
+			FieldMappings:  fieldMappings,
+		})
+	}
+	return entityTypeName, mappings
+}
+
+// keySelectionSetFieldNames parses one @key selection set and returns its
+// top-level field names; composite (nested) key sets return their top-level
+// names, which then fail the argument-name match unless an argument carries
+// the object — the conservative outcome.
+func keySelectionSetFieldNames(typeName, selectionSet string) ([]string, bool) {
+	fragment, report := plan.RequiredFieldsFragment(typeName, selectionSet, false)
+	if report == nil || report.HasErrors() || fragment == nil || len(fragment.FragmentDefinitions) == 0 {
+		return nil, false
+	}
+	fieldNames := fragment.SelectionSetFieldNames(fragment.FragmentDefinitions[0].SelectionSet)
+	return fieldNames, len(fieldNames) != 0
 }

--- a/v2/pkg/engine/cache/cache_key_builder.go
+++ b/v2/pkg/engine/cache/cache_key_builder.go
@@ -70,3 +70,18 @@ func (b *cacheKeyBuilder) buildEntitySpec(info *resolve.FetchInfo) (resolve.Cach
 	}
 	return spec, true
 }
+
+// buildRootFieldSpec builds the key spec for a root-field fetch: scope +
+// the fetch's first root-field coordinate. Root-field keys carry no @key
+// candidates (the value is whole-response scoped); entity-key mappings for
+// by-key root fields land with task 15.
+func (b *cacheKeyBuilder) buildRootFieldSpec(info *resolve.FetchInfo) (resolve.CacheKeySpec, bool) {
+	if info == nil || len(info.RootFields) == 0 {
+		return resolve.CacheKeySpec{}, false
+	}
+	return resolve.CacheKeySpec{
+		Scope:     resolve.CacheScopeRootField,
+		TypeName:  info.RootFields[0].TypeName,
+		FieldName: info.RootFields[0].FieldName,
+	}, true
+}

--- a/v2/pkg/engine/cache/cache_key_builder.go
+++ b/v2/pkg/engine/cache/cache_key_builder.go
@@ -1,0 +1,20 @@
+package cache
+
+import (
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
+)
+
+// cacheKeyBuilder freezes every resolvable @key set of a cached type into
+// multi-key resolve.CacheKeySpec candidates BY VALUE. It is the SOLE
+// federation reader on the plan side: no federation type or pointer ever
+// reaches the runtime config it produces.
+//
+// Skeleton only — the freeze logic lands with task 06.
+type cacheKeyBuilder struct {
+	// federation is the per-datasource federation metadata, keyed by
+	// datasource ID; read-only input to the freeze.
+	federation map[string]plan.FederationMetaData
+	// definition is the composed schema the @key selection sets resolve against.
+	definition *ast.Document
+}

--- a/v2/pkg/engine/cache/cache_key_builder.go
+++ b/v2/pkg/engine/cache/cache_key_builder.go
@@ -1,20 +1,72 @@
 package cache
 
 import (
+	"slices"
+	"strings"
+
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/representationvariable"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 )
 
-// cacheKeyBuilder freezes every resolvable @key set of a cached type into
+// cacheKeyBuilder turns every resolvable @key set of a cached type into
 // multi-key resolve.CacheKeySpec candidates BY VALUE. It is the SOLE
-// federation reader on the plan side: no federation type or pointer ever
-// reaches the runtime config it produces.
-//
-// Skeleton only — the freeze logic lands with task 06.
+// federation reader on the plan side: the representation nodes it emits are
+// built fresh per candidate via the shared representationvariable package, so
+// no federation type or pointer ever reaches the runtime config.
 type cacheKeyBuilder struct {
 	// federation is the per-datasource federation metadata, keyed by
-	// datasource ID; read-only input to the freeze.
+	// datasource ID; read-only input.
 	federation map[string]plan.FederationMetaData
 	// definition is the composed schema the @key selection sets resolve against.
 	definition *ast.Document
+}
+
+// buildEntitySpec builds the multi-key spec for an entity fetch: one candidate
+// per resolvable @key set of the fetched entity type, deterministically
+// ordered by selection-set string. None is required — candidates are
+// best-effort renderable at lookup and backfilled at write. Returns
+// (zero, false) when the fetch resolves no entity or no usable key exists.
+func (b *cacheKeyBuilder) buildEntitySpec(info *resolve.FetchInfo) (resolve.CacheKeySpec, bool) {
+	if info == nil || len(info.RootFields) == 0 {
+		return resolve.CacheKeySpec{}, false
+	}
+	typeName := info.RootFields[0].TypeName
+	fed, ok := b.federation[info.DataSourceID]
+	if !ok {
+		return resolve.CacheKeySpec{}, false
+	}
+	if !fed.HasEntity(typeName) {
+		return resolve.CacheKeySpec{}, false
+	}
+
+	spec := resolve.CacheKeySpec{
+		Scope:    resolve.CacheScopeEntity,
+		TypeName: typeName,
+	}
+	keySets := fed.RequiredFieldsByKey(typeName)
+	slices.SortFunc(keySets, func(a, b plan.FederationFieldConfiguration) int {
+		return strings.Compare(a.SelectionSet, b.SelectionSet)
+	})
+	for _, keySet := range keySets {
+		node, err := representationvariable.BuildRepresentationVariableNode(b.definition, keySet, fed)
+		// Best-effort multi-key: a malformed @key fragment must not drop caching
+		// for the whole entity, so skip only that candidate and keep the others.
+		// Two malformed shapes exist: a selection set that fails to build (err),
+		// and one whose fields do not exist in the schema — the representation
+		// walker silently drops unknown fields, leaving only the __typename
+		// field, and a __typename-only key would collide across ALL entities of
+		// the type. If EVERY @key is malformed, the zero-candidate check below
+		// returns (zero, false) and the entity is simply not cached — the
+		// conservative, correct fallback.
+		if err != nil || node == nil || len(node.Fields) < 2 {
+			continue
+		}
+		spec.Candidates = append(spec.Candidates, resolve.CacheKeyCandidate{Representation: node})
+	}
+	if len(spec.Candidates) == 0 {
+		return resolve.CacheKeySpec{}, false
+	}
+	return spec, true
 }

--- a/v2/pkg/engine/cache/cache_key_builder_test.go
+++ b/v2/pkg/engine/cache/cache_key_builder_test.go
@@ -1,0 +1,260 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astparser"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/representationvariable"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+const keyBuilderDefinition = `
+	scalar String
+	scalar Int
+
+	type Product {
+		upc: String!
+		sku: String!
+		name: String!
+		brand: Brand!
+	}
+
+	type Brand {
+		id: String!
+		name: String!
+	}
+`
+
+// newKeyBuilderFederation builds initialized federation metadata (entity index
+// + parsed key selection sets) for the given Product key sets.
+func newKeyBuilderFederation(t *testing.T, keySelectionSets ...string) plan.FederationMetaData {
+	t.Helper()
+	keys := make(plan.FederationFieldConfigurations, 0, len(keySelectionSets))
+	for _, selectionSet := range keySelectionSets {
+		keys = append(keys, plan.FederationFieldConfiguration{
+			TypeName:     "Product",
+			SelectionSet: selectionSet,
+		})
+	}
+	metadata := &plan.DataSourceMetadata{
+		FederationMetaData: plan.FederationMetaData{Keys: keys},
+	}
+	require.NoError(t, metadata.Init())
+	return metadata.FederationMetaData
+}
+
+func newKeyBuilder(t *testing.T, definition *ast.Document, fed plan.FederationMetaData) *cacheKeyBuilder {
+	t.Helper()
+	return &cacheKeyBuilder{
+		federation: map[string]plan.FederationMetaData{"products": fed},
+		definition: definition,
+	}
+}
+
+func parseKeyBuilderDefinition(t *testing.T) *ast.Document {
+	t.Helper()
+	definition, report := astparser.ParseGraphqlDocumentString(keyBuilderDefinition)
+	require.False(t, report.HasErrors(), "parse definition: %v", report)
+	return &definition
+}
+
+func productEntityInfo() *resolve.FetchInfo {
+	return &resolve.FetchInfo{
+		DataSourceID: "products",
+		RootFields:   []resolve.GraphCoordinate{{TypeName: "Product"}},
+	}
+}
+
+func TestCacheKeyBuilderEntitySpec(t *testing.T) {
+	definition := parseKeyBuilderDefinition(t)
+
+	t.Run("single @key", func(t *testing.T) {
+		builder := newKeyBuilder(t, definition, newKeyBuilderFederation(t, "upc"))
+		spec, ok := builder.buildEntitySpec(productEntityInfo())
+		require.True(t, ok)
+		assert.Equal(t, resolve.CacheKeySpec{
+			Scope:    resolve.CacheScopeEntity,
+			TypeName: "Product",
+			Candidates: []resolve.CacheKeyCandidate{
+				{
+					Representation: &resolve.Object{
+						Nullable: true,
+						Fields: []*resolve.Field{
+							{
+								Name:        []byte("__typename"),
+								Value:       &resolve.String{Path: []string{"__typename"}},
+								OnTypeNames: [][]byte{[]byte("Product")},
+							},
+							{
+								Name:        []byte("upc"),
+								Value:       &resolve.String{Path: []string{"upc"}},
+								OnTypeNames: [][]byte{[]byte("Product")},
+							},
+						},
+					},
+				},
+			},
+		}, spec)
+	})
+
+	t.Run("multiple @key sets ordered by selection set, composite + nested", func(t *testing.T) {
+		// Deliberately registered in reverse order; candidates must come out
+		// sorted by selection-set string ("sku brand { id }" < "upc").
+		builder := newKeyBuilder(t, definition, newKeyBuilderFederation(t, "upc", "sku brand { id }"))
+		spec, ok := builder.buildEntitySpec(productEntityInfo())
+		require.True(t, ok)
+		assert.Equal(t, resolve.CacheKeySpec{
+			Scope:    resolve.CacheScopeEntity,
+			TypeName: "Product",
+			Candidates: []resolve.CacheKeyCandidate{
+				{
+					Representation: &resolve.Object{
+						Nullable: true,
+						Fields: []*resolve.Field{
+							{
+								Name:        []byte("__typename"),
+								Value:       &resolve.String{Path: []string{"__typename"}},
+								OnTypeNames: [][]byte{[]byte("Product")},
+							},
+							{
+								Name:        []byte("sku"),
+								Value:       &resolve.String{Path: []string{"sku"}},
+								OnTypeNames: [][]byte{[]byte("Product")},
+							},
+							{
+								Name: []byte("brand"),
+								Value: &resolve.Object{
+									Path: []string{"brand"},
+									Fields: []*resolve.Field{
+										{
+											Name:  []byte("id"),
+											Value: &resolve.String{Path: []string{"id"}},
+										},
+									},
+								},
+								OnTypeNames: [][]byte{[]byte("Product")},
+							},
+						},
+					},
+				},
+				{
+					Representation: &resolve.Object{
+						Nullable: true,
+						Fields: []*resolve.Field{
+							{
+								Name:        []byte("__typename"),
+								Value:       &resolve.String{Path: []string{"__typename"}},
+								OnTypeNames: [][]byte{[]byte("Product")},
+							},
+							{
+								Name:        []byte("upc"),
+								Value:       &resolve.String{Path: []string{"upc"}},
+								OnTypeNames: [][]byte{[]byte("Product")},
+							},
+						},
+					},
+				},
+			},
+		}, spec)
+	})
+
+	t.Run("no @key means no spec", func(t *testing.T) {
+		builder := newKeyBuilder(t, definition, newKeyBuilderFederation(t))
+		spec, ok := builder.buildEntitySpec(productEntityInfo())
+		assert.False(t, ok)
+		assert.Equal(t, resolve.CacheKeySpec{}, spec)
+	})
+
+	t.Run("unknown datasource means no spec", func(t *testing.T) {
+		builder := newKeyBuilder(t, definition, newKeyBuilderFederation(t, "upc"))
+		spec, ok := builder.buildEntitySpec(&resolve.FetchInfo{
+			DataSourceID: "unknown",
+			RootFields:   []resolve.GraphCoordinate{{TypeName: "Product"}},
+		})
+		assert.False(t, ok)
+		assert.Equal(t, resolve.CacheKeySpec{}, spec)
+	})
+
+	t.Run("nil info and missing root fields mean no spec", func(t *testing.T) {
+		builder := newKeyBuilder(t, definition, newKeyBuilderFederation(t, "upc"))
+		_, ok := builder.buildEntitySpec(nil)
+		assert.False(t, ok)
+		_, ok = builder.buildEntitySpec(&resolve.FetchInfo{DataSourceID: "products"})
+		assert.False(t, ok)
+	})
+
+	t.Run("a broken @key candidate is skipped, others survive", func(t *testing.T) {
+		builder := newKeyBuilder(t, definition, newKeyBuilderFederation(t, "doesNotExist", "upc"))
+		spec, ok := builder.buildEntitySpec(productEntityInfo())
+		require.True(t, ok)
+		require.Len(t, spec.Candidates, 1)
+		assert.Equal(t, resolve.CacheKeyCandidate{
+			Representation: &resolve.Object{
+				Nullable: true,
+				Fields: []*resolve.Field{
+					{
+						Name:        []byte("__typename"),
+						Value:       &resolve.String{Path: []string{"__typename"}},
+						OnTypeNames: [][]byte{[]byte("Product")},
+					},
+					{
+						Name:        []byte("upc"),
+						Value:       &resolve.String{Path: []string{"upc"}},
+						OnTypeNames: [][]byte{[]byte("Product")},
+					},
+				},
+			},
+		}, spec.Candidates[0])
+	})
+
+	t.Run("every @key broken means no spec", func(t *testing.T) {
+		builder := newKeyBuilder(t, definition, newKeyBuilderFederation(t, "doesNotExist"))
+		spec, ok := builder.buildEntitySpec(productEntityInfo())
+		assert.False(t, ok)
+		assert.Equal(t, resolve.CacheKeySpec{}, spec)
+	})
+
+	t.Run("no pointer aliasing: mutating the source federation leaves the spec intact", func(t *testing.T) {
+		fed := newKeyBuilderFederation(t, "upc")
+		builder := newKeyBuilder(t, definition, fed)
+		spec, ok := builder.buildEntitySpec(productEntityInfo())
+		require.True(t, ok)
+
+		before := resolve.CacheKeySpec{
+			Scope:      spec.Scope,
+			TypeName:   spec.TypeName,
+			Candidates: spec.Candidates,
+		}
+		// Mutate the source federation metadata AND the builder's map copy.
+		fed.Keys[0].TypeName = "Mutated"
+		fed.Keys[0].SelectionSet = "mutated"
+		builderFed := builder.federation["products"]
+		if len(builderFed.Keys) > 0 {
+			builderFed.Keys[0].TypeName = "AlsoMutated"
+		}
+
+		assert.True(t, before.Equals(spec))
+		assert.Equal(t, "Product", spec.TypeName)
+		assert.Equal(t, [][]byte{[]byte("Product")}, spec.Candidates[0].Representation.Fields[0].OnTypeNames)
+	})
+
+	t.Run("candidate node equals the datasource representation node for the same @key", func(t *testing.T) {
+		fed := newKeyBuilderFederation(t, "sku brand { id }")
+		builder := newKeyBuilder(t, definition, fed)
+		spec, ok := builder.buildEntitySpec(productEntityInfo())
+		require.True(t, ok)
+		require.Len(t, spec.Candidates, 1)
+
+		datasourceNode, err := representationvariable.BuildRepresentationVariableNode(definition, plan.FederationFieldConfiguration{
+			TypeName:     "Product",
+			SelectionSet: "sku brand { id }",
+		}, fed)
+		require.NoError(t, err)
+		assert.Equal(t, datasourceNode, spec.Candidates[0].Representation)
+	})
+}

--- a/v2/pkg/engine/cache/cache_key_template.go
+++ b/v2/pkg/engine/cache/cache_key_template.go
@@ -82,9 +82,12 @@ func (t cacheKeyTemplate) render(item *astjson.Value) (string, bool) {
 
 // renderRepresentationValue extracts the canonical key value for one template
 // node from the item: objects recurse over the template's fields, scalars pass
-// through (numbers canonicalized to their JSON string so 1 and 1.0 cannot
-// split the key space); a null or absent value makes the candidate
-// unrenderable.
+// through. Numbers are unified with STRINGS of the same literal (the number 1
+// and the string "1" render the same key material) — astjson preserves the
+// original literal, so 1 and 1.0 remain DISTINCT keys: a conservative split
+// (extra miss, never wrong data). Full numeric canonicalization is deliberately
+// avoided: parsing to float64 would corrupt integers beyond 2^53. A null or
+// absent value makes the candidate unrenderable.
 func renderRepresentationValue(node resolve.Node, value *astjson.Value) (*astjson.Value, bool) {
 	if value == nil || value.Type() == astjson.TypeNull {
 		return nil, false

--- a/v2/pkg/engine/cache/cache_key_template.go
+++ b/v2/pkg/engine/cache/cache_key_template.go
@@ -1,6 +1,9 @@
 package cache
 
 import (
+	"cmp"
+	"slices"
+
 	"github.com/wundergraph/astjson"
 
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
@@ -157,4 +160,58 @@ func hex64(sum uint64) string {
 		sum >>= 4
 	}
 	return string(buf[:])
+}
+
+// rootFieldCacheKey renders the whole-response root-field key: the policy
+// prefix plus a preimage of the fetch's root-field coordinate and the request
+// variables in canonical (name-sorted) form. The QUERY TEXT is deliberately
+// excluded so alias-variant operations share the entry (coverage and
+// normalization guard servability and shape). PRECONDITION: operations are
+// normalized with variable extraction (the engine always does this), so inline
+// argument literals are variables and cannot collide under one key.
+func rootFieldCacheKey(cfg *resolve.FetchCacheConfig, headerHash uint64, ctx *resolve.Context) string {
+	prefix := cacheKeyPrefix(cfg, headerHash)
+	preimage := make([]byte, 0, 64)
+	preimage = append(preimage, cfg.KeySpec.TypeName...)
+	preimage = append(preimage, '.')
+	preimage = append(preimage, cfg.KeySpec.FieldName...)
+	preimage = append(preimage, ':')
+	preimage = append(preimage, canonicalVariables(ctx)...)
+	return renderCacheKey(prefix, preimage)
+}
+
+// canonicalVariables renders the request variables with name-sorted top-level
+// keys, so clients sending the same variables in different order share keys.
+func canonicalVariables(ctx *resolve.Context) []byte {
+	if ctx == nil || ctx.Variables == nil {
+		return []byte("null")
+	}
+	obj, err := ctx.Variables.Object()
+	if err != nil {
+		return ctx.Variables.MarshalTo(nil)
+	}
+	type pair struct {
+		name  string
+		value *astjson.Value
+	}
+	pairs := make([]pair, 0, obj.Len())
+	obj.Visit(func(key []byte, v *astjson.Value) {
+		pairs = append(pairs, pair{name: string(key), value: v})
+	})
+	slices.SortFunc(pairs, func(a, b pair) int {
+		return cmp.Compare(a.name, b.name)
+	})
+	out := make([]byte, 0, 64)
+	out = append(out, '{')
+	for i, p := range pairs {
+		if i > 0 {
+			out = append(out, ',')
+		}
+		out = append(out, '"')
+		out = append(out, p.name...)
+		out = append(out, '"', ':')
+		out = p.value.MarshalTo(out)
+	}
+	out = append(out, '}')
+	return out
 }

--- a/v2/pkg/engine/cache/cache_key_template.go
+++ b/v2/pkg/engine/cache/cache_key_template.go
@@ -40,47 +40,79 @@ func newCacheKeyTemplates(cfg *resolve.FetchCacheConfig, headerHash uint64) []ca
 
 // render produces the candidate's key for one entity item, best-effort: it
 // returns ok=false when any referenced key field is absent or null in the
-// item (an unrenderable candidate is skipped, never an error).
+// item (an unrenderable candidate is skipped, never an error). The canonical
+// key JSON is written DIRECTLY to a byte buffer — the hot lookup path builds
+// no intermediate astjson values (profiled: value building dominated the
+// cache-side allocations) — and the preimage bytes are identical to the
+// former astjson-marshal form, so keys stay stable.
 func (t cacheKeyTemplate) render(item *astjson.Value) (string, bool) {
 	if t.representation == nil || item == nil {
 		return "", false
 	}
-	typename := item.Get("__typename")
-	if typename == nil {
+	preimage := make([]byte, 0, 64)
+	preimage = append(preimage, `{"__typename":`...)
+	if typename := item.Get("__typename"); typename != nil {
+		preimage = typename.MarshalTo(preimage)
+	} else {
 		// Entity items always carry __typename in federation responses; the
 		// template's type name stands in when a caller renders from a value
 		// that legitimately lacks it (e.g. argument-derived lookups, task 15).
+		// GraphQL type names never need JSON escaping.
 		if t.representation.TypeName == "" {
 			return "", false
 		}
-		typename = astjson.StringValue(nil, t.representation.TypeName)
+		preimage = append(preimage, '"')
+		preimage = append(preimage, t.representation.TypeName...)
+		preimage = append(preimage, '"')
 	}
-	keyObj := astjson.ObjectValue(nil)
-	keyObj.Set(nil, "__typename", typename)
-	keysObj := astjson.ObjectValue(nil)
-	renderedFields := 0
-	for _, field := range t.representation.Fields {
+	preimage = append(preimage, `,"key":`...)
+	keyStart := len(preimage)
+	preimage, ok := appendRepresentationObject(preimage, t.representation, item)
+	if !ok {
+		return "", false
+	}
+	if len(preimage) == keyStart+2 {
+		// A key without any key field ("{}") would collide across all entities
+		// of the type; treat it as unrenderable.
+		return "", false
+	}
+	preimage = append(preimage, '}')
+	return renderCacheKey(t.prefix, preimage), true
+}
+
+// appendRepresentationObject writes one canonical key object for the template
+// node from the item: fields in template order (GraphQL names never need JSON
+// escaping), objects recurse, and every field must render.
+func appendRepresentationObject(buf []byte, node *resolve.Object, value *astjson.Value) ([]byte, bool) {
+	buf = append(buf, '{')
+	rendered := 0
+	for _, field := range node.Fields {
 		name := string(field.Name)
 		if name == "__typename" {
 			continue
 		}
-		value, ok := renderRepresentationValue(field.Value, item.Get(name))
-		if !ok {
-			return "", false
+		if rendered > 0 {
+			buf = append(buf, ',')
 		}
-		keysObj.Set(nil, name, value)
-		renderedFields++
+		buf = append(buf, '"')
+		buf = append(buf, name...)
+		buf = append(buf, '"', ':')
+		var ok bool
+		buf, ok = appendRepresentationValue(buf, field.Value, value.Get(name))
+		if !ok {
+			return buf, false
+		}
+		rendered++
 	}
-	if renderedFields == 0 {
-		// A key without any key field would collide across all entities of the
-		// type; treat it as unrenderable.
-		return "", false
+	if rendered == 0 && len(node.Fields) > 0 {
+		// Every field was __typename: nothing key-worthy below this node.
+		return buf, false
 	}
-	keyObj.Set(nil, "key", keysObj)
-	return renderCacheKey(t.prefix, keyObj.MarshalTo(nil)), true
+	buf = append(buf, '}')
+	return buf, true
 }
 
-// renderRepresentationValue extracts the canonical key value for one template
+// appendRepresentationValue writes the canonical key value for one template
 // node from the item: objects recurse over the template's fields, scalars pass
 // through. Numbers are unified with STRINGS of the same literal (the number 1
 // and the string "1" render the same key material) — astjson preserves the
@@ -88,35 +120,24 @@ func (t cacheKeyTemplate) render(item *astjson.Value) (string, bool) {
 // (extra miss, never wrong data). Full numeric canonicalization is deliberately
 // avoided: parsing to float64 would corrupt integers beyond 2^53. A null or
 // absent value makes the candidate unrenderable.
-func renderRepresentationValue(node resolve.Node, value *astjson.Value) (*astjson.Value, bool) {
+func appendRepresentationValue(buf []byte, node resolve.Node, value *astjson.Value) ([]byte, bool) {
 	if value == nil || value.Type() == astjson.TypeNull {
-		return nil, false
+		return buf, false
 	}
 	switch typed := node.(type) {
 	case *resolve.Object:
 		if value.Type() != astjson.TypeObject {
-			return nil, false
+			return buf, false
 		}
-		out := astjson.ObjectValue(nil)
-		rendered := 0
-		for _, field := range typed.Fields {
-			name := string(field.Name)
-			if name == "__typename" {
-				continue
-			}
-			child, ok := renderRepresentationValue(field.Value, value.Get(name))
-			if !ok {
-				return nil, false
-			}
-			out.Set(nil, name, child)
-			rendered++
-		}
-		return out, rendered > 0
+		return appendRepresentationObject(buf, typed, value)
 	default:
 		if value.Type() == astjson.TypeNumber {
-			return astjson.StringValue(nil, string(value.MarshalTo(nil))), true
+			buf = append(buf, '"')
+			buf = value.MarshalTo(buf)
+			buf = append(buf, '"')
+			return buf, true
 		}
-		return value, true
+		return value.MarshalTo(buf), true
 	}
 }
 

--- a/v2/pkg/engine/cache/cache_key_template.go
+++ b/v2/pkg/engine/cache/cache_key_template.go
@@ -1,0 +1,160 @@
+package cache
+
+import (
+	"github.com/wundergraph/astjson"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/pool"
+)
+
+// cacheKeyTemplate is the SOLE source of read, write, and invalidate keys for
+// ONE key candidate: the same template renders the same byte-identical key
+// wherever it is used, so the read and write key spaces cannot silently
+// diverge. The final key is "<prefix>:<16-hex xxhash64 of the preimage>",
+// where the preimage is "<prefix>:<canonical rendered key JSON>". L1 and L2
+// share these keys (derive once; the L1 store reuses them from task 17 on).
+type cacheKeyTemplate struct {
+	// prefix is the visible key prefix: the policy's CacheName, plus the
+	// subgraph header hash when the policy varies by headers.
+	prefix string
+	// representation is the frozen @key template node for this candidate.
+	representation *resolve.Object
+}
+
+// newCacheKeyTemplates derives one template per candidate for a fetch, from
+// the config and the request's subgraph header hash.
+func newCacheKeyTemplates(cfg *resolve.FetchCacheConfig, headerHash uint64) []cacheKeyTemplate {
+	prefix := cacheKeyPrefix(cfg, headerHash)
+	templates := make([]cacheKeyTemplate, 0, len(cfg.KeySpec.Candidates))
+	for _, candidate := range cfg.KeySpec.Candidates {
+		templates = append(templates, cacheKeyTemplate{
+			prefix:         prefix,
+			representation: candidate.Representation,
+		})
+	}
+	return templates
+}
+
+// render produces the candidate's key for one entity item, best-effort: it
+// returns ok=false when any referenced key field is absent or null in the
+// item (an unrenderable candidate is skipped, never an error).
+func (t cacheKeyTemplate) render(item *astjson.Value) (string, bool) {
+	if t.representation == nil || item == nil {
+		return "", false
+	}
+	typename := item.Get("__typename")
+	if typename == nil {
+		// Entity items always carry __typename in federation responses; the
+		// template's type name stands in when a caller renders from a value
+		// that legitimately lacks it (e.g. argument-derived lookups, task 15).
+		if t.representation.TypeName == "" {
+			return "", false
+		}
+		typename = astjson.StringValue(nil, t.representation.TypeName)
+	}
+	keyObj := astjson.ObjectValue(nil)
+	keyObj.Set(nil, "__typename", typename)
+	keysObj := astjson.ObjectValue(nil)
+	renderedFields := 0
+	for _, field := range t.representation.Fields {
+		name := string(field.Name)
+		if name == "__typename" {
+			continue
+		}
+		value, ok := renderRepresentationValue(field.Value, item.Get(name))
+		if !ok {
+			return "", false
+		}
+		keysObj.Set(nil, name, value)
+		renderedFields++
+	}
+	if renderedFields == 0 {
+		// A key without any key field would collide across all entities of the
+		// type; treat it as unrenderable.
+		return "", false
+	}
+	keyObj.Set(nil, "key", keysObj)
+	return renderCacheKey(t.prefix, keyObj.MarshalTo(nil)), true
+}
+
+// renderRepresentationValue extracts the canonical key value for one template
+// node from the item: objects recurse over the template's fields, scalars pass
+// through (numbers canonicalized to their JSON string so 1 and 1.0 cannot
+// split the key space); a null or absent value makes the candidate
+// unrenderable.
+func renderRepresentationValue(node resolve.Node, value *astjson.Value) (*astjson.Value, bool) {
+	if value == nil || value.Type() == astjson.TypeNull {
+		return nil, false
+	}
+	switch typed := node.(type) {
+	case *resolve.Object:
+		if value.Type() != astjson.TypeObject {
+			return nil, false
+		}
+		out := astjson.ObjectValue(nil)
+		rendered := 0
+		for _, field := range typed.Fields {
+			name := string(field.Name)
+			if name == "__typename" {
+				continue
+			}
+			child, ok := renderRepresentationValue(field.Value, value.Get(name))
+			if !ok {
+				return nil, false
+			}
+			out.Set(nil, name, child)
+			rendered++
+		}
+		return out, rendered > 0
+	default:
+		if value.Type() == astjson.TypeNumber {
+			return astjson.StringValue(nil, string(value.MarshalTo(nil))), true
+		}
+		return value, true
+	}
+}
+
+// cacheKeyPrefix returns the visible key prefix: the policy's CacheName, plus
+// "h<headerHash>" when the policy folds the subgraph header hash into the key
+// (the sole vary-by knob).
+func cacheKeyPrefix(cfg *resolve.FetchCacheConfig, headerHash uint64) string {
+	if cfg == nil {
+		return ""
+	}
+	if cfg.IncludeSubgraphHeaderPrefix {
+		return cfg.CacheName + ":h" + hex64(headerHash)
+	}
+	return cfg.CacheName
+}
+
+// renderCacheKey hashes the preimage "<prefix>:<payload>" with the pooled
+// xxhash64 and returns "<prefix>:<16-hex sum>" (or the bare sum when there is
+// no prefix).
+func renderCacheKey(prefix string, payload []byte) string {
+	if prefix == "" {
+		return hashHex(payload)
+	}
+	preimage := make([]byte, 0, len(prefix)+1+len(payload))
+	preimage = append(preimage, prefix...)
+	preimage = append(preimage, ':')
+	preimage = append(preimage, payload...)
+	return prefix + ":" + hashHex(preimage)
+}
+
+func hashHex(value []byte) string {
+	h := pool.Hash64.Get()
+	_, _ = h.Write(value)
+	sum := h.Sum64()
+	pool.Hash64.Put(h)
+	return hex64(sum)
+}
+
+func hex64(sum uint64) string {
+	var buf [16]byte
+	const digits = "0123456789abcdef"
+	for i := 15; i >= 0; i-- {
+		buf[i] = digits[sum&0xf]
+		sum >>= 4
+	}
+	return string(buf[:])
+}

--- a/v2/pkg/engine/cache/cachetesting/fakes.go
+++ b/v2/pkg/engine/cache/cachetesting/fakes.go
@@ -1,0 +1,509 @@
+// Package cachetesting provides the shared, cosmo-free test doubles for the
+// caching implementation: a recording controller/request-cache pair, an
+// in-memory L2 store with an ordered op log, a gate-channel datasource for
+// deterministic ordering, and a registry that swaps real plan datasources for
+// in-process fakes. Time and TTLs are never faked here — tests wrap
+// time-dependent bodies in testing/synctest, which fakes the real time calls.
+package cachetesting
+
+import (
+	"context"
+	"net/http"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wundergraph/astjson"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/datasource/httpclient"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// Call is one normalized cache-hook invocation recorded by FakeRequestCache,
+// with every loader-supplied signal flattened for full-value assertions.
+type Call struct {
+	Op           string
+	FetchPath    string
+	Items        int
+	InputBytes   string
+	HeaderHash   uint64
+	ResponseData string
+	MergePath    []string
+	HasErrors    bool
+	FetchFailed  bool
+	EmptyEntity  bool
+	StatusCode   int
+	Decision     resolve.Decision
+}
+
+// ScriptedDecision is what FakeRequestCache returns for a fetch path.
+type ScriptedDecision struct {
+	Decision resolve.Decision
+	Handle   *resolve.FetchCacheHandle
+}
+
+// StoreOp is one entry of FakeStore's ordered operation log.
+type StoreOp struct {
+	Kind  string // "Get" or "Set"
+	Key   string
+	Value string        // set only for "Set"
+	TTL   time.Duration // set only for "Set"
+}
+
+// FakeCacheController counts BeginRequest calls and hands out a fixed
+// RequestCache, so lifecycle laziness (exactly one BeginRequest per request)
+// is observable.
+type FakeCacheController struct {
+	begins atomic.Int64
+	rc     resolve.RequestCache
+}
+
+func NewFakeCacheController(rc resolve.RequestCache) *FakeCacheController {
+	return &FakeCacheController{rc: rc}
+}
+
+func (f *FakeCacheController) BeginRequest(*resolve.Context) resolve.RequestCache {
+	f.begins.Add(1)
+	return f.rc
+}
+
+// Begins returns how often BeginRequest ran.
+func (f *FakeCacheController) Begins() int64 {
+	return f.begins.Load()
+}
+
+// FakeRequestCache records every hook invocation as a normalized Call and
+// returns scripted decisions keyed by the fetch's response path. It is safe
+// for concurrent use (parallel fetches within one request).
+type FakeRequestCache struct {
+	mu            sync.Mutex
+	calls         []Call
+	resultHandles []*resolve.FetchCacheHandle
+	script        map[string]ScriptedDecision
+	errs          map[string]error
+}
+
+func NewFakeRequestCache(script map[string]ScriptedDecision) *FakeRequestCache {
+	return &FakeRequestCache{
+		script: script,
+		errs:   make(map[string]error),
+	}
+}
+
+// SetError makes the given hook ("Skipped" or "Result") fail for a fetch path.
+func (f *FakeRequestCache) SetError(fetchPath, op string, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.errs[fetchPath+op] = err
+}
+
+func (f *FakeRequestCache) PrepareFetch(in resolve.PrepareFetchInput) (resolve.Decision, *resolve.FetchCacheHandle) {
+	path := pathOf(in.Item)
+	scripted := f.script[path]
+	f.record(Call{
+		Op:         "Prepare",
+		FetchPath:  path,
+		Items:      len(in.Items),
+		InputBytes: string(in.Input),
+		HeaderHash: in.HeaderHash,
+		Decision:   scripted.Decision,
+	})
+	return scripted.Decision, scripted.Handle
+}
+
+func (f *FakeRequestCache) OnFetchSkipped(h *resolve.FetchCacheHandle, in resolve.MergeInput) error {
+	path := pathOf(in.Item)
+	f.record(mergeCall("Skipped", path, in))
+	return f.err(path, "Skipped")
+}
+
+func (f *FakeRequestCache) OnFetchResult(h *resolve.FetchCacheHandle, in resolve.MergeInput) error {
+	path := pathOf(in.Item)
+	f.recordResultHandle(h)
+	f.record(mergeCall("Result", path, in))
+	return f.err(path, "Result")
+}
+
+func (f *FakeRequestCache) EndRequest() {
+	f.record(Call{Op: "End"})
+}
+
+// Calls returns a copy of the recorded calls in invocation order.
+func (f *FakeRequestCache) Calls() []Call {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return slices.Clone(f.calls)
+}
+
+// ResultHandles returns the handles OnFetchResult received, in order, so tests
+// can assert pointer identity with the handle PrepareFetch returned.
+func (f *FakeRequestCache) ResultHandles() []*resolve.FetchCacheHandle {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return slices.Clone(f.resultHandles)
+}
+
+func (f *FakeRequestCache) record(call Call) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, call)
+}
+
+func (f *FakeRequestCache) recordResultHandle(h *resolve.FetchCacheHandle) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.resultHandles = append(f.resultHandles, h)
+}
+
+func (f *FakeRequestCache) err(path, op string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.errs[path+op]
+}
+
+// RecordingController bundles a FakeCacheController with its FakeRequestCache
+// for the common "one recording cache per test" case.
+type RecordingController struct {
+	controller *FakeCacheController
+	request    *FakeRequestCache
+}
+
+func NewRecordingController(script map[string]ScriptedDecision) *RecordingController {
+	request := NewFakeRequestCache(script)
+	return &RecordingController{
+		controller: NewFakeCacheController(request),
+		request:    request,
+	}
+}
+
+func (r *RecordingController) BeginRequest(ctx *resolve.Context) resolve.RequestCache {
+	return r.controller.BeginRequest(ctx)
+}
+
+func (r *RecordingController) Calls() []Call {
+	return r.request.Calls()
+}
+
+func (r *RecordingController) Begins() int64 {
+	return r.controller.Begins()
+}
+
+func (r *RecordingController) ResultHandles() []*resolve.FetchCacheHandle {
+	return r.request.ResultHandles()
+}
+
+// StoredEntry is one FakeStore value with its absolute expiry.
+type StoredEntry struct {
+	Value     []byte
+	ExpiresAt time.Time
+}
+
+// FakeStore is the in-memory L2 store double: values with absolute ExpiresAt
+// (real time.Now, faked by synctest in tests) and an ordered StoreOp log.
+// A Get past expiry is a miss; expired entries are not purged, so the log
+// stays complete.
+type FakeStore struct {
+	mu   sync.Mutex
+	data map[string]StoredEntry
+	ops  []StoreOp
+}
+
+func NewFakeStore() *FakeStore {
+	return &FakeStore{data: make(map[string]StoredEntry)}
+}
+
+// Seed inserts a value WITHOUT logging an op, for arranging preconditions.
+func (s *FakeStore) Seed(key string, v []byte, ttl time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[key] = StoredEntry{
+		Value:     slices.Clone(v),
+		ExpiresAt: time.Now().Add(ttl),
+	}
+}
+
+func (s *FakeStore) Set(key string, v []byte, ttl time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[key] = StoredEntry{
+		Value:     slices.Clone(v),
+		ExpiresAt: time.Now().Add(ttl),
+	}
+	s.ops = append(s.ops, StoreOp{Kind: "Set", Key: key, Value: string(v), TTL: ttl})
+}
+
+func (s *FakeStore) Get(key string) (StoredEntry, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ops = append(s.ops, StoreOp{Kind: "Get", Key: key})
+	entry, ok := s.data[key]
+	if !ok || !time.Now().Before(entry.ExpiresAt) {
+		return StoredEntry{}, false
+	}
+	entry.Value = slices.Clone(entry.Value)
+	return entry, true
+}
+
+// Ops returns a copy of the ordered operation log.
+func (s *FakeStore) Ops() []StoreOp {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.ops)
+}
+
+// GatedDataSource is an in-process DataSource whose Load can be ordered
+// deterministically with gate channels: it announces arrival on Arrived, then
+// blocks until Release yields, then returns Resp/Err. Nil channels skip the
+// respective step. Tests coordinate the channels with synctest.Wait — never
+// with latency sleeps.
+type GatedDataSource struct {
+	Name        string
+	Resp        []byte
+	Err         error
+	Arrived     chan<- string
+	Release     <-chan struct{}
+	LoadCounter *atomic.Int64
+}
+
+// DataSourceGate is the per-fetch gate configuration FakeRegistry attaches to
+// a swapped datasource.
+type DataSourceGate struct {
+	Arrived chan<- string
+	Release <-chan struct{}
+}
+
+func (g *GatedDataSource) Load(ctx context.Context, headers http.Header, input []byte) ([]byte, error) {
+	if g.LoadCounter != nil {
+		g.LoadCounter.Add(1)
+	}
+	if g.Arrived != nil {
+		g.Arrived <- g.Name
+	}
+	if g.Release != nil {
+		<-g.Release
+	}
+	return g.Resp, g.Err
+}
+
+func (g *GatedDataSource) LoadWithFiles(context.Context, http.Header, []byte, []*httpclient.FileUpload) ([]byte, error) {
+	panic("cache tests never upload files")
+}
+
+// RecordingObserver is the CacheObserver double: it counts lifecycle calls and
+// records the handles and shadow-compare cache keys it sees. The compare
+// itself is controller logic (task 12); the observer only records.
+type RecordingObserver struct {
+	mu              sync.Mutex
+	beginRequests   int
+	endRequests     int
+	observedHandles []*resolve.FetchCacheHandle
+	shadowKeys      []string
+}
+
+func (o *RecordingObserver) BeginRequest(ctx *resolve.Context) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.beginRequests++
+}
+
+func (o *RecordingObserver) EndRequest(ctx *resolve.Context) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.endRequests++
+}
+
+func (o *RecordingObserver) OnFetchObserved(h *resolve.FetchCacheHandle) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.observedHandles = append(o.observedHandles, h)
+}
+
+func (o *RecordingObserver) CompareShadow(h *resolve.FetchCacheHandle, fresh *astjson.Value, tx *resolve.CacheTransaction) {
+	if h == nil {
+		return
+	}
+	keys := make([]string, 0, len(h.ShadowStash))
+	for _, entry := range h.ShadowStash {
+		keys = append(keys, entry.CacheKey)
+	}
+	slices.Sort(keys)
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.shadowKeys = append(o.shadowKeys, keys...)
+}
+
+func (o *RecordingObserver) OnEntity(h *resolve.FetchCacheHandle, entity *astjson.Value) {}
+
+func (o *RecordingObserver) OnFieldValue(coordinate resolve.GraphCoordinate, value resolve.FieldValue) {
+}
+
+// Counts returns (beginRequests, endRequests).
+func (o *RecordingObserver) Counts() (int, int) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.beginRequests, o.endRequests
+}
+
+// ObservedHandles returns the handles passed to OnFetchObserved, in order.
+func (o *RecordingObserver) ObservedHandles() []*resolve.FetchCacheHandle {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return slices.Clone(o.observedHandles)
+}
+
+// ShadowKeys returns the recorded shadow-compare cache keys.
+func (o *RecordingObserver) ShadowKeys() []string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return slices.Clone(o.shadowKeys)
+}
+
+// FakeRegistry hands out GatedDataSources with canned responses and tracks
+// per-fetch load counts, so tests can assert "no network on a hit" without a
+// socket.
+type FakeRegistry struct {
+	mu        sync.Mutex
+	responses map[string]string
+	release   chan struct{}
+	loads     map[string]*atomic.Int64
+	gates     map[string]DataSourceGate
+}
+
+// NewFakeRegistry builds a registry over canned responses. Response keys are
+// tried in order: "DataSourceName:ResponsePath", "DataSourceName",
+// "ResponsePath", "*".
+func NewFakeRegistry(responses map[string]string) *FakeRegistry {
+	release := make(chan struct{})
+	close(release) // ungated by default: Load returns immediately
+	return &FakeRegistry{
+		responses: responses,
+		release:   release,
+		loads:     make(map[string]*atomic.Int64),
+	}
+}
+
+// SetGate attaches gate channels to the datasource identified by name + path;
+// call it before SwapDataSources.
+func (r *FakeRegistry) SetGate(name, path string, gate DataSourceGate) {
+	key := name + ":" + path
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.gates == nil {
+		r.gates = make(map[string]DataSourceGate)
+	}
+	r.gates[key] = gate
+}
+
+// SwapDataSources walks a fetch tree and replaces every fetch's transport with
+// a registry-backed GatedDataSource (via Fetch.SetDataSource — no switch over
+// concrete fetch types).
+func SwapDataSources(node *resolve.FetchTreeNode, reg *FakeRegistry) {
+	if node == nil || reg == nil {
+		return
+	}
+	if node.Item != nil && node.Item.Fetch != nil {
+		node.Item.Fetch.SetDataSource(reg.dataSourceFor(node.Item))
+	}
+	for _, child := range node.ChildNodes {
+		SwapDataSources(child, reg)
+	}
+}
+
+// LoadCount returns how often the datasource identified by name + path loaded.
+func (r *FakeRegistry) LoadCount(name, path string) int64 {
+	return r.loadCounter(name, path).Load()
+}
+
+func (r *FakeRegistry) dataSourceFor(item *resolve.FetchItem) resolve.DataSource {
+	name := dataSourceName(item)
+	path := pathOf(item)
+	resp := r.responseFor(name, path)
+	gate := r.gateFor(name, path)
+	var release <-chan struct{} = r.release
+	if gate.Release != nil {
+		release = gate.Release
+	}
+	return &GatedDataSource{
+		Name:        name,
+		Resp:        []byte(resp),
+		Arrived:     gate.Arrived,
+		Release:     release,
+		LoadCounter: r.loadCounter(name, path),
+	}
+}
+
+func (r *FakeRegistry) gateFor(name, path string) DataSourceGate {
+	key := name + ":" + path
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.gates[key]
+}
+
+func (r *FakeRegistry) loadCounter(name, path string) *atomic.Int64 {
+	key := name + ":" + path
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	counter := r.loads[key]
+	if counter == nil {
+		counter = &atomic.Int64{}
+		r.loads[key] = counter
+	}
+	return counter
+}
+
+func (r *FakeRegistry) responseFor(name, path string) string {
+	keys := []string{name + ":" + path, name, path, "*"}
+	for _, key := range keys {
+		if value, ok := r.responses[key]; ok {
+			return value
+		}
+	}
+	return ""
+}
+
+// Compact normalizes a JSON string for full-value response assertions.
+func Compact(tb testing.TB, s string) string {
+	tb.Helper()
+	v, err := astjson.ParseBytes([]byte(s))
+	if err != nil {
+		tb.Fatalf("compact json: %v", err)
+	}
+	return string(v.MarshalTo(nil))
+}
+
+func pathOf(item *resolve.FetchItem) string {
+	if item == nil {
+		return ""
+	}
+	return item.ResponsePath
+}
+
+func dataSourceName(item *resolve.FetchItem) string {
+	if item == nil || item.Fetch == nil || item.Fetch.FetchInfo() == nil {
+		return ""
+	}
+	return item.Fetch.FetchInfo().DataSourceName
+}
+
+func mergeCall(op, path string, in resolve.MergeInput) Call {
+	return Call{
+		Op:           op,
+		FetchPath:    path,
+		Items:        len(in.Items),
+		ResponseData: string(valueBytes(in.ResponseData)),
+		MergePath:    slices.Clone(in.MergePath),
+		HasErrors:    in.HasErrors,
+		FetchFailed:  in.FetchFailed,
+		EmptyEntity:  in.EmptyEntity,
+		StatusCode:   in.StatusCode,
+	}
+}
+
+func valueBytes(v *astjson.Value) []byte {
+	if v == nil {
+		return nil
+	}
+	return v.MarshalTo(nil)
+}

--- a/v2/pkg/engine/cache/cachetesting/fakes.go
+++ b/v2/pkg/engine/cache/cachetesting/fakes.go
@@ -464,13 +464,24 @@ func SwapDataSources(node *resolve.FetchTreeNode, reg *FakeRegistry) {
 	}
 }
 
-// LoadCount returns how often the datasource identified by name + path loaded.
+// LoadCount returns how often the datasource identified by name + path
+// loaded, or -1 when no such datasource was ever swapped in (counters are
+// created eagerly at swap time) — a typo'd name/path pair can then never
+// satisfy a zero-loads assertion vacuously.
 func (r *FakeRegistry) LoadCount(name, path string) int64 {
-	return r.loadCounter(name, path).Load()
+	key := name + ":" + path
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	counter := r.loads[key]
+	if counter == nil {
+		return -1
+	}
+	return counter.Load()
 }
 
 // Inputs returns the exact input bytes every Load of the datasource
-// identified by name + path received, in order.
+// identified by name + path received, in order. An unknown pair returns nil —
+// assert LoadCount alongside when "no inputs" is the expectation.
 func (r *FakeRegistry) Inputs(name, path string) []string {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/v2/pkg/engine/cache/cachetesting/fakes.go
+++ b/v2/pkg/engine/cache/cachetesting/fakes.go
@@ -7,6 +7,7 @@
 package cachetesting
 
 import (
+	"cmp"
 	"context"
 	"net/http"
 	"slices"
@@ -291,15 +292,25 @@ func (g *GatedDataSource) LoadWithFiles(context.Context, http.Header, []byte, []
 	panic("cache tests never upload files")
 }
 
-// RecordingObserver is the CacheObserver double: it counts lifecycle calls and
-// records the handles and shadow-compare cache keys it sees. The compare
-// itself is controller logic (task 12); the observer only records.
+// ShadowCompare is one recorded shadow probe: the stashed entry's key, its
+// age (CacheTTL - RemainingTTL), and whether the cached bytes equal the fresh
+// value the fetch produced for that item.
+type ShadowCompare struct {
+	CacheKey string
+	IsFresh  bool
+	CacheAge time.Duration
+}
+
+// RecordingObserver is the CacheObserver double: it counts lifecycle calls,
+// records the handles it sees, and materializes shadow compares (byte
+// equality of stashed vs fresh, per item). Production observer wiring arrives
+// with ART (task 20); this double pins the compare inputs.
 type RecordingObserver struct {
 	mu              sync.Mutex
 	beginRequests   int
 	endRequests     int
 	observedHandles []*resolve.FetchCacheHandle
-	shadowKeys      []string
+	compares        []ShadowCompare
 }
 
 func (o *RecordingObserver) BeginRequest(ctx *resolve.Context) {
@@ -324,14 +335,40 @@ func (o *RecordingObserver) CompareShadow(h *resolve.FetchCacheHandle, fresh *as
 	if h == nil {
 		return
 	}
-	keys := make([]string, 0, len(h.ShadowStash))
-	for _, entry := range h.ShadowStash {
-		keys = append(keys, entry.CacheKey)
+	var batch []*astjson.Value
+	if h.BatchEntityKey && fresh != nil {
+		batch = fresh.GetArray()
 	}
-	slices.Sort(keys)
+	compares := make([]ShadowCompare, 0, len(h.ShadowStash))
+	for itemIndex, entry := range h.ShadowStash {
+		freshValue := fresh
+		if h.BatchEntityKey {
+			freshValue = nil
+			if itemIndex >= 0 && itemIndex < len(h.Items) {
+				if batchIndex := h.Items[itemIndex].BatchIndex; batchIndex >= 0 && batchIndex < len(batch) {
+					freshValue = batch[batchIndex]
+				}
+			}
+		}
+		compares = append(compares, ShadowCompare{
+			CacheKey: entry.CacheKey,
+			IsFresh:  string(marshalValue(entry.CachedValue)) == string(marshalValue(freshValue)),
+			CacheAge: entry.CacheTTL - entry.RemainingTTL,
+		})
+	}
+	slices.SortFunc(compares, func(a, b ShadowCompare) int {
+		return cmp.Compare(a.CacheKey, b.CacheKey)
+	})
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	o.shadowKeys = append(o.shadowKeys, keys...)
+	o.compares = append(o.compares, compares...)
+}
+
+func marshalValue(v *astjson.Value) []byte {
+	if v == nil {
+		return nil
+	}
+	return v.MarshalTo(nil)
 }
 
 func (o *RecordingObserver) OnEntity(h *resolve.FetchCacheHandle, entity *astjson.Value) {}
@@ -353,11 +390,11 @@ func (o *RecordingObserver) ObservedHandles() []*resolve.FetchCacheHandle {
 	return slices.Clone(o.observedHandles)
 }
 
-// ShadowKeys returns the recorded shadow-compare cache keys.
-func (o *RecordingObserver) ShadowKeys() []string {
+// Compares returns the recorded shadow probes, sorted by cache key per call.
+func (o *RecordingObserver) Compares() []ShadowCompare {
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	return slices.Clone(o.shadowKeys)
+	return slices.Clone(o.compares)
 }
 
 // FakeRegistry hands out GatedDataSources with canned responses and tracks

--- a/v2/pkg/engine/cache/cachetesting/fakes.go
+++ b/v2/pkg/engine/cache/cachetesting/fakes.go
@@ -292,7 +292,7 @@ func (g *GatedDataSource) Load(ctx context.Context, headers http.Header, input [
 		g.LoadCounter.Add(1)
 	}
 	if g.RecordInput != nil {
-		g.RecordInput(slices.Clone(input))
+		g.RecordInput(input) // the recorder copies (string conversion) only while under its cap
 	}
 	if g.Arrived != nil {
 		g.Arrived <- g.Name
@@ -477,10 +477,18 @@ func (r *FakeRegistry) Inputs(name, path string) []string {
 	return slices.Clone(r.inputs[name+":"+path])
 }
 
+// maxRecordedInputs bounds per-datasource input recording so long-running
+// callers (benchmarks) do not accumulate unbounded copies; assertions read
+// the first loads, which is what the e2e rows need.
+const maxRecordedInputs = 16
+
 func (r *FakeRegistry) recordInput(key string) func([]byte) {
 	return func(input []byte) {
 		r.mu.Lock()
 		defer r.mu.Unlock()
+		if len(r.inputs[key]) >= maxRecordedInputs {
+			return
+		}
 		if r.inputs == nil {
 			r.inputs = make(map[string][]string)
 		}

--- a/v2/pkg/engine/cache/cachetesting/fakes.go
+++ b/v2/pkg/engine/cache/cachetesting/fakes.go
@@ -266,6 +266,9 @@ type GatedDataSource struct {
 	Arrived     chan<- string
 	Release     <-chan struct{}
 	LoadCounter *atomic.Int64
+	// RecordInput (optional) receives every Load's input bytes, so tests can
+	// assert the EXACT request the subgraph saw (e.g. partial-batch filtering).
+	RecordInput func(input []byte)
 }
 
 // DataSourceGate is the per-fetch gate configuration FakeRegistry attaches to
@@ -278,6 +281,9 @@ type DataSourceGate struct {
 func (g *GatedDataSource) Load(ctx context.Context, headers http.Header, input []byte) ([]byte, error) {
 	if g.LoadCounter != nil {
 		g.LoadCounter.Add(1)
+	}
+	if g.RecordInput != nil {
+		g.RecordInput(slices.Clone(input))
 	}
 	if g.Arrived != nil {
 		g.Arrived <- g.Name
@@ -406,6 +412,7 @@ type FakeRegistry struct {
 	release   chan struct{}
 	loads     map[string]*atomic.Int64
 	gates     map[string]DataSourceGate
+	inputs    map[string][]string
 }
 
 // NewFakeRegistry builds a registry over canned responses. Response keys are
@@ -453,6 +460,25 @@ func (r *FakeRegistry) LoadCount(name, path string) int64 {
 	return r.loadCounter(name, path).Load()
 }
 
+// Inputs returns the exact input bytes every Load of the datasource
+// identified by name + path received, in order.
+func (r *FakeRegistry) Inputs(name, path string) []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return slices.Clone(r.inputs[name+":"+path])
+}
+
+func (r *FakeRegistry) recordInput(key string) func([]byte) {
+	return func(input []byte) {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		if r.inputs == nil {
+			r.inputs = make(map[string][]string)
+		}
+		r.inputs[key] = append(r.inputs[key], string(input))
+	}
+}
+
 func (r *FakeRegistry) dataSourceFor(item *resolve.FetchItem) resolve.DataSource {
 	name := dataSourceName(item)
 	path := pathOf(item)
@@ -468,6 +494,7 @@ func (r *FakeRegistry) dataSourceFor(item *resolve.FetchItem) resolve.DataSource
 		Arrived:     gate.Arrived,
 		Release:     release,
 		LoadCounter: r.loadCounter(name, path),
+		RecordInput: r.recordInput(name + ":" + path),
 	}
 }
 

--- a/v2/pkg/engine/cache/cachetesting/fakes.go
+++ b/v2/pkg/engine/cache/cachetesting/fakes.go
@@ -254,6 +254,15 @@ func (s *FakeStore) Ops() []StoreOp {
 	return slices.Clone(s.ops)
 }
 
+// ResetOps clears the operation log (the DATA stays), so a multi-request test
+// can assert each request's ops in isolation instead of re-listing the
+// accumulated history.
+func (s *FakeStore) ResetOps() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ops = nil
+}
+
 // GatedDataSource is an in-process DataSource whose Load can be ordered
 // deterministically with gate channels: it announces arrival on Arrived, then
 // blocks until Release yields, then returns Resp/Err. Nil channels skip the

--- a/v2/pkg/engine/cache/cachetesting/fakes_test.go
+++ b/v2/pkg/engine/cache/cachetesting/fakes_test.go
@@ -1,0 +1,206 @@
+package cachetesting
+
+import (
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/astjson"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// TestFakeStoreTTLExpiry proves TTL semantics against the real clock inside a
+// synctest bubble: a value is served before its TTL and is a miss after the
+// bubble's fake time passes it, with the full op log recorded.
+func TestFakeStoreTTLExpiry(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		store := NewFakeStore()
+		store.Set("product:1", []byte(`{"name":"Table"}`), time.Second)
+
+		entry, ok := store.Get("product:1")
+		require.True(t, ok)
+		assert.Equal(t, []byte(`{"name":"Table"}`), entry.Value)
+
+		time.Sleep(2 * time.Second) // advances fake time past the TTL
+
+		_, ok = store.Get("product:1")
+		assert.False(t, ok)
+
+		assert.Equal(t, []StoreOp{
+			{Kind: "Set", Key: "product:1", Value: `{"name":"Table"}`, TTL: time.Second},
+			{Kind: "Get", Key: "product:1"},
+			{Kind: "Get", Key: "product:1"},
+		}, store.Ops())
+	})
+}
+
+// TestFakeStoreSeedDoesNotLog pins that Seed arranges state without polluting
+// the op log.
+func TestFakeStoreSeedDoesNotLog(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		store := NewFakeStore()
+		store.Seed("user:1", []byte(`{"username":"me"}`), time.Minute)
+
+		entry, ok := store.Get("user:1")
+		require.True(t, ok)
+		assert.Equal(t, []byte(`{"username":"me"}`), entry.Value)
+		assert.Equal(t, []StoreOp{
+			{Kind: "Get", Key: "user:1"},
+		}, store.Ops())
+	})
+}
+
+// TestGatedDataSourceOrdering proves the gate semantics: Load announces
+// arrival, blocks until released (observable via synctest.Wait, never via
+// latency), and then returns the canned response.
+func TestGatedDataSourceOrdering(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		arrived := make(chan string, 1)
+		release := make(chan struct{})
+		counter := &atomic.Int64{}
+		ds := &GatedDataSource{
+			Name:        "products",
+			Resp:        []byte(`{"data":{}}`),
+			Arrived:     arrived,
+			Release:     release,
+			LoadCounter: counter,
+		}
+
+		var done atomic.Bool
+		var out []byte
+		var err error
+		go func() {
+			out, err = ds.Load(t.Context(), nil, []byte(`{}`))
+			done.Store(true)
+		}()
+
+		synctest.Wait()
+		assert.Equal(t, "products", <-arrived)
+		assert.Equal(t, int64(1), counter.Load())
+		assert.False(t, done.Load()) // still gated
+
+		close(release)
+		synctest.Wait()
+		assert.True(t, done.Load())
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`{"data":{}}`), out)
+	})
+}
+
+// TestFakeRequestCacheRecordsCalls pins the full normalized Call log across
+// all four hooks, including scripted decisions and the merge-path carrier.
+func TestFakeRequestCacheRecordsCalls(t *testing.T) {
+	handle := &resolve.FetchCacheHandle{Decision: resolve.DecisionSkipFullHit}
+	fake := NewFakeRequestCache(map[string]ScriptedDecision{
+		"topProducts": {Decision: resolve.DecisionSkipFullHit, Handle: handle},
+	})
+
+	item := &resolve.FetchItem{ResponsePath: "topProducts"}
+	items := []*astjson.Value{astjson.MustParseBytes([]byte(`{"upc":"1"}`))}
+
+	decision, gotHandle := fake.PrepareFetch(resolve.PrepareFetchInput{
+		Item:       item,
+		Items:      items,
+		Input:      []byte(`{"query":"{topProducts{upc}}"}`),
+		HeaderHash: 42,
+	})
+	assert.Equal(t, resolve.DecisionSkipFullHit, decision)
+	assert.Same(t, handle, gotHandle)
+
+	responseData := astjson.MustParseBytes([]byte(`{"topProducts":[{"upc":"1"}]}`))
+	require.NoError(t, fake.OnFetchSkipped(handle, resolve.MergeInput{
+		Item:  item,
+		Items: items,
+	}))
+	require.NoError(t, fake.OnFetchResult(handle, resolve.MergeInput{
+		Item:         item,
+		Items:        items,
+		ResponseData: responseData,
+		MergePath:    []string{"nested"},
+		HasErrors:    true,
+		FetchFailed:  true,
+		EmptyEntity:  true,
+		StatusCode:   500,
+	}))
+	fake.EndRequest()
+
+	assert.Equal(t, []Call{
+		{
+			Op:         "Prepare",
+			FetchPath:  "topProducts",
+			Items:      1,
+			InputBytes: `{"query":"{topProducts{upc}}"}`,
+			HeaderHash: 42,
+			Decision:   resolve.DecisionSkipFullHit,
+		},
+		{
+			Op:        "Skipped",
+			FetchPath: "topProducts",
+			Items:     1,
+		},
+		{
+			Op:           "Result",
+			FetchPath:    "topProducts",
+			Items:        1,
+			ResponseData: `{"topProducts":[{"upc":"1"}]}`,
+			MergePath:    []string{"nested"},
+			HasErrors:    true,
+			FetchFailed:  true,
+			EmptyEntity:  true,
+			StatusCode:   500,
+		},
+		{Op: "End"},
+	}, fake.Calls())
+
+	assert.Equal(t, []*resolve.FetchCacheHandle{handle}, fake.ResultHandles())
+}
+
+// TestFakeRegistrySwapDataSources pins the response-key fallback order and the
+// per-fetch load counting of swapped datasources.
+func TestFakeRegistrySwapDataSources(t *testing.T) {
+	reg := NewFakeRegistry(map[string]string{
+		"products:topProducts": `{"data":{"topProducts":[]}}`,
+		"reviews":              `{"data":{"_entities":[]}}`,
+		"*":                    `{"data":{}}`,
+	})
+
+	single := &resolve.SingleFetch{
+		Info: &resolve.FetchInfo{DataSourceName: "products"},
+	}
+	entity := &resolve.EntityFetch{
+		Info: &resolve.FetchInfo{DataSourceName: "reviews"},
+	}
+	other := &resolve.BatchEntityFetch{
+		Info: &resolve.FetchInfo{DataSourceName: "inventory"},
+	}
+	tree := &resolve.FetchTreeNode{
+		Kind: resolve.FetchTreeNodeKindSequence,
+		ChildNodes: []*resolve.FetchTreeNode{
+			{Kind: resolve.FetchTreeNodeKindSingle, Item: &resolve.FetchItem{Fetch: single, ResponsePath: "topProducts"}},
+			{Kind: resolve.FetchTreeNodeKindSingle, Item: &resolve.FetchItem{Fetch: entity, ResponsePath: "topProducts.reviews"}},
+			{Kind: resolve.FetchTreeNodeKindSingle, Item: &resolve.FetchItem{Fetch: other, ResponsePath: "other"}},
+		},
+	}
+	SwapDataSources(tree, reg)
+
+	load := func(ds resolve.DataSource) string {
+		t.Helper()
+		out, err := ds.Load(t.Context(), nil, nil)
+		require.NoError(t, err)
+		return string(out)
+	}
+
+	assert.Equal(t, `{"data":{"topProducts":[]}}`, load(single.FetchConfiguration.DataSource)) // name:path key
+	assert.Equal(t, `{"data":{"_entities":[]}}`, load(entity.DataSource))                      // name key
+	assert.Equal(t, `{"data":{}}`, load(other.DataSource))                                     // "*" fallback
+
+	assert.Equal(t, int64(1), reg.LoadCount("products", "topProducts"))
+	assert.Equal(t, int64(1), reg.LoadCount("reviews", "topProducts.reviews"))
+	assert.Equal(t, int64(1), reg.LoadCount("inventory", "other"))
+	assert.Equal(t, int64(0), reg.LoadCount("products", "unknown"))
+}

--- a/v2/pkg/engine/cache/cachetesting/fakes_test.go
+++ b/v2/pkg/engine/cache/cachetesting/fakes_test.go
@@ -202,5 +202,7 @@ func TestFakeRegistrySwapDataSources(t *testing.T) {
 	assert.Equal(t, int64(1), reg.LoadCount("products", "topProducts"))
 	assert.Equal(t, int64(1), reg.LoadCount("reviews", "topProducts.reviews"))
 	assert.Equal(t, int64(1), reg.LoadCount("inventory", "other"))
-	assert.Equal(t, int64(0), reg.LoadCount("products", "unknown"))
+	// A never-swapped name/path pair is -1, never 0: a typo cannot satisfy a
+	// zero-loads assertion vacuously.
+	assert.Equal(t, int64(-1), reg.LoadCount("products", "unknown"))
 }

--- a/v2/pkg/engine/cache/cachetesting/realish.go
+++ b/v2/pkg/engine/cache/cachetesting/realish.go
@@ -1,0 +1,33 @@
+package cachetesting
+
+import (
+	"time"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/cache"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// StoreAdapter adapts FakeStore to the cache.Store interface (remaining-TTL
+// view over the store's absolute expiries).
+type StoreAdapter struct {
+	Store *FakeStore
+}
+
+func (s StoreAdapter) Get(key string) ([]byte, time.Duration, bool) {
+	entry, ok := s.Store.Get(key)
+	if !ok {
+		return nil, 0, false
+	}
+	return entry.Value, time.Until(entry.ExpiresAt), true
+}
+
+func (s StoreAdapter) Set(key string, value []byte, ttl time.Duration) {
+	s.Store.Set(key, value, ttl)
+}
+
+// NewRealishCache builds the REAL cache controller over the in-memory
+// FakeStore, for end-to-end rows that exercise actual lookup/write behavior
+// instead of scripted decisions. obs may be nil.
+func NewRealishCache(store *FakeStore, obs resolve.CacheObserver) resolve.CacheController {
+	return cache.NewController(StoreAdapter{Store: store}, obs)
+}

--- a/v2/pkg/engine/cache/configure_caching.go
+++ b/v2/pkg/engine/cache/configure_caching.go
@@ -44,8 +44,9 @@ func NewConfigurator(providers map[string]cacheconfig.CacheConfigProvider, feder
 // response: fetchCacheConfigurator assembles and sets the per-fetch
 // *resolve.FetchCacheConfig, then optimizeL1Cache narrows cfg.L1 across all
 // trees. It must run AFTER createConcreteSingleFetchTypes (the concrete fetch
-// types carry the config) and BEFORE organizeFetchTree/buildDeferTree (it
-// expects the flat trees).
+// types carry the config); the passes walk flat AND organized trees alike,
+// and the defer pipeline calls it AFTER buildDeferTree so the group trees and
+// their ancestry come from the authoritative DeferTree.
 //
 // treeParents gives the narrowing pass the defer-group ancestry: one entry per
 // tree, the index of the tree whose group ENCLOSES it (-1 for a root). The

--- a/v2/pkg/engine/cache/configure_caching.go
+++ b/v2/pkg/engine/cache/configure_caching.go
@@ -1,0 +1,58 @@
+// Package cache is the ONE common home for all cache logic (PLAN.md D5): the
+// plan-side postprocess passes (key building, fetch config assembly, L1
+// narrowing) and, in later tasks, the runtime controller modules. The resolve
+// package holds only the contract types and never imports this package;
+// plan/postprocess hold only thin shims calling into it.
+package cache
+
+import (
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// Configurator orchestrates the caching postprocess passes over finished fetch
+// trees. It is constructed once per postprocess.Processor and holds the SINGLE
+// planner no-op gate: with no providers configured, ConfigureCaching returns
+// immediately and no fetch is ever touched.
+type Configurator struct {
+	providers    map[string]cacheconfig.CacheConfigProvider
+	configurator *fetchCacheConfigurator
+	l1           *optimizeL1Cache
+}
+
+// NewConfigurator builds the caching pass pipeline. providers and federation
+// are keyed by datasource ID; definition is the composed schema the key
+// builder resolves @key selection sets against.
+func NewConfigurator(providers map[string]cacheconfig.CacheConfigProvider, federation map[string]plan.FederationMetaData, definition *ast.Document) *Configurator {
+	keyBuilder := &cacheKeyBuilder{
+		federation: federation,
+		definition: definition,
+	}
+	return &Configurator{
+		providers: providers,
+		configurator: &fetchCacheConfigurator{
+			providers:  providers,
+			keyBuilder: keyBuilder,
+		},
+		l1: &optimizeL1Cache{},
+	}
+}
+
+// ConfigureCaching runs the caching passes over the given fetch trees of one
+// response: fetchCacheConfigurator assembles and sets the per-fetch
+// *resolve.FetchCacheConfig, then optimizeL1Cache narrows cfg.L1 across all
+// trees. It must run AFTER createConcreteSingleFetchTypes (the concrete fetch
+// types carry the config) and BEFORE organizeFetchTree/buildDeferTree (it
+// expects the flat trees).
+func (c *Configurator) ConfigureCaching(response *resolve.GraphQLResponse, trees ...*resolve.FetchTreeNode) {
+	if len(c.providers) == 0 {
+		// The single planner no-op gate: no caching configured, nothing runs.
+		return
+	}
+	for _, tree := range trees {
+		c.configurator.configureTree(response, tree)
+	}
+	c.l1.optimize(trees)
+}

--- a/v2/pkg/engine/cache/configure_caching.go
+++ b/v2/pkg/engine/cache/configure_caching.go
@@ -46,7 +46,14 @@ func NewConfigurator(providers map[string]cacheconfig.CacheConfigProvider, feder
 // trees. It must run AFTER createConcreteSingleFetchTypes (the concrete fetch
 // types carry the config) and BEFORE organizeFetchTree/buildDeferTree (it
 // expects the flat trees).
-func (c *Configurator) ConfigureCaching(response *resolve.GraphQLResponse, trees ...*resolve.FetchTreeNode) {
+//
+// treeParents gives the narrowing pass the defer-group ancestry: one entry per
+// tree, the index of the tree whose group ENCLOSES it (-1 for a root). The
+// resolver resolves a parent group fully before its children, so an ancestor
+// tree's fetches execute before every descendant tree's. Pass nil when there
+// is only the root tree (or when ancestry is unknown — the pass then assumes
+// only root-before-defers).
+func (c *Configurator) ConfigureCaching(response *resolve.GraphQLResponse, treeParents []int, trees ...*resolve.FetchTreeNode) {
 	if len(c.providers) == 0 {
 		// The single planner no-op gate: no caching configured, nothing runs.
 		return
@@ -54,5 +61,5 @@ func (c *Configurator) ConfigureCaching(response *resolve.GraphQLResponse, trees
 	for _, tree := range trees {
 		c.configurator.configureTree(response, tree)
 	}
-	c.l1.optimize(trees)
+	c.l1.optimize(trees, treeParents)
 }

--- a/v2/pkg/engine/cache/configure_caching_test.go
+++ b/v2/pkg/engine/cache/configure_caching_test.go
@@ -52,7 +52,7 @@ func TestConfigureCachingNoOpGate(t *testing.T) {
 		c := NewConfigurator(nil, nil, nil)
 		tree := fetchTreeFixture()
 		response := &resolve.GraphQLResponse{Fetches: tree}
-		c.ConfigureCaching(response, tree)
+		c.ConfigureCaching(response, nil, tree)
 		assert.Equal(t, fetchTreeFixture(), tree)
 		assert.Nil(t, tree.ChildNodes[0].Item.Fetch.CacheConfig())
 		assert.Nil(t, tree.ChildNodes[1].Item.Fetch.CacheConfig())
@@ -65,7 +65,7 @@ func TestConfigureCachingNoOpGate(t *testing.T) {
 		c := NewConfigurator(providers, nil, nil)
 		tree := fetchTreeFixture()
 		response := &resolve.GraphQLResponse{Fetches: tree}
-		c.ConfigureCaching(response, tree)
+		c.ConfigureCaching(response, nil, tree)
 		assert.Equal(t, fetchTreeFixture(), tree)
 		assert.Nil(t, tree.ChildNodes[0].Item.Fetch.CacheConfig())
 		assert.Nil(t, tree.ChildNodes[1].Item.Fetch.CacheConfig())

--- a/v2/pkg/engine/cache/configure_caching_test.go
+++ b/v2/pkg/engine/cache/configure_caching_test.go
@@ -1,0 +1,73 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// fetchTreeFixture builds a small flat fetch tree with one single fetch and
+// one entity fetch, mirroring what the caching passes receive from postprocess.
+func fetchTreeFixture() *resolve.FetchTreeNode {
+	return &resolve.FetchTreeNode{
+		Kind: resolve.FetchTreeNodeKindSequence,
+		ChildNodes: []*resolve.FetchTreeNode{
+			{
+				Kind: resolve.FetchTreeNodeKindSingle,
+				Item: &resolve.FetchItem{
+					Fetch: &resolve.SingleFetch{
+						FetchDependencies: resolve.FetchDependencies{FetchID: 1},
+						Info: &resolve.FetchInfo{
+							DataSourceID:   "products",
+							DataSourceName: "products",
+						},
+					},
+				},
+			},
+			{
+				Kind: resolve.FetchTreeNodeKindSingle,
+				Item: &resolve.FetchItem{
+					Fetch: &resolve.EntityFetch{
+						FetchDependencies: resolve.FetchDependencies{FetchID: 2, DependsOnFetchIDs: []int{1}},
+						Info: &resolve.FetchInfo{
+							DataSourceID:   "reviews",
+							DataSourceName: "reviews",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestConfigureCachingNoOpGate pins the single planner no-op gate: with no
+// providers, ConfigureCaching leaves the fetch tree byte-identical and stamps
+// no config; with providers configured, the task-03 skeletons are wired but
+// inert, so the tree is still untouched.
+func TestConfigureCachingNoOpGate(t *testing.T) {
+	t.Run("no providers configured", func(t *testing.T) {
+		c := NewConfigurator(nil, nil, nil)
+		tree := fetchTreeFixture()
+		response := &resolve.GraphQLResponse{Fetches: tree}
+		c.ConfigureCaching(response, tree)
+		assert.Equal(t, fetchTreeFixture(), tree)
+		assert.Nil(t, tree.ChildNodes[0].Item.Fetch.CacheConfig())
+		assert.Nil(t, tree.ChildNodes[1].Item.Fetch.CacheConfig())
+	})
+
+	t.Run("providers configured, skeleton passes are inert", func(t *testing.T) {
+		providers := map[string]cacheconfig.CacheConfigProvider{
+			"products": &cacheconfig.CachingConfiguration{},
+		}
+		c := NewConfigurator(providers, nil, nil)
+		tree := fetchTreeFixture()
+		response := &resolve.GraphQLResponse{Fetches: tree}
+		c.ConfigureCaching(response, tree)
+		assert.Equal(t, fetchTreeFixture(), tree)
+		assert.Nil(t, tree.ChildNodes[0].Item.Fetch.CacheConfig())
+		assert.Nil(t, tree.ChildNodes[1].Item.Fetch.CacheConfig())
+	})
+}

--- a/v2/pkg/engine/cache/controller.go
+++ b/v2/pkg/engine/cache/controller.go
@@ -230,9 +230,9 @@ func (r *requestCache) prepareItemState(tx *resolve.CacheTransaction, cfg *resol
 		state.FromCacheCandidates = append(state.FromCacheCandidates, hit.candidate)
 		parsed = append(parsed, hit.cached)
 	}
-	if selectMultiCandidateCacheValue(tx, &state, parsed, cfg.ProvidesData) {
-		state.FromCache = reorderToSelectionOrder(tx, state.FromCache, cfg.ProvidesData)
-	}
+	// The selected value stays in NORMALIZED (stored) form on the handle;
+	// OnFetchSkipped denormalizes it to the requesting aliases at splice time.
+	selectMultiCandidateCacheValue(tx, r.ctx, &state, parsed, cfg.ProvidesData)
 	return state, missedKeys, mustWriteBack || state.NeedsWriteback
 }
 
@@ -260,12 +260,15 @@ func (r *requestCache) OnFetchSkipped(h *resolve.FetchCacheHandle, in resolve.Me
 		if item.FromCache == nil || item.Item == nil {
 			continue
 		}
-		cached := tx.StructuralCopy(item.FromCache)
-		if cached.Type() == astjson.TypeNull {
+		if item.FromCache.Type() == astjson.TypeNull {
 			// Negative sentinels land with task 11; a null value has nothing
 			// to splice.
 			continue
 		}
+		// Denormalize the stored value to the requesting operation's aliases in
+		// selection order; the walk builds a fresh transaction-owned value, so
+		// it is also the aliasing-safe copy for the splice.
+		cached := denormalizeToSelection(tx, r.ctx, item.FromCache, cfg.ProvidesData)
 		if len(in.MergePath) > 0 {
 			if _, err := tx.MergeValuesWithPath(item.Item, cached, in.MergePath...); err != nil {
 				return err
@@ -335,17 +338,26 @@ func (r *requestCache) OnFetchResult(h *resolve.FetchCacheHandle, in resolve.Mer
 			}
 			itemToStore = entity
 		}
+		// Normalize to the stored form (schema names + argument suffixes)
+		// before caching; trees without aliases or args skip the transform
+		// (HasAliases is the fast-path gate) and store the raw value.
+		toStore := itemToStore
+		if cfg.ProvidesData != nil && cfg.ProvidesData.HasAliases {
+			toStore = normalizeToSchema(tx, r.ctx, itemToStore, cfg.ProvidesData)
+		}
 		// Marshal ONCE per item; the deferred set holds bytes only.
-		value := itemToStore.MarshalTo(nil)
+		value := toStore.MarshalTo(nil)
 		for _, key := range item.RenderedKeys {
 			r.deferSet(key, value, cfg.TTL, resolve.CacheWriteReasonRefresh)
 		}
 		for _, candidate := range item.PendingCandidates {
 			// Re-render candidates that could not render at lookup from the
 			// FRESH data (best-effort backfill); a candidate the response still
-			// cannot render is skipped silently — never required.
+			// cannot render is skipped silently — never required. Rendering
+			// uses the NORMALIZED value: representation fields carry schema
+			// names, which an alias-shaped response would not match.
 			template := cacheKeyTemplate{prefix: r.prefixes[h], representation: candidate.Representation}
-			key, ok := template.render(itemToStore)
+			key, ok := template.render(toStore)
 			if !ok {
 				continue
 			}

--- a/v2/pkg/engine/cache/controller.go
+++ b/v2/pkg/engine/cache/controller.go
@@ -119,6 +119,34 @@ func (r *requestCache) useL2(cfg *resolve.FetchCacheConfig) bool {
 	return cfg != nil && cfg.L2 && r.store != nil
 }
 
+// registerHandle records the per-handle side state and stamps the handle's
+// observability fields: the fetch's ART trace destination (nil when tracing
+// is off) and the key-hashing knob. Observability never adds calls outside
+// the controller — the observer reads the handle at EndRequest.
+func (r *requestCache) registerHandle(h *resolve.FetchCacheHandle, cfg *resolve.FetchCacheConfig, in resolve.PrepareFetchInput) {
+	r.configs[h] = cfg
+	r.prefixes[h] = cacheKeyPrefix(cfg, in.HeaderHash)
+	h.HashAnalyticsKeys = cfg.HashAnalyticsKeys
+	if in.Item != nil && in.Item.Fetch != nil {
+		h.Trace = fetchLoadTrace(in.Item.Fetch)
+	}
+}
+
+// fetchLoadTrace returns the fetch's ART trace destination (nil when tracing
+// is disabled for the request).
+func fetchLoadTrace(fetch resolve.Fetch) *resolve.DataSourceLoadTrace {
+	switch f := fetch.(type) {
+	case *resolve.SingleFetch:
+		return f.Trace
+	case *resolve.EntityFetch:
+		return f.Trace
+	case *resolve.BatchEntityFetch:
+		return f.Trace
+	default:
+		return nil
+	}
+}
+
 // l1Put stores one L1 value; the caller passes a transaction-owned value
 // (ParseBytes/StructuralCopy product — never a heap value smuggled into
 // arena-noscan memory) and holds the transaction.
@@ -204,8 +232,7 @@ func (r *requestCache) PrepareFetch(in resolve.PrepareFetchInput) (resolve.Decis
 		ShadowStash:   shadowStash,
 		Items:         items,
 	}
-	r.configs[handle] = cfg
-	r.prefixes[handle] = cacheKeyPrefix(cfg, in.HeaderHash)
+	r.registerHandle(handle, cfg, in)
 	r.missedKeys[handle] = missedByItem
 	return decision, handle
 }
@@ -236,6 +263,7 @@ func shadowStashEntry(tx *resolve.CacheTransaction, cfg *resolve.FetchCacheConfi
 	state.SelectedRemainingTTL = 0
 	state.NegativeHit = false
 	state.NeedsWriteback = false
+	state.ServedFromLayer = ""
 	return entry
 }
 
@@ -306,8 +334,7 @@ func (r *requestCache) prepareRootFieldFetch(in resolve.PrepareFetchInput, cfg *
 		WasHit:   fromCache != nil,
 		Items:    items,
 	}
-	r.configs[handle] = cfg
-	r.prefixes[handle] = cacheKeyPrefix(cfg, in.HeaderHash)
+	r.registerHandle(handle, cfg, in)
 	return decision, handle
 }
 
@@ -376,8 +403,7 @@ func (r *requestCache) prepareRootFieldEntityReuse(in resolve.PrepareFetchInput,
 		MustWriteBack: allCovered && mustWriteBack,
 		Items:         items,
 	}
-	r.configs[handle] = cfg
-	r.prefixes[handle] = cacheKeyPrefix(cfg, in.HeaderHash)
+	r.registerHandle(handle, cfg, in)
 	r.missedKeys[handle] = missedByItem
 	r.reuseProvides[handle] = subtree
 	return decision, handle, true
@@ -518,8 +544,7 @@ func (r *requestCache) prepareBatchFetch(in resolve.PrepareFetchInput, cfg *reso
 		PartialInput:   partialInput,
 		Items:          items,
 	}
-	r.configs[handle] = cfg
-	r.prefixes[handle] = cacheKeyPrefix(cfg, in.HeaderHash)
+	r.registerHandle(handle, cfg, in)
 	r.missedKeys[handle] = missedByItem
 	return decision, handle
 }
@@ -562,10 +587,12 @@ func (r *requestCache) prepareItemState(tx *resolve.CacheTransaction, cfg *resol
 				// this request.
 				state.FromCache = tx.StructuralCopy(stored)
 				state.NegativeHit = true
+				state.ServedFromLayer = "l1"
 				return state, nil, false
 			}
 			if covers(r.ctx, stored, cfg.ProvidesData) {
 				state.FromCache = tx.StructuralCopy(stored)
+				state.ServedFromLayer = "l1"
 				return state, nil, false
 			}
 		}
@@ -628,6 +655,7 @@ func (r *requestCache) prepareItemState(tx *resolve.CacheTransaction, cfg *resol
 		}
 	}
 	if state.NegativeHit {
+		state.ServedFromLayer = "l2"
 		if cfg.L1 {
 			r.populateL1(tx, &state)
 		}
@@ -636,6 +664,9 @@ func (r *requestCache) prepareItemState(tx *resolve.CacheTransaction, cfg *resol
 	// The selected value stays in NORMALIZED (stored) form on the handle;
 	// OnFetchSkipped denormalizes it to the requesting aliases at splice time.
 	selectMultiCandidateCacheValue(tx, r.ctx, &state, parsed, cfg.ProvidesData)
+	if state.FromCache != nil {
+		state.ServedFromLayer = "l2"
+	}
 	if cfg.L1 && state.FromCache != nil {
 		r.populateL1(tx, &state)
 	}
@@ -675,7 +706,8 @@ func (r *requestCache) OnFetchSkipped(h *resolve.FetchCacheHandle, in resolve.Me
 
 	prefix := r.prefixes[h]
 	missedByItem := r.missedKeys[h]
-	for i, item := range h.Items {
+	for i := range h.Items {
+		item := &h.Items[i]
 		if item.FromCache == nil || item.Item == nil {
 			continue
 		}
@@ -707,7 +739,7 @@ func (r *requestCache) OnFetchSkipped(h *resolve.FetchCacheHandle, in resolve.Me
 // value into every merge target, then settle the best-effort write-back
 // duties (refresh after a merged/older selection, backfill of missed keys,
 // pending-candidate re-render). Shared by OnFetchSkipped and the partial arm.
-func (r *requestCache) spliceCachedItem(tx *resolve.CacheTransaction, cfg *resolve.FetchCacheConfig, prefix string, provides resolve.Node, item resolve.ItemCacheState, missed []string, targets []*astjson.Value, fetchMergePath []string) error {
+func (r *requestCache) spliceCachedItem(tx *resolve.CacheTransaction, cfg *resolve.FetchCacheConfig, prefix string, provides resolve.Node, item *resolve.ItemCacheState, missed []string, targets []*astjson.Value, fetchMergePath []string) error {
 	if item.FromCache == nil {
 		return nil
 	}
@@ -753,9 +785,13 @@ func (r *requestCache) spliceCachedItem(tx *resolve.CacheTransaction, cfg *resol
 		for _, key := range item.RenderedKeys {
 			r.deferSet(key, value, cfg.TTL, resolve.CacheWriteReasonRefresh)
 		}
+		item.WriteReason = resolve.CacheWriteReasonRefresh
 	} else {
 		for _, key := range missed {
 			r.deferSet(key, value, cfg.TTL, resolve.CacheWriteReasonBackfill)
+		}
+		if len(missed) > 0 {
+			item.WriteReason = resolve.CacheWriteReasonBackfill
 		}
 	}
 	for _, candidate := range item.PendingCandidates {
@@ -862,7 +898,8 @@ func (r *requestCache) OnFetchResult(h *resolve.FetchCacheHandle, in resolve.Mer
 	if provides == nil {
 		provides = cfg.ProvidesData
 	}
-	for _, item := range h.Items {
+	for itemIndex := range h.Items {
+		item := &h.Items[itemIndex]
 		itemToStore := in.ResponseData
 		if h.BatchEntityKey {
 			if item.BatchIndex < 0 || item.BatchIndex >= len(batch) {
@@ -899,7 +936,7 @@ func (r *requestCache) OnFetchResult(h *resolve.FetchCacheHandle, in resolve.Mer
 // pending candidates re-rendered from the normalized value (a candidate the
 // response still cannot render is skipped silently — best-effort, never
 // required). Shared by OnFetchResult and the partial arm.
-func (r *requestCache) writeFetchedValue(tx *resolve.CacheTransaction, cfg *resolve.FetchCacheConfig, h *resolve.FetchCacheHandle, item resolve.ItemCacheState, itemToStore *astjson.Value, provides *resolve.Object) {
+func (r *requestCache) writeFetchedValue(tx *resolve.CacheTransaction, cfg *resolve.FetchCacheConfig, h *resolve.FetchCacheHandle, item *resolve.ItemCacheState, itemToStore *astjson.Value, provides *resolve.Object) {
 	toStore := itemToStore
 	if provides != nil && provides.HasAliases {
 		toStore = normalizeToSchema(tx, r.ctx, itemToStore, provides)
@@ -932,12 +969,22 @@ func (r *requestCache) writeFetchedValue(tx *resolve.CacheTransaction, cfg *reso
 			r.deferSet(key, value, cfg.TTL, reason)
 		}
 	}
+	if len(keys) > 0 && (cfg.L1 || r.useL2(cfg)) {
+		item.WriteReason = resolve.CacheWriteReasonRefresh
+	}
 }
 
 // EndRequest flushes the deferred L2 writes — bytes only, no lock, no arena,
 // no transaction — and finalizes observability. It runs once, single-threaded,
 // after the root tree and every defer group have resolved.
 func (r *requestCache) EndRequest() {
+	if r.obs != nil {
+		// Finalize observability: single-threaded, no lock, no arena — the
+		// observer reads each finished handle (trace assembly, counters).
+		for h := range r.configs {
+			r.obs.OnFetchObserved(h)
+		}
+	}
 	recorder, _ := r.store.(WriteReasonRecorder)
 	for _, set := range r.deferred {
 		if recorder != nil {

--- a/v2/pkg/engine/cache/controller.go
+++ b/v2/pkg/engine/cache/controller.go
@@ -113,8 +113,10 @@ func (r *requestCache) PrepareFetch(in resolve.PrepareFetchInput) (resolve.Decis
 	if !r.useL2(cfg) {
 		return resolve.DecisionFetch, nil
 	}
+	if cfg.KeySpec.Scope == resolve.CacheScopeRootField {
+		return r.prepareRootFieldFetch(in, cfg)
+	}
 	if cfg.KeySpec.Scope != resolve.CacheScopeEntity {
-		// Root-field caching lands with task 13.
 		return resolve.DecisionFetch, nil
 	}
 	if in.BatchStats != nil {
@@ -207,6 +209,71 @@ func shadowStashEntry(tx *resolve.CacheTransaction, cfg *resolve.FetchCacheConfi
 	state.NegativeHit = false
 	state.NeedsWriteback = false
 	return entry
+}
+
+// prepareRootFieldFetch is the root-field arm: ONE whole-response-scoped key
+// per fetch (field coordinate + canonical request variables), one lookup, one
+// coverage walk, with the served value shared across the fetch's merge
+// targets. Root-field shadow is the historical ASYMMETRY: a hit force-refetches
+// and overwrites L2, but never stashes and never compares.
+func (r *requestCache) prepareRootFieldFetch(in resolve.PrepareFetchInput, cfg *resolve.FetchCacheConfig) (resolve.Decision, *resolve.FetchCacheHandle) {
+	if len(in.Items) == 0 {
+		return resolve.DecisionFetch, nil
+	}
+	key := rootFieldCacheKey(cfg, in.HeaderHash, r.ctx)
+
+	tx := in.Arena.Begin()
+	defer tx.Commit()
+
+	value, remaining, hit := r.store.Get(key)
+	var fromCache *astjson.Value
+	var candidate *resolve.CacheCandidate
+	if hit {
+		if cached, err := tx.ParseBytes(value); err == nil {
+			candidate = &resolve.CacheCandidate{
+				Value:        append([]byte(nil), value...),
+				RemainingTTL: remaining,
+			}
+			if cfg.ProvidesData != nil && covers(r.ctx, cached, cfg.ProvidesData) {
+				fromCache = cached
+			}
+		}
+	}
+	if cfg.ShadowMode {
+		// The root-field shadow asymmetry: read, then force-refetch WITHOUT a
+		// stash or compare — the plain DecisionFetch below makes a compare
+		// structurally impossible, and the normal write path overwrites L2.
+		fromCache = nil
+	}
+
+	items := make([]resolve.ItemCacheState, 0, len(in.Items))
+	for _, item := range in.Items {
+		state := resolve.ItemCacheState{
+			Item:         item,
+			RenderedKeys: []string{key},
+			FromCache:    fromCache,
+		}
+		if candidate != nil {
+			state.FromCacheCandidates = []resolve.CacheCandidate{*candidate}
+		}
+		if fromCache != nil {
+			state.SelectedRemainingTTL = remaining
+		}
+		items = append(items, state)
+	}
+
+	decision := resolve.DecisionFetch
+	if fromCache != nil {
+		decision = resolve.DecisionSkipFullHit
+	}
+	handle := &resolve.FetchCacheHandle{
+		Decision: decision,
+		WasHit:   fromCache != nil,
+		Items:    items,
+	}
+	r.configs[handle] = cfg
+	r.prefixes[handle] = cacheKeyPrefix(cfg, in.HeaderHash)
+	return decision, handle
 }
 
 // prepareBatchFetch is the batch arm: one ItemCacheState per UNIQUE
@@ -492,6 +559,20 @@ func (r *requestCache) OnFetchResult(h *resolve.FetchCacheHandle, in resolve.Mer
 		// fresh response BEFORE any write, inside this hook's transaction
 		// (compare -> write-L1 -> write-L2 order; no second lock acquisition).
 		r.obs.CompareShadow(h, in.ResponseData, tx)
+	}
+
+	if cfg.KeySpec.Scope == resolve.CacheScopeRootField {
+		// One whole-response value under the fetch's single key, written once
+		// (the items share it).
+		toStore := in.ResponseData
+		if cfg.ProvidesData != nil && cfg.ProvidesData.HasAliases {
+			toStore = normalizeToSchema(tx, r.ctx, toStore, cfg.ProvidesData)
+		}
+		value := toStore.MarshalTo(nil)
+		for _, key := range h.Items[0].RenderedKeys {
+			r.deferSet(key, value, cfg.TTL, resolve.CacheWriteReasonRefresh)
+		}
+		return nil
 	}
 
 	// A batch response is the _entities array: each unique representation's

--- a/v2/pkg/engine/cache/controller.go
+++ b/v2/pkg/engine/cache/controller.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"slices"
 	"time"
 
 	"github.com/wundergraph/astjson"
@@ -44,10 +45,12 @@ func (c *Controller) BeginRequest(ctx *resolve.Context) resolve.RequestCache {
 		c.obs.BeginRequest(ctx)
 	}
 	return &requestCache{
-		store:   c.store,
-		obs:     c.obs,
-		ctx:     ctx,
-		configs: make(map[*resolve.FetchCacheHandle]*resolve.FetchCacheConfig),
+		store:      c.store,
+		obs:        c.obs,
+		ctx:        ctx,
+		configs:    make(map[*resolve.FetchCacheHandle]*resolve.FetchCacheConfig),
+		prefixes:   make(map[*resolve.FetchCacheHandle]string),
+		missedKeys: make(map[*resolve.FetchCacheHandle][][]string),
 	}
 }
 
@@ -74,13 +77,21 @@ type requestCache struct {
 	// configs threads each handle's config from PrepareFetch to the merge hook
 	// (the handle itself is opaque to the loader and carries no config).
 	configs map[*resolve.FetchCacheHandle]*resolve.FetchCacheConfig
+	// prefixes keeps each handle's key prefix so the merge hooks can re-render
+	// pending candidates with the same templates the lookup used.
+	prefixes map[*resolve.FetchCacheHandle]string
+	// missedKeys records, per handle and item, the rendered keys whose lookup
+	// MISSED, so a hit served from another key can backfill them.
+	missedKeys map[*resolve.FetchCacheHandle][][]string
 }
 
-// deferredSet is one pending L2 write, held as bytes until EndRequest.
+// deferredSet is one pending L2 write, held as bytes until EndRequest; reason
+// is metadata only (refresh vs backfill) and never gates the write.
 type deferredSet struct {
-	key   string
-	value []byte
-	ttl   time.Duration
+	key    string
+	value  []byte
+	ttl    time.Duration
+	reason resolve.CacheWriteReason
 }
 
 // useL2 reports whether this fetch participates in L2 through this controller.
@@ -117,38 +128,24 @@ func (r *requestCache) PrepareFetch(in resolve.PrepareFetchInput) (resolve.Decis
 	if len(templates) == 0 {
 		return resolve.DecisionFetch, nil
 	}
-	// Task 07 handles the single-candidate case; multi-key selection lands
-	// with task 08.
-	template := templates[0]
 
 	tx := in.Arena.Begin()
 	defer tx.Commit()
 
 	items := make([]resolve.ItemCacheState, 0, len(in.Items))
+	missedByItem := make([][]string, 0, len(in.Items))
 	allCovered := true
+	mustWriteBack := false
 	for _, item := range in.Items {
-		state := resolve.ItemCacheState{Item: item}
-		key, ok := template.render(item)
-		if ok {
-			state.RenderedKeys = []string{key}
-			if value, remaining, hit := r.store.Get(key); hit {
-				// Parse the cached bytes ONCE, onto the transaction's arena.
-				if cached, err := tx.ParseBytes(value); err == nil {
-					state.FromCacheCandidates = []resolve.CacheCandidate{{
-						Value:        append([]byte(nil), value...),
-						RemainingTTL: remaining,
-					}}
-					if covers(cached, cfg.ProvidesData) {
-						state.FromCache = cached
-						state.SelectedRemainingTTL = remaining
-					}
-				}
-			}
-		}
+		state, missed, itemMustWriteBack := r.prepareItemState(tx, cfg, templates, item)
 		if state.FromCache == nil {
 			allCovered = false
 		}
+		if itemMustWriteBack {
+			mustWriteBack = true
+		}
 		items = append(items, state)
+		missedByItem = append(missedByItem, missed)
 	}
 
 	decision := resolve.DecisionFetch
@@ -158,23 +155,108 @@ func (r *requestCache) PrepareFetch(in resolve.PrepareFetchInput) (resolve.Decis
 	handle := &resolve.FetchCacheHandle{
 		Decision: decision,
 		WasHit:   allCovered,
-		Items:    items,
+		// MustWriteBack matters only on a full hit: OnFetchSkipped then still
+		// owes best-effort backfill/refresh writes for the keys that missed,
+		// the candidates that could not render, or a merged/older selection.
+		MustWriteBack: allCovered && mustWriteBack,
+		Items:         items,
 	}
 	r.configs[handle] = cfg
+	r.prefixes[handle] = cacheKeyPrefix(cfg, in.HeaderHash)
+	r.missedKeys[handle] = missedByItem
 	return decision, handle
+}
+
+// prepareItemState runs the per-item multi-key ladder: best-effort render of
+// EVERY candidate (renderable → RenderedKeys, not renderable →
+// PendingCandidates), lookup under all rendered keys, freshest-first candidate
+// collection, multi-candidate selection, and reorder of the chosen value to
+// selection order. It returns the item state, the rendered keys whose lookup
+// missed, and whether a full hit on this item still owes write-backs.
+func (r *requestCache) prepareItemState(tx *resolve.CacheTransaction, cfg *resolve.FetchCacheConfig, templates []cacheKeyTemplate, item *astjson.Value) (resolve.ItemCacheState, []string, bool) {
+	state := resolve.ItemCacheState{Item: item}
+	mustWriteBack := false
+	var missedKeys []string
+	type lookupHit struct {
+		candidate resolve.CacheCandidate
+		cached    *astjson.Value
+	}
+	hits := make([]lookupHit, 0, len(templates))
+	for i, template := range templates {
+		key, ok := template.render(item)
+		if !ok {
+			// An unrenderable candidate is skipped at lookup and retried at
+			// write time from the fresh data — never an error (no candidate is
+			// required in the best-effort multi-key model).
+			state.PendingCandidates = append(state.PendingCandidates, cfg.KeySpec.Candidates[i])
+			mustWriteBack = true
+			continue
+		}
+		state.RenderedKeys = append(state.RenderedKeys, key)
+		value, remaining, hit := r.store.Get(key)
+		if !hit {
+			missedKeys = append(missedKeys, key)
+			mustWriteBack = true
+			continue
+		}
+		cached, err := tx.ParseBytes(value)
+		if err != nil {
+			// Malformed cached bytes are treated as a miss for this key; the
+			// write path will refresh it.
+			missedKeys = append(missedKeys, key)
+			mustWriteBack = true
+			continue
+		}
+		hits = append(hits, lookupHit{
+			candidate: resolve.CacheCandidate{
+				Value:        append([]byte(nil), value...),
+				RemainingTTL: remaining,
+			},
+			cached: cached,
+		})
+	}
+	if len(hits) == 0 {
+		return state, missedKeys, mustWriteBack
+	}
+
+	// Freshest first: a known remaining TTL beats an unknown one, larger beats
+	// smaller; the stable sort keeps candidate order for ties.
+	slices.SortStableFunc(hits, func(a, b lookupHit) int {
+		return compareCacheCandidateFreshness(a.candidate.RemainingTTL, b.candidate.RemainingTTL)
+	})
+	state.FromCacheCandidates = make([]resolve.CacheCandidate, 0, len(hits))
+	parsed := make([]*astjson.Value, 0, len(hits))
+	for _, hit := range hits {
+		state.FromCacheCandidates = append(state.FromCacheCandidates, hit.candidate)
+		parsed = append(parsed, hit.cached)
+	}
+	if selectMultiCandidateCacheValue(tx, &state, parsed, cfg.ProvidesData) {
+		state.FromCache = reorderToSelectionOrder(tx, state.FromCache, cfg.ProvidesData)
+	}
+	return state, missedKeys, mustWriteBack || state.NeedsWriteback
 }
 
 // OnFetchSkipped splices the chosen cached values into the merge targets at
 // the surfaced merge path, inside one CacheTransaction; StructuralCopy guards
-// against aliasing when one cached value serves multiple targets.
+// against aliasing when one cached value serves multiple targets. A hit that
+// left other candidate keys missed, unrenderable, or shape-stale still owes
+// best-effort write-backs (no network): refresh the canonical keys after a
+// merged/older selection, backfill the missed keys, and re-render pending
+// candidates from the served value.
 func (r *requestCache) OnFetchSkipped(h *resolve.FetchCacheHandle, in resolve.MergeInput) error {
-	if h == nil || r.configs[h] == nil {
+	if h == nil {
+		return nil
+	}
+	cfg := r.configs[h]
+	if cfg == nil {
 		return nil
 	}
 	tx := in.Arena.Begin()
 	defer tx.Commit()
 
-	for _, item := range h.Items {
+	prefix := r.prefixes[h]
+	missedByItem := r.missedKeys[h]
+	for i, item := range h.Items {
 		if item.FromCache == nil || item.Item == nil {
 			continue
 		}
@@ -190,6 +272,30 @@ func (r *requestCache) OnFetchSkipped(h *resolve.FetchCacheHandle, in resolve.Me
 			}
 		} else if _, err := tx.MergeValues(item.Item, cached); err != nil {
 			return err
+		}
+
+		value := item.FromCache.MarshalTo(nil)
+		if item.NeedsWriteback {
+			// The served value was synthesized or older-but-covering: rewrite
+			// the canonical entries so the next lookup hits on the first rung.
+			for _, key := range item.RenderedKeys {
+				r.deferSet(key, value, cfg.TTL, resolve.CacheWriteReasonRefresh)
+			}
+		} else if i < len(missedByItem) {
+			for _, key := range missedByItem[i] {
+				r.deferSet(key, value, cfg.TTL, resolve.CacheWriteReasonBackfill)
+			}
+		}
+		for _, candidate := range item.PendingCandidates {
+			// A candidate unrenderable from the request item may render from
+			// the SERVED value (it can carry more fields); skip silently when
+			// it still cannot render — best-effort, never required.
+			template := cacheKeyTemplate{prefix: prefix, representation: candidate.Representation}
+			key, ok := template.render(item.FromCache)
+			if !ok {
+				continue
+			}
+			r.deferSet(key, value, cfg.TTL, resolve.CacheWriteReasonBackfill)
 		}
 	}
 	return nil
@@ -232,7 +338,18 @@ func (r *requestCache) OnFetchResult(h *resolve.FetchCacheHandle, in resolve.Mer
 		// Marshal ONCE per item; the deferred set holds bytes only.
 		value := itemToStore.MarshalTo(nil)
 		for _, key := range item.RenderedKeys {
-			r.deferSet(key, value, cfg.TTL)
+			r.deferSet(key, value, cfg.TTL, resolve.CacheWriteReasonRefresh)
+		}
+		for _, candidate := range item.PendingCandidates {
+			// Re-render candidates that could not render at lookup from the
+			// FRESH data (best-effort backfill); a candidate the response still
+			// cannot render is skipped silently — never required.
+			template := cacheKeyTemplate{prefix: r.prefixes[h], representation: candidate.Representation}
+			key, ok := template.render(itemToStore)
+			if !ok {
+				continue
+			}
+			r.deferSet(key, value, cfg.TTL, resolve.CacheWriteReasonBackfill)
 		}
 	}
 	return nil
@@ -242,7 +359,11 @@ func (r *requestCache) OnFetchResult(h *resolve.FetchCacheHandle, in resolve.Mer
 // no transaction — and finalizes observability. It runs once, single-threaded,
 // after the root tree and every defer group have resolved.
 func (r *requestCache) EndRequest() {
+	recorder, _ := r.store.(WriteReasonRecorder)
 	for _, set := range r.deferred {
+		if recorder != nil {
+			recorder.RecordWriteReason(set.key, set.reason)
+		}
 		r.store.Set(set.key, set.value, set.ttl)
 	}
 	r.deferred = nil
@@ -251,10 +372,19 @@ func (r *requestCache) EndRequest() {
 	}
 }
 
-func (r *requestCache) deferSet(key string, value []byte, ttl time.Duration) {
+// WriteReasonRecorder is an optional Store extension: a store implementing it
+// receives each write's reason (refresh vs backfill) right before the Set.
+// Reasons are metadata only — they never gate a write — and exist so tests and
+// observability can distinguish refresh from backfill traffic.
+type WriteReasonRecorder interface {
+	RecordWriteReason(key string, reason resolve.CacheWriteReason)
+}
+
+func (r *requestCache) deferSet(key string, value []byte, ttl time.Duration, reason resolve.CacheWriteReason) {
 	r.deferred = append(r.deferred, deferredSet{
-		key:   key,
-		value: append([]byte(nil), value...),
-		ttl:   ttl,
+		key:    key,
+		value:  append([]byte(nil), value...),
+		ttl:    ttl,
+		reason: reason,
 	})
 }

--- a/v2/pkg/engine/cache/controller.go
+++ b/v2/pkg/engine/cache/controller.go
@@ -102,6 +102,9 @@ type handleState struct {
 	// root-field handles: the cached value is the ENTITY, so the walks use the
 	// root field's value subtree instead of the whole-response tree.
 	reuseProvides *resolve.Object
+	// observed marks the handle as already passed to the observer, so a
+	// pre-render FlushTraces and EndRequest's own pass observe it ONCE.
+	observed bool
 }
 
 // deferredSet is one pending L2 write, held as bytes until EndRequest; reason
@@ -1007,17 +1010,30 @@ func (r *requestCache) writeFetchedValue(tx *resolve.CacheTransaction, cfg *reso
 	}
 }
 
+// FlushTraces passes every not-yet-observed handle to the observer (trace
+// assembly, counters) — single-threaded, no lock, no arena. The resolver calls
+// it right before the response renders so extensions.trace carries the cache
+// sections; EndRequest runs the same pass for whatever remains, so each handle
+// is observed exactly once either way.
+func (r *requestCache) FlushTraces() {
+	if r.obs == nil {
+		return
+	}
+	for h, state := range r.states {
+		if state.observed {
+			continue
+		}
+		state.observed = true
+		r.obs.OnFetchObserved(h)
+	}
+}
+
 // EndRequest flushes the deferred L2 writes — bytes only, no lock, no arena,
 // no transaction — and finalizes observability. It runs once, single-threaded,
 // after the root tree and every defer group have resolved.
 func (r *requestCache) EndRequest() {
-	if r.obs != nil {
-		// Finalize observability: single-threaded, no lock, no arena — the
-		// observer reads each finished handle (trace assembly, counters).
-		for h := range r.states {
-			r.obs.OnFetchObserved(h)
-		}
-	}
+	// Finalize observability for handles not already flushed pre-render.
+	r.FlushTraces()
 	recorder, _ := r.store.(WriteReasonRecorder)
 	for _, set := range r.deferred {
 		if recorder != nil {

--- a/v2/pkg/engine/cache/controller.go
+++ b/v2/pkg/engine/cache/controller.go
@@ -45,13 +45,10 @@ func (c *Controller) BeginRequest(ctx *resolve.Context) resolve.RequestCache {
 		c.obs.BeginRequest(ctx)
 	}
 	return &requestCache{
-		store:         c.store,
-		obs:           c.obs,
-		ctx:           ctx,
-		configs:       make(map[*resolve.FetchCacheHandle]*resolve.FetchCacheConfig),
-		prefixes:      make(map[*resolve.FetchCacheHandle]string),
-		missedKeys:    make(map[*resolve.FetchCacheHandle][][]string),
-		reuseProvides: make(map[*resolve.FetchCacheHandle]*resolve.Object),
+		store: c.store,
+		obs:   c.obs,
+		ctx:   ctx,
+		// states allocates lazily on the first cached fetch.
 	}
 }
 
@@ -75,19 +72,11 @@ type requestCache struct {
 	// deferred is the request-end L2 write set: BYTES only, so the flush needs
 	// neither lock nor arena.
 	deferred []deferredSet
-	// configs threads each handle's config from PrepareFetch to the merge hook
-	// (the handle itself is opaque to the loader and carries no config).
-	configs map[*resolve.FetchCacheHandle]*resolve.FetchCacheConfig
-	// prefixes keeps each handle's key prefix so the merge hooks can re-render
-	// pending candidates with the same templates the lookup used.
-	prefixes map[*resolve.FetchCacheHandle]string
-	// missedKeys records, per handle and item, the rendered keys whose lookup
-	// MISSED, so a hit served from another key can backfill them.
-	missedKeys map[*resolve.FetchCacheHandle][][]string
-	// reuseProvides overrides the coverage/transform tree for by-key
-	// root-field handles: the cached value is the ENTITY, so the walks use the
-	// root field's value subtree instead of the whole-response tree.
-	reuseProvides map[*resolve.FetchCacheHandle]*resolve.Object
+	// states threads each handle's controller-side state from PrepareFetch to
+	// the merge hooks (the handle itself is opaque to the loader). ONE lazily
+	// allocated map instead of one per field — profiled: per-handle side-map
+	// inserts were a measurable share of the hit path's allocations.
+	states map[*resolve.FetchCacheHandle]*handleState
 	// l1 is the request-lifetime entity store: NORMALIZED *astjson.Value
 	// (never bytes, never marshaled) under the SAME derived keys as L2.
 	// EXTERNAL-LOCK INVARIANT: guarded by the caller's CacheTransaction (the
@@ -97,6 +86,22 @@ type requestCache struct {
 	// is allocated lazily on the first write. This is NOT the removed
 	// @requestScoped feature (D11).
 	l1 map[string]*astjson.Value
+}
+
+// handleState is the controller-side per-handle state.
+type handleState struct {
+	// cfg is the handle's fetch config (the loader never carries it).
+	cfg *resolve.FetchCacheConfig
+	// prefix is the key prefix, so merge hooks re-render pending candidates
+	// with the same templates the lookup used.
+	prefix string
+	// missedKeys records, per item, the rendered keys whose lookup MISSED, so
+	// a hit served from another key can backfill them.
+	missedKeys [][]string
+	// reuseProvides overrides the coverage/transform tree for by-key
+	// root-field handles: the cached value is the ENTITY, so the walks use the
+	// root field's value subtree instead of the whole-response tree.
+	reuseProvides *resolve.Object
 }
 
 // deferredSet is one pending L2 write, held as bytes until EndRequest; reason
@@ -123,13 +128,20 @@ func (r *requestCache) useL2(cfg *resolve.FetchCacheConfig) bool {
 // observability fields: the fetch's ART trace destination (nil when tracing
 // is off) and the key-hashing knob. Observability never adds calls outside
 // the controller — the observer reads the handle at EndRequest.
-func (r *requestCache) registerHandle(h *resolve.FetchCacheHandle, cfg *resolve.FetchCacheConfig, in resolve.PrepareFetchInput) {
-	r.configs[h] = cfg
-	r.prefixes[h] = cacheKeyPrefix(cfg, in.HeaderHash)
+func (r *requestCache) registerHandle(h *resolve.FetchCacheHandle, cfg *resolve.FetchCacheConfig, in resolve.PrepareFetchInput) *handleState {
+	state := &handleState{
+		cfg:    cfg,
+		prefix: cacheKeyPrefix(cfg, in.HeaderHash),
+	}
+	if r.states == nil {
+		r.states = make(map[*resolve.FetchCacheHandle]*handleState)
+	}
+	r.states[h] = state
 	h.HashAnalyticsKeys = cfg.HashAnalyticsKeys
 	if in.Item != nil && in.Item.Fetch != nil {
 		h.Trace = in.Item.Fetch.LoadTrace()
 	}
+	return state
 }
 
 // l1Put stores one L1 value; the caller passes a transaction-owned value
@@ -217,8 +229,8 @@ func (r *requestCache) PrepareFetch(in resolve.PrepareFetchInput) (resolve.Decis
 		ShadowStash:   shadowStash,
 		Items:         items,
 	}
-	r.registerHandle(handle, cfg, in)
-	r.missedKeys[handle] = missedByItem
+	state := r.registerHandle(handle, cfg, in)
+	state.missedKeys = missedByItem
 	return decision, handle
 }
 
@@ -388,9 +400,9 @@ func (r *requestCache) prepareRootFieldEntityReuse(in resolve.PrepareFetchInput,
 		MustWriteBack: allCovered && mustWriteBack,
 		Items:         items,
 	}
-	r.registerHandle(handle, cfg, in)
-	r.missedKeys[handle] = missedByItem
-	r.reuseProvides[handle] = subtree
+	state := r.registerHandle(handle, cfg, in)
+	state.missedKeys = missedByItem
+	state.reuseProvides = subtree
 	return decision, handle, true
 }
 
@@ -529,8 +541,8 @@ func (r *requestCache) prepareBatchFetch(in resolve.PrepareFetchInput, cfg *reso
 		PartialInput:   partialInput,
 		Items:          items,
 	}
-	r.registerHandle(handle, cfg, in)
-	r.missedKeys[handle] = missedByItem
+	state := r.registerHandle(handle, cfg, in)
+	state.missedKeys = missedByItem
 	return decision, handle
 }
 
@@ -688,15 +700,16 @@ func (r *requestCache) OnFetchSkipped(h *resolve.FetchCacheHandle, in resolve.Me
 	if h == nil {
 		return nil
 	}
-	cfg := r.configs[h]
-	if cfg == nil {
+	state := r.states[h]
+	if state == nil {
 		return nil
 	}
+	cfg := state.cfg
 	tx := in.Arena.Begin()
 	defer tx.Commit()
 
-	prefix := r.prefixes[h]
-	missedByItem := r.missedKeys[h]
+	prefix := state.prefix
+	missedByItem := state.missedKeys
 	for i := range h.Items {
 		item := &h.Items[i]
 		if item.FromCache == nil || item.Item == nil {
@@ -712,8 +725,8 @@ func (r *requestCache) OnFetchSkipped(h *resolve.FetchCacheHandle, in resolve.Me
 			}
 		}
 		provides := resolve.Node(cfg.ProvidesData)
-		if subtree := r.reuseProvides[h]; subtree != nil {
-			provides = subtree
+		if state.reuseProvides != nil {
+			provides = state.reuseProvides
 		}
 		var missed []string
 		if i < len(missedByItem) {
@@ -807,16 +820,17 @@ func (r *requestCache) OnFetchResult(h *resolve.FetchCacheHandle, in resolve.Mer
 	if h == nil {
 		return nil
 	}
-	cfg := r.configs[h]
-	if cfg == nil {
+	state := r.states[h]
+	if state == nil {
 		return nil
 	}
+	cfg := state.cfg
 	if h.Decision == resolve.DecisionFetchPartial {
 		// The partial arm owns splice + realign + writes and runs BEFORE the
 		// failure gate: on a failed partial fetch the covered splice must
 		// still happen (the cached data is valid; the loader already rendered
 		// the fetch errors), and only the fetched subset is skipped.
-		return r.onPartialBatchResult(h, in, cfg)
+		return r.onPartialBatchResult(h, in, state)
 	}
 	if in.FetchFailed || in.HasErrors {
 		// All failure signals block ALL writes — including negative ones: a
@@ -885,7 +899,7 @@ func (r *requestCache) OnFetchResult(h *resolve.FetchCacheHandle, in resolve.Mer
 			return nil
 		}
 	}
-	provides := r.reuseProvides[h]
+	provides := state.reuseProvides
 	if provides == nil {
 		provides = cfg.ProvidesData
 	}
@@ -935,7 +949,7 @@ func (r *requestCache) writeFetchedValue(tx *resolve.CacheTransaction, cfg *reso
 	keys := item.RenderedKeys
 	backfillFrom := len(keys)
 	for _, candidate := range item.PendingCandidates {
-		template := cacheKeyTemplate{prefix: r.prefixes[h], representation: candidate.Representation}
+		template := cacheKeyTemplate{prefix: r.states[h].prefix, representation: candidate.Representation}
 		key, ok := template.render(toStore)
 		if !ok {
 			continue
@@ -978,7 +992,7 @@ func (r *requestCache) EndRequest() {
 	if r.obs != nil {
 		// Finalize observability: single-threaded, no lock, no arena — the
 		// observer reads each finished handle (trace assembly, counters).
-		for h := range r.configs {
+		for h := range r.states {
 			r.obs.OnFetchObserved(h)
 		}
 	}

--- a/v2/pkg/engine/cache/controller.go
+++ b/v2/pkg/engine/cache/controller.go
@@ -45,12 +45,13 @@ func (c *Controller) BeginRequest(ctx *resolve.Context) resolve.RequestCache {
 		c.obs.BeginRequest(ctx)
 	}
 	return &requestCache{
-		store:      c.store,
-		obs:        c.obs,
-		ctx:        ctx,
-		configs:    make(map[*resolve.FetchCacheHandle]*resolve.FetchCacheConfig),
-		prefixes:   make(map[*resolve.FetchCacheHandle]string),
-		missedKeys: make(map[*resolve.FetchCacheHandle][][]string),
+		store:         c.store,
+		obs:           c.obs,
+		ctx:           ctx,
+		configs:       make(map[*resolve.FetchCacheHandle]*resolve.FetchCacheConfig),
+		prefixes:      make(map[*resolve.FetchCacheHandle]string),
+		missedKeys:    make(map[*resolve.FetchCacheHandle][][]string),
+		reuseProvides: make(map[*resolve.FetchCacheHandle]*resolve.Object),
 	}
 }
 
@@ -83,6 +84,10 @@ type requestCache struct {
 	// missedKeys records, per handle and item, the rendered keys whose lookup
 	// MISSED, so a hit served from another key can backfill them.
 	missedKeys map[*resolve.FetchCacheHandle][][]string
+	// reuseProvides overrides the coverage/transform tree for by-key
+	// root-field handles: the cached value is the ENTITY, so the walks use the
+	// root field's value subtree instead of the whole-response tree.
+	reuseProvides map[*resolve.FetchCacheHandle]*resolve.Object
 }
 
 // deferredSet is one pending L2 write, held as bytes until EndRequest; reason
@@ -220,6 +225,13 @@ func (r *requestCache) prepareRootFieldFetch(in resolve.PrepareFetchInput, cfg *
 	if len(in.Items) == 0 {
 		return resolve.DecisionFetch, nil
 	}
+	if len(cfg.KeySpec.EntityKeyMappings) > 0 {
+		if decision, handle, ok := r.prepareRootFieldEntityReuse(in, cfg); ok {
+			return decision, handle
+		}
+		// The reuse preconditions did not hold (e.g. a non-object subtree);
+		// fall back to the plain root-field path.
+	}
 	key := rootFieldCacheKey(cfg, in.HeaderHash, r.ctx)
 
 	tx := in.Arena.Begin()
@@ -274,6 +286,124 @@ func (r *requestCache) prepareRootFieldFetch(in resolve.PrepareFetchInput, cfg *
 	r.configs[handle] = cfg
 	r.prefixes[handle] = cacheKeyPrefix(cfg, in.HeaderHash)
 	return decision, handle
+}
+
+// prepareRootFieldEntityReuse serves a BY-KEY root field from the ENTITY key
+// space: the lookup item derives from the field's arguments (via the frozen
+// EntityKeyMappings), the entity candidates flow through the SAME best-effort
+// multi-key machinery as entity fetches (arg-derived renders at lookup,
+// data-derived candidates backfill at write), and the served entity value
+// splices AT the field's response key. Reuse works exactly when the policy
+// shares its CacheName with the entity policy — the prefix makes read key ==
+// write key by construction.
+func (r *requestCache) prepareRootFieldEntityReuse(in resolve.PrepareFetchInput, cfg *resolve.FetchCacheConfig) (resolve.Decision, *resolve.FetchCacheHandle, bool) {
+	responseKey, subtree, ok := rootFieldSubtree(cfg.ProvidesData, cfg.KeySpec.FieldName)
+	if !ok {
+		return resolve.DecisionFetch, nil, false
+	}
+	templates := newCacheKeyTemplates(cfg, in.HeaderHash)
+	if len(templates) == 0 {
+		return resolve.DecisionFetch, nil, false
+	}
+	lookupItem := entityLookupItem(r.ctx, cfg.KeySpec.EntityKeyMappings)
+
+	tx := in.Arena.Begin()
+	defer tx.Commit()
+
+	// The coverage/selection walks run against the FIELD subtree — the cached
+	// value is the entity, not the whole response.
+	reuseCfg := *cfg
+	reuseCfg.ProvidesData = subtree
+
+	items := make([]resolve.ItemCacheState, 0, len(in.Items))
+	missedByItem := make([][]string, 0, len(in.Items))
+	allCovered := true
+	mustWriteBack := false
+	for _, item := range in.Items {
+		state, missed, itemMustWriteBack := r.prepareItemState(tx, &reuseCfg, templates, lookupItem)
+		state.Item = item
+		// The entity value splices (and extracts, on the write side) at the
+		// field's RESPONSE key.
+		state.EntityMergePath = []string{responseKey}
+		if cfg.ShadowMode {
+			// The root-field shadow asymmetry applies here too: read, then
+			// force-refetch without a stash or compare.
+			state.FromCache = nil
+			state.SelectedRemainingTTL = 0
+			state.NegativeHit = false
+			state.NeedsWriteback = false
+		}
+		if state.FromCache == nil {
+			allCovered = false
+		}
+		if itemMustWriteBack {
+			mustWriteBack = true
+		}
+		items = append(items, state)
+		missedByItem = append(missedByItem, missed)
+	}
+
+	decision := resolve.DecisionFetch
+	if allCovered {
+		decision = resolve.DecisionSkipFullHit
+	}
+	handle := &resolve.FetchCacheHandle{
+		Decision:      decision,
+		WasHit:        allCovered,
+		MustWriteBack: allCovered && mustWriteBack,
+		Items:         items,
+	}
+	r.configs[handle] = cfg
+	r.prefixes[handle] = cacheKeyPrefix(cfg, in.HeaderHash)
+	r.missedKeys[handle] = missedByItem
+	r.reuseProvides[handle] = subtree
+	return decision, handle, true
+}
+
+// rootFieldSubtree finds the root field's value node in the ProvidesData tree
+// (matched by SCHEMA name, alias-aware) and returns its response key and
+// object subtree; a non-object subtree (lists etc.) declines reuse.
+func rootFieldSubtree(tree *resolve.Object, fieldName string) (string, *resolve.Object, bool) {
+	if tree == nil {
+		return "", nil, false
+	}
+	for _, field := range tree.Fields {
+		schemaName := string(field.Name)
+		if len(field.OriginalName) > 0 {
+			schemaName = string(field.OriginalName)
+		}
+		if schemaName != fieldName {
+			continue
+		}
+		subtree, ok := field.Value.(*resolve.Object)
+		if !ok {
+			return "", nil, false
+		}
+		return string(field.Name), subtree, true
+	}
+	return "", nil, false
+}
+
+// entityLookupItem builds the arg-derived entity item the templates render
+// from: one field per mapping, read from the request variables by the key
+// field's name (the documented v1 constraint). Missing variables simply leave
+// the candidate unrenderable — best-effort, never an error.
+func entityLookupItem(ctx *resolve.Context, mappings []resolve.EntityKeyMapping) *astjson.Value {
+	item := astjson.ObjectValue(nil)
+	if ctx == nil {
+		return item
+	}
+	variables := ctx.VariablesView()
+	for _, mapping := range mappings {
+		for _, fieldMapping := range mapping.FieldMappings {
+			value := variables.Get(fieldMapping.ArgumentPath...)
+			if value == nil {
+				continue
+			}
+			item.Set(nil, fieldMapping.EntityKeyField, value)
+		}
+	}
+	return item
 }
 
 // prepareBatchFetch is the batch arm: one ItemCacheState per UNIQUE
@@ -467,6 +597,16 @@ func (r *requestCache) OnFetchSkipped(h *resolve.FetchCacheHandle, in resolve.Me
 			// from the uncached one — caching must never change the response.
 			continue
 		}
+		provides := resolve.Node(cfg.ProvidesData)
+		if subtree := r.reuseProvides[h]; subtree != nil {
+			provides = subtree
+		}
+		// A by-key root-field item carries its own merge path (the field's
+		// response key); everything else uses the fetch-level merge path.
+		mergePath := in.MergePath
+		if len(item.EntityMergePath) > 0 {
+			mergePath = item.EntityMergePath
+		}
 		for _, target := range targets {
 			if target == nil {
 				continue
@@ -475,9 +615,9 @@ func (r *requestCache) OnFetchSkipped(h *resolve.FetchCacheHandle, in resolve.Me
 			// aliases in selection order; the walk builds a fresh
 			// transaction-owned value per target, so it is also the
 			// aliasing-safe copy for the splice.
-			cached := denormalizeToSelection(tx, r.ctx, item.FromCache, cfg.ProvidesData)
-			if len(in.MergePath) > 0 {
-				if _, err := tx.MergeValuesWithPath(target, cached, in.MergePath...); err != nil {
+			cached := denormalizeToSelection(tx, r.ctx, item.FromCache, provides)
+			if len(mergePath) > 0 {
+				if _, err := tx.MergeValuesWithPath(target, cached, mergePath...); err != nil {
 					return err
 				}
 			} else if _, err := tx.MergeValues(target, cached); err != nil {
@@ -561,7 +701,7 @@ func (r *requestCache) OnFetchResult(h *resolve.FetchCacheHandle, in resolve.Mer
 		r.obs.CompareShadow(h, in.ResponseData, tx)
 	}
 
-	if cfg.KeySpec.Scope == resolve.CacheScopeRootField {
+	if cfg.KeySpec.Scope == resolve.CacheScopeRootField && len(cfg.KeySpec.EntityKeyMappings) == 0 {
 		// One whole-response value under the fetch's single key, written once
 		// (the items share it).
 		toStore := in.ResponseData
@@ -584,6 +724,10 @@ func (r *requestCache) OnFetchResult(h *resolve.FetchCacheHandle, in resolve.Mer
 			return nil
 		}
 	}
+	provides := r.reuseProvides[h]
+	if provides == nil {
+		provides = cfg.ProvidesData
+	}
 	for _, item := range h.Items {
 		itemToStore := in.ResponseData
 		if h.BatchEntityKey {
@@ -601,12 +745,21 @@ func (r *requestCache) OnFetchResult(h *resolve.FetchCacheHandle, in resolve.Mer
 			}
 			itemToStore = entity
 		}
+		if len(item.EntityMergePath) > 0 {
+			// A by-key root field caches the ENTITY below its response key,
+			// never the whole-response wrapper.
+			entity := itemToStore.Get(item.EntityMergePath...)
+			if entity == nil {
+				continue
+			}
+			itemToStore = entity
+		}
 		// Normalize to the stored form (schema names + argument suffixes)
 		// before caching; trees without aliases or args skip the transform
 		// (HasAliases is the fast-path gate) and store the raw value.
 		toStore := itemToStore
-		if cfg.ProvidesData != nil && cfg.ProvidesData.HasAliases {
-			toStore = normalizeToSchema(tx, r.ctx, itemToStore, cfg.ProvidesData)
+		if provides != nil && provides.HasAliases {
+			toStore = normalizeToSchema(tx, r.ctx, itemToStore, provides)
 		}
 		// Marshal ONCE per item; the deferred set holds bytes only.
 		value := toStore.MarshalTo(nil)

--- a/v2/pkg/engine/cache/controller.go
+++ b/v2/pkg/engine/cache/controller.go
@@ -128,22 +128,7 @@ func (r *requestCache) registerHandle(h *resolve.FetchCacheHandle, cfg *resolve.
 	r.prefixes[h] = cacheKeyPrefix(cfg, in.HeaderHash)
 	h.HashAnalyticsKeys = cfg.HashAnalyticsKeys
 	if in.Item != nil && in.Item.Fetch != nil {
-		h.Trace = fetchLoadTrace(in.Item.Fetch)
-	}
-}
-
-// fetchLoadTrace returns the fetch's ART trace destination (nil when tracing
-// is disabled for the request).
-func fetchLoadTrace(fetch resolve.Fetch) *resolve.DataSourceLoadTrace {
-	switch f := fetch.(type) {
-	case *resolve.SingleFetch:
-		return f.Trace
-	case *resolve.EntityFetch:
-		return f.Trace
-	case *resolve.BatchEntityFetch:
-		return f.Trace
-	default:
-		return nil
+		h.Trace = in.Item.Fetch.LoadTrace()
 	}
 }
 
@@ -644,15 +629,21 @@ func (r *requestCache) prepareItemState(tx *resolve.CacheTransaction, cfg *resol
 	parsed := make([]*astjson.Value, 0, len(hits))
 	for _, hit := range hits {
 		state.FromCacheCandidates = append(state.FromCacheCandidates, hit.candidate)
-		parsed = append(parsed, hit.cached)
-		// A TOP-LEVEL null cached value is the negative sentinel: the entity is
-		// KNOWN to not exist, so the item is served as null without a coverage
-		// walk (there is nothing to cover). The freshest sentinel wins.
-		if hit.cached != nil && hit.cached.Type() == astjson.TypeNull && state.FromCache == nil {
-			state.FromCache = hit.cached
-			state.SelectedRemainingTTL = hit.candidate.RemainingTTL
-			state.NegativeHit = true
+		if hit.cached != nil && hit.cached.Type() == astjson.TypeNull {
+			// Sentinels never enter the positive selection ladder below.
+			continue
 		}
+		parsed = append(parsed, hit.cached)
+	}
+	// A TOP-LEVEL null cached value is the negative sentinel: the entity is
+	// KNOWN to not exist, so the item is served as null without a coverage
+	// walk (there is nothing to cover). Only the FRESHEST candidate is
+	// authoritative — a STALER sentinel on a sibling @key must never override
+	// a fresher positive value.
+	if freshest := hits[0]; freshest.cached != nil && freshest.cached.Type() == astjson.TypeNull {
+		state.FromCache = freshest.cached
+		state.SelectedRemainingTTL = freshest.candidate.RemainingTTL
+		state.NegativeHit = true
 	}
 	if state.NegativeHit {
 		state.ServedFromLayer = "l2"
@@ -970,7 +961,13 @@ func (r *requestCache) writeFetchedValue(tx *resolve.CacheTransaction, cfg *reso
 		}
 	}
 	if len(keys) > 0 && (cfg.L1 || r.useL2(cfg)) {
-		item.WriteReason = resolve.CacheWriteReasonRefresh
+		// Item-level trace label: a write set consisting ONLY of re-rendered
+		// pending candidates is a pure backfill.
+		if backfillFrom == 0 {
+			item.WriteReason = resolve.CacheWriteReasonBackfill
+		} else {
+			item.WriteReason = resolve.CacheWriteReasonRefresh
+		}
 	}
 }
 

--- a/v2/pkg/engine/cache/controller.go
+++ b/v2/pkg/engine/cache/controller.go
@@ -500,7 +500,7 @@ func (r *requestCache) prepareBatchFetch(in resolve.PrepareFetchInput, cfg *reso
 	}
 
 	decision := resolve.DecisionFetch
-	var partialInput []byte
+	var batchFetchKeep []bool
 	switch {
 	case shadowStash != nil:
 		decision = resolve.DecisionFetchShadow
@@ -511,10 +511,10 @@ func (r *requestCache) prepareBatchFetch(in resolve.PrepareFetchInput, cfg *reso
 		// root-field policies as PartialBatchLoad — either enables the batch
 		// partial path. Shadow wins over partial (read-never-serve).
 		if (cfg.EnablePartialCacheLoad || cfg.PartialBatchLoad) && !cfg.ShadowMode {
-			// SOME buckets covered: filter the representations to the missing
-			// ones and go partial. keep[i] mirrors the bucket order (which is
-			// the representations order). An unexpected input shape falls back
-			// to the plain full fetch — never a wrong request.
+			// SOME buckets covered: mark the missing ones and go partial.
+			// keep[i] mirrors the bucket order (which is the representations
+			// order); the LOADER assembles the reduced input from the
+			// already-rendered segments — no bytes are parsed back.
 			keep := make([]bool, len(items))
 			anyCovered := false
 			for i := range items {
@@ -524,10 +524,8 @@ func (r *requestCache) prepareBatchFetch(in resolve.PrepareFetchInput, cfg *reso
 				}
 			}
 			if anyCovered {
-				if reduced, ok := filterBatchInput(in.Input, keep); ok {
-					decision = resolve.DecisionFetchPartial
-					partialInput = reduced
-				}
+				decision = resolve.DecisionFetchPartial
+				batchFetchKeep = keep
 			}
 		}
 	}
@@ -538,7 +536,7 @@ func (r *requestCache) prepareBatchFetch(in resolve.PrepareFetchInput, cfg *reso
 		BatchEntityKey: true,
 		Shadow:         shadowStash != nil,
 		ShadowStash:    shadowStash,
-		PartialInput:   partialInput,
+		BatchFetchKeep: batchFetchKeep,
 		Items:          items,
 	}
 	state := r.registerHandle(handle, cfg, in)

--- a/v2/pkg/engine/cache/controller.go
+++ b/v2/pkg/engine/cache/controller.go
@@ -94,6 +94,12 @@ type deferredSet struct {
 	reason resolve.CacheWriteReason
 }
 
+// negativeCacheSentinel is the stored form of a negative entry: a whole-value
+// JSON null. It is distinguishable from "no entry" (a store miss) and from a
+// positive null FIELD value (which always lives inside an object) — the read
+// path routes on a TOP-LEVEL TypeNull cached value only.
+const negativeCacheSentinel = "null"
+
 // useL2 reports whether this fetch participates in L2 through this controller.
 func (r *requestCache) useL2(cfg *resolve.FetchCacheConfig) bool {
 	return cfg != nil && cfg.L2 && r.store != nil
@@ -285,6 +291,17 @@ func (r *requestCache) prepareItemState(tx *resolve.CacheTransaction, cfg *resol
 	for _, hit := range hits {
 		state.FromCacheCandidates = append(state.FromCacheCandidates, hit.candidate)
 		parsed = append(parsed, hit.cached)
+		// A TOP-LEVEL null cached value is the negative sentinel: the entity is
+		// KNOWN to not exist, so the item is served as null without a coverage
+		// walk (there is nothing to cover). The freshest sentinel wins.
+		if hit.cached != nil && hit.cached.Type() == astjson.TypeNull && state.FromCache == nil {
+			state.FromCache = hit.cached
+			state.SelectedRemainingTTL = hit.candidate.RemainingTTL
+			state.NegativeHit = true
+		}
+	}
+	if state.NegativeHit {
+		return state, missedKeys, mustWriteBack
 	}
 	// The selected value stays in NORMALIZED (stored) form on the handle;
 	// OnFetchSkipped denormalizes it to the requesting aliases at splice time.
@@ -316,11 +333,6 @@ func (r *requestCache) OnFetchSkipped(h *resolve.FetchCacheHandle, in resolve.Me
 		if item.FromCache == nil || item.Item == nil {
 			continue
 		}
-		if item.FromCache.Type() == astjson.TypeNull {
-			// Negative sentinels land with task 11; a null value has nothing
-			// to splice.
-			continue
-		}
 		// A batch item splices into EVERY merge target of its unique
 		// representation (the BatchStats bucket at its original position).
 		targets := []*astjson.Value{item.Item}
@@ -329,6 +341,15 @@ func (r *requestCache) OnFetchSkipped(h *resolve.FetchCacheHandle, in resolve.Me
 			if item.BatchIndex >= 0 && item.BatchIndex < len(in.BatchStats) {
 				targets = in.BatchStats[item.BatchIndex]
 			}
+		}
+		if item.FromCache.Type() == astjson.TypeNull {
+			// A negative hit splices NOTHING: a real successful-but-empty
+			// entity fetch leaves the merge targets untouched (mergeResult
+			// early-returns), and the resolvable then renders the null bubble
+			// and its non-null error exactly as it would uncached. Replacing
+			// the target with null here would make the cached response DIFFER
+			// from the uncached one — caching must never change the response.
+			continue
 		}
 		for _, target := range targets {
 			if target == nil {
@@ -388,11 +409,30 @@ func (r *requestCache) OnFetchResult(h *resolve.FetchCacheHandle, in resolve.Mer
 		return nil
 	}
 	if in.FetchFailed || in.HasErrors {
+		// All failure signals block ALL writes — including negative ones: a
+		// transport/parse failure or errored response is a transient error,
+		// never a proof of nonexistence (FetchFailed wins over EmptyEntity).
+		return nil
+	}
+	if in.EmptyEntity && in.ResponseData != nil && in.ResponseData.Type() == astjson.TypeNull {
+		// The ONE non-failure that still writes: a SUCCESSFUL fetch that
+		// legitimately returned no entity caches the null sentinel so repeated
+		// lookups for a nonexistent entity skip the network.
+		if cfg.NegativeCacheTTL <= 0 {
+			return nil
+		}
+		tx := in.Arena.Begin()
+		defer tx.Commit()
+		for i := range h.Items {
+			h.Items[i].FromCache = tx.Null()
+			h.Items[i].NegativeHit = true
+			for _, key := range h.Items[i].RenderedKeys {
+				r.deferSet(key, []byte(negativeCacheSentinel), cfg.NegativeCacheTTL, resolve.CacheWriteReasonRefresh)
+			}
+		}
 		return nil
 	}
 	if in.ResponseData == nil || in.ResponseData.Type() == astjson.TypeNull {
-		// Includes the EmptyEntity case for now; the negative-cache sentinel
-		// write lands with task 11.
 		return nil
 	}
 	tx := in.Arena.Begin()

--- a/v2/pkg/engine/cache/controller.go
+++ b/v2/pkg/engine/cache/controller.go
@@ -477,11 +477,36 @@ func (r *requestCache) prepareBatchFetch(in resolve.PrepareFetchInput, cfg *reso
 	}
 
 	decision := resolve.DecisionFetch
+	var partialInput []byte
 	switch {
 	case shadowStash != nil:
 		decision = resolve.DecisionFetchShadow
 	case allCovered:
 		decision = resolve.DecisionSkipFullHit
+	default:
+		// Entity policies expose the knob as EnablePartialCacheLoad;
+		// root-field policies as PartialBatchLoad — either enables the batch
+		// partial path. Shadow wins over partial (read-never-serve).
+		if (cfg.EnablePartialCacheLoad || cfg.PartialBatchLoad) && !cfg.ShadowMode {
+			// SOME buckets covered: filter the representations to the missing
+			// ones and go partial. keep[i] mirrors the bucket order (which is
+			// the representations order). An unexpected input shape falls back
+			// to the plain full fetch — never a wrong request.
+			keep := make([]bool, len(items))
+			anyCovered := false
+			for i := range items {
+				keep[i] = items[i].FromCache == nil
+				if !keep[i] {
+					anyCovered = true
+				}
+			}
+			if anyCovered {
+				if reduced, ok := filterBatchInput(in.Input, keep); ok {
+					decision = resolve.DecisionFetchPartial
+					partialInput = reduced
+				}
+			}
+		}
 	}
 	handle := &resolve.FetchCacheHandle{
 		Decision:       decision,
@@ -490,6 +515,7 @@ func (r *requestCache) prepareBatchFetch(in resolve.PrepareFetchInput, cfg *reso
 		BatchEntityKey: true,
 		Shadow:         shadowStash != nil,
 		ShadowStash:    shadowStash,
+		PartialInput:   partialInput,
 		Items:          items,
 	}
 	r.configs[handle] = cfg
@@ -662,66 +688,86 @@ func (r *requestCache) OnFetchSkipped(h *resolve.FetchCacheHandle, in resolve.Me
 				targets = in.BatchStats[item.BatchIndex]
 			}
 		}
-		if item.FromCache.Type() == astjson.TypeNull {
-			// A negative hit splices NOTHING: a real successful-but-empty
-			// entity fetch leaves the merge targets untouched (mergeResult
-			// early-returns), and the resolvable then renders the null bubble
-			// and its non-null error exactly as it would uncached. Replacing
-			// the target with null here would make the cached response DIFFER
-			// from the uncached one — caching must never change the response.
-			continue
-		}
 		provides := resolve.Node(cfg.ProvidesData)
 		if subtree := r.reuseProvides[h]; subtree != nil {
 			provides = subtree
 		}
-		// A by-key root-field item carries its own merge path (the field's
-		// response key); everything else uses the fetch-level merge path.
-		mergePath := in.MergePath
-		if len(item.EntityMergePath) > 0 {
-			mergePath = item.EntityMergePath
+		var missed []string
+		if i < len(missedByItem) {
+			missed = missedByItem[i]
 		}
-		for _, target := range targets {
-			if target == nil {
-				continue
-			}
-			// Denormalize the stored value to the requesting operation's
-			// aliases in selection order; the walk builds a fresh
-			// transaction-owned value per target, so it is also the
-			// aliasing-safe copy for the splice.
-			cached := denormalizeToSelection(tx, r.ctx, item.FromCache, provides)
-			if len(mergePath) > 0 {
-				if _, err := tx.MergeValuesWithPath(target, cached, mergePath...); err != nil {
-					return err
-				}
-			} else if _, err := tx.MergeValues(target, cached); err != nil {
+		if err := r.spliceCachedItem(tx, cfg, prefix, provides, item, missed, targets, in.MergePath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// spliceCachedItem serves ONE covered item: splice the denormalized cached
+// value into every merge target, then settle the best-effort write-back
+// duties (refresh after a merged/older selection, backfill of missed keys,
+// pending-candidate re-render). Shared by OnFetchSkipped and the partial arm.
+func (r *requestCache) spliceCachedItem(tx *resolve.CacheTransaction, cfg *resolve.FetchCacheConfig, prefix string, provides resolve.Node, item resolve.ItemCacheState, missed []string, targets []*astjson.Value, fetchMergePath []string) error {
+	if item.FromCache == nil {
+		return nil
+	}
+	if item.FromCache.Type() == astjson.TypeNull {
+		// A negative hit splices NOTHING and writes nothing: a real
+		// successful-but-empty entity fetch leaves the merge targets untouched
+		// (mergeResult early-returns), and the resolvable then renders the
+		// null bubble and its non-null error exactly as it would uncached.
+		// Replacing the target with null here would make the cached response
+		// DIFFER from the uncached one — caching must never change the
+		// response.
+		return nil
+	}
+
+	// A by-key root-field item carries its own merge path (the field's
+	// response key); everything else uses the fetch-level merge path.
+	mergePath := fetchMergePath
+	if len(item.EntityMergePath) > 0 {
+		mergePath = item.EntityMergePath
+	}
+	for _, target := range targets {
+		if target == nil {
+			continue
+		}
+		// Denormalize the stored value to the requesting operation's
+		// aliases in selection order; the walk builds a fresh
+		// transaction-owned value per target, so it is also the
+		// aliasing-safe copy for the splice.
+		cached := denormalizeToSelection(tx, r.ctx, item.FromCache, provides)
+		if len(mergePath) > 0 {
+			if _, err := tx.MergeValuesWithPath(target, cached, mergePath...); err != nil {
 				return err
 			}
+		} else if _, err := tx.MergeValues(target, cached); err != nil {
+			return err
 		}
+	}
 
-		value := item.FromCache.MarshalTo(nil)
-		if item.NeedsWriteback {
-			// The served value was synthesized or older-but-covering: rewrite
-			// the canonical entries so the next lookup hits on the first rung.
-			for _, key := range item.RenderedKeys {
-				r.deferSet(key, value, cfg.TTL, resolve.CacheWriteReasonRefresh)
-			}
-		} else if i < len(missedByItem) {
-			for _, key := range missedByItem[i] {
-				r.deferSet(key, value, cfg.TTL, resolve.CacheWriteReasonBackfill)
-			}
+	value := item.FromCache.MarshalTo(nil)
+	if item.NeedsWriteback {
+		// The served value was synthesized or older-but-covering: rewrite
+		// the canonical entries so the next lookup hits on the first rung.
+		for _, key := range item.RenderedKeys {
+			r.deferSet(key, value, cfg.TTL, resolve.CacheWriteReasonRefresh)
 		}
-		for _, candidate := range item.PendingCandidates {
-			// A candidate unrenderable from the request item may render from
-			// the SERVED value (it can carry more fields); skip silently when
-			// it still cannot render — best-effort, never required.
-			template := cacheKeyTemplate{prefix: prefix, representation: candidate.Representation}
-			key, ok := template.render(item.FromCache)
-			if !ok {
-				continue
-			}
+	} else {
+		for _, key := range missed {
 			r.deferSet(key, value, cfg.TTL, resolve.CacheWriteReasonBackfill)
 		}
+	}
+	for _, candidate := range item.PendingCandidates {
+		// A candidate unrenderable from the request item may render from
+		// the SERVED value (it can carry more fields); skip silently when
+		// it still cannot render — best-effort, never required.
+		template := cacheKeyTemplate{prefix: prefix, representation: candidate.Representation}
+		key, ok := template.render(item.FromCache)
+		if !ok {
+			continue
+		}
+		r.deferSet(key, value, cfg.TTL, resolve.CacheWriteReasonBackfill)
 	}
 	return nil
 }
@@ -737,6 +783,13 @@ func (r *requestCache) OnFetchResult(h *resolve.FetchCacheHandle, in resolve.Mer
 	cfg := r.configs[h]
 	if cfg == nil {
 		return nil
+	}
+	if h.Decision == resolve.DecisionFetchPartial {
+		// The partial arm owns splice + realign + writes and runs BEFORE the
+		// failure gate: on a failed partial fetch the covered splice must
+		// still happen (the cached data is valid; the loader already rendered
+		// the fetch errors), and only the fetched subset is skipped.
+		return r.onPartialBatchResult(h, in, cfg)
 	}
 	if in.FetchFailed || in.HasErrors {
 		// All failure signals block ALL writes — including negative ones: a
@@ -835,47 +888,50 @@ func (r *requestCache) OnFetchResult(h *resolve.FetchCacheHandle, in resolve.Mer
 			}
 			itemToStore = entity
 		}
-		// Normalize to the stored form (schema names + argument suffixes)
-		// before caching; trees without aliases or args skip the transform
-		// (HasAliases is the fast-path gate) and store the raw value.
-		toStore := itemToStore
-		if provides != nil && provides.HasAliases {
-			toStore = normalizeToSchema(tx, r.ctx, itemToStore, provides)
-		}
-		// One key derivation feeds BOTH layers: the rendered keys plus the
-		// pending candidates re-rendered from the FRESH normalized value (a
-		// candidate the response still cannot render is skipped silently —
-		// best-effort, never required).
-		keys := item.RenderedKeys
-		backfillFrom := len(keys)
-		for _, candidate := range item.PendingCandidates {
-			template := cacheKeyTemplate{prefix: r.prefixes[h], representation: candidate.Representation}
-			key, ok := template.render(toStore)
-			if !ok {
-				continue
-			}
-			keys = append(keys, key)
-		}
-		if cfg.L1 {
-			// write-L1 before write-L2; POINTER store, zero marshaling.
-			copied := tx.StructuralCopy(toStore)
-			for _, key := range keys {
-				r.l1Put(key, copied)
-			}
-		}
-		if r.useL2(cfg) {
-			// Marshal ONCE per item — only the L2 path holds bytes.
-			value := toStore.MarshalTo(nil)
-			for i, key := range keys {
-				reason := resolve.CacheWriteReasonRefresh
-				if i >= backfillFrom {
-					reason = resolve.CacheWriteReasonBackfill
-				}
-				r.deferSet(key, value, cfg.TTL, reason)
-			}
-		}
+		r.writeFetchedValue(tx, cfg, h, item, itemToStore, provides)
 	}
 	return nil
+}
+
+// writeFetchedValue caches one FRESH per-item value: normalize to the stored
+// form (schema names + argument suffixes; HasAliases is the fast-path gate),
+// then feed BOTH layers from one key derivation — the rendered keys plus the
+// pending candidates re-rendered from the normalized value (a candidate the
+// response still cannot render is skipped silently — best-effort, never
+// required). Shared by OnFetchResult and the partial arm.
+func (r *requestCache) writeFetchedValue(tx *resolve.CacheTransaction, cfg *resolve.FetchCacheConfig, h *resolve.FetchCacheHandle, item resolve.ItemCacheState, itemToStore *astjson.Value, provides *resolve.Object) {
+	toStore := itemToStore
+	if provides != nil && provides.HasAliases {
+		toStore = normalizeToSchema(tx, r.ctx, itemToStore, provides)
+	}
+	keys := item.RenderedKeys
+	backfillFrom := len(keys)
+	for _, candidate := range item.PendingCandidates {
+		template := cacheKeyTemplate{prefix: r.prefixes[h], representation: candidate.Representation}
+		key, ok := template.render(toStore)
+		if !ok {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	if cfg.L1 {
+		// write-L1 before write-L2; POINTER store, zero marshaling.
+		copied := tx.StructuralCopy(toStore)
+		for _, key := range keys {
+			r.l1Put(key, copied)
+		}
+	}
+	if r.useL2(cfg) {
+		// Marshal ONCE per item — only the L2 path holds bytes.
+		value := toStore.MarshalTo(nil)
+		for i, key := range keys {
+			reason := resolve.CacheWriteReasonRefresh
+			if i >= backfillFrom {
+				reason = resolve.CacheWriteReasonBackfill
+			}
+			r.deferSet(key, value, cfg.TTL, reason)
+		}
+	}
 }
 
 // EndRequest flushes the deferred L2 writes — bytes only, no lock, no arena,

--- a/v2/pkg/engine/cache/controller.go
+++ b/v2/pkg/engine/cache/controller.go
@@ -113,12 +113,6 @@ func (r *requestCache) PrepareFetch(in resolve.PrepareFetchInput) (resolve.Decis
 	if !r.useL2(cfg) {
 		return resolve.DecisionFetch, nil
 	}
-	if cfg.ShadowMode {
-		// Shadow mode (read-never-serve) lands with task 12; until then a
-		// shadow-configured fetch behaves as a plain miss so no cached value
-		// can ever be served.
-		return resolve.DecisionFetch, nil
-	}
 	if cfg.KeySpec.Scope != resolve.CacheScopeEntity {
 		// Root-field caching lands with task 13.
 		return resolve.DecisionFetch, nil
@@ -139,10 +133,17 @@ func (r *requestCache) PrepareFetch(in resolve.PrepareFetchInput) (resolve.Decis
 
 	items := make([]resolve.ItemCacheState, 0, len(in.Items))
 	missedByItem := make([][]string, 0, len(in.Items))
+	var shadowStash map[int]resolve.ShadowCacheEntry
 	allCovered := true
 	mustWriteBack := false
-	for _, item := range in.Items {
+	for i, item := range in.Items {
 		state, missed, itemMustWriteBack := r.prepareItemState(tx, cfg, templates, item)
+		if entry := shadowStashEntry(tx, cfg, &state); entry != nil {
+			if shadowStash == nil {
+				shadowStash = make(map[int]resolve.ShadowCacheEntry)
+			}
+			shadowStash[i] = *entry
+		}
 		if state.FromCache == nil {
 			allCovered = false
 		}
@@ -154,7 +155,12 @@ func (r *requestCache) PrepareFetch(in resolve.PrepareFetchInput) (resolve.Decis
 	}
 
 	decision := resolve.DecisionFetch
-	if allCovered {
+	switch {
+	case shadowStash != nil:
+		// Shadow reads never serve: the loader treats FetchShadow exactly like
+		// Fetch (full network, full merge); the stash drives the compare.
+		decision = resolve.DecisionFetchShadow
+	case allCovered:
 		decision = resolve.DecisionSkipFullHit
 	}
 	handle := &resolve.FetchCacheHandle{
@@ -164,12 +170,43 @@ func (r *requestCache) PrepareFetch(in resolve.PrepareFetchInput) (resolve.Decis
 		// owes best-effort backfill/refresh writes for the keys that missed,
 		// the candidates that could not render, or a merged/older selection.
 		MustWriteBack: allCovered && mustWriteBack,
+		Shadow:        shadowStash != nil,
+		ShadowStash:   shadowStash,
 		Items:         items,
 	}
 	r.configs[handle] = cfg
 	r.prefixes[handle] = cacheKeyPrefix(cfg, in.HeaderHash)
 	r.missedKeys[handle] = missedByItem
 	return decision, handle
+}
+
+// shadowStashEntry moves a shadow-configured item's would-be-served value into
+// a stash entry and CLEARS the serving fields, so nothing can be served while
+// the compare still sees the exact selection (value, key, freshness, TTL).
+// Returns nil when the config is not in shadow mode or nothing was selected.
+func shadowStashEntry(tx *resolve.CacheTransaction, cfg *resolve.FetchCacheConfig, state *resolve.ItemCacheState) *resolve.ShadowCacheEntry {
+	if !cfg.ShadowMode || state.FromCache == nil {
+		return nil
+	}
+	cacheTTL := cfg.TTL
+	if state.NegativeHit {
+		cacheTTL = cfg.NegativeCacheTTL
+	}
+	shadowKey := ""
+	if len(state.RenderedKeys) > 0 {
+		shadowKey = state.RenderedKeys[0]
+	}
+	entry := &resolve.ShadowCacheEntry{
+		CachedValue:  tx.StructuralCopy(state.FromCache),
+		CacheKey:     shadowKey,
+		RemainingTTL: state.SelectedRemainingTTL,
+		CacheTTL:     cacheTTL,
+	}
+	state.FromCache = nil
+	state.SelectedRemainingTTL = 0
+	state.NegativeHit = false
+	state.NeedsWriteback = false
+	return entry
 }
 
 // prepareBatchFetch is the batch arm: one ItemCacheState per UNIQUE
@@ -193,6 +230,7 @@ func (r *requestCache) prepareBatchFetch(in resolve.PrepareFetchInput, cfg *reso
 
 	items := make([]resolve.ItemCacheState, 0, len(in.BatchStats))
 	missedByItem := make([][]string, 0, len(in.BatchStats))
+	var shadowStash map[int]resolve.ShadowCacheEntry
 	allCovered := true
 	mustWriteBack := false
 	for i, bucket := range in.BatchStats {
@@ -202,6 +240,12 @@ func (r *requestCache) prepareBatchFetch(in resolve.PrepareFetchInput, cfg *reso
 		}
 		state, missed, itemMustWriteBack := r.prepareItemState(tx, cfg, templates, representative)
 		state.BatchIndex = i
+		if entry := shadowStashEntry(tx, cfg, &state); entry != nil {
+			if shadowStash == nil {
+				shadowStash = make(map[int]resolve.ShadowCacheEntry)
+			}
+			shadowStash[i] = *entry
+		}
 		if state.FromCache == nil {
 			allCovered = false
 		}
@@ -213,7 +257,10 @@ func (r *requestCache) prepareBatchFetch(in resolve.PrepareFetchInput, cfg *reso
 	}
 
 	decision := resolve.DecisionFetch
-	if allCovered {
+	switch {
+	case shadowStash != nil:
+		decision = resolve.DecisionFetchShadow
+	case allCovered:
 		decision = resolve.DecisionSkipFullHit
 	}
 	handle := &resolve.FetchCacheHandle{
@@ -221,6 +268,8 @@ func (r *requestCache) prepareBatchFetch(in resolve.PrepareFetchInput, cfg *reso
 		WasHit:         allCovered,
 		MustWriteBack:  allCovered && mustWriteBack,
 		BatchEntityKey: true,
+		Shadow:         shadowStash != nil,
+		ShadowStash:    shadowStash,
 		Items:          items,
 	}
 	r.configs[handle] = cfg
@@ -437,6 +486,13 @@ func (r *requestCache) OnFetchResult(h *resolve.FetchCacheHandle, in resolve.Mer
 	}
 	tx := in.Arena.Begin()
 	defer tx.Commit()
+
+	if h.Shadow && r.obs != nil {
+		// The staleness probe: compare the stashed cached values against the
+		// fresh response BEFORE any write, inside this hook's transaction
+		// (compare -> write-L1 -> write-L2 order; no second lock acquisition).
+		r.obs.CompareShadow(h, in.ResponseData, tx)
+	}
 
 	// A batch response is the _entities array: each unique representation's
 	// value sits at its original batch position.

--- a/v2/pkg/engine/cache/controller.go
+++ b/v2/pkg/engine/cache/controller.go
@@ -642,7 +642,11 @@ func (r *requestCache) prepareItemState(tx *resolve.CacheTransaction, cfg *resol
 	for _, hit := range hits {
 		state.FromCacheCandidates = append(state.FromCacheCandidates, hit.candidate)
 		if hit.cached != nil && hit.cached.Type() == astjson.TypeNull {
-			// Sentinels never enter the positive selection ladder below.
+			// Sentinels never enter the positive selection ladder below; the
+			// nil placeholder keeps parsed POSITIONALLY ALIGNED with
+			// FromCacheCandidates, so the ladder reads each selected value's
+			// OWN RemainingTTL (the ladder skips nil entries).
+			parsed = append(parsed, nil)
 			continue
 		}
 		parsed = append(parsed, hit.cached)
@@ -659,7 +663,7 @@ func (r *requestCache) prepareItemState(tx *resolve.CacheTransaction, cfg *resol
 	}
 	if state.NegativeHit {
 		state.ServedFromLayer = "l2"
-		if cfg.L1 {
+		if cfg.L1 && !cfg.ShadowMode {
 			r.populateL1(tx, &state)
 		}
 		return state, missedKeys, mustWriteBack
@@ -670,7 +674,10 @@ func (r *requestCache) prepareItemState(tx *resolve.CacheTransaction, cfg *resol
 	if state.FromCache != nil {
 		state.ServedFromLayer = "l2"
 	}
-	if cfg.L1 && state.FromCache != nil {
+	// Only SERVED values may enter the shared L1. Under shadow the selection is
+	// a probe that the stash clears right after this returns — leaking it into
+	// L1 would let a sibling L1 reader serve a value shadow mode never served.
+	if cfg.L1 && !cfg.ShadowMode && state.FromCache != nil {
 		r.populateL1(tx, &state)
 	}
 	return state, missedKeys, mustWriteBack || state.NeedsWriteback
@@ -782,6 +789,16 @@ func (r *requestCache) spliceCachedItem(tx *resolve.CacheTransaction, cfg *resol
 		}
 	}
 
+	if !r.useL2(cfg) {
+		// L1-only: a served hit owes no L2 write-backs (there may be no store
+		// at all) — refresh, backfill, and pending-candidate renders are L2
+		// duties.
+		return nil
+	}
+	if !item.NeedsWriteback && len(missed) == 0 && len(item.PendingCandidates) == 0 {
+		// Pure hit with nothing owed: skip the marshal entirely (hot path).
+		return nil
+	}
 	value := item.FromCache.MarshalTo(nil)
 	if item.NeedsWriteback {
 		// The served value was synthesized or older-but-covering: rewrite
@@ -942,6 +959,13 @@ func (r *requestCache) OnFetchResult(h *resolve.FetchCacheHandle, in resolve.Mer
 // response still cannot render is skipped silently — best-effort, never
 // required). Shared by OnFetchResult and the partial arm.
 func (r *requestCache) writeFetchedValue(tx *resolve.CacheTransaction, cfg *resolve.FetchCacheConfig, h *resolve.FetchCacheHandle, item *resolve.ItemCacheState, itemToStore *astjson.Value, provides *resolve.Object) {
+	if itemToStore == nil || itemToStore.Type() == astjson.TypeNull {
+		// A null element is a MISSING entity, not a value: storing it would
+		// fabricate a negative sentinel under the positive TTL (bypassing the
+		// NegativeCacheTTL knob). Negative caching rides the loader's
+		// whole-response EmptyEntity signal only.
+		return
+	}
 	toStore := itemToStore
 	if provides != nil && provides.HasAliases {
 		toStore = normalizeToSchema(tx, r.ctx, itemToStore, provides)

--- a/v2/pkg/engine/cache/controller.go
+++ b/v2/pkg/engine/cache/controller.go
@@ -118,8 +118,7 @@ func (r *requestCache) PrepareFetch(in resolve.PrepareFetchInput) (resolve.Decis
 		return resolve.DecisionFetch, nil
 	}
 	if in.BatchStats != nil {
-		// Batch entity caching lands with task 10.
-		return resolve.DecisionFetch, nil
+		return r.prepareBatchFetch(in, cfg)
 	}
 	if len(in.Items) == 0 {
 		return resolve.DecisionFetch, nil
@@ -160,6 +159,63 @@ func (r *requestCache) PrepareFetch(in resolve.PrepareFetchInput) (resolve.Decis
 		// the candidates that could not render, or a merged/older selection.
 		MustWriteBack: allCovered && mustWriteBack,
 		Items:         items,
+	}
+	r.configs[handle] = cfg
+	r.prefixes[handle] = cacheKeyPrefix(cfg, in.HeaderHash)
+	r.missedKeys[handle] = missedByItem
+	return decision, handle
+}
+
+// prepareBatchFetch is the batch arm: one ItemCacheState per UNIQUE
+// representation (BatchStats bucket), keyed and looked up individually, with
+// the original batch position recorded for the splice and (task 19) the
+// partial realign. Full-batch semantics: ALL covered serves, ANY uncovered
+// refetches everything.
+func (r *requestCache) prepareBatchFetch(in resolve.PrepareFetchInput, cfg *resolve.FetchCacheConfig) (resolve.Decision, *resolve.FetchCacheHandle) {
+	if len(in.BatchStats) == 0 {
+		// The loader's empty-batch skip normally prevents this call entirely;
+		// an empty batch has nothing to serve or write.
+		return resolve.DecisionFetch, nil
+	}
+	templates := newCacheKeyTemplates(cfg, in.HeaderHash)
+	if len(templates) == 0 {
+		return resolve.DecisionFetch, nil
+	}
+
+	tx := in.Arena.Begin()
+	defer tx.Commit()
+
+	items := make([]resolve.ItemCacheState, 0, len(in.BatchStats))
+	missedByItem := make([][]string, 0, len(in.BatchStats))
+	allCovered := true
+	mustWriteBack := false
+	for i, bucket := range in.BatchStats {
+		var representative *astjson.Value
+		if len(bucket) > 0 {
+			representative = bucket[0]
+		}
+		state, missed, itemMustWriteBack := r.prepareItemState(tx, cfg, templates, representative)
+		state.BatchIndex = i
+		if state.FromCache == nil {
+			allCovered = false
+		}
+		if itemMustWriteBack {
+			mustWriteBack = true
+		}
+		items = append(items, state)
+		missedByItem = append(missedByItem, missed)
+	}
+
+	decision := resolve.DecisionFetch
+	if allCovered {
+		decision = resolve.DecisionSkipFullHit
+	}
+	handle := &resolve.FetchCacheHandle{
+		Decision:       decision,
+		WasHit:         allCovered,
+		MustWriteBack:  allCovered && mustWriteBack,
+		BatchEntityKey: true,
+		Items:          items,
 	}
 	r.configs[handle] = cfg
 	r.prefixes[handle] = cacheKeyPrefix(cfg, in.HeaderHash)
@@ -265,16 +321,31 @@ func (r *requestCache) OnFetchSkipped(h *resolve.FetchCacheHandle, in resolve.Me
 			// to splice.
 			continue
 		}
-		// Denormalize the stored value to the requesting operation's aliases in
-		// selection order; the walk builds a fresh transaction-owned value, so
-		// it is also the aliasing-safe copy for the splice.
-		cached := denormalizeToSelection(tx, r.ctx, item.FromCache, cfg.ProvidesData)
-		if len(in.MergePath) > 0 {
-			if _, err := tx.MergeValuesWithPath(item.Item, cached, in.MergePath...); err != nil {
+		// A batch item splices into EVERY merge target of its unique
+		// representation (the BatchStats bucket at its original position).
+		targets := []*astjson.Value{item.Item}
+		if h.BatchEntityKey {
+			targets = nil
+			if item.BatchIndex >= 0 && item.BatchIndex < len(in.BatchStats) {
+				targets = in.BatchStats[item.BatchIndex]
+			}
+		}
+		for _, target := range targets {
+			if target == nil {
+				continue
+			}
+			// Denormalize the stored value to the requesting operation's
+			// aliases in selection order; the walk builds a fresh
+			// transaction-owned value per target, so it is also the
+			// aliasing-safe copy for the splice.
+			cached := denormalizeToSelection(tx, r.ctx, item.FromCache, cfg.ProvidesData)
+			if len(in.MergePath) > 0 {
+				if _, err := tx.MergeValuesWithPath(target, cached, in.MergePath...); err != nil {
+					return err
+				}
+			} else if _, err := tx.MergeValues(target, cached); err != nil {
 				return err
 			}
-		} else if _, err := tx.MergeValues(item.Item, cached); err != nil {
-			return err
 		}
 
 		value := item.FromCache.MarshalTo(nil)
@@ -327,8 +398,23 @@ func (r *requestCache) OnFetchResult(h *resolve.FetchCacheHandle, in resolve.Mer
 	tx := in.Arena.Begin()
 	defer tx.Commit()
 
+	// A batch response is the _entities array: each unique representation's
+	// value sits at its original batch position.
+	var batch []*astjson.Value
+	if h.BatchEntityKey {
+		batch = in.ResponseData.GetArray()
+		if batch == nil {
+			return nil
+		}
+	}
 	for _, item := range h.Items {
 		itemToStore := in.ResponseData
+		if h.BatchEntityKey {
+			if item.BatchIndex < 0 || item.BatchIndex >= len(batch) {
+				continue
+			}
+			itemToStore = batch[item.BatchIndex]
+		}
 		if len(in.MergePath) > 0 {
 			// The response merges into the item at the merge path; the value to
 			// cache is the entity BELOW that path (D4), never the wrapper.

--- a/v2/pkg/engine/cache/controller.go
+++ b/v2/pkg/engine/cache/controller.go
@@ -88,6 +88,15 @@ type requestCache struct {
 	// root-field handles: the cached value is the ENTITY, so the walks use the
 	// root field's value subtree instead of the whole-response tree.
 	reuseProvides map[*resolve.FetchCacheHandle]*resolve.Object
+	// l1 is the request-lifetime entity store: NORMALIZED *astjson.Value
+	// (never bytes, never marshaled) under the SAME derived keys as L2.
+	// EXTERNAL-LOCK INVARIANT: guarded by the caller's CacheTransaction (the
+	// DataBuffer lock) like everything else on requestCache — no internal
+	// mutex. Values are isolated by tx.StructuralCopy at BOTH boundaries
+	// (write and read), so merges can never corrupt a stored value. The map
+	// is allocated lazily on the first write. This is NOT the removed
+	// @requestScoped feature (D11).
+	l1 map[string]*astjson.Value
 }
 
 // deferredSet is one pending L2 write, held as bytes until EndRequest; reason
@@ -110,15 +119,29 @@ func (r *requestCache) useL2(cfg *resolve.FetchCacheConfig) bool {
 	return cfg != nil && cfg.L2 && r.store != nil
 }
 
+// l1Put stores one L1 value; the caller passes a transaction-owned value
+// (ParseBytes/StructuralCopy product — never a heap value smuggled into
+// arena-noscan memory) and holds the transaction.
+func (r *requestCache) l1Put(key string, value *astjson.Value) {
+	if r.l1 == nil {
+		r.l1 = make(map[string]*astjson.Value)
+	}
+	r.l1[key] = value
+}
+
 // PrepareFetch renders the candidate key from the item data, looks L2 up,
 // runs the always-on coverage walk, and AND-reduces per-item hits into the
 // decision. It opens exactly one CacheTransaction for all arena work.
 func (r *requestCache) PrepareFetch(in resolve.PrepareFetchInput) (resolve.Decision, *resolve.FetchCacheHandle) {
 	cfg := in.Config
-	if !r.useL2(cfg) {
+	if cfg == nil || (!cfg.L1 && !r.useL2(cfg)) {
 		return resolve.DecisionFetch, nil
 	}
 	if cfg.KeySpec.Scope == resolve.CacheScopeRootField {
+		if !r.useL2(cfg) {
+			// Root fields are L2 providers only (task 13); L1 never applies.
+			return resolve.DecisionFetch, nil
+		}
 		return r.prepareRootFieldFetch(in, cfg)
 	}
 	if cfg.KeySpec.Scope != resolve.CacheScopeEntity {
@@ -485,11 +508,6 @@ func (r *requestCache) prepareItemState(tx *resolve.CacheTransaction, cfg *resol
 	state := resolve.ItemCacheState{Item: item}
 	mustWriteBack := false
 	var missedKeys []string
-	type lookupHit struct {
-		candidate resolve.CacheCandidate
-		cached    *astjson.Value
-	}
-	hits := make([]lookupHit, 0, len(templates))
 	for i, template := range templates {
 		key, ok := template.render(item)
 		if !ok {
@@ -501,6 +519,43 @@ func (r *requestCache) prepareItemState(tx *resolve.CacheTransaction, cfg *resol
 			continue
 		}
 		state.RenderedKeys = append(state.RenderedKeys, key)
+	}
+
+	// L1 first: keys are derived ONCE and shared with L2; a covering L1 hit
+	// serves with zero parsing and zero marshaling and SHORT-CIRCUITS every
+	// L2 read (and therefore every L2 write-back — coverage never required
+	// L2 here).
+	if cfg.L1 {
+		for _, key := range state.RenderedKeys {
+			stored := r.l1[key]
+			if stored == nil {
+				continue
+			}
+			if stored.Type() == astjson.TypeNull {
+				// The L1 negative sentinel: the entity is KNOWN missing within
+				// this request.
+				state.FromCache = tx.StructuralCopy(stored)
+				state.NegativeHit = true
+				return state, nil, false
+			}
+			if covers(r.ctx, stored, cfg.ProvidesData) {
+				state.FromCache = tx.StructuralCopy(stored)
+				return state, nil, false
+			}
+		}
+	}
+	if !r.useL2(cfg) {
+		// L1-only: a miss is a plain fetch; there is no L2 to read or back
+		// fill.
+		return state, nil, false
+	}
+
+	type lookupHit struct {
+		candidate resolve.CacheCandidate
+		cached    *astjson.Value
+	}
+	hits := make([]lookupHit, 0, len(templates))
+	for _, key := range state.RenderedKeys {
 		value, remaining, hit := r.store.Get(key)
 		if !hit {
 			missedKeys = append(missedKeys, key)
@@ -547,12 +602,31 @@ func (r *requestCache) prepareItemState(tx *resolve.CacheTransaction, cfg *resol
 		}
 	}
 	if state.NegativeHit {
+		if cfg.L1 {
+			r.populateL1(tx, &state)
+		}
 		return state, missedKeys, mustWriteBack
 	}
 	// The selected value stays in NORMALIZED (stored) form on the handle;
 	// OnFetchSkipped denormalizes it to the requesting aliases at splice time.
 	selectMultiCandidateCacheValue(tx, r.ctx, &state, parsed, cfg.ProvidesData)
+	if cfg.L1 && state.FromCache != nil {
+		r.populateL1(tx, &state)
+	}
 	return state, missedKeys, mustWriteBack || state.NeedsWriteback
+}
+
+// populateL1 stores an L2-served value in L1 under every rendered key, so a
+// later fetch of the same entity in this request skips L2 entirely. One
+// structural copy is shared across the keys; the read boundary copies again.
+func (r *requestCache) populateL1(tx *resolve.CacheTransaction, state *resolve.ItemCacheState) {
+	if state.FromCache == nil || len(state.RenderedKeys) == 0 {
+		return
+	}
+	copied := tx.StructuralCopy(state.FromCache)
+	for _, key := range state.RenderedKeys {
+		r.l1Put(key, copied)
+	}
 }
 
 // OnFetchSkipped splices the chosen cached values into the merge targets at
@@ -674,7 +748,7 @@ func (r *requestCache) OnFetchResult(h *resolve.FetchCacheHandle, in resolve.Mer
 		// The ONE non-failure that still writes: a SUCCESSFUL fetch that
 		// legitimately returned no entity caches the null sentinel so repeated
 		// lookups for a nonexistent entity skip the network.
-		if cfg.NegativeCacheTTL <= 0 {
+		if !cfg.L1 && cfg.NegativeCacheTTL <= 0 {
 			return nil
 		}
 		tx := in.Arena.Begin()
@@ -683,7 +757,14 @@ func (r *requestCache) OnFetchResult(h *resolve.FetchCacheHandle, in resolve.Mer
 			h.Items[i].FromCache = tx.Null()
 			h.Items[i].NegativeHit = true
 			for _, key := range h.Items[i].RenderedKeys {
-				r.deferSet(key, []byte(negativeCacheSentinel), cfg.NegativeCacheTTL, resolve.CacheWriteReasonRefresh)
+				if cfg.L1 {
+					// Within the request the nonexistence is a fact — the L1
+					// sentinel needs no TTL knob.
+					r.l1Put(key, tx.Null())
+				}
+				if r.useL2(cfg) && cfg.NegativeCacheTTL > 0 {
+					r.deferSet(key, []byte(negativeCacheSentinel), cfg.NegativeCacheTTL, resolve.CacheWriteReasonRefresh)
+				}
 			}
 		}
 		return nil
@@ -761,23 +842,37 @@ func (r *requestCache) OnFetchResult(h *resolve.FetchCacheHandle, in resolve.Mer
 		if provides != nil && provides.HasAliases {
 			toStore = normalizeToSchema(tx, r.ctx, itemToStore, provides)
 		}
-		// Marshal ONCE per item; the deferred set holds bytes only.
-		value := toStore.MarshalTo(nil)
-		for _, key := range item.RenderedKeys {
-			r.deferSet(key, value, cfg.TTL, resolve.CacheWriteReasonRefresh)
-		}
+		// One key derivation feeds BOTH layers: the rendered keys plus the
+		// pending candidates re-rendered from the FRESH normalized value (a
+		// candidate the response still cannot render is skipped silently —
+		// best-effort, never required).
+		keys := item.RenderedKeys
+		backfillFrom := len(keys)
 		for _, candidate := range item.PendingCandidates {
-			// Re-render candidates that could not render at lookup from the
-			// FRESH data (best-effort backfill); a candidate the response still
-			// cannot render is skipped silently — never required. Rendering
-			// uses the NORMALIZED value: representation fields carry schema
-			// names, which an alias-shaped response would not match.
 			template := cacheKeyTemplate{prefix: r.prefixes[h], representation: candidate.Representation}
 			key, ok := template.render(toStore)
 			if !ok {
 				continue
 			}
-			r.deferSet(key, value, cfg.TTL, resolve.CacheWriteReasonBackfill)
+			keys = append(keys, key)
+		}
+		if cfg.L1 {
+			// write-L1 before write-L2; POINTER store, zero marshaling.
+			copied := tx.StructuralCopy(toStore)
+			for _, key := range keys {
+				r.l1Put(key, copied)
+			}
+		}
+		if r.useL2(cfg) {
+			// Marshal ONCE per item — only the L2 path holds bytes.
+			value := toStore.MarshalTo(nil)
+			for i, key := range keys {
+				reason := resolve.CacheWriteReasonRefresh
+				if i >= backfillFrom {
+					reason = resolve.CacheWriteReasonBackfill
+				}
+				r.deferSet(key, value, cfg.TTL, reason)
+			}
 		}
 	}
 	return nil

--- a/v2/pkg/engine/cache/controller.go
+++ b/v2/pkg/engine/cache/controller.go
@@ -1,0 +1,260 @@
+package cache
+
+import (
+	"time"
+
+	"github.com/wundergraph/astjson"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// Store is the L2 backend the controller talks to. Get returns the value and
+// its remaining TTL; ok=false means miss or expired. Implementations must be
+// safe for concurrent use (the controller calls them from parallel fetch
+// hooks, under the request's DataBuffer.Lock).
+type Store interface {
+	Get(key string) (value []byte, remainingTTL time.Duration, ok bool)
+	Set(key string, value []byte, ttl time.Duration)
+}
+
+// Controller is the long-lived cache lifecycle port (implements
+// resolve.CacheController): one per integrator/cache instance, holding only
+// immutable collaborators. All per-request mutable state lives on the
+// requestCache BeginRequest hands out.
+//
+// Task 07 scope: the L2 entity controller for the single-candidate case.
+// Multi-key freshness/reorder/backfill (08), normalization (09), batch (10),
+// negative (11), shadow (12), root fields (13), L1 (17) and partial (19)
+// extend it.
+type Controller struct {
+	store Store
+	obs   resolve.CacheObserver
+}
+
+// NewController builds a controller over an L2 store; obs may be nil (no
+// observability).
+func NewController(store Store, obs resolve.CacheObserver) *Controller {
+	return &Controller{store: store, obs: obs}
+}
+
+// BeginRequest hands out the request-lifetime working surface. Called lazily,
+// once per request, under DataBuffer.Lock (the loader's cacheRequest).
+func (c *Controller) BeginRequest(ctx *resolve.Context) resolve.RequestCache {
+	if c.obs != nil {
+		c.obs.BeginRequest(ctx)
+	}
+	return &requestCache{
+		store:   c.store,
+		obs:     c.obs,
+		ctx:     ctx,
+		configs: make(map[*resolve.FetchCacheHandle]*resolve.FetchCacheConfig),
+	}
+}
+
+// requestCache is the per-request working surface (implements
+// resolve.RequestCache).
+//
+// Concurrency invariant (external lock, no internal mutex): PrepareFetch /
+// OnFetchSkipped / OnFetchResult run from parallel per-fetch (and
+// per-defer-group) goroutines, but each opens exactly ONE CacheTransaction via
+// in.Arena.Begin(), which holds the request's single DataBuffer.Lock for the
+// whole hook body. Every mutable field below (the deferred-write set and the
+// per-handle config map; later the shared L1 map) is read and written only
+// while that lock is held. EndRequest runs once, single-threaded, after the
+// whole tree resolves and touches only `deferred` (bytes), so it needs no lock
+// either. Verified under -race by the transaction/e2e rows.
+type requestCache struct {
+	store Store
+	obs   resolve.CacheObserver
+	ctx   *resolve.Context
+
+	// deferred is the request-end L2 write set: BYTES only, so the flush needs
+	// neither lock nor arena.
+	deferred []deferredSet
+	// configs threads each handle's config from PrepareFetch to the merge hook
+	// (the handle itself is opaque to the loader and carries no config).
+	configs map[*resolve.FetchCacheHandle]*resolve.FetchCacheConfig
+}
+
+// deferredSet is one pending L2 write, held as bytes until EndRequest.
+type deferredSet struct {
+	key   string
+	value []byte
+	ttl   time.Duration
+}
+
+// useL2 reports whether this fetch participates in L2 through this controller.
+func (r *requestCache) useL2(cfg *resolve.FetchCacheConfig) bool {
+	return cfg != nil && cfg.L2 && r.store != nil
+}
+
+// PrepareFetch renders the candidate key from the item data, looks L2 up,
+// runs the always-on coverage walk, and AND-reduces per-item hits into the
+// decision. It opens exactly one CacheTransaction for all arena work.
+func (r *requestCache) PrepareFetch(in resolve.PrepareFetchInput) (resolve.Decision, *resolve.FetchCacheHandle) {
+	cfg := in.Config
+	if !r.useL2(cfg) {
+		return resolve.DecisionFetch, nil
+	}
+	if cfg.ShadowMode {
+		// Shadow mode (read-never-serve) lands with task 12; until then a
+		// shadow-configured fetch behaves as a plain miss so no cached value
+		// can ever be served.
+		return resolve.DecisionFetch, nil
+	}
+	if cfg.KeySpec.Scope != resolve.CacheScopeEntity {
+		// Root-field caching lands with task 13.
+		return resolve.DecisionFetch, nil
+	}
+	if in.BatchStats != nil {
+		// Batch entity caching lands with task 10.
+		return resolve.DecisionFetch, nil
+	}
+	if len(in.Items) == 0 {
+		return resolve.DecisionFetch, nil
+	}
+	templates := newCacheKeyTemplates(cfg, in.HeaderHash)
+	if len(templates) == 0 {
+		return resolve.DecisionFetch, nil
+	}
+	// Task 07 handles the single-candidate case; multi-key selection lands
+	// with task 08.
+	template := templates[0]
+
+	tx := in.Arena.Begin()
+	defer tx.Commit()
+
+	items := make([]resolve.ItemCacheState, 0, len(in.Items))
+	allCovered := true
+	for _, item := range in.Items {
+		state := resolve.ItemCacheState{Item: item}
+		key, ok := template.render(item)
+		if ok {
+			state.RenderedKeys = []string{key}
+			if value, remaining, hit := r.store.Get(key); hit {
+				// Parse the cached bytes ONCE, onto the transaction's arena.
+				if cached, err := tx.ParseBytes(value); err == nil {
+					state.FromCacheCandidates = []resolve.CacheCandidate{{
+						Value:        append([]byte(nil), value...),
+						RemainingTTL: remaining,
+					}}
+					if covers(cached, cfg.ProvidesData) {
+						state.FromCache = cached
+						state.SelectedRemainingTTL = remaining
+					}
+				}
+			}
+		}
+		if state.FromCache == nil {
+			allCovered = false
+		}
+		items = append(items, state)
+	}
+
+	decision := resolve.DecisionFetch
+	if allCovered {
+		decision = resolve.DecisionSkipFullHit
+	}
+	handle := &resolve.FetchCacheHandle{
+		Decision: decision,
+		WasHit:   allCovered,
+		Items:    items,
+	}
+	r.configs[handle] = cfg
+	return decision, handle
+}
+
+// OnFetchSkipped splices the chosen cached values into the merge targets at
+// the surfaced merge path, inside one CacheTransaction; StructuralCopy guards
+// against aliasing when one cached value serves multiple targets.
+func (r *requestCache) OnFetchSkipped(h *resolve.FetchCacheHandle, in resolve.MergeInput) error {
+	if h == nil || r.configs[h] == nil {
+		return nil
+	}
+	tx := in.Arena.Begin()
+	defer tx.Commit()
+
+	for _, item := range h.Items {
+		if item.FromCache == nil || item.Item == nil {
+			continue
+		}
+		cached := tx.StructuralCopy(item.FromCache)
+		if cached.Type() == astjson.TypeNull {
+			// Negative sentinels land with task 11; a null value has nothing
+			// to splice.
+			continue
+		}
+		if len(in.MergePath) > 0 {
+			if _, err := tx.MergeValuesWithPath(item.Item, cached, in.MergePath...); err != nil {
+				return err
+			}
+		} else if _, err := tx.MergeValues(item.Item, cached); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// OnFetchResult applies the write gate and defers the L2 writes (bytes) to the
+// request-end flush. The gate is !FetchFailed && !HasErrors && ResponseData !=
+// nil && Type() != Null — it can never reduce to !HasErrors alone, because
+// transport/empty-body/parse failures reach this hook with HasErrors == false.
+func (r *requestCache) OnFetchResult(h *resolve.FetchCacheHandle, in resolve.MergeInput) error {
+	if h == nil {
+		return nil
+	}
+	cfg := r.configs[h]
+	if cfg == nil {
+		return nil
+	}
+	if in.FetchFailed || in.HasErrors {
+		return nil
+	}
+	if in.ResponseData == nil || in.ResponseData.Type() == astjson.TypeNull {
+		// Includes the EmptyEntity case for now; the negative-cache sentinel
+		// write lands with task 11.
+		return nil
+	}
+	tx := in.Arena.Begin()
+	defer tx.Commit()
+
+	for _, item := range h.Items {
+		itemToStore := in.ResponseData
+		if len(in.MergePath) > 0 {
+			// The response merges into the item at the merge path; the value to
+			// cache is the entity BELOW that path (D4), never the wrapper.
+			entity := itemToStore.Get(in.MergePath...)
+			if entity == nil {
+				continue
+			}
+			itemToStore = entity
+		}
+		// Marshal ONCE per item; the deferred set holds bytes only.
+		value := itemToStore.MarshalTo(nil)
+		for _, key := range item.RenderedKeys {
+			r.deferSet(key, value, cfg.TTL)
+		}
+	}
+	return nil
+}
+
+// EndRequest flushes the deferred L2 writes — bytes only, no lock, no arena,
+// no transaction — and finalizes observability. It runs once, single-threaded,
+// after the root tree and every defer group have resolved.
+func (r *requestCache) EndRequest() {
+	for _, set := range r.deferred {
+		r.store.Set(set.key, set.value, set.ttl)
+	}
+	r.deferred = nil
+	if r.obs != nil {
+		r.obs.EndRequest(r.ctx)
+	}
+}
+
+func (r *requestCache) deferSet(key string, value []byte, ttl time.Duration) {
+	r.deferred = append(r.deferred, deferredSet{
+		key:   key,
+		value: append([]byte(nil), value...),
+		ttl:   ttl,
+	})
+}

--- a/v2/pkg/engine/cache/controller_batch_test.go
+++ b/v2/pkg/engine/cache/controller_batch_test.go
@@ -187,9 +187,11 @@ func TestControllerBatchRows(t *testing.T) {
 			{Kind: "Get", Key: foundKey},
 			{Kind: "Set", Key: foundKey, Value: `{"__typename":"Product","name":"Desk","price":80}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
 		}, store.ops)
-		// Neither layer holds the missing entity: the next lookup is a plain
-		// miss, never a negative hit.
-		decisionB, handleB := prepare(t, rc, cfg, productItem(t, "1"))
+		// Nothing was PERSISTED for the missing entity: a fresh request (whose
+		// L1 starts empty, so the lookup can only hit L2) is a plain miss,
+		// never a negative hit.
+		rcB := newRC(store)
+		decisionB, handleB := prepare(t, rcB, cfg, productItem(t, "1"))
 		assert.Equal(t, resolve.DecisionFetch, decisionB)
 		assert.False(t, handleB.Items[0].NegativeHit)
 	})

--- a/v2/pkg/engine/cache/controller_batch_test.go
+++ b/v2/pkg/engine/cache/controller_batch_test.go
@@ -97,6 +97,7 @@ func TestControllerBatchRows(t *testing.T) {
 		store := newTestStore()
 		cfg := entityConfig(t, time.Minute)
 		keys := primeBatch(t, store, cfg, []string{"1"}, `[{"__typename":"Product","name":"Table","price":100}]`)
+		store.ops = nil // the mixed batch's ops assert in isolation
 
 		rc := newRC(store)
 		buckets := [][]*astjson.Value{{productItem(t, "1")}, {productItem(t, "3")}}
@@ -116,8 +117,6 @@ func TestControllerBatchRows(t *testing.T) {
 		rc.EndRequest()
 		missKey := handle.Items[1].RenderedKeys[0]
 		assert.Equal(t, []testStoreOp{
-			{Kind: "Get", Key: keys[0]},
-			{Kind: "Set", Key: keys[0], Value: `{"__typename":"Product","name":"Table","price":100}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
 			{Kind: "Get", Key: keys[0]},
 			{Kind: "Get", Key: missKey},
 			{Kind: "Set", Key: keys[0], Value: `{"__typename":"Product","name":"Table","price":100}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},

--- a/v2/pkg/engine/cache/controller_batch_test.go
+++ b/v2/pkg/engine/cache/controller_batch_test.go
@@ -1,0 +1,168 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/astjson"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// batchInput builds a PrepareFetchInput with one BatchStats bucket per item;
+// each bucket's targets alias the representative (the common loader shape).
+func batchInput(cfg *resolve.FetchCacheConfig, buckets ...[]*astjson.Value) resolve.PrepareFetchInput {
+	in := prepareInput(cfg)
+	in.BatchStats = buckets
+	return in
+}
+
+// TestControllerBatchRows covers the I rows: per-item keying, full-batch
+// serve/refetch semantics, per-element backfill, batch splice targets.
+func TestControllerBatchRows(t *testing.T) {
+	newRC := func(store Store) resolve.RequestCache {
+		return NewController(store, nil).BeginRequest(nil)
+	}
+
+	primeBatch := func(t *testing.T, store *testStore, cfg *resolve.FetchCacheConfig, upcs []string, entities string) []string {
+		t.Helper()
+		rc := newRC(store)
+		buckets := make([][]*astjson.Value, 0, len(upcs))
+		for _, upc := range upcs {
+			buckets = append(buckets, []*astjson.Value{productItem(t, upc)})
+		}
+		decision, handle := rc.PrepareFetch(batchInput(cfg, buckets...))
+		require.Equal(t, resolve.DecisionFetch, decision)
+		require.NotNil(t, handle)
+		require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+			BatchStats:   buckets,
+			ResponseData: astjson.MustParseBytes([]byte(entities)),
+			Arena:        beginner(),
+		}))
+		rc.EndRequest()
+		keys := make([]string, 0, len(handle.Items))
+		for _, item := range handle.Items {
+			require.Len(t, item.RenderedKeys, 1)
+			keys = append(keys, item.RenderedKeys[0])
+		}
+		return keys
+	}
+
+	t.Run("[I1] per-item keying: N entities produce N distinct Gets and Sets", func(t *testing.T) {
+		store := newTestStore()
+		cfg := entityConfig(t, time.Minute)
+		keys := primeBatch(t, store, cfg, []string{"1", "2"},
+			`[{"__typename":"Product","name":"Table","price":100},{"__typename":"Product","name":"Chair","price":50}]`)
+		require.Len(t, keys, 2)
+		assert.NotEqual(t, keys[0], keys[1])
+		assert.Equal(t, []testStoreOp{
+			{Kind: "Get", Key: keys[0]},
+			{Kind: "Get", Key: keys[1]},
+			{Kind: "Set", Key: keys[0], Value: `{"__typename":"Product","name":"Table","price":100}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
+			{Kind: "Set", Key: keys[1], Value: `{"__typename":"Product","name":"Chair","price":50}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
+		}, store.ops)
+	})
+
+	t.Run("[I2] full-batch hit serves every merge target at the merge path", func(t *testing.T) {
+		store := newTestStore()
+		cfg := entityConfig(t, time.Minute)
+		primeBatch(t, store, cfg, []string{"1", "2"},
+			`[{"__typename":"Product","name":"Table","price":100},{"__typename":"Product","name":"Chair","price":50}]`)
+
+		rc := newRC(store)
+		// Bucket 0 has TWO merge targets (a deduplicated representation).
+		target0a := productItem(t, "1")
+		target0b := productItem(t, "1")
+		target1 := productItem(t, "2")
+		buckets := [][]*astjson.Value{{target0a, target0b}, {target1}}
+		decision, handle := rc.PrepareFetch(batchInput(cfg, buckets...))
+		require.Equal(t, resolve.DecisionSkipFullHit, decision)
+		assert.True(t, handle.BatchEntityKey)
+		assert.Equal(t, []int{0, 1}, []int{handle.Items[0].BatchIndex, handle.Items[1].BatchIndex})
+
+		require.NoError(t, rc.OnFetchSkipped(handle, resolve.MergeInput{
+			BatchStats: buckets,
+			MergePath:  []string{"details"},
+			Arena:      beginner(),
+		}))
+		assert.Equal(t, `{"__typename":"Product","upc":"1","details":{"name":"Table","price":100,"__typename":"Product"}}`, string(target0a.MarshalTo(nil)))
+		assert.Equal(t, `{"__typename":"Product","upc":"1","details":{"name":"Table","price":100,"__typename":"Product"}}`, string(target0b.MarshalTo(nil)))
+		assert.Equal(t, `{"__typename":"Product","upc":"2","details":{"name":"Chair","price":50,"__typename":"Product"}}`, string(target1.MarshalTo(nil)))
+	})
+
+	t.Run("[I3] mixed batch never partially serves: full refetch with lookups logged", func(t *testing.T) {
+		store := newTestStore()
+		cfg := entityConfig(t, time.Minute)
+		keys := primeBatch(t, store, cfg, []string{"1"}, `[{"__typename":"Product","name":"Table","price":100}]`)
+
+		rc := newRC(store)
+		buckets := [][]*astjson.Value{{productItem(t, "1")}, {productItem(t, "3")}}
+		decision, handle := rc.PrepareFetch(batchInput(cfg, buckets...))
+		require.Equal(t, resolve.DecisionFetch, decision)
+		assert.False(t, handle.WasHit)
+		// Item 0 is covered, item 1 not — but full-batch semantics refetch all.
+		assert.NotNil(t, handle.Items[0].FromCache)
+		assert.Nil(t, handle.Items[1].FromCache)
+
+		// The full refetch writes EVERY entity afterwards.
+		require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+			BatchStats:   buckets,
+			ResponseData: astjson.MustParseBytes([]byte(`[{"__typename":"Product","name":"Table","price":100},{"__typename":"Product","name":"Desk","price":80}]`)),
+			Arena:        beginner(),
+		}))
+		rc.EndRequest()
+		missKey := handle.Items[1].RenderedKeys[0]
+		assert.Equal(t, []testStoreOp{
+			{Kind: "Get", Key: keys[0]},
+			{Kind: "Set", Key: keys[0], Value: `{"__typename":"Product","name":"Table","price":100}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
+			{Kind: "Get", Key: keys[0]},
+			{Kind: "Get", Key: missKey},
+			{Kind: "Set", Key: keys[0], Value: `{"__typename":"Product","name":"Table","price":100}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
+			{Kind: "Set", Key: missKey, Value: `{"__typename":"Product","name":"Desk","price":80}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
+		}, store.ops)
+	})
+
+	t.Run("[I4] per-element multi-key backfill from the batch response", func(t *testing.T) {
+		cfg := multiKeyConfig(t)
+		skuKey, upcKey := deriveMultiKeys(t, cfg)
+		store := newTestStore()
+		rc := newRC(store)
+		// Items lack sku, so the sku candidate is pending per element.
+		buckets := [][]*astjson.Value{{productItem(t, "1")}}
+		decision, handle := rc.PrepareFetch(batchInput(cfg, buckets...))
+		require.Equal(t, resolve.DecisionFetch, decision)
+		require.Len(t, handle.Items[0].PendingCandidates, 1)
+
+		require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+			BatchStats:   buckets,
+			ResponseData: astjson.MustParseBytes([]byte(`[{"__typename":"Product","name":"Table","price":100,"sku":"S1"}]`)),
+			Arena:        beginner(),
+		}))
+		rc.EndRequest()
+		assert.Equal(t, []testStoreOp{
+			{Kind: "Get", Key: upcKey},
+			{Kind: "Set", Key: upcKey, Value: `{"__typename":"Product","name":"Table","price":100,"sku":"S1"}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
+			{Kind: "Set", Key: skuKey, Value: `{"__typename":"Product","name":"Table","price":100,"sku":"S1"}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonBackfill},
+		}, store.ops)
+	})
+
+	t.Run("[I5] a non-array batch response writes nothing", func(t *testing.T) {
+		store := newTestStore()
+		cfg := entityConfig(t, time.Minute)
+		rc := newRC(store)
+		buckets := [][]*astjson.Value{{productItem(t, "1")}}
+		_, handle := rc.PrepareFetch(batchInput(cfg, buckets...))
+		require.NotNil(t, handle)
+		require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+			BatchStats:   buckets,
+			ResponseData: astjson.MustParseBytes([]byte(`{"not":"an array"}`)),
+			Arena:        beginner(),
+		}))
+		rc.EndRequest()
+		key := handle.Items[0].RenderedKeys[0]
+		assert.Equal(t, []testStoreOp{{Kind: "Get", Key: key}}, store.ops)
+	})
+}

--- a/v2/pkg/engine/cache/controller_batch_test.go
+++ b/v2/pkg/engine/cache/controller_batch_test.go
@@ -164,4 +164,33 @@ func TestControllerBatchRows(t *testing.T) {
 		key := handle.Items[0].RenderedKeys[0]
 		assert.Equal(t, []testStoreOp{{Kind: "Get", Key: key}}, store.ops)
 	})
+
+	t.Run("[I6] a null batch element writes nothing: never a fake negative sentinel", func(t *testing.T) {
+		store := newTestStore()
+		cfg := entityConfig(t, time.Minute)
+		rc := newRC(store)
+		buckets := [][]*astjson.Value{{productItem(t, "1")}, {productItem(t, "2")}}
+		decision, handle := rc.PrepareFetch(batchInput(cfg, buckets...))
+		require.Equal(t, resolve.DecisionFetch, decision)
+		require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+			BatchStats:   buckets,
+			ResponseData: astjson.MustParseBytes([]byte(`[null,{"__typename":"Product","name":"Desk","price":80}]`)),
+			Arena:        beginner(),
+		}))
+		rc.EndRequest()
+		missingKey := handle.Items[0].RenderedKeys[0]
+		foundKey := handle.Items[1].RenderedKeys[0]
+		// The null element writes NOTHING: caching it under cfg.TTL would read
+		// back as a negative hit and bypass the NegativeCacheTTL knob.
+		assert.Equal(t, []testStoreOp{
+			{Kind: "Get", Key: missingKey},
+			{Kind: "Get", Key: foundKey},
+			{Kind: "Set", Key: foundKey, Value: `{"__typename":"Product","name":"Desk","price":80}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
+		}, store.ops)
+		// Neither layer holds the missing entity: the next lookup is a plain
+		// miss, never a negative hit.
+		decisionB, handleB := prepare(t, rc, cfg, productItem(t, "1"))
+		assert.Equal(t, resolve.DecisionFetch, decisionB)
+		assert.False(t, handleB.Items[0].NegativeHit)
+	})
 }

--- a/v2/pkg/engine/cache/controller_l1_test.go
+++ b/v2/pkg/engine/cache/controller_l1_test.go
@@ -149,6 +149,36 @@ func TestControllerL1Rows(t *testing.T) {
 		assert.Empty(t, store.ops)
 	})
 
+	t.Run("L1-only: a hit owing a pending-candidate render still emits ZERO store ops", func(t *testing.T) {
+		store := newTestStore()
+		cfg := multiKeyConfig(t) // sku + upc candidates
+		cfg.TTL = 0
+		cfg.L1, cfg.L2 = true, false
+		rc := NewController(store, nil).BeginRequest(nil)
+
+		// Fetch A renders only upc; the response carries sku, so L1 holds the
+		// value under BOTH keys.
+		itemA := astjson.MustParseBytes([]byte(`{"__typename":"Product","upc":"1"}`))
+		l1Fetch(t, rc, cfg, itemA, astjson.MustParseBytes([]byte(`{"__typename":"Product","name":"Table","price":100,"sku":"S1"}`)))
+
+		// Fetch B misses sku again: its PENDING sku candidate renders from the
+		// SERVED value at splice time — an L2 write-back duty that must stay
+		// gated off without L2.
+		itemB := astjson.MustParseBytes([]byte(`{"__typename":"Product","upc":"1"}`))
+		decision, handleB := prepare(t, rc, cfg, itemB)
+		assert.Equal(t, resolve.DecisionSkipFullHit, decision)
+		require.Len(t, handleB.Items[0].PendingCandidates, 1)
+		require.NoError(t, rc.OnFetchSkipped(handleB, resolve.MergeInput{
+			Items: []*astjson.Value{itemB},
+			Arena: beginner(),
+		}))
+		rc.EndRequest()
+		assert.Equal(t,
+			`{"__typename":"Product","upc":"1","name":"Table","price":100,"sku":"S1"}`,
+			string(itemB.MarshalTo(nil)))
+		assert.Empty(t, store.ops)
+	})
+
 	t.Run("negative L1: an EmptyEntity result serves the next lookup as a negative hit", func(t *testing.T) {
 		store := newTestStore()
 		cfg := entityConfig(t, 0)

--- a/v2/pkg/engine/cache/controller_l1_test.go
+++ b/v2/pkg/engine/cache/controller_l1_test.go
@@ -115,6 +115,7 @@ func TestControllerL1Rows(t *testing.T) {
 		store := newTestStore()
 		cfg := entityConfig(t, time.Minute)
 		key := writeThrough(t, NewController(store, nil).BeginRequest(nil), cfg, productItem(t, "1"), fresh)
+		store.ops = nil // request 2's ops assert in isolation
 
 		rc := NewController(store, nil).BeginRequest(nil)
 		itemA := productItem(t, "1")
@@ -125,11 +126,8 @@ func TestControllerL1Rows(t *testing.T) {
 		decisionB, _ := prepare(t, rc, cfg, itemB)
 		assert.Equal(t, resolve.DecisionSkipFullHit, decisionB)
 		rc.EndRequest()
-		assert.Equal(t, []testStoreOp{
-			{Kind: "Get", Key: key},
-			{Kind: "Set", Key: key, Value: fresh, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
-			{Kind: "Get", Key: key}, // request 2, fetch A only — fetch B rode L1
-		}, store.ops)
+		// Fetch A's single L2 Get is request 2's ONLY store op — fetch B rode L1.
+		assert.Equal(t, []testStoreOp{{Kind: "Get", Key: key}}, store.ops)
 	})
 
 	t.Run("multi-key backfill reaches L1: a pending-rendered key serves the next lookup", func(t *testing.T) {

--- a/v2/pkg/engine/cache/controller_l1_test.go
+++ b/v2/pkg/engine/cache/controller_l1_test.go
@@ -1,0 +1,204 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/astjson"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// l1Fetch runs one miss->fetch->result cycle on rc, feeding the L1 (and L2
+// when enabled) from responseData.
+func l1Fetch(t *testing.T, rc resolve.RequestCache, cfg *resolve.FetchCacheConfig, item *astjson.Value, responseData *astjson.Value) *resolve.FetchCacheHandle {
+	t.Helper()
+	decision, handle := prepare(t, rc, cfg, item)
+	require.Equal(t, resolve.DecisionFetch, decision)
+	require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+		Items:        []*astjson.Value{item},
+		ResponseData: responseData,
+		Arena:        beginner(),
+	}))
+	return handle
+}
+
+// TestControllerL1Rows covers the request-lifetime L1 store rows.
+func TestControllerL1Rows(t *testing.T) {
+	fresh := `{"__typename":"Product","name":"Table","price":100}`
+
+	t.Run("in-request reuse: fetch A populates L1, fetch B hits with zero store ops (shared key)", func(t *testing.T) {
+		store := newTestStore()
+		cfg := entityConfig(t, time.Minute) // L1 + L2
+		rc := NewController(store, nil).BeginRequest(nil)
+
+		handleA := l1Fetch(t, rc, cfg, productItem(t, "1"), astjson.MustParseBytes([]byte(fresh)))
+
+		itemB := productItem(t, "1")
+		decision, handleB := prepare(t, rc, cfg, itemB)
+		assert.Equal(t, resolve.DecisionSkipFullHit, decision)
+		// SHARED KEYS: the L1 key IS the L2 key — one derivation per fetch.
+		assert.Equal(t, handleA.Items[0].RenderedKeys, handleB.Items[0].RenderedKeys)
+		require.NoError(t, rc.OnFetchSkipped(handleB, resolve.MergeInput{
+			Items: []*astjson.Value{itemB},
+			Arena: beginner(),
+		}))
+		assert.Equal(t,
+			`{"__typename":"Product","upc":"1","name":"Table","price":100}`,
+			string(itemB.MarshalTo(nil)))
+		rc.EndRequest()
+		// A's miss Get and A's flush Set are the ONLY store ops: B's L1 hit
+		// short-circuited the L2 Get entirely (and owed no write-back).
+		key := handleA.Items[0].RenderedKeys[0]
+		assert.Equal(t, []testStoreOp{
+			{Kind: "Get", Key: key},
+			{Kind: "Set", Key: key, Value: fresh, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
+		}, store.ops)
+	})
+
+	t.Run("[J] L1-only: full round-trip with ZERO store ops (zero marshaling path)", func(t *testing.T) {
+		store := newTestStore()
+		cfg := entityConfig(t, 0) // TTL 0: L1 true, L2 false
+		rc := NewController(store, nil).BeginRequest(nil)
+
+		l1Fetch(t, rc, cfg, productItem(t, "1"), astjson.MustParseBytes([]byte(fresh)))
+		itemB := productItem(t, "1")
+		decision, handleB := prepare(t, rc, cfg, itemB)
+		assert.Equal(t, resolve.DecisionSkipFullHit, decision)
+		require.NoError(t, rc.OnFetchSkipped(handleB, resolve.MergeInput{
+			Items: []*astjson.Value{itemB},
+			Arena: beginner(),
+		}))
+		rc.EndRequest()
+		assert.Equal(t,
+			`{"__typename":"Product","upc":"1","name":"Table","price":100}`,
+			string(itemB.MarshalTo(nil)))
+		assert.Empty(t, store.ops)
+	})
+
+	t.Run("write isolation: mutating the response after the write leaves L1 unaffected", func(t *testing.T) {
+		cfg := entityConfig(t, 0)
+		rc := NewController(newTestStore(), nil).BeginRequest(nil)
+		responseData := astjson.MustParseBytes([]byte(fresh))
+		l1Fetch(t, rc, cfg, productItem(t, "1"), responseData)
+
+		// Corrupt the source AFTER the L1 write.
+		responseData.Set(nil, "name", astjson.MustParseBytes([]byte(`"CORRUPTED"`)))
+
+		itemB := productItem(t, "1")
+		_, handleB := prepare(t, rc, cfg, itemB)
+		require.NotNil(t, handleB.Items[0].FromCache)
+		assert.Equal(t, fresh, string(handleB.Items[0].FromCache.MarshalTo(nil)))
+	})
+
+	t.Run("read isolation: mutating a served value leaves L1 unaffected", func(t *testing.T) {
+		cfg := entityConfig(t, 0)
+		rc := NewController(newTestStore(), nil).BeginRequest(nil)
+		l1Fetch(t, rc, cfg, productItem(t, "1"), astjson.MustParseBytes([]byte(fresh)))
+
+		itemB := productItem(t, "1")
+		_, handleB := prepare(t, rc, cfg, itemB)
+		require.NotNil(t, handleB.Items[0].FromCache)
+		// Corrupt the SERVED copy.
+		handleB.Items[0].FromCache.Set(nil, "name", astjson.MustParseBytes([]byte(`"CORRUPTED"`)))
+
+		itemC := productItem(t, "1")
+		_, handleC := prepare(t, rc, cfg, itemC)
+		require.NotNil(t, handleC.Items[0].FromCache)
+		assert.Equal(t, fresh, string(handleC.Items[0].FromCache.MarshalTo(nil)))
+	})
+
+	t.Run("an L2 hit populates L1: the second lookup emits no second Get", func(t *testing.T) {
+		store := newTestStore()
+		cfg := entityConfig(t, time.Minute)
+		key := writeThrough(t, NewController(store, nil).BeginRequest(nil), cfg, productItem(t, "1"), fresh)
+
+		rc := NewController(store, nil).BeginRequest(nil)
+		itemA := productItem(t, "1")
+		decisionA, _ := prepare(t, rc, cfg, itemA)
+		require.Equal(t, resolve.DecisionSkipFullHit, decisionA)
+
+		itemB := productItem(t, "1")
+		decisionB, _ := prepare(t, rc, cfg, itemB)
+		assert.Equal(t, resolve.DecisionSkipFullHit, decisionB)
+		rc.EndRequest()
+		assert.Equal(t, []testStoreOp{
+			{Kind: "Get", Key: key},
+			{Kind: "Set", Key: key, Value: fresh, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
+			{Kind: "Get", Key: key}, // request 2, fetch A only — fetch B rode L1
+		}, store.ops)
+	})
+
+	t.Run("multi-key backfill reaches L1: a pending-rendered key serves the next lookup", func(t *testing.T) {
+		store := newTestStore()
+		cfg := multiKeyConfig(t) // sku + upc candidates
+		cfg.TTL = 0
+		cfg.L1, cfg.L2 = true, false
+		rc := NewController(store, nil).BeginRequest(nil)
+
+		// The item carries only upc; sku renders from the RESPONSE (backfill).
+		itemA := astjson.MustParseBytes([]byte(`{"__typename":"Product","upc":"1"}`))
+		l1Fetch(t, rc, cfg, itemA, astjson.MustParseBytes([]byte(`{"__typename":"Product","name":"Table","price":100,"sku":"S1"}`)))
+
+		// The next lookup knows only the SKU.
+		itemB := astjson.MustParseBytes([]byte(`{"__typename":"Product","sku":"S1"}`))
+		decision, handleB := prepare(t, rc, cfg, itemB)
+		assert.Equal(t, resolve.DecisionSkipFullHit, decision)
+		require.NotNil(t, handleB.Items[0].FromCache)
+		assert.Empty(t, store.ops)
+	})
+
+	t.Run("negative L1: an EmptyEntity result serves the next lookup as a negative hit", func(t *testing.T) {
+		store := newTestStore()
+		cfg := entityConfig(t, 0)
+		// The coverage tree must allow a null entity for the sentinel path.
+		cfg.ProvidesData = &resolve.Object{
+			Nullable: true,
+			Fields:   cfg.ProvidesData.Fields,
+		}
+		rc := NewController(store, nil).BeginRequest(nil)
+		itemA := productItem(t, "404")
+		decision, handleA := prepare(t, rc, cfg, itemA)
+		require.Equal(t, resolve.DecisionFetch, decision)
+		require.NoError(t, rc.OnFetchResult(handleA, resolve.MergeInput{
+			Items:        []*astjson.Value{itemA},
+			ResponseData: astjson.MustParseBytes([]byte(`null`)),
+			EmptyEntity:  true,
+			Arena:        beginner(),
+		}))
+
+		itemB := productItem(t, "404")
+		decisionB, handleB := prepare(t, rc, cfg, itemB)
+		assert.Equal(t, resolve.DecisionSkipFullHit, decisionB)
+		assert.True(t, handleB.Items[0].NegativeHit)
+		assert.Empty(t, store.ops)
+	})
+
+	t.Run("[H4] shadow stashes an L1-selected value too: read-never-serve stays absolute", func(t *testing.T) {
+		store := newTestStore()
+		cfg := shadowConfig(t) // L1 + L2 + shadow
+		rc := NewController(store, nil).BeginRequest(nil)
+		l1Fetch(t, rc, cfg, productItem(t, "1"), astjson.MustParseBytes([]byte(fresh)))
+
+		itemB := productItem(t, "1")
+		decision, handleB := prepare(t, rc, cfg, itemB)
+		assert.Equal(t, resolve.DecisionFetchShadow, decision)
+		assert.Nil(t, handleB.Items[0].FromCache)
+		require.Contains(t, handleB.ShadowStash, 0)
+		assert.Equal(t, fresh, string(handleB.ShadowStash[0].CachedValue.MarshalTo(nil)))
+	})
+
+	t.Run("no bleed across requests: a fresh request cache starts with an empty L1", func(t *testing.T) {
+		store := newTestStore()
+		cfg := entityConfig(t, 0)
+		controller := NewController(store, nil)
+		l1Fetch(t, controller.BeginRequest(nil), cfg, productItem(t, "1"), astjson.MustParseBytes([]byte(fresh)))
+
+		// A NEW request (e.g. the next subscription event after clone): miss.
+		decision, _ := prepare(t, controller.BeginRequest(nil), cfg, productItem(t, "1"))
+		assert.Equal(t, resolve.DecisionFetch, decision)
+	})
+}

--- a/v2/pkg/engine/cache/controller_negative_test.go
+++ b/v2/pkg/engine/cache/controller_negative_test.go
@@ -57,9 +57,10 @@ func TestControllerNegativeRows(t *testing.T) {
 		assert.Equal(t, astjson.TypeNull, handle.Items[0].FromCache.Type())
 	})
 
-	t.Run("[G2] NegativeCacheTTL == 0 disables the path: zero writes", func(t *testing.T) {
+	t.Run("[G2] NegativeCacheTTL == 0 disables the L2 path: zero store writes", func(t *testing.T) {
 		store := newTestStore()
 		cfg := negativeConfig(t, 0)
+		cfg.L1 = false // isolate the L2 rule; the L1 sentinel has no TTL knob (task 17)
 		rc := newRC(store)
 		item := productItem(t, "404")
 		_, handle := prepare(t, rc, cfg, item)

--- a/v2/pkg/engine/cache/controller_negative_test.go
+++ b/v2/pkg/engine/cache/controller_negative_test.go
@@ -1,0 +1,162 @@
+package cache
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/astjson"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// negativeConfig is the entity config with negative caching enabled.
+func negativeConfig(t *testing.T, negativeTTL time.Duration) *resolve.FetchCacheConfig {
+	t.Helper()
+	cfg := entityConfig(t, time.Minute)
+	cfg.NegativeCacheTTL = negativeTTL
+	return cfg
+}
+
+// emptyEntityInput is the loader's post-merge view of a SUCCESSFUL fetch that
+// returned no entity: parsed response, null data, EmptyEntity set.
+func emptyEntityInput(item *astjson.Value) resolve.MergeInput {
+	return resolve.MergeInput{
+		Items:        []*astjson.Value{item},
+		ResponseData: astjson.MustParseBytes([]byte(`null`)),
+		EmptyEntity:  true,
+		StatusCode:   200,
+		Arena:        beginner(),
+	}
+}
+
+// TestControllerNegativeRows covers the G rows.
+func TestControllerNegativeRows(t *testing.T) {
+	newRC := func(store Store) resolve.RequestCache {
+		return NewController(store, nil).BeginRequest(nil)
+	}
+
+	t.Run("[G1] empty entity writes the exact sentinel with NegativeCacheTTL", func(t *testing.T) {
+		store := newTestStore()
+		cfg := negativeConfig(t, 5*time.Second)
+		rc := newRC(store)
+		item := productItem(t, "404")
+		_, handle := prepare(t, rc, cfg, item)
+		require.NoError(t, rc.OnFetchResult(handle, emptyEntityInput(item)))
+		rc.EndRequest()
+		key := handle.Items[0].RenderedKeys[0]
+		assert.Equal(t, []testStoreOp{
+			{Kind: "Get", Key: key},
+			{Kind: "Set", Key: key, Value: "null", TTL: 5 * time.Second, Reason: resolve.CacheWriteReasonRefresh},
+		}, store.ops)
+		assert.True(t, handle.Items[0].NegativeHit)
+		require.NotNil(t, handle.Items[0].FromCache)
+		assert.Equal(t, astjson.TypeNull, handle.Items[0].FromCache.Type())
+	})
+
+	t.Run("[G2] NegativeCacheTTL == 0 disables the path: zero writes", func(t *testing.T) {
+		store := newTestStore()
+		cfg := negativeConfig(t, 0)
+		rc := newRC(store)
+		item := productItem(t, "404")
+		_, handle := prepare(t, rc, cfg, item)
+		require.NoError(t, rc.OnFetchResult(handle, emptyEntityInput(item)))
+		rc.EndRequest()
+		key := handle.Items[0].RenderedKeys[0]
+		assert.Equal(t, []testStoreOp{{Kind: "Get", Key: key}}, store.ops)
+		assert.False(t, handle.Items[0].NegativeHit)
+	})
+
+	t.Run("[G3] a sentinel hit serves null with zero network and NegativeHit recorded", func(t *testing.T) {
+		store := newTestStore()
+		cfg := negativeConfig(t, 5*time.Second)
+		// Prime the sentinel through the controller itself (read key == write key).
+		primeRC := newRC(store)
+		primeItem := productItem(t, "404")
+		_, primeHandle := prepare(t, primeRC, cfg, primeItem)
+		require.NoError(t, primeRC.OnFetchResult(primeHandle, emptyEntityInput(primeItem)))
+		primeRC.EndRequest()
+
+		rc := newRC(store)
+		item := productItem(t, "404")
+		decision, handle := prepare(t, rc, cfg, item)
+		assert.Equal(t, resolve.DecisionSkipFullHit, decision)
+		require.Len(t, handle.Items, 1)
+		assert.True(t, handle.Items[0].NegativeHit)
+		require.NotNil(t, handle.Items[0].FromCache)
+		assert.Equal(t, astjson.TypeNull, handle.Items[0].FromCache.Type())
+
+		// The splice leaves the target UNTOUCHED (exactly like a real
+		// successful-but-empty fetch, whose mergeResult early-returns), so the
+		// resolvable renders the identical null bubble and error either way.
+		require.NoError(t, rc.OnFetchSkipped(handle, resolve.MergeInput{
+			Items: []*astjson.Value{item},
+			Arena: beginner(),
+		}))
+		assert.Equal(t, `{"__typename":"Product","upc":"404"}`, string(item.MarshalTo(nil)))
+	})
+
+	t.Run("[G4] the sentinel expires after NegativeCacheTTL and the network runs again", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			store := newTestStore()
+			cfg := negativeConfig(t, 5*time.Second)
+			primeRC := newRC(store)
+			primeItem := productItem(t, "404")
+			_, primeHandle := prepare(t, primeRC, cfg, primeItem)
+			require.NoError(t, primeRC.OnFetchResult(primeHandle, emptyEntityInput(primeItem)))
+			primeRC.EndRequest()
+
+			decision, _ := prepare(t, newRC(store), cfg, productItem(t, "404"))
+			assert.Equal(t, resolve.DecisionSkipFullHit, decision)
+
+			time.Sleep(5*time.Second + time.Second)
+			decision, handle := prepare(t, newRC(store), cfg, productItem(t, "404"))
+			assert.Equal(t, resolve.DecisionFetch, decision)
+			assert.False(t, handle.Items[0].NegativeHit)
+		})
+	})
+
+	t.Run("[G5] EmptyEntity with a failure signal never writes", func(t *testing.T) {
+		failureRows := []struct {
+			name   string
+			mutate func(in *resolve.MergeInput)
+		}{
+			{"FetchFailed wins over EmptyEntity", func(in *resolve.MergeInput) { in.FetchFailed = true }},
+			{"HasErrors wins over EmptyEntity", func(in *resolve.MergeInput) { in.HasErrors = true }},
+			{"both signals", func(in *resolve.MergeInput) { in.FetchFailed = true; in.HasErrors = true }},
+		}
+		for _, row := range failureRows {
+			t.Run(row.name, func(t *testing.T) {
+				store := newTestStore()
+				cfg := negativeConfig(t, 5*time.Second)
+				rc := newRC(store)
+				item := productItem(t, "404")
+				_, handle := prepare(t, rc, cfg, item)
+				in := emptyEntityInput(item)
+				row.mutate(&in)
+				require.NoError(t, rc.OnFetchResult(handle, in))
+				rc.EndRequest()
+				key := handle.Items[0].RenderedKeys[0]
+				assert.Equal(t, []testStoreOp{{Kind: "Get", Key: key}}, store.ops)
+				assert.False(t, handle.Items[0].NegativeHit)
+			})
+		}
+	})
+
+	t.Run("[G6] a positive value with a null FIELD is not a sentinel", func(t *testing.T) {
+		store := newTestStore()
+		cfg := negativeConfig(t, 5*time.Second)
+		// A positive cached value whose nullable field is null: served as a
+		// normal hit, NEVER routed through the negative path.
+		writeThrough(t, newRC(store), cfg, productItem(t, "1"), `{"__typename":"Product","name":"Table","price":null}`)
+
+		decision, handle := prepare(t, newRC(store), cfg, productItem(t, "1"))
+		assert.Equal(t, resolve.DecisionSkipFullHit, decision)
+		assert.False(t, handle.Items[0].NegativeHit)
+		require.NotNil(t, handle.Items[0].FromCache)
+		assert.Equal(t, astjson.TypeObject, handle.Items[0].FromCache.Type())
+	})
+}

--- a/v2/pkg/engine/cache/controller_rootfield_test.go
+++ b/v2/pkg/engine/cache/controller_rootfield_test.go
@@ -76,6 +76,7 @@ func TestControllerRootFieldRows(t *testing.T) {
 		store := newTestStore()
 		cfg := rootFieldConfig(time.Minute)
 		key := primeRoot(t, store, cfg, nil, responseData)
+		store.ops = nil // request 2's ops assert in isolation
 
 		rc := newRC(store, nil)
 		item := rootItem()
@@ -88,11 +89,8 @@ func TestControllerRootFieldRows(t *testing.T) {
 		}))
 		assert.Equal(t, responseData, string(item.MarshalTo(nil)))
 		rc.EndRequest()
-		assert.Equal(t, []testStoreOp{
-			{Kind: "Get", Key: key},
-			{Kind: "Set", Key: key, Value: responseData, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
-			{Kind: "Get", Key: key},
-		}, store.ops)
+		// The hit's single Get under the SAME key the prime wrote.
+		assert.Equal(t, []testStoreOp{{Kind: "Get", Key: key}}, store.ops)
 	})
 
 	t.Run("[D-root] coverage failure: a smaller cached value never serves a bigger selection", func(t *testing.T) {

--- a/v2/pkg/engine/cache/controller_rootfield_test.go
+++ b/v2/pkg/engine/cache/controller_rootfield_test.go
@@ -1,0 +1,187 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/astjson"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// rootFieldConfig is a root-field-scope config over Query.products.
+func rootFieldConfig(ttl time.Duration) *resolve.FetchCacheConfig {
+	cfg := &resolve.FetchCacheConfig{
+		L2:        ttl > 0,
+		CacheName: "root-fields",
+		TTL:       ttl,
+		KeySpec: resolve.CacheKeySpec{
+			Scope:     resolve.CacheScopeRootField,
+			TypeName:  "Query",
+			FieldName: "products",
+		},
+		ProvidesData: &resolve.Object{
+			Fields: []*resolve.Field{
+				{
+					Name: []byte("products"),
+					Value: &resolve.Array{
+						Nullable: false,
+						Path:     []string{"products"},
+						Item: &resolve.Object{
+							Nullable: false,
+							Fields: []*resolve.Field{
+								{Name: []byte("name"), Value: &resolve.Scalar{Nullable: false, Path: []string{"name"}}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	resolve.ComputeHasAliases(cfg.ProvidesData)
+	return cfg
+}
+
+func rootItem() *astjson.Value {
+	return astjson.MustParseBytes([]byte(`{}`))
+}
+
+// TestControllerRootFieldRows covers the runtime root-field arms of the D and
+// F rows plus the flush and shadow-asymmetry rows.
+func TestControllerRootFieldRows(t *testing.T) {
+	newRC := func(store Store, ctx *resolve.Context) resolve.RequestCache {
+		return NewController(store, nil).BeginRequest(ctx)
+	}
+	responseData := `{"products":[{"name":"Table"},{"name":"Chair"}]}`
+
+	primeRoot := func(t *testing.T, store *testStore, cfg *resolve.FetchCacheConfig, ctx *resolve.Context, data string) string {
+		t.Helper()
+		rc := newRC(store, ctx)
+		item := rootItem()
+		decision, handle := prepare(t, rc, cfg, item)
+		require.Equal(t, resolve.DecisionFetch, decision)
+		require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+			Items:        []*astjson.Value{item},
+			ResponseData: astjson.MustParseBytes([]byte(data)),
+			Arena:        beginner(),
+		}))
+		rc.EndRequest()
+		return handle.Items[0].RenderedKeys[0]
+	}
+
+	t.Run("[D-root] miss then hit: read key == write key, splice serves the whole value", func(t *testing.T) {
+		store := newTestStore()
+		cfg := rootFieldConfig(time.Minute)
+		key := primeRoot(t, store, cfg, nil, responseData)
+
+		rc := newRC(store, nil)
+		item := rootItem()
+		decision, handle := prepare(t, rc, cfg, item)
+		require.Equal(t, resolve.DecisionSkipFullHit, decision)
+		assert.Equal(t, []string{key}, handle.Items[0].RenderedKeys)
+		require.NoError(t, rc.OnFetchSkipped(handle, resolve.MergeInput{
+			Items: []*astjson.Value{item},
+			Arena: beginner(),
+		}))
+		assert.Equal(t, responseData, string(item.MarshalTo(nil)))
+		rc.EndRequest()
+		assert.Equal(t, []testStoreOp{
+			{Kind: "Get", Key: key},
+			{Kind: "Set", Key: key, Value: responseData, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
+			{Kind: "Get", Key: key},
+		}, store.ops)
+	})
+
+	t.Run("[D-root] coverage failure: a smaller cached value never serves a bigger selection", func(t *testing.T) {
+		store := newTestStore()
+		cfg := rootFieldConfig(time.Minute)
+		// The cached value lacks the products field entirely.
+		primeRoot(t, store, cfg, nil, `{"promotions":[]}`)
+
+		decision, handle := prepare(t, newRC(store, nil), cfg, rootItem())
+		assert.Equal(t, resolve.DecisionFetch, decision)
+		assert.Nil(t, handle.Items[0].FromCache)
+		assert.Len(t, handle.Items[0].FromCacheCandidates, 1)
+	})
+
+	t.Run("[key] different variables produce different keys; order does not matter", func(t *testing.T) {
+		cfg := rootFieldConfig(time.Minute)
+		ctxA := variableContext(t, `{"a":1,"b":2}`)
+		ctxAReordered := variableContext(t, `{"b":2,"a":1}`)
+		ctxB := variableContext(t, `{"a":9,"b":2}`)
+		keyA := rootFieldCacheKey(cfg, 0, ctxA)
+		keyAReordered := rootFieldCacheKey(cfg, 0, ctxAReordered)
+		keyB := rootFieldCacheKey(cfg, 0, ctxB)
+		assert.Equal(t, keyA, keyAReordered)
+		assert.NotEqual(t, keyA, keyB)
+	})
+
+	t.Run("[F-root] the write gate blocks failed fetches", func(t *testing.T) {
+		store := newTestStore()
+		cfg := rootFieldConfig(time.Minute)
+		rc := newRC(store, nil)
+		item := rootItem()
+		_, handle := prepare(t, rc, cfg, item)
+		require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+			Items:       []*astjson.Value{item},
+			FetchFailed: true,
+			Arena:       beginner(),
+		}))
+		rc.EndRequest()
+		assert.Equal(t, []testStoreOp{{Kind: "Get", Key: handle.Items[0].RenderedKeys[0]}}, store.ops)
+	})
+
+	t.Run("[H5] root-field shadow: hit force-refetches, ZERO compares, L2 overwritten", func(t *testing.T) {
+		store := newTestStore()
+		cfg := rootFieldConfig(time.Minute)
+		cfg.ShadowMode = true
+		key := primeRoot(t, store, cfg, nil, responseData)
+
+		obs := &recordingShadowObserver{}
+		rc := NewController(store, obs).BeginRequest(nil)
+		item := rootItem()
+		decision, handle := prepare(t, rc, cfg, item)
+		// The asymmetry: a plain Fetch — no stash, no Shadow flag, so a
+		// compare is structurally impossible.
+		assert.Equal(t, resolve.DecisionFetch, decision)
+		assert.False(t, handle.Shadow)
+		assert.Nil(t, handle.ShadowStash)
+
+		changed := `{"products":[{"name":"Renamed"}]}`
+		require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+			Items:        []*astjson.Value{item},
+			ResponseData: astjson.MustParseBytes([]byte(changed)),
+			Arena:        beginner(),
+		}))
+		rc.EndRequest()
+		assert.Empty(t, obs.compares)
+		value, _, ok := store.Get(key)
+		require.True(t, ok)
+		assert.Equal(t, changed, string(value))
+	})
+
+	t.Run("[J] NO-OP vs L2 produce identical data through the splice", func(t *testing.T) {
+		store := newTestStore()
+		cfg := rootFieldConfig(time.Minute)
+		primeRoot(t, store, cfg, nil, responseData)
+
+		// L2: served from cache.
+		rc := newRC(store, nil)
+		cachedItem := rootItem()
+		decision, handle := prepare(t, rc, cfg, cachedItem)
+		require.Equal(t, resolve.DecisionSkipFullHit, decision)
+		require.NoError(t, rc.OnFetchSkipped(handle, resolve.MergeInput{Items: []*astjson.Value{cachedItem}, Arena: beginner()}))
+
+		// NO-OP (nil config): the loader would merge the network response; the
+		// resulting item data is identical.
+		networkItem := rootItem()
+		tx := beginner().Begin()
+		_, err := tx.MergeValues(networkItem, astjson.MustParseBytes([]byte(responseData)))
+		tx.Commit()
+		require.NoError(t, err)
+		assert.Equal(t, string(networkItem.MarshalTo(nil)), string(cachedItem.MarshalTo(nil)))
+	})
+}

--- a/v2/pkg/engine/cache/controller_shadow_test.go
+++ b/v2/pkg/engine/cache/controller_shadow_test.go
@@ -1,0 +1,190 @@
+package cache
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/astjson"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// shadowConfig is the entity config in shadow mode.
+func shadowConfig(t *testing.T) *resolve.FetchCacheConfig {
+	t.Helper()
+	cfg := entityConfig(t, time.Minute)
+	cfg.ShadowMode = true
+	return cfg
+}
+
+// recordingShadowObserver is the in-package observer double (cachetesting
+// cannot be imported here); it records compares as (key, isFresh, age).
+type recordingShadowObserver struct {
+	compares []struct {
+		key     string
+		isFresh bool
+		age     time.Duration
+	}
+}
+
+func (o *recordingShadowObserver) BeginRequest(*resolve.Context) {}
+func (o *recordingShadowObserver) EndRequest(*resolve.Context)   {}
+func (o *recordingShadowObserver) OnFetchObserved(*resolve.FetchCacheHandle) {
+}
+
+func (o *recordingShadowObserver) CompareShadow(h *resolve.FetchCacheHandle, fresh *astjson.Value, tx *resolve.CacheTransaction) {
+	for _, entry := range h.ShadowStash {
+		freshBytes := []byte("null")
+		if fresh != nil {
+			freshBytes = fresh.MarshalTo(nil)
+		}
+		o.compares = append(o.compares, struct {
+			key     string
+			isFresh bool
+			age     time.Duration
+		}{
+			key:     entry.CacheKey,
+			isFresh: string(entry.CachedValue.MarshalTo(nil)) == string(freshBytes),
+			age:     entry.CacheTTL - entry.RemainingTTL,
+		})
+	}
+}
+
+func (o *recordingShadowObserver) OnEntity(*resolve.FetchCacheHandle, *astjson.Value)       {}
+func (o *recordingShadowObserver) OnFieldValue(resolve.GraphCoordinate, resolve.FieldValue) {}
+
+// TestControllerShadowRows covers the H rows.
+func TestControllerShadowRows(t *testing.T) {
+	fresh := `{"__typename":"Product","name":"Table","price":100}`
+
+	primeShadow := func(t *testing.T, store *testStore, cfg *resolve.FetchCacheConfig) string {
+		t.Helper()
+		// A shadow MISS behaves exactly like a plain miss: fetch + write.
+		return writeThrough(t, NewController(store, nil).BeginRequest(nil), cfg, productItem(t, "1"), fresh)
+	}
+
+	t.Run("[H1] shadow hit stashes, never serves, and forces the fetch", func(t *testing.T) {
+		store := newTestStore()
+		cfg := shadowConfig(t)
+		key := primeShadow(t, store, cfg)
+
+		rc := NewController(store, nil).BeginRequest(nil)
+		decision, handle := prepare(t, rc, cfg, productItem(t, "1"))
+		assert.Equal(t, resolve.DecisionFetchShadow, decision)
+		assert.True(t, handle.Shadow)
+		assert.False(t, handle.WasHit)
+		require.Len(t, handle.Items, 1)
+		// Nothing is servable; the read is stashed.
+		assert.Nil(t, handle.Items[0].FromCache)
+		require.Contains(t, handle.ShadowStash, 0)
+		assert.Equal(t, key, handle.ShadowStash[0].CacheKey)
+		assert.Equal(t, fresh, string(handle.ShadowStash[0].CachedValue.MarshalTo(nil)))
+		// The store shows the read happened.
+		assert.Equal(t, []testStoreOp{
+			{Kind: "Get", Key: key},
+			{Kind: "Set", Key: key, Value: fresh, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
+			{Kind: "Get", Key: key},
+		}, store.ops)
+	})
+
+	t.Run("[H2] compare MATCH: exact CacheAge, compare precedes the L2 overwrite", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			store := newTestStore()
+			cfg := shadowConfig(t)
+			key := primeShadow(t, store, cfg)
+
+			time.Sleep(20 * time.Second) // age the entry inside the bubble
+
+			obs := &recordingShadowObserver{}
+			rc := NewController(store, obs).BeginRequest(nil)
+			item := productItem(t, "1")
+			decision, handle := prepare(t, rc, cfg, item)
+			require.Equal(t, resolve.DecisionFetchShadow, decision)
+
+			require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+				Items:        []*astjson.Value{item},
+				ResponseData: astjson.MustParseBytes([]byte(fresh)),
+				Arena:        beginner(),
+			}))
+			// The compare ran BEFORE any write (the deferred set flushes at
+			// EndRequest; the compare is already recorded here).
+			require.Len(t, obs.compares, 1)
+			assert.Equal(t, key, obs.compares[0].key)
+			assert.True(t, obs.compares[0].isFresh)
+			assert.Equal(t, 20*time.Second, obs.compares[0].age)
+
+			rc.EndRequest()
+			// L2 was overwritten with the fresh value after the compare.
+			value, _, ok := store.Get(key)
+			require.True(t, ok)
+			assert.Equal(t, fresh, string(value))
+		})
+	})
+
+	t.Run("[H3] compare MISMATCH: IsFresh false, L2 overwritten with fresh", func(t *testing.T) {
+		store := newTestStore()
+		cfg := shadowConfig(t)
+		key := primeShadow(t, store, cfg)
+
+		obs := &recordingShadowObserver{}
+		rc := NewController(store, obs).BeginRequest(nil)
+		item := productItem(t, "1")
+		_, handle := prepare(t, rc, cfg, item)
+		changed := `{"__typename":"Product","name":"Renamed","price":100}`
+		require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+			Items:        []*astjson.Value{item},
+			ResponseData: astjson.MustParseBytes([]byte(changed)),
+			Arena:        beginner(),
+		}))
+		require.Len(t, obs.compares, 1)
+		assert.False(t, obs.compares[0].isFresh)
+
+		rc.EndRequest()
+		value, _, ok := store.Get(key)
+		require.True(t, ok)
+		assert.Equal(t, changed, string(value))
+	})
+
+	t.Run("[H6] nil observer: force-fetch, nothing recorded, writes still land", func(t *testing.T) {
+		store := newTestStore()
+		cfg := shadowConfig(t)
+		key := primeShadow(t, store, cfg)
+
+		rc := NewController(store, nil).BeginRequest(nil)
+		item := productItem(t, "1")
+		decision, handle := prepare(t, rc, cfg, item)
+		require.Equal(t, resolve.DecisionFetchShadow, decision)
+		require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+			Items:        []*astjson.Value{item},
+			ResponseData: astjson.MustParseBytes([]byte(fresh)),
+			Arena:        beginner(),
+		}))
+		rc.EndRequest()
+		value, _, ok := store.Get(key)
+		require.True(t, ok)
+		assert.Equal(t, fresh, string(value))
+	})
+
+	t.Run("[H7] L2-off shadow never yields DecisionFetchShadow", func(t *testing.T) {
+		cfg := shadowConfig(t)
+		cfg.L2 = false // NO-OP / L1-only shapes: the L2 controller stays out entirely
+		rc := NewController(newTestStore(), nil).BeginRequest(nil)
+		decision, handle := prepare(t, rc, cfg, productItem(t, "1"))
+		assert.Equal(t, resolve.DecisionFetch, decision)
+		assert.Nil(t, handle)
+	})
+
+	t.Run("[H] shadow miss is a plain fetch (no stash, no shadow decision)", func(t *testing.T) {
+		store := newTestStore()
+		cfg := shadowConfig(t)
+		rc := NewController(store, nil).BeginRequest(nil)
+		decision, handle := prepare(t, rc, cfg, productItem(t, "1"))
+		assert.Equal(t, resolve.DecisionFetch, decision)
+		assert.False(t, handle.Shadow)
+		assert.Nil(t, handle.ShadowStash)
+	})
+}

--- a/v2/pkg/engine/cache/controller_shadow_test.go
+++ b/v2/pkg/engine/cache/controller_shadow_test.go
@@ -171,11 +171,24 @@ func TestControllerShadowRows(t *testing.T) {
 
 	t.Run("[H7] L2-off shadow never yields DecisionFetchShadow", func(t *testing.T) {
 		cfg := shadowConfig(t)
-		cfg.L2 = false // NO-OP / L1-only shapes: the L2 controller stays out entirely
+		cfg.L2 = false
+		cfg.L1 = false // NO-OP shape: the controller stays out entirely
 		rc := NewController(newTestStore(), nil).BeginRequest(nil)
 		decision, handle := prepare(t, rc, cfg, productItem(t, "1"))
 		assert.Equal(t, resolve.DecisionFetch, decision)
 		assert.Nil(t, handle)
+	})
+
+	t.Run("[H7] L1-only shadow is a plain fetch with no stash", func(t *testing.T) {
+		cfg := shadowConfig(t)
+		cfg.L2 = false // L1 stays true: shadow semantics are L2-read-only
+		store := newTestStore()
+		rc := NewController(store, nil).BeginRequest(nil)
+		decision, handle := prepare(t, rc, cfg, productItem(t, "1"))
+		assert.Equal(t, resolve.DecisionFetch, decision)
+		require.NotNil(t, handle)
+		assert.False(t, handle.Shadow)
+		assert.Empty(t, store.ops)
 	})
 
 	t.Run("[H] shadow miss is a plain fetch (no stash, no shadow decision)", func(t *testing.T) {

--- a/v2/pkg/engine/cache/controller_shadow_test.go
+++ b/v2/pkg/engine/cache/controller_shadow_test.go
@@ -71,6 +71,7 @@ func TestControllerShadowRows(t *testing.T) {
 		store := newTestStore()
 		cfg := shadowConfig(t)
 		key := primeShadow(t, store, cfg)
+		store.ops = nil // the shadow request's ops assert in isolation
 
 		rc := NewController(store, nil).BeginRequest(nil)
 		decision, handle := prepare(t, rc, cfg, productItem(t, "1"))
@@ -83,12 +84,8 @@ func TestControllerShadowRows(t *testing.T) {
 		require.Contains(t, handle.ShadowStash, 0)
 		assert.Equal(t, key, handle.ShadowStash[0].CacheKey)
 		assert.Equal(t, fresh, string(handle.ShadowStash[0].CachedValue.MarshalTo(nil)))
-		// The store shows the read happened.
-		assert.Equal(t, []testStoreOp{
-			{Kind: "Get", Key: key},
-			{Kind: "Set", Key: key, Value: fresh, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
-			{Kind: "Get", Key: key},
-		}, store.ops)
+		// The store shows the read happened (and nothing else).
+		assert.Equal(t, []testStoreOp{{Kind: "Get", Key: key}}, store.ops)
 	})
 
 	t.Run("[H2] compare MATCH: exact CacheAge, compare precedes the L2 overwrite", func(t *testing.T) {

--- a/v2/pkg/engine/cache/controller_shadow_test.go
+++ b/v2/pkg/engine/cache/controller_shadow_test.go
@@ -188,6 +188,29 @@ func TestControllerShadowRows(t *testing.T) {
 		assert.Empty(t, store.ops)
 	})
 
+	t.Run("[H] a shadow probe never populates L1: the second read still probes L2", func(t *testing.T) {
+		store := newTestStore()
+		cfg := shadowConfig(t) // L1 + L2 + shadow
+		key := primeShadow(t, store, cfg)
+		store.ops = nil // the shadow request's ops assert in isolation
+
+		rc := NewController(store, nil).BeginRequest(nil)
+		_, handleA := prepare(t, rc, cfg, productItem(t, "1"))
+		stashA, okA := handleA.ShadowStash[0]
+		require.True(t, okA)
+		assert.Equal(t, fresh, string(stashA.CachedValue.MarshalTo(nil)))
+		_, handleB := prepare(t, rc, cfg, productItem(t, "1"))
+		stashB, okB := handleB.ShadowStash[0]
+		require.True(t, okB)
+		assert.Equal(t, fresh, string(stashB.CachedValue.MarshalTo(nil)))
+		// BOTH reads hit L2: only SERVED values enter the request's L1, and a
+		// shadow probe serves nothing.
+		assert.Equal(t, []testStoreOp{
+			{Kind: "Get", Key: key},
+			{Kind: "Get", Key: key},
+		}, store.ops)
+	})
+
 	t.Run("[H] shadow miss is a plain fetch (no stash, no shadow decision)", func(t *testing.T) {
 		store := newTestStore()
 		cfg := shadowConfig(t)

--- a/v2/pkg/engine/cache/controller_test.go
+++ b/v2/pkg/engine/cache/controller_test.go
@@ -538,14 +538,6 @@ func TestControllerGates(t *testing.T) {
 		assert.Nil(t, handle)
 	})
 
-	t.Run("shadow mode fetches until task 12", func(t *testing.T) {
-		cfg := entityConfig(t, time.Minute)
-		cfg.ShadowMode = true
-		decision, handle := rc.PrepareFetch(prepareInput(cfg, productItem(t, "1")))
-		assert.Equal(t, resolve.DecisionFetch, decision)
-		assert.Nil(t, handle)
-	})
-
 	t.Run("root-field scope fetches until task 13", func(t *testing.T) {
 		cfg := entityConfig(t, time.Minute)
 		cfg.KeySpec.Scope = resolve.CacheScopeRootField

--- a/v2/pkg/engine/cache/controller_test.go
+++ b/v2/pkg/engine/cache/controller_test.go
@@ -1,0 +1,563 @@
+package cache
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/astjson"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// testStore is the minimal in-memory Store for controller unit tests, with an
+// ordered op log mirroring cachetesting.FakeStore (which cannot be imported
+// here: cachetesting imports this package).
+type testStore struct {
+	data map[string]testStoreEntry
+	ops  []testStoreOp
+}
+
+type testStoreEntry struct {
+	value     []byte
+	expiresAt time.Time
+}
+
+type testStoreOp struct {
+	Kind  string
+	Key   string
+	Value string
+	TTL   time.Duration
+}
+
+func newTestStore() *testStore {
+	return &testStore{data: map[string]testStoreEntry{}}
+}
+
+func (s *testStore) Get(key string) ([]byte, time.Duration, bool) {
+	s.ops = append(s.ops, testStoreOp{Kind: "Get", Key: key})
+	entry, ok := s.data[key]
+	if !ok || !time.Now().Before(entry.expiresAt) {
+		return nil, 0, false
+	}
+	return append([]byte(nil), entry.value...), time.Until(entry.expiresAt), true
+}
+
+func (s *testStore) Set(key string, value []byte, ttl time.Duration) {
+	s.data[key] = testStoreEntry{value: append([]byte(nil), value...), expiresAt: time.Now().Add(ttl)}
+	s.ops = append(s.ops, testStoreOp{Kind: "Set", Key: key, Value: string(value), TTL: ttl})
+}
+
+// productProvidesData is the coverage tree used across the controller rows:
+// name non-nullable, price nullable.
+func productProvidesData() *resolve.Object {
+	return &resolve.Object{
+		Fields: []*resolve.Field{
+			{
+				Name:        []byte("name"),
+				Value:       &resolve.Scalar{Nullable: false, Path: []string{"name"}},
+				OnTypeNames: [][]byte{[]byte("Product")},
+			},
+			{
+				Name:        []byte("price"),
+				Value:       &resolve.Scalar{Nullable: true, Path: []string{"price"}},
+				OnTypeNames: [][]byte{[]byte("Product")},
+			},
+		},
+	}
+}
+
+// entityConfig builds a single-candidate ("upc") entity config over the shared
+// key-builder fixture.
+func entityConfig(t *testing.T, ttl time.Duration) *resolve.FetchCacheConfig {
+	t.Helper()
+	builder := newKeyBuilder(t, parseKeyBuilderDefinition(t), newKeyBuilderFederation(t, "upc"))
+	spec, ok := builder.buildEntitySpec(productEntityInfo())
+	require.True(t, ok)
+	return &resolve.FetchCacheConfig{
+		L1:           true,
+		L2:           ttl > 0,
+		CacheName:    "entities",
+		TTL:          ttl,
+		KeySpec:      spec,
+		ProvidesData: productProvidesData(),
+	}
+}
+
+func beginner() resolve.TransactionBeginner {
+	return resolve.NewTransactionBeginner(nil, &resolve.DataBuffer{})
+}
+
+func prepareInput(cfg *resolve.FetchCacheConfig, items ...*astjson.Value) resolve.PrepareFetchInput {
+	return resolve.PrepareFetchInput{
+		Items:  items,
+		Config: cfg,
+		Input:  []byte(`{"body":{"query":"..."}}`),
+		Arena:  beginner(),
+	}
+}
+
+func productItem(t *testing.T, upc string) *astjson.Value {
+	t.Helper()
+	return astjson.MustParseBytes([]byte(`{"__typename":"Product","upc":"` + upc + `"}`))
+}
+
+// prepare runs one PrepareFetch and returns decision + handle.
+func prepare(t *testing.T, rc resolve.RequestCache, cfg *resolve.FetchCacheConfig, items ...*astjson.Value) (resolve.Decision, *resolve.FetchCacheHandle) {
+	t.Helper()
+	return rc.PrepareFetch(prepareInput(cfg, items...))
+}
+
+// writeThrough runs the miss → fetch-result → flush cycle for one item and
+// returns the key it wrote under.
+func writeThrough(t *testing.T, rc resolve.RequestCache, cfg *resolve.FetchCacheConfig, item *astjson.Value, responseData string) string {
+	t.Helper()
+	decision, handle := prepare(t, rc, cfg, item)
+	require.Equal(t, resolve.DecisionFetch, decision)
+	require.NotNil(t, handle)
+	require.Len(t, handle.Items, 1)
+	require.Len(t, handle.Items[0].RenderedKeys, 1)
+	require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+		Items:        []*astjson.Value{item},
+		ResponseData: astjson.MustParseBytes([]byte(responseData)),
+		Arena:        beginner(),
+	}))
+	rc.EndRequest()
+	return handle.Items[0].RenderedKeys[0]
+}
+
+// TestControllerDecisionRows covers the D core rows: full hit, miss, coverage
+// failure (stale partial NOT served), nullability, and ProvidesData == nil.
+func TestControllerDecisionRows(t *testing.T) {
+	newRC := func(store Store) resolve.RequestCache {
+		return NewController(store, nil).BeginRequest(nil)
+	}
+
+	t.Run("[D1] full hit: covering value skips the fetch", func(t *testing.T) {
+		store := newTestStore()
+		cfg := entityConfig(t, time.Minute)
+		key := writeThrough(t, newRC(store), cfg, productItem(t, "1"), `{"__typename":"Product","name":"Table","price":100}`)
+
+		decision, handle := prepare(t, newRC(store), cfg, productItem(t, "1"))
+		require.NotNil(t, handle)
+		assert.Equal(t, resolve.DecisionSkipFullHit, decision)
+		assert.Equal(t, resolve.DecisionSkipFullHit, handle.Decision)
+		assert.True(t, handle.WasHit)
+		require.Len(t, handle.Items, 1)
+		// Key fidelity (O row): the read key IS the write key.
+		assert.Equal(t, []string{key}, handle.Items[0].RenderedKeys)
+		require.NotNil(t, handle.Items[0].FromCache)
+		assert.Equal(t, `{"__typename":"Product","name":"Table","price":100}`, string(handle.Items[0].FromCache.MarshalTo(nil)))
+	})
+
+	t.Run("[D2] miss: empty store fetches", func(t *testing.T) {
+		store := newTestStore()
+		cfg := entityConfig(t, time.Minute)
+		decision, handle := prepare(t, newRC(store), cfg, productItem(t, "1"))
+		require.NotNil(t, handle)
+		assert.Equal(t, resolve.DecisionFetch, decision)
+		assert.False(t, handle.WasHit)
+		require.Len(t, handle.Items, 1)
+		assert.Nil(t, handle.Items[0].FromCache)
+		assert.Nil(t, handle.Items[0].FromCacheCandidates)
+	})
+
+	t.Run("[D3] coverage failure: stale partial value is NOT served", func(t *testing.T) {
+		store := newTestStore()
+		cfg := entityConfig(t, time.Minute)
+		// The cached value lacks the non-nullable "name" field.
+		key := writeThrough(t, newRC(store), cfg, productItem(t, "1"), `{"__typename":"Product","price":100}`)
+
+		decision, handle := prepare(t, newRC(store), cfg, productItem(t, "1"))
+		require.NotNil(t, handle)
+		assert.Equal(t, resolve.DecisionFetch, decision)
+		require.Len(t, handle.Items, 1)
+		assert.Nil(t, handle.Items[0].FromCache)
+		// The candidate WAS found — coverage rejected it.
+		assert.Equal(t, []resolve.CacheCandidate{{
+			Value:        []byte(`{"__typename":"Product","price":100}`),
+			RemainingTTL: handle.Items[0].FromCacheCandidates[0].RemainingTTL,
+		}}, handle.Items[0].FromCacheCandidates)
+		assert.Equal(t, []string{key}, handle.Items[0].RenderedKeys)
+	})
+
+	t.Run("[D4] null accepted where nullable", func(t *testing.T) {
+		store := newTestStore()
+		cfg := entityConfig(t, time.Minute)
+		writeThrough(t, newRC(store), cfg, productItem(t, "1"), `{"__typename":"Product","name":"Table","price":null}`)
+
+		decision, handle := prepare(t, newRC(store), cfg, productItem(t, "1"))
+		require.NotNil(t, handle)
+		assert.Equal(t, resolve.DecisionSkipFullHit, decision)
+	})
+
+	t.Run("[D5] null rejected where non-nullable", func(t *testing.T) {
+		store := newTestStore()
+		cfg := entityConfig(t, time.Minute)
+		writeThrough(t, newRC(store), cfg, productItem(t, "1"), `{"__typename":"Product","name":null,"price":100}`)
+
+		decision, handle := prepare(t, newRC(store), cfg, productItem(t, "1"))
+		require.NotNil(t, handle)
+		assert.Equal(t, resolve.DecisionFetch, decision)
+		assert.Nil(t, handle.Items[0].FromCache)
+	})
+
+	t.Run("[D14] ProvidesData nil disables the coverage walk: always a miss", func(t *testing.T) {
+		store := newTestStore()
+		cfg := entityConfig(t, time.Minute)
+		writeThrough(t, newRC(store), cfg, productItem(t, "1"), `{"__typename":"Product","name":"Table","price":100}`)
+
+		noProvides := entityConfig(t, time.Minute)
+		noProvides.ProvidesData = nil
+		decision, handle := prepare(t, newRC(store), noProvides, productItem(t, "1"))
+		require.NotNil(t, handle)
+		assert.Equal(t, resolve.DecisionFetch, decision)
+		assert.Nil(t, handle.Items[0].FromCache)
+	})
+
+	t.Run("[D] partial hit degrades to fetch (AND-reduction)", func(t *testing.T) {
+		store := newTestStore()
+		cfg := entityConfig(t, time.Minute)
+		writeThrough(t, newRC(store), cfg, productItem(t, "1"), `{"__typename":"Product","name":"Table","price":100}`)
+
+		decision, handle := prepare(t, newRC(store), cfg, productItem(t, "1"), productItem(t, "2"))
+		require.NotNil(t, handle)
+		assert.Equal(t, resolve.DecisionFetch, decision)
+		require.Len(t, handle.Items, 2)
+		assert.NotNil(t, handle.Items[0].FromCache)
+		assert.Nil(t, handle.Items[1].FromCache)
+	})
+
+	t.Run("[L] malformed cached bytes are a miss, never a panic", func(t *testing.T) {
+		store := newTestStore()
+		cfg := entityConfig(t, time.Minute)
+		key := writeThrough(t, newRC(store), cfg, productItem(t, "1"), `{"__typename":"Product","name":"Table","price":100}`)
+		store.data[key] = testStoreEntry{value: []byte(`{not json`), expiresAt: time.Now().Add(time.Hour)}
+
+		decision, handle := prepare(t, newRC(store), cfg, productItem(t, "1"))
+		require.NotNil(t, handle)
+		assert.Equal(t, resolve.DecisionFetch, decision)
+		assert.Nil(t, handle.Items[0].FromCache)
+		assert.Nil(t, handle.Items[0].FromCacheCandidates)
+	})
+
+	t.Run("[F/TTL] a written value expires exactly after its TTL", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			store := newTestStore()
+			cfg := entityConfig(t, time.Minute)
+			writeThrough(t, newRC(store), cfg, productItem(t, "1"), `{"__typename":"Product","name":"Table","price":100}`)
+
+			decision, _ := prepare(t, newRC(store), cfg, productItem(t, "1"))
+			assert.Equal(t, resolve.DecisionSkipFullHit, decision)
+
+			time.Sleep(time.Minute + time.Second)
+			decision, _ = prepare(t, newRC(store), cfg, productItem(t, "1"))
+			assert.Equal(t, resolve.DecisionFetch, decision)
+		})
+	})
+}
+
+// TestControllerWriteGateRows covers the F rows: only a clean fetch writes;
+// transport/empty/parse failures, GraphQL errors, null data, status fallback,
+// and empty entities all produce ZERO writes.
+func TestControllerWriteGateRows(t *testing.T) {
+	prepareMiss := func(t *testing.T, store *testStore, cfg *resolve.FetchCacheConfig, item *astjson.Value) (resolve.RequestCache, *resolve.FetchCacheHandle) {
+		t.Helper()
+		rc := NewController(store, nil).BeginRequest(nil)
+		decision, handle := prepare(t, rc, cfg, item)
+		require.Equal(t, resolve.DecisionFetch, decision)
+		require.NotNil(t, handle)
+		return rc, handle
+	}
+
+	t.Run("[F1] clean fetch writes exactly once with the exact TTL", func(t *testing.T) {
+		store := newTestStore()
+		cfg := entityConfig(t, time.Minute)
+		item := productItem(t, "1")
+		rc, handle := prepareMiss(t, store, cfg, item)
+		require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+			Items:        []*astjson.Value{item},
+			ResponseData: astjson.MustParseBytes([]byte(`{"__typename":"Product","name":"Table","price":100}`)),
+			StatusCode:   200,
+			Arena:        beginner(),
+		}))
+		key := handle.Items[0].RenderedKeys[0]
+		rc.EndRequest()
+		assert.Equal(t, []testStoreOp{
+			{Kind: "Get", Key: key},
+			{Kind: "Set", Key: key, Value: `{"__typename":"Product","name":"Table","price":100}`, TTL: time.Minute},
+		}, store.ops)
+	})
+
+	gateRows := []struct {
+		name string
+		in   func(item *astjson.Value) resolve.MergeInput
+	}{
+		{
+			// The historical blocking bug: transport failures arrive with
+			// HasErrors == false — the gate must key off FetchFailed.
+			name: "[F2] transport failure writes nothing",
+			in: func(item *astjson.Value) resolve.MergeInput {
+				return resolve.MergeInput{Items: []*astjson.Value{item}, FetchFailed: true, Arena: beginner()}
+			},
+		},
+		{
+			name: "[F3] empty body writes nothing",
+			in: func(item *astjson.Value) resolve.MergeInput {
+				return resolve.MergeInput{Items: []*astjson.Value{item}, FetchFailed: true, StatusCode: 200, Arena: beginner()}
+			},
+		},
+		{
+			name: "[F4] parse failure writes nothing",
+			in: func(item *astjson.Value) resolve.MergeInput {
+				return resolve.MergeInput{Items: []*astjson.Value{item}, FetchFailed: true, StatusCode: 200, Arena: beginner()}
+			},
+		},
+		{
+			name: "[F5] GraphQL errors write nothing even with data present",
+			in: func(item *astjson.Value) resolve.MergeInput {
+				return resolve.MergeInput{
+					Items:        []*astjson.Value{item},
+					ResponseData: astjson.MustParseBytes([]byte(`{"__typename":"Product","name":"Table","price":100}`)),
+					HasErrors:    true,
+					Arena:        beginner(),
+				}
+			},
+		},
+		{
+			name: "[F6] JSON-null data writes nothing",
+			in: func(item *astjson.Value) resolve.MergeInput {
+				return resolve.MergeInput{Items: []*astjson.Value{item}, ResponseData: astjson.MustParseBytes([]byte(`null`)), Arena: beginner()}
+			},
+		},
+		{
+			name: "[F7] status fallback (failed fetch with 500) writes nothing",
+			in: func(item *astjson.Value) resolve.MergeInput {
+				return resolve.MergeInput{Items: []*astjson.Value{item}, FetchFailed: true, StatusCode: 500, Arena: beginner()}
+			},
+		},
+		{
+			name: "[F8] successful-but-empty entity writes nothing (negative caching is task 11)",
+			in: func(item *astjson.Value) resolve.MergeInput {
+				return resolve.MergeInput{
+					Items:        []*astjson.Value{item},
+					ResponseData: astjson.MustParseBytes([]byte(`null`)),
+					EmptyEntity:  true,
+					StatusCode:   200,
+					Arena:        beginner(),
+				}
+			},
+		},
+	}
+	for _, row := range gateRows {
+		t.Run(row.name, func(t *testing.T) {
+			store := newTestStore()
+			cfg := entityConfig(t, time.Minute)
+			item := productItem(t, "1")
+			rc, handle := prepareMiss(t, store, cfg, item)
+			key := handle.Items[0].RenderedKeys[0]
+			require.NoError(t, rc.OnFetchResult(handle, row.in(item)))
+			rc.EndRequest()
+			// Only the lookup Get; ZERO Sets.
+			assert.Equal(t, []testStoreOp{{Kind: "Get", Key: key}}, store.ops)
+		})
+	}
+}
+
+// TestControllerFlushRows covers the K rows: writes accumulate as bytes and
+// flush once per instance at EndRequest.
+func TestControllerFlushRows(t *testing.T) {
+	t.Run("[K1/K2] writes accumulate and flush as one batch at EndRequest", func(t *testing.T) {
+		store := newTestStore()
+		cfg := entityConfig(t, time.Minute)
+		rc := NewController(store, nil).BeginRequest(nil)
+
+		item1 := productItem(t, "1")
+		item2 := productItem(t, "2")
+		_, h1 := prepare(t, rc, cfg, item1)
+		_, h2 := prepare(t, rc, cfg, item2)
+		require.NoError(t, rc.OnFetchResult(h1, resolve.MergeInput{
+			Items:        []*astjson.Value{item1},
+			ResponseData: astjson.MustParseBytes([]byte(`{"__typename":"Product","name":"Table","price":100}`)),
+			Arena:        beginner(),
+		}))
+		require.NoError(t, rc.OnFetchResult(h2, resolve.MergeInput{
+			Items:        []*astjson.Value{item2},
+			ResponseData: astjson.MustParseBytes([]byte(`{"__typename":"Product","name":"Chair","price":50}`)),
+			Arena:        beginner(),
+		}))
+
+		var setsBeforeFlush int
+		for _, op := range store.ops {
+			if op.Kind == "Set" {
+				setsBeforeFlush++
+			}
+		}
+		assert.Equal(t, 0, setsBeforeFlush)
+
+		rc.EndRequest()
+		assert.Equal(t, []testStoreOp{
+			{Kind: "Get", Key: h1.Items[0].RenderedKeys[0]},
+			{Kind: "Get", Key: h2.Items[0].RenderedKeys[0]},
+			{Kind: "Set", Key: h1.Items[0].RenderedKeys[0], Value: `{"__typename":"Product","name":"Table","price":100}`, TTL: time.Minute},
+			{Kind: "Set", Key: h2.Items[0].RenderedKeys[0], Value: `{"__typename":"Product","name":"Chair","price":50}`, TTL: time.Minute},
+		}, store.ops)
+	})
+
+	t.Run("[K3] the flush holds bytes: later value mutation cannot leak into the store", func(t *testing.T) {
+		store := newTestStore()
+		cfg := entityConfig(t, time.Minute)
+		rc := NewController(store, nil).BeginRequest(nil)
+		item := productItem(t, "1")
+		_, handle := prepare(t, rc, cfg, item)
+		responseData := astjson.MustParseBytes([]byte(`{"__typename":"Product","name":"Table","price":100}`))
+		require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+			Items:        []*astjson.Value{item},
+			ResponseData: responseData,
+			Arena:        beginner(),
+		}))
+		// Mutate the response value AFTER the hook, BEFORE the flush.
+		responseData.Set(nil, "name", astjson.StringValue(nil, "Mutated"))
+		rc.EndRequest()
+
+		value, _, ok := store.Get(handle.Items[0].RenderedKeys[0])
+		require.True(t, ok)
+		assert.Equal(t, `{"__typename":"Product","name":"Table","price":100}`, string(value))
+	})
+
+	t.Run("[K4] nothing to flush: EndRequest is a no-op on the store", func(t *testing.T) {
+		store := newTestStore()
+		rc := NewController(store, nil).BeginRequest(nil)
+		rc.EndRequest()
+		assert.Empty(t, store.ops)
+	})
+}
+
+// TestControllerMergePath covers the D4 deviation: splice and write honor the
+// surfaced non-root merge path.
+func TestControllerMergePath(t *testing.T) {
+	t.Run("write stores the entity BELOW the merge path", func(t *testing.T) {
+		store := newTestStore()
+		cfg := entityConfig(t, time.Minute)
+		rc := NewController(store, nil).BeginRequest(nil)
+		item := productItem(t, "1")
+		_, handle := prepare(t, rc, cfg, item)
+		require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+			Items:        []*astjson.Value{item},
+			ResponseData: astjson.MustParseBytes([]byte(`{"wrapper":{"__typename":"Product","name":"Table","price":100}}`)),
+			MergePath:    []string{"wrapper"},
+			Arena:        beginner(),
+		}))
+		rc.EndRequest()
+		value, _, ok := store.Get(handle.Items[0].RenderedKeys[0])
+		require.True(t, ok)
+		assert.Equal(t, `{"__typename":"Product","name":"Table","price":100}`, string(value))
+	})
+
+	t.Run("splice merges the cached value AT the merge path", func(t *testing.T) {
+		store := newTestStore()
+		cfg := entityConfig(t, time.Minute)
+		writeThrough(t, NewController(store, nil).BeginRequest(nil), cfg, productItem(t, "1"), `{"__typename":"Product","name":"Table","price":100}`)
+
+		rc := NewController(store, nil).BeginRequest(nil)
+		item := productItem(t, "1")
+		decision, handle := prepare(t, rc, cfg, item)
+		require.Equal(t, resolve.DecisionSkipFullHit, decision)
+		require.NoError(t, rc.OnFetchSkipped(handle, resolve.MergeInput{
+			Items:     []*astjson.Value{item},
+			MergePath: []string{"nested"},
+			Arena:     beginner(),
+		}))
+		assert.Equal(t,
+			`{"__typename":"Product","upc":"1","nested":{"__typename":"Product","name":"Table","price":100}}`,
+			string(item.MarshalTo(nil)))
+	})
+
+	t.Run("splice merges at the item root when the merge path is empty", func(t *testing.T) {
+		store := newTestStore()
+		cfg := entityConfig(t, time.Minute)
+		writeThrough(t, NewController(store, nil).BeginRequest(nil), cfg, productItem(t, "1"), `{"__typename":"Product","name":"Table","price":100}`)
+
+		rc := NewController(store, nil).BeginRequest(nil)
+		item := productItem(t, "1")
+		decision, handle := prepare(t, rc, cfg, item)
+		require.Equal(t, resolve.DecisionSkipFullHit, decision)
+		require.NoError(t, rc.OnFetchSkipped(handle, resolve.MergeInput{
+			Items: []*astjson.Value{item},
+			Arena: beginner(),
+		}))
+		assert.Equal(t,
+			`{"__typename":"Product","upc":"1","name":"Table","price":100}`,
+			string(item.MarshalTo(nil)))
+	})
+}
+
+// TestControllerGates covers the prepare-side gates and nil-guards (O rows).
+func TestControllerGates(t *testing.T) {
+	rc := NewController(newTestStore(), nil).BeginRequest(nil)
+
+	t.Run("nil config fetches", func(t *testing.T) {
+		decision, handle := rc.PrepareFetch(prepareInput(nil, productItem(t, "1")))
+		assert.Equal(t, resolve.DecisionFetch, decision)
+		assert.Nil(t, handle)
+	})
+
+	t.Run("L1-only config is untouched by the L2 controller (task 17)", func(t *testing.T) {
+		cfg := entityConfig(t, 0) // TTL 0 => L2 false, L1 true
+		decision, handle := rc.PrepareFetch(prepareInput(cfg, productItem(t, "1")))
+		assert.Equal(t, resolve.DecisionFetch, decision)
+		assert.Nil(t, handle)
+	})
+
+	t.Run("shadow mode fetches until task 12", func(t *testing.T) {
+		cfg := entityConfig(t, time.Minute)
+		cfg.ShadowMode = true
+		decision, handle := rc.PrepareFetch(prepareInput(cfg, productItem(t, "1")))
+		assert.Equal(t, resolve.DecisionFetch, decision)
+		assert.Nil(t, handle)
+	})
+
+	t.Run("root-field scope fetches until task 13", func(t *testing.T) {
+		cfg := entityConfig(t, time.Minute)
+		cfg.KeySpec.Scope = resolve.CacheScopeRootField
+		decision, handle := rc.PrepareFetch(prepareInput(cfg, productItem(t, "1")))
+		assert.Equal(t, resolve.DecisionFetch, decision)
+		assert.Nil(t, handle)
+	})
+
+	t.Run("batch fetches until task 10", func(t *testing.T) {
+		cfg := entityConfig(t, time.Minute)
+		in := prepareInput(cfg, productItem(t, "1"))
+		in.BatchStats = [][]*astjson.Value{{productItem(t, "1")}}
+		decision, handle := rc.PrepareFetch(in)
+		assert.Equal(t, resolve.DecisionFetch, decision)
+		assert.Nil(t, handle)
+	})
+
+	t.Run("zero items fetch", func(t *testing.T) {
+		cfg := entityConfig(t, time.Minute)
+		decision, handle := rc.PrepareFetch(prepareInput(cfg))
+		assert.Equal(t, resolve.DecisionFetch, decision)
+		assert.Nil(t, handle)
+	})
+
+	t.Run("unrenderable candidate is a miss", func(t *testing.T) {
+		cfg := entityConfig(t, time.Minute)
+		item := astjson.MustParseBytes([]byte(`{"__typename":"Product"}`)) // no upc
+		decision, handle := rc.PrepareFetch(prepareInput(cfg, item))
+		assert.Equal(t, resolve.DecisionFetch, decision)
+		require.NotNil(t, handle)
+		assert.Nil(t, handle.Items[0].RenderedKeys)
+	})
+
+	t.Run("merge hooks tolerate nil handles and unknown handles", func(t *testing.T) {
+		assert.NoError(t, rc.OnFetchSkipped(nil, resolve.MergeInput{Arena: beginner()}))
+		assert.NoError(t, rc.OnFetchResult(nil, resolve.MergeInput{Arena: beginner()}))
+		unknown := &resolve.FetchCacheHandle{}
+		assert.NoError(t, rc.OnFetchSkipped(unknown, resolve.MergeInput{Arena: beginner()}))
+		assert.NoError(t, rc.OnFetchResult(unknown, resolve.MergeInput{Arena: beginner()}))
+	})
+}

--- a/v2/pkg/engine/cache/controller_test.go
+++ b/v2/pkg/engine/cache/controller_test.go
@@ -538,14 +538,6 @@ func TestControllerGates(t *testing.T) {
 		assert.Nil(t, handle)
 	})
 
-	t.Run("root-field scope fetches until task 13", func(t *testing.T) {
-		cfg := entityConfig(t, time.Minute)
-		cfg.KeySpec.Scope = resolve.CacheScopeRootField
-		decision, handle := rc.PrepareFetch(prepareInput(cfg, productItem(t, "1")))
-		assert.Equal(t, resolve.DecisionFetch, decision)
-		assert.Nil(t, handle)
-	})
-
 	t.Run("[I] empty batch short-circuits without a handle", func(t *testing.T) {
 		cfg := entityConfig(t, time.Minute)
 		in := prepareInput(cfg)

--- a/v2/pkg/engine/cache/controller_test.go
+++ b/v2/pkg/engine/cache/controller_test.go
@@ -15,26 +15,42 @@ import (
 
 // testStore is the minimal in-memory Store for controller unit tests, with an
 // ordered op log mirroring cachetesting.FakeStore (which cannot be imported
-// here: cachetesting imports this package).
+// here: cachetesting imports this package). It implements WriteReasonRecorder
+// so the ops carry the refresh/backfill tag.
 type testStore struct {
-	data map[string]testStoreEntry
-	ops  []testStoreOp
+	data       map[string]testStoreEntry
+	ops        []testStoreOp
+	nextReason resolve.CacheWriteReason
 }
 
 type testStoreEntry struct {
 	value     []byte
 	expiresAt time.Time
+	// noTTL marks an entry whose remaining TTL is UNKNOWN: Get reports it as a
+	// hit with remaining 0 (some backends do not expose TTLs).
+	noTTL bool
 }
 
 type testStoreOp struct {
-	Kind  string
-	Key   string
-	Value string
-	TTL   time.Duration
+	Kind   string
+	Key    string
+	Value  string
+	TTL    time.Duration
+	Reason resolve.CacheWriteReason
 }
 
 func newTestStore() *testStore {
 	return &testStore{data: map[string]testStoreEntry{}}
+}
+
+// seed arranges a value without logging ops.
+func (s *testStore) seed(key string, value []byte, ttl time.Duration) {
+	s.data[key] = testStoreEntry{value: append([]byte(nil), value...), expiresAt: time.Now().Add(ttl)}
+}
+
+// seedNoTTL arranges a value whose remaining TTL is unknown to the store.
+func (s *testStore) seedNoTTL(key string, value []byte) {
+	s.data[key] = testStoreEntry{value: append([]byte(nil), value...), expiresAt: time.Now().Add(time.Hour), noTTL: true}
 }
 
 func (s *testStore) Get(key string) ([]byte, time.Duration, bool) {
@@ -43,12 +59,20 @@ func (s *testStore) Get(key string) ([]byte, time.Duration, bool) {
 	if !ok || !time.Now().Before(entry.expiresAt) {
 		return nil, 0, false
 	}
+	if entry.noTTL {
+		return append([]byte(nil), entry.value...), 0, true
+	}
 	return append([]byte(nil), entry.value...), time.Until(entry.expiresAt), true
+}
+
+func (s *testStore) RecordWriteReason(key string, reason resolve.CacheWriteReason) {
+	s.nextReason = reason
 }
 
 func (s *testStore) Set(key string, value []byte, ttl time.Duration) {
 	s.data[key] = testStoreEntry{value: append([]byte(nil), value...), expiresAt: time.Now().Add(ttl)}
-	s.ops = append(s.ops, testStoreOp{Kind: "Set", Key: key, Value: string(value), TTL: ttl})
+	s.ops = append(s.ops, testStoreOp{Kind: "Set", Key: key, Value: string(value), TTL: ttl, Reason: s.nextReason})
+	s.nextReason = ""
 }
 
 // productProvidesData is the coverage tree used across the controller rows:
@@ -150,7 +174,9 @@ func TestControllerDecisionRows(t *testing.T) {
 		// Key fidelity (O row): the read key IS the write key.
 		assert.Equal(t, []string{key}, handle.Items[0].RenderedKeys)
 		require.NotNil(t, handle.Items[0].FromCache)
-		assert.Equal(t, `{"__typename":"Product","name":"Table","price":100}`, string(handle.Items[0].FromCache.MarshalTo(nil)))
+		// The chosen value is reordered to selection order (name, price first),
+		// with cached-only extras (__typename) appended after.
+		assert.Equal(t, `{"name":"Table","price":100,"__typename":"Product"}`, string(handle.Items[0].FromCache.MarshalTo(nil)))
 	})
 
 	t.Run("[D2] miss: empty store fetches", func(t *testing.T) {
@@ -288,7 +314,7 @@ func TestControllerWriteGateRows(t *testing.T) {
 		rc.EndRequest()
 		assert.Equal(t, []testStoreOp{
 			{Kind: "Get", Key: key},
-			{Kind: "Set", Key: key, Value: `{"__typename":"Product","name":"Table","price":100}`, TTL: time.Minute},
+			{Kind: "Set", Key: key, Value: `{"__typename":"Product","name":"Table","price":100}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
 		}, store.ops)
 	})
 
@@ -402,8 +428,8 @@ func TestControllerFlushRows(t *testing.T) {
 		assert.Equal(t, []testStoreOp{
 			{Kind: "Get", Key: h1.Items[0].RenderedKeys[0]},
 			{Kind: "Get", Key: h2.Items[0].RenderedKeys[0]},
-			{Kind: "Set", Key: h1.Items[0].RenderedKeys[0], Value: `{"__typename":"Product","name":"Table","price":100}`, TTL: time.Minute},
-			{Kind: "Set", Key: h2.Items[0].RenderedKeys[0], Value: `{"__typename":"Product","name":"Chair","price":50}`, TTL: time.Minute},
+			{Kind: "Set", Key: h1.Items[0].RenderedKeys[0], Value: `{"__typename":"Product","name":"Table","price":100}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
+			{Kind: "Set", Key: h2.Items[0].RenderedKeys[0], Value: `{"__typename":"Product","name":"Chair","price":50}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
 		}, store.ops)
 	})
 
@@ -472,7 +498,7 @@ func TestControllerMergePath(t *testing.T) {
 			Arena:     beginner(),
 		}))
 		assert.Equal(t,
-			`{"__typename":"Product","upc":"1","nested":{"__typename":"Product","name":"Table","price":100}}`,
+			`{"__typename":"Product","upc":"1","nested":{"name":"Table","price":100,"__typename":"Product"}}`,
 			string(item.MarshalTo(nil)))
 	})
 

--- a/v2/pkg/engine/cache/controller_test.go
+++ b/v2/pkg/engine/cache/controller_test.go
@@ -554,10 +554,10 @@ func TestControllerGates(t *testing.T) {
 		assert.Nil(t, handle)
 	})
 
-	t.Run("batch fetches until task 10", func(t *testing.T) {
+	t.Run("[I] empty batch short-circuits without a handle", func(t *testing.T) {
 		cfg := entityConfig(t, time.Minute)
-		in := prepareInput(cfg, productItem(t, "1"))
-		in.BatchStats = [][]*astjson.Value{{productItem(t, "1")}}
+		in := prepareInput(cfg)
+		in.BatchStats = [][]*astjson.Value{}
 		decision, handle := rc.PrepareFetch(in)
 		assert.Equal(t, resolve.DecisionFetch, decision)
 		assert.Nil(t, handle)

--- a/v2/pkg/engine/cache/controller_test.go
+++ b/v2/pkg/engine/cache/controller_test.go
@@ -531,11 +531,13 @@ func TestControllerGates(t *testing.T) {
 		assert.Nil(t, handle)
 	})
 
-	t.Run("L1-only config is untouched by the L2 controller (task 17)", func(t *testing.T) {
+	t.Run("L1-only config participates without touching the store (task 17)", func(t *testing.T) {
+		store := newTestStore()
 		cfg := entityConfig(t, 0) // TTL 0 => L2 false, L1 true
-		decision, handle := rc.PrepareFetch(prepareInput(cfg, productItem(t, "1")))
+		decision, handle := NewController(store, nil).BeginRequest(nil).PrepareFetch(prepareInput(cfg, productItem(t, "1")))
 		assert.Equal(t, resolve.DecisionFetch, decision)
-		assert.Nil(t, handle)
+		require.NotNil(t, handle)
+		assert.Empty(t, store.ops)
 	})
 
 	t.Run("[I] empty batch short-circuits without a handle", func(t *testing.T) {

--- a/v2/pkg/engine/cache/controller_test.go
+++ b/v2/pkg/engine/cache/controller_test.go
@@ -174,9 +174,9 @@ func TestControllerDecisionRows(t *testing.T) {
 		// Key fidelity (O row): the read key IS the write key.
 		assert.Equal(t, []string{key}, handle.Items[0].RenderedKeys)
 		require.NotNil(t, handle.Items[0].FromCache)
-		// The chosen value is reordered to selection order (name, price first),
-		// with cached-only extras (__typename) appended after.
-		assert.Equal(t, `{"name":"Table","price":100,"__typename":"Product"}`, string(handle.Items[0].FromCache.MarshalTo(nil)))
+		// FromCache stays in the STORED (normalized) form; denormalization to
+		// the requesting aliases happens at splice time.
+		assert.Equal(t, `{"__typename":"Product","name":"Table","price":100}`, string(handle.Items[0].FromCache.MarshalTo(nil)))
 	})
 
 	t.Run("[D2] miss: empty store fetches", func(t *testing.T) {

--- a/v2/pkg/engine/cache/coverage.go
+++ b/v2/pkg/engine/cache/coverage.go
@@ -19,12 +19,42 @@ func covers(ctx *resolve.Context, value *astjson.Value, obj *resolve.Object) boo
 	if value == nil || obj == nil {
 		return false
 	}
+	typeName := valueTypeName(value)
 	for _, field := range obj.Fields {
+		if skipFieldForTypeName(field, typeName) {
+			continue
+		}
 		fieldValue := value.Get(normalizedFieldName(ctx, field))
 		if fieldValue == nil {
 			return false
 		}
 		if !coversNode(ctx, fieldValue, field.Value) {
+			return false
+		}
+	}
+	return true
+}
+
+// valueTypeName reads the cached value's __typename ("" when absent).
+func valueTypeName(value *astjson.Value) string {
+	typeName := value.Get("__typename")
+	if typeName == nil {
+		return ""
+	}
+	return string(typeName.GetStringBytes())
+}
+
+// skipFieldForTypeName reports whether a type-conditioned field does not apply
+// to the cached value's concrete type: requiring it would turn every valid
+// polymorphic response into a coverage miss. An absent __typename keeps the
+// field REQUIRED (conservative: no evidence the condition is satisfied means
+// no serve).
+func skipFieldForTypeName(field *resolve.Field, typeName string) bool {
+	if len(field.OnTypeNames) == 0 || typeName == "" {
+		return false
+	}
+	for _, onTypeName := range field.OnTypeNames {
+		if string(onTypeName) == typeName {
 			return false
 		}
 	}

--- a/v2/pkg/engine/cache/coverage.go
+++ b/v2/pkg/engine/cache/coverage.go
@@ -1,0 +1,71 @@
+package cache
+
+import (
+	"github.com/wundergraph/astjson"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// covers is the per-item coverage walk: it reports whether the cached value
+// contains EVERY field of the fetch's ProvidesData tree, with null accepted
+// only where the schema allows it. A partially-covering (stale-shape) value
+// must never be served — the walk is the always-on guard between "some cached
+// bytes exist" and "this fetch can be skipped".
+//
+// Task 07 reads fields by their response name; store-time normalization
+// (schema names + argument-suffix keys, task 09) extends the naming.
+func covers(value *astjson.Value, obj *resolve.Object) bool {
+	if value == nil || obj == nil {
+		return false
+	}
+	for _, field := range obj.Fields {
+		fieldValue := value.Get(string(field.Name))
+		if fieldValue == nil {
+			return false
+		}
+		if !coversNode(fieldValue, field.Value) {
+			return false
+		}
+	}
+	return true
+}
+
+// coversNode applies the coverage rules per node shape: scalars accept null
+// only when nullable; objects recurse (null OK when nullable); arrays require
+// every element to cover the item shape.
+func coversNode(value *astjson.Value, node resolve.Node) bool {
+	switch typed := node.(type) {
+	case *resolve.Scalar:
+		return value.Type() != astjson.TypeNull || typed.Nullable
+	case *resolve.Object:
+		if value.Type() == astjson.TypeNull {
+			return typed.Nullable
+		}
+		if value.Type() != astjson.TypeObject {
+			return false
+		}
+		return covers(value, typed)
+	case *resolve.Array:
+		if value.Type() == astjson.TypeNull {
+			return typed.Nullable
+		}
+		if value.Type() != astjson.TypeArray {
+			return false
+		}
+		if typed.Item == nil {
+			return true
+		}
+		items, err := value.Array()
+		if err != nil {
+			return false
+		}
+		for _, item := range items {
+			if !coversNode(item, typed.Item) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}

--- a/v2/pkg/engine/cache/coverage.go
+++ b/v2/pkg/engine/cache/coverage.go
@@ -12,18 +12,19 @@ import (
 // must never be served — the walk is the always-on guard between "some cached
 // bytes exist" and "this fetch can be skipped".
 //
-// Task 07 reads fields by their response name; store-time normalization
-// (schema names + argument-suffix keys, task 09) extends the naming.
-func covers(value *astjson.Value, obj *resolve.Object) bool {
+// Cached values are stored NORMALIZED (task 09), so the walk reads fields by
+// their normalized name — schema name plus argument suffix — which is exactly
+// what makes an argument-mismatched cached field a MISS instead of a hit.
+func covers(ctx *resolve.Context, value *astjson.Value, obj *resolve.Object) bool {
 	if value == nil || obj == nil {
 		return false
 	}
 	for _, field := range obj.Fields {
-		fieldValue := value.Get(string(field.Name))
+		fieldValue := value.Get(normalizedFieldName(ctx, field))
 		if fieldValue == nil {
 			return false
 		}
-		if !coversNode(fieldValue, field.Value) {
+		if !coversNode(ctx, fieldValue, field.Value) {
 			return false
 		}
 	}
@@ -33,7 +34,7 @@ func covers(value *astjson.Value, obj *resolve.Object) bool {
 // coversNode applies the coverage rules per node shape: scalars accept null
 // only when nullable; objects recurse (null OK when nullable); arrays require
 // every element to cover the item shape.
-func coversNode(value *astjson.Value, node resolve.Node) bool {
+func coversNode(ctx *resolve.Context, value *astjson.Value, node resolve.Node) bool {
 	switch typed := node.(type) {
 	case *resolve.Scalar:
 		return value.Type() != astjson.TypeNull || typed.Nullable
@@ -44,7 +45,7 @@ func coversNode(value *astjson.Value, node resolve.Node) bool {
 		if value.Type() != astjson.TypeObject {
 			return false
 		}
-		return covers(value, typed)
+		return covers(ctx, value, typed)
 	case *resolve.Array:
 		if value.Type() == astjson.TypeNull {
 			return typed.Nullable
@@ -60,7 +61,7 @@ func coversNode(value *astjson.Value, node resolve.Node) bool {
 			return false
 		}
 		for _, item := range items {
-			if !coversNode(item, typed.Item) {
+			if !coversNode(ctx, item, typed.Item) {
 				return false
 			}
 		}

--- a/v2/pkg/engine/cache/coverage_test.go
+++ b/v2/pkg/engine/cache/coverage_test.go
@@ -1,0 +1,59 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/wundergraph/astjson"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// TestCoversTypeConditionedFields pins that fields guarded by OnTypeNames are
+// required only when the cached value's __typename matches — a concrete-type
+// response must not miss coverage because of a SIBLING type's fields.
+func TestCoversTypeConditionedFields(t *testing.T) {
+	polymorphic := &resolve.Object{
+		Fields: []*resolve.Field{
+			{
+				Name:        []byte("name"),
+				Value:       &resolve.Scalar{Nullable: false, Path: []string{"name"}},
+				OnTypeNames: [][]byte{[]byte("Book"), []byte("Movie")},
+			},
+			{
+				Name:        []byte("pages"),
+				Value:       &resolve.Scalar{Nullable: false, Path: []string{"pages"}},
+				OnTypeNames: [][]byte{[]byte("Book")},
+			},
+			{
+				Name:        []byte("runtime"),
+				Value:       &resolve.Scalar{Nullable: false, Path: []string{"runtime"}},
+				OnTypeNames: [][]byte{[]byte("Movie")},
+			},
+		},
+	}
+
+	t.Run("a Book value covers without the Movie-only field", func(t *testing.T) {
+		value := astjson.MustParseBytes([]byte(`{"__typename":"Book","name":"Dune","pages":412}`))
+		assert.True(t, covers(nil, value, polymorphic))
+	})
+
+	t.Run("a Book value missing its OWN conditioned field does not cover", func(t *testing.T) {
+		value := astjson.MustParseBytes([]byte(`{"__typename":"Book","name":"Dune"}`))
+		assert.False(t, covers(nil, value, polymorphic))
+	})
+
+	t.Run("without __typename every conditioned field stays required (conservative)", func(t *testing.T) {
+		value := astjson.MustParseBytes([]byte(`{"name":"Dune","pages":412}`))
+		assert.False(t, covers(nil, value, polymorphic))
+	})
+
+	t.Run("unconditioned fields are unaffected", func(t *testing.T) {
+		plain := &resolve.Object{Fields: []*resolve.Field{
+			{Name: []byte("name"), Value: &resolve.Scalar{Nullable: false, Path: []string{"name"}}},
+		}}
+		assert.True(t, covers(nil, astjson.MustParseBytes([]byte(`{"__typename":"Book","name":"Dune"}`)), plain))
+		assert.False(t, covers(nil, astjson.MustParseBytes([]byte(`{"__typename":"Book"}`)), plain))
+	})
+}

--- a/v2/pkg/engine/cache/entity_reuse_test.go
+++ b/v2/pkg/engine/cache/entity_reuse_test.go
@@ -1,0 +1,236 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/astjson"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astparser"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+const reuseDefinition = `
+	scalar String
+	scalar ID
+
+	type Query {
+		product(upc: String!): Product
+		productByName(name: String!): Product
+		products(first: String): [Product!]!
+	}
+
+	type Product {
+		upc: String!
+		sku: String!
+		name: String!
+	}
+`
+
+func parseReuseDefinition(t *testing.T) *ast.Document {
+	t.Helper()
+	definition, report := astparser.ParseGraphqlDocumentString(reuseDefinition)
+	require.False(t, report.HasErrors(), "parse definition: %v", report)
+	return &definition
+}
+
+func reuseRootFieldInfo(fieldName string) *resolve.FetchInfo {
+	return &resolve.FetchInfo{
+		DataSourceID: "products",
+		RootFields:   []resolve.GraphCoordinate{{TypeName: "Query", FieldName: fieldName}},
+	}
+}
+
+// TestBuildRootFieldSpecEntityKeyMappings covers the builder rows: mappings
+// derived structurally from definition + federation, entity candidates frozen
+// with the type-name fallback, and the no-mapping cases.
+func TestBuildRootFieldSpecEntityKeyMappings(t *testing.T) {
+	builder := &cacheKeyBuilder{
+		federation: newKeyBuilder(t, parseReuseDefinition(t), newKeyBuilderFederation(t, "upc", "sku")).federation,
+		definition: parseReuseDefinition(t),
+	}
+
+	t.Run("by-key root field gets the mapping and the FULL entity candidate set", func(t *testing.T) {
+		spec, ok := builder.buildRootFieldSpec(reuseRootFieldInfo("product"))
+		require.True(t, ok)
+		assert.Equal(t, []resolve.EntityKeyMapping{
+			{
+				EntityTypeName: "Product",
+				FieldMappings: []resolve.EntityFieldMapping{
+					{EntityKeyField: "upc", ArgumentPath: []string{"upc"}, ArgumentIsEntityKey: true},
+				},
+			},
+		}, spec.EntityKeyMappings)
+		// BOTH entity candidates are frozen (sorted: sku first), each carrying
+		// the entity type name for arg-derived rendering.
+		require.Len(t, spec.Candidates, 2)
+		assert.Equal(t, "Product", spec.Candidates[0].Representation.TypeName)
+		assert.Equal(t, "Product", spec.Candidates[1].Representation.TypeName)
+		assert.Equal(t, resolve.CacheScopeRootField, spec.Scope)
+		assert.Equal(t, "Query", spec.TypeName)
+		assert.Equal(t, "product", spec.FieldName)
+	})
+
+	t.Run("arguments not covering any key set derive no mapping", func(t *testing.T) {
+		spec, ok := builder.buildRootFieldSpec(reuseRootFieldInfo("productByName"))
+		require.True(t, ok)
+		assert.Nil(t, spec.EntityKeyMappings)
+		assert.Nil(t, spec.Candidates)
+	})
+
+	t.Run("non-entity return types derive no mapping", func(t *testing.T) {
+		spec, ok := builder.buildRootFieldSpec(&resolve.FetchInfo{
+			DataSourceID: "unknown",
+			RootFields:   []resolve.GraphCoordinate{{TypeName: "Query", FieldName: "product"}},
+		})
+		require.True(t, ok)
+		assert.Nil(t, spec.EntityKeyMappings)
+	})
+
+	t.Run("multi-root-field fetches derive no mapping", func(t *testing.T) {
+		info := reuseRootFieldInfo("product")
+		info.RootFields = append(info.RootFields, resolve.GraphCoordinate{TypeName: "Query", FieldName: "products"})
+		spec, ok := builder.buildRootFieldSpec(info)
+		require.True(t, ok)
+		assert.Nil(t, spec.EntityKeyMappings)
+	})
+}
+
+// reuseConfig builds the by-key root-field config through the REAL builder.
+func reuseConfig(t *testing.T) *resolve.FetchCacheConfig {
+	t.Helper()
+	builder := &cacheKeyBuilder{
+		federation: newKeyBuilder(t, parseReuseDefinition(t), newKeyBuilderFederation(t, "upc", "sku")).federation,
+		definition: parseReuseDefinition(t),
+	}
+	spec, ok := builder.buildRootFieldSpec(reuseRootFieldInfo("product"))
+	require.True(t, ok)
+	require.Len(t, spec.Candidates, 2)
+	cfg := &resolve.FetchCacheConfig{
+		L2:        true,
+		CacheName: "entities", // SHARED with the entity policy: read key == write key
+		TTL:       time.Minute,
+		KeySpec:   spec,
+		ProvidesData: &resolve.Object{
+			Fields: []*resolve.Field{
+				{
+					Name: []byte("product"),
+					Value: &resolve.Object{
+						Nullable: true,
+						Path:     []string{"product"},
+						Fields: []*resolve.Field{
+							{Name: []byte("name"), Value: &resolve.Scalar{Nullable: false, Path: []string{"name"}}},
+						},
+					},
+				},
+			},
+		},
+	}
+	resolve.ComputeHasAliases(cfg.ProvidesData)
+	return cfg
+}
+
+// entityWriteKeys derives the entity-space keys (sku, upc) exactly as an
+// entity fetch renders them, for cross-checking read key == write key.
+func entityWriteKeys(t *testing.T, cacheName string, item string) (string, string) {
+	t.Helper()
+	cfg := multiKeyConfig(t)
+	cfg.CacheName = cacheName
+	rc := NewController(newTestStore(), nil).BeginRequest(nil)
+	_, handle := prepare(t, rc, cfg, astjson.MustParseBytes([]byte(item)))
+	require.Len(t, handle.Items[0].RenderedKeys, 2)
+	return handle.Items[0].RenderedKeys[0], handle.Items[0].RenderedKeys[1]
+}
+
+// TestEntityReuseRuntimeRows covers E3/E5 for by-key root fields.
+func TestEntityReuseRuntimeRows(t *testing.T) {
+	t.Run("[E3] lookup renders ONLY the arg-derived candidate; data-derived key backfills", func(t *testing.T) {
+		skuKey, upcKey := entityWriteKeys(t, "entities", `{"__typename":"Product","upc":"1","sku":"S1"}`)
+		store := newTestStore()
+		ctx := variableContext(t, `{"upc":"1"}`)
+		rc := NewController(store, nil).BeginRequest(ctx)
+		cfg := reuseConfig(t)
+
+		dataRoot := astjson.MustParseBytes([]byte(`{}`))
+		decision, handle := prepare(t, rc, cfg, dataRoot)
+		require.Equal(t, resolve.DecisionFetch, decision)
+		// Only the upc candidate rendered from the argument; sku is pending.
+		assert.Equal(t, []string{upcKey}, handle.Items[0].RenderedKeys)
+		require.Len(t, handle.Items[0].PendingCandidates, 1)
+		assert.Equal(t, []string{"product"}, handle.Items[0].EntityMergePath)
+
+		// The response carries sku, so the pending candidate backfills.
+		require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+			Items:        []*astjson.Value{dataRoot},
+			ResponseData: astjson.MustParseBytes([]byte(`{"product":{"__typename":"Product","name":"Table","sku":"S1"}}`)),
+			Arena:        beginner(),
+		}))
+		rc.EndRequest()
+		assert.Equal(t, []testStoreOp{
+			{Kind: "Get", Key: upcKey},
+			{Kind: "Set", Key: upcKey, Value: `{"__typename":"Product","name":"Table","sku":"S1"}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
+			{Kind: "Set", Key: skuKey, Value: `{"__typename":"Product","name":"Table","sku":"S1"}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonBackfill},
+		}, store.ops)
+	})
+
+	t.Run("a hit on the entity entry serves the root field at its response key", func(t *testing.T) {
+		_, upcKey := entityWriteKeys(t, "entities", `{"__typename":"Product","upc":"1","sku":"S1"}`)
+		store := newTestStore()
+		// Primed exactly as an entity fetch would write it.
+		store.seed(upcKey, []byte(`{"__typename":"Product","name":"Table"}`), time.Minute)
+
+		ctx := variableContext(t, `{"upc":"1"}`)
+		rc := NewController(store, nil).BeginRequest(ctx)
+		cfg := reuseConfig(t)
+		dataRoot := astjson.MustParseBytes([]byte(`{}`))
+		decision, handle := prepare(t, rc, cfg, dataRoot)
+		require.Equal(t, resolve.DecisionSkipFullHit, decision)
+
+		require.NoError(t, rc.OnFetchSkipped(handle, resolve.MergeInput{
+			Items: []*astjson.Value{dataRoot},
+			Arena: beginner(),
+		}))
+		assert.Equal(t, `{"product":{"name":"Table","__typename":"Product"}}`, string(dataRoot.MarshalTo(nil)))
+	})
+
+	t.Run("[E5] read-hit backfill: the pending key renders from the served entity value", func(t *testing.T) {
+		skuKey, upcKey := entityWriteKeys(t, "entities", `{"__typename":"Product","upc":"1","sku":"S1"}`)
+		store := newTestStore()
+		store.seed(upcKey, []byte(`{"__typename":"Product","name":"Table","sku":"S1"}`), time.Minute)
+
+		ctx := variableContext(t, `{"upc":"1"}`)
+		rc := NewController(store, nil).BeginRequest(ctx)
+		cfg := reuseConfig(t)
+		dataRoot := astjson.MustParseBytes([]byte(`{}`))
+		decision, handle := prepare(t, rc, cfg, dataRoot)
+		require.Equal(t, resolve.DecisionSkipFullHit, decision)
+		assert.True(t, handle.MustWriteBack)
+
+		require.NoError(t, rc.OnFetchSkipped(handle, resolve.MergeInput{
+			Items: []*astjson.Value{dataRoot},
+			Arena: beginner(),
+		}))
+		rc.EndRequest()
+		assert.Equal(t, []testStoreOp{
+			{Kind: "Get", Key: upcKey},
+			{Kind: "Set", Key: skuKey, Value: `{"__typename":"Product","name":"Table","sku":"S1"}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonBackfill},
+		}, store.ops)
+	})
+
+	t.Run("a missing argument variable falls back to a plain fetch and backfills post-response", func(t *testing.T) {
+		store := newTestStore()
+		rc := NewController(store, nil).BeginRequest(variableContext(t, `{}`))
+		cfg := reuseConfig(t)
+		dataRoot := astjson.MustParseBytes([]byte(`{}`))
+		decision, handle := prepare(t, rc, cfg, dataRoot)
+		require.Equal(t, resolve.DecisionFetch, decision)
+		// Nothing renderable at lookup: no Gets at all, both candidates pending.
+		assert.Nil(t, handle.Items[0].RenderedKeys)
+		assert.Len(t, handle.Items[0].PendingCandidates, 2)
+		assert.Empty(t, store.ops)
+	})
+}

--- a/v2/pkg/engine/cache/fetch_cache_configurator.go
+++ b/v2/pkg/engine/cache/fetch_cache_configurator.go
@@ -45,32 +45,52 @@ func (c *fetchCacheConfigurator) buildConfig(fetch resolve.Fetch, pd map[*resolv
 	if provider == nil {
 		return nil
 	}
-	if !fetch.IsEntityFetch() && !fetch.IsBatchEntityFetch() {
-		// Root-field caching lands with task 13.
-		return nil
-	}
-
-	policy, ok := provider.EntityPolicy(info.RootFields[0].TypeName)
-	if !ok {
-		return nil
-	}
-	spec, ok := c.keyBuilder.buildEntitySpec(info)
-	if !ok {
-		return nil
-	}
-	cfg := resolve.FetchCacheConfig{
-		// L1 marks ELIGIBILITY here; optimizeL1Cache (task 16) narrows it to
-		// the fetches whose values are actually reusable within the request.
-		L1:                          true,
-		L2:                          policy.TTL > 0 || policy.NegativeCacheTTL > 0,
-		CacheName:                   policy.CacheName,
-		TTL:                         policy.TTL,
-		NegativeCacheTTL:            policy.NegativeCacheTTL,
-		IncludeSubgraphHeaderPrefix: policy.IncludeSubgraphHeaderPrefix,
-		EnablePartialCacheLoad:      policy.EnablePartialCacheLoad,
-		ShadowMode:                  policy.ShadowMode,
-		HashAnalyticsKeys:           policy.HashAnalyticsKeys,
-		KeySpec:                     spec,
+	var cfg resolve.FetchCacheConfig
+	if fetch.IsEntityFetch() || fetch.IsBatchEntityFetch() {
+		policy, ok := provider.EntityPolicy(info.RootFields[0].TypeName)
+		if !ok {
+			return nil
+		}
+		spec, ok := c.keyBuilder.buildEntitySpec(info)
+		if !ok {
+			return nil
+		}
+		cfg = resolve.FetchCacheConfig{
+			// L1 marks ELIGIBILITY here; optimizeL1Cache (task 16) narrows it
+			// to the fetches whose values are actually reusable within the
+			// request.
+			L1:                          true,
+			L2:                          policy.TTL > 0 || policy.NegativeCacheTTL > 0,
+			CacheName:                   policy.CacheName,
+			TTL:                         policy.TTL,
+			NegativeCacheTTL:            policy.NegativeCacheTTL,
+			IncludeSubgraphHeaderPrefix: policy.IncludeSubgraphHeaderPrefix,
+			EnablePartialCacheLoad:      policy.EnablePartialCacheLoad,
+			ShadowMode:                  policy.ShadowMode,
+			HashAnalyticsKeys:           policy.HashAnalyticsKeys,
+			KeySpec:                     spec,
+		}
+	} else {
+		policy, ok := rootFieldPolicyForAllRootFields(provider, info)
+		if !ok {
+			return nil
+		}
+		spec, ok := c.keyBuilder.buildRootFieldSpec(info)
+		if !ok {
+			return nil
+		}
+		cfg = resolve.FetchCacheConfig{
+			// Root fields act only as L2 providers; root->entity L1 promotion
+			// is an out-of-core follow-up.
+			L1:                          false,
+			L2:                          policy.TTL > 0,
+			CacheName:                   policy.CacheName,
+			TTL:                         policy.TTL,
+			IncludeSubgraphHeaderPrefix: policy.IncludeSubgraphHeaderPrefix,
+			ShadowMode:                  policy.ShadowMode,
+			PartialBatchLoad:            policy.PartialBatchLoad,
+			KeySpec:                     spec,
+		}
 	}
 	cfg.ProvidesData = pd[info]
 	if cfg.ProvidesData != nil {
@@ -82,4 +102,35 @@ func (c *fetchCacheConfigurator) buildConfig(fetch resolve.Fetch, pd map[*resolv
 		return nil
 	}
 	return &cfg
+}
+
+// rootFieldPolicyForAllRootFields returns a policy only when EVERY root field
+// of the fetch resolves to the SAME policy. A merged fetch mixing policies (or
+// mixing cached and uncached fields) declines caching entirely — the
+// conservative safety net; task 14 splits such fetches so the decline stays a
+// rare residual.
+func rootFieldPolicyForAllRootFields(provider cacheconfig.CacheConfigProvider, info *resolve.FetchInfo) (cacheconfig.RootFieldCachePolicy, bool) {
+	first, ok := provider.RootFieldPolicy(info.RootFields[0].TypeName, info.RootFields[0].FieldName)
+	if !ok {
+		return cacheconfig.RootFieldCachePolicy{}, false
+	}
+	for _, rootField := range info.RootFields[1:] {
+		policy, ok := provider.RootFieldPolicy(rootField.TypeName, rootField.FieldName)
+		if !ok || !sameRootFieldCachePolicy(first, policy) {
+			return cacheconfig.RootFieldCachePolicy{}, false
+		}
+	}
+	return first, true
+}
+
+// sameRootFieldCachePolicy compares the policy VALUES, excluding the
+// coordinate: a merged fetch whose root fields all carry equal cache settings
+// is cacheable as one unit (the value covers all its fields; coverage guards
+// servability).
+func sameRootFieldCachePolicy(a, b cacheconfig.RootFieldCachePolicy) bool {
+	return a.CacheName == b.CacheName &&
+		a.TTL == b.TTL &&
+		a.IncludeSubgraphHeaderPrefix == b.IncludeSubgraphHeaderPrefix &&
+		a.ShadowMode == b.ShadowMode &&
+		a.PartialBatchLoad == b.PartialBatchLoad
 }

--- a/v2/pkg/engine/cache/fetch_cache_configurator.go
+++ b/v2/pkg/engine/cache/fetch_cache_configurator.go
@@ -1,0 +1,24 @@
+package cache
+
+import (
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// fetchCacheConfigurator assembles the self-contained *resolve.FetchCacheConfig
+// for each cache-eligible fetch (policy + frozen key spec + ProvidesData) and
+// sets it on the concrete fetch via Fetch.SetCacheConfig — after
+// createConcreteSingleFetchTypes, so the config lands on the final fetch types.
+//
+// Skeleton only — the entity arm lands with task 06, the root-field arm with
+// task 13.
+type fetchCacheConfigurator struct {
+	providers  map[string]cacheconfig.CacheConfigProvider
+	keyBuilder *cacheKeyBuilder
+}
+
+// configureTree walks one flat fetch tree and stamps per-fetch cache config.
+// Inert until task 06; every fetch keeps a nil Cache, preserving the planner
+// no-op gate.
+func (c *fetchCacheConfigurator) configureTree(response *resolve.GraphQLResponse, tree *resolve.FetchTreeNode) {
+}

--- a/v2/pkg/engine/cache/fetch_cache_configurator.go
+++ b/v2/pkg/engine/cache/fetch_cache_configurator.go
@@ -47,6 +47,16 @@ func (c *fetchCacheConfigurator) buildConfig(fetch resolve.Fetch, pd map[*resolv
 	}
 	var cfg resolve.FetchCacheConfig
 	if fetch.IsEntityFetch() || fetch.IsBatchEntityFetch() {
+		// Policy and key spec both derive from RootFields[0].TypeName, so a
+		// fetch resolving entities of MIXED types (an abstract-path entity
+		// fetch collects one root coordinate per enclosing concrete type) has
+		// no single policy or key space — decline caching entirely, the
+		// conservative mirror of the root-field all-or-nothing rule below.
+		for _, rootField := range info.RootFields[1:] {
+			if rootField.TypeName != info.RootFields[0].TypeName {
+				return nil
+			}
+		}
 		policy, ok := provider.EntityPolicy(info.RootFields[0].TypeName)
 		if !ok {
 			return nil

--- a/v2/pkg/engine/cache/fetch_cache_configurator.go
+++ b/v2/pkg/engine/cache/fetch_cache_configurator.go
@@ -6,19 +6,80 @@ import (
 )
 
 // fetchCacheConfigurator assembles the self-contained *resolve.FetchCacheConfig
-// for each cache-eligible fetch (policy + frozen key spec + ProvidesData) and
+// for each cache-eligible fetch (policy + built key spec + ProvidesData) and
 // sets it on the concrete fetch via Fetch.SetCacheConfig — after
 // createConcreteSingleFetchTypes, so the config lands on the final fetch types.
-//
-// Skeleton only — the entity arm lands with task 06, the root-field arm with
-// task 13.
+// Task 06 covers the entity arm; the root-field arm lands with task 13.
 type fetchCacheConfigurator struct {
 	providers  map[string]cacheconfig.CacheConfigProvider
 	keyBuilder *cacheKeyBuilder
 }
 
-// configureTree walks one flat fetch tree and stamps per-fetch cache config.
-// Inert until task 06; every fetch keeps a nil Cache, preserving the planner
-// no-op gate.
+// configureTree walks one flat fetch tree and sets per-fetch cache config; a
+// fetch keeps a nil Cache when its datasource has no provider, its coordinate
+// has no policy, no usable key exists, or the assembled config enables nothing.
 func (c *fetchCacheConfigurator) configureTree(response *resolve.GraphQLResponse, tree *resolve.FetchTreeNode) {
+	if tree == nil {
+		return
+	}
+	if tree.Item != nil && tree.Item.Fetch != nil {
+		if cfg := c.buildConfig(tree.Item.Fetch, response.CacheProvidesData()); cfg != nil {
+			tree.Item.Fetch.SetCacheConfig(cfg)
+		}
+	}
+	for _, child := range tree.ChildNodes {
+		c.configureTree(response, child)
+	}
+}
+
+// buildConfig assembles the config for one fetch, or nil when the fetch is not
+// cacheable. Info may be nil despite the engine forcing FetchInfo on — e.g.
+// integrators driving postprocess directly — and then the fetch is simply not
+// cached.
+func (c *fetchCacheConfigurator) buildConfig(fetch resolve.Fetch, pd map[*resolve.FetchInfo]*resolve.Object) *resolve.FetchCacheConfig {
+	info := fetch.FetchInfo()
+	if info == nil || len(info.RootFields) == 0 {
+		return nil
+	}
+	provider := c.providers[info.DataSourceID]
+	if provider == nil {
+		return nil
+	}
+	if !fetch.IsEntityFetch() && !fetch.IsBatchEntityFetch() {
+		// Root-field caching lands with task 13.
+		return nil
+	}
+
+	policy, ok := provider.EntityPolicy(info.RootFields[0].TypeName)
+	if !ok {
+		return nil
+	}
+	spec, ok := c.keyBuilder.buildEntitySpec(info)
+	if !ok {
+		return nil
+	}
+	cfg := resolve.FetchCacheConfig{
+		// L1 marks ELIGIBILITY here; optimizeL1Cache (task 16) narrows it to
+		// the fetches whose values are actually reusable within the request.
+		L1:                          true,
+		L2:                          policy.TTL > 0 || policy.NegativeCacheTTL > 0,
+		CacheName:                   policy.CacheName,
+		TTL:                         policy.TTL,
+		NegativeCacheTTL:            policy.NegativeCacheTTL,
+		IncludeSubgraphHeaderPrefix: policy.IncludeSubgraphHeaderPrefix,
+		EnablePartialCacheLoad:      policy.EnablePartialCacheLoad,
+		ShadowMode:                  policy.ShadowMode,
+		HashAnalyticsKeys:           policy.HashAnalyticsKeys,
+		KeySpec:                     spec,
+	}
+	cfg.ProvidesData = pd[info]
+	if cfg.ProvidesData != nil {
+		resolve.ComputeHasAliases(cfg.ProvidesData)
+	}
+	if !cfg.L1 && !cfg.L2 && !cfg.ShadowMode {
+		// All-flags-false safety net: a config that enables nothing must not
+		// reach the loader (the per-fetch gate is cfg == nil).
+		return nil
+	}
+	return &cfg
 }

--- a/v2/pkg/engine/cache/fetch_cache_configurator_rootfield_test.go
+++ b/v2/pkg/engine/cache/fetch_cache_configurator_rootfield_test.go
@@ -1,0 +1,107 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+func rootFieldInfo(fields ...string) *resolve.FetchInfo {
+	info := &resolve.FetchInfo{DataSourceID: "products"}
+	for _, field := range fields {
+		info.RootFields = append(info.RootFields, resolve.GraphCoordinate{TypeName: "Query", FieldName: field})
+	}
+	return info
+}
+
+func rootFieldProviders(policies ...cacheconfig.RootFieldCachePolicy) map[string]cacheconfig.CacheConfigProvider {
+	return map[string]cacheconfig.CacheConfigProvider{
+		"products": &cacheconfig.CachingConfiguration{RootFields: policies},
+	}
+}
+
+func configureRootFieldFetch(t *testing.T, providers map[string]cacheconfig.CacheConfigProvider, info *resolve.FetchInfo) *resolve.SingleFetch {
+	t.Helper()
+	configurator := &fetchCacheConfigurator{
+		providers:  providers,
+		keyBuilder: newKeyBuilder(t, parseKeyBuilderDefinition(t), newKeyBuilderFederation(t)),
+	}
+	fetch := &resolve.SingleFetch{Info: info}
+	tree := &resolve.FetchTreeNode{Kind: resolve.FetchTreeNodeKindSingle, Item: &resolve.FetchItem{Fetch: fetch}}
+	configurator.configureTree(&resolve.GraphQLResponse{}, tree)
+	return fetch
+}
+
+// TestFetchCacheConfiguratorRootFieldArm covers the plan-side root-field rows:
+// full config for a single cached root field, and the conservative declines.
+func TestFetchCacheConfiguratorRootFieldArm(t *testing.T) {
+	products := cacheconfig.RootFieldCachePolicy{
+		TypeName:                    "Query",
+		FieldName:                   "products",
+		CacheName:                   "root-fields",
+		TTL:                         time.Minute,
+		IncludeSubgraphHeaderPrefix: true,
+		ShadowMode:                  true,
+		PartialBatchLoad:            true,
+	}
+
+	t.Run("single cached root field receives the full config", func(t *testing.T) {
+		fetch := configureRootFieldFetch(t, rootFieldProviders(products), rootFieldInfo("products"))
+		require.NotNil(t, fetch.Cache)
+		assert.Equal(t, &resolve.FetchCacheConfig{
+			L1:                          false,
+			L2:                          true,
+			CacheName:                   "root-fields",
+			TTL:                         time.Minute,
+			IncludeSubgraphHeaderPrefix: true,
+			ShadowMode:                  true,
+			PartialBatchLoad:            true,
+			KeySpec: resolve.CacheKeySpec{
+				Scope:     resolve.CacheScopeRootField,
+				TypeName:  "Query",
+				FieldName: "products",
+			},
+		}, fetch.Cache)
+	})
+
+	t.Run("identical policy VALUES across a merged fetch keep the config", func(t *testing.T) {
+		promotions := products
+		promotions.FieldName = "promotions"
+		fetch := configureRootFieldFetch(t, rootFieldProviders(products, promotions), rootFieldInfo("products", "promotions"))
+		require.NotNil(t, fetch.Cache)
+		// The key spec carries the FIRST coordinate; the cached value covers
+		// all of the fetch's fields and coverage guards servability.
+		assert.Equal(t, resolve.CacheKeySpec{
+			Scope:     resolve.CacheScopeRootField,
+			TypeName:  "Query",
+			FieldName: "products",
+		}, fetch.Cache.KeySpec)
+	})
+
+	t.Run("mixed policies decline caching", func(t *testing.T) {
+		promotions := cacheconfig.RootFieldCachePolicy{
+			TypeName:  "Query",
+			FieldName: "promotions",
+			CacheName: "other-cache",
+			TTL:       time.Second,
+		}
+		fetch := configureRootFieldFetch(t, rootFieldProviders(products, promotions), rootFieldInfo("products", "promotions"))
+		assert.Nil(t, fetch.Cache)
+	})
+
+	t.Run("cached + uncached merge declines caching", func(t *testing.T) {
+		fetch := configureRootFieldFetch(t, rootFieldProviders(products), rootFieldInfo("products", "promotions"))
+		assert.Nil(t, fetch.Cache)
+	})
+
+	t.Run("all-flags-false policy yields nil config", func(t *testing.T) {
+		inert := cacheconfig.RootFieldCachePolicy{TypeName: "Query", FieldName: "products", CacheName: "root-fields"}
+		fetch := configureRootFieldFetch(t, rootFieldProviders(inert), rootFieldInfo("products"))
+		assert.Nil(t, fetch.Cache)
+	})
+}

--- a/v2/pkg/engine/cache/fetch_cache_configurator_test.go
+++ b/v2/pkg/engine/cache/fetch_cache_configurator_test.go
@@ -1,0 +1,212 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+func newEntityConfigurator(t *testing.T, providers map[string]cacheconfig.CacheConfigProvider) *fetchCacheConfigurator {
+	t.Helper()
+	return &fetchCacheConfigurator{
+		providers:  providers,
+		keyBuilder: newKeyBuilder(t, parseKeyBuilderDefinition(t), newKeyBuilderFederation(t, "upc")),
+	}
+}
+
+func productProviders(policy cacheconfig.EntityCachePolicy) map[string]cacheconfig.CacheConfigProvider {
+	return map[string]cacheconfig.CacheConfigProvider{
+		"products": &cacheconfig.CachingConfiguration{
+			Entities: []cacheconfig.EntityCachePolicy{policy},
+		},
+	}
+}
+
+// upcCandidate is the single expected candidate for the "upc" key.
+func upcCandidate() []resolve.CacheKeyCandidate {
+	return []resolve.CacheKeyCandidate{
+		{
+			Representation: &resolve.Object{
+				Nullable: true,
+				Fields: []*resolve.Field{
+					{
+						Name:        []byte("__typename"),
+						Value:       &resolve.String{Path: []string{"__typename"}},
+						OnTypeNames: [][]byte{[]byte("Product")},
+					},
+					{
+						Name:        []byte("upc"),
+						Value:       &resolve.String{Path: []string{"upc"}},
+						OnTypeNames: [][]byte{[]byte("Product")},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestFetchCacheConfiguratorEntityArm(t *testing.T) {
+	fullPolicy := cacheconfig.EntityCachePolicy{
+		TypeName:                    "Product",
+		CacheName:                   "products",
+		TTL:                         time.Minute,
+		NegativeCacheTTL:            5 * time.Second,
+		IncludeSubgraphHeaderPrefix: true,
+		EnablePartialCacheLoad:      true,
+		HashAnalyticsKeys:           true,
+		ShadowMode:                  true,
+	}
+
+	t.Run("entity fetch receives the full config", func(t *testing.T) {
+		configurator := newEntityConfigurator(t, productProviders(fullPolicy))
+		info := productEntityInfo()
+		providesData := &resolve.Object{
+			Fields: []*resolve.Field{
+				{
+					Name:         []byte("productName"),
+					OriginalName: []byte("name"),
+					Value:        &resolve.Scalar{Nullable: false, Path: []string{"productName"}},
+					OnTypeNames:  [][]byte{[]byte("Product")},
+				},
+			},
+		}
+		fetch := &resolve.EntityFetch{Info: info}
+		response := &resolve.GraphQLResponse{}
+		response.SetCacheProvidesData(map[*resolve.FetchInfo]*resolve.Object{info: providesData})
+		tree := &resolve.FetchTreeNode{
+			Kind: resolve.FetchTreeNodeKindSequence,
+			ChildNodes: []*resolve.FetchTreeNode{
+				{Kind: resolve.FetchTreeNodeKindSingle, Item: &resolve.FetchItem{Fetch: fetch}},
+			},
+		}
+		configurator.configureTree(response, tree)
+
+		require.NotNil(t, fetch.Cache)
+		assert.Equal(t, &resolve.FetchCacheConfig{
+			L1:                          true,
+			L2:                          true,
+			CacheName:                   "products",
+			TTL:                         time.Minute,
+			NegativeCacheTTL:            5 * time.Second,
+			IncludeSubgraphHeaderPrefix: true,
+			EnablePartialCacheLoad:      true,
+			ShadowMode:                  true,
+			HashAnalyticsKeys:           true,
+			KeySpec: resolve.CacheKeySpec{
+				Scope:      resolve.CacheScopeEntity,
+				TypeName:   "Product",
+				Candidates: upcCandidate(),
+			},
+			ProvidesData: &resolve.Object{
+				HasAliases: true, // ComputeHasAliases folded in (OriginalName present)
+				Fields: []*resolve.Field{
+					{
+						Name:         []byte("productName"),
+						OriginalName: []byte("name"),
+						Value:        &resolve.Scalar{Nullable: false, Path: []string{"productName"}},
+						OnTypeNames:  [][]byte{[]byte("Product")},
+					},
+				},
+			},
+		}, fetch.Cache)
+		// The ProvidesData is the side-table's tree itself, not a copy.
+		assert.Same(t, providesData, fetch.Cache.ProvidesData)
+	})
+
+	t.Run("batch entity fetch receives config through the interface", func(t *testing.T) {
+		configurator := newEntityConfigurator(t, productProviders(cacheconfig.EntityCachePolicy{
+			TypeName:  "Product",
+			CacheName: "products",
+			TTL:       time.Minute,
+		}))
+		fetch := &resolve.BatchEntityFetch{Info: productEntityInfo()}
+		tree := &resolve.FetchTreeNode{Kind: resolve.FetchTreeNodeKindSingle, Item: &resolve.FetchItem{Fetch: fetch}}
+		configurator.configureTree(&resolve.GraphQLResponse{}, tree)
+
+		require.NotNil(t, fetch.Cache)
+		assert.Equal(t, &resolve.FetchCacheConfig{
+			L1:        true,
+			L2:        true,
+			CacheName: "products",
+			TTL:       time.Minute,
+			KeySpec: resolve.CacheKeySpec{
+				Scope:      resolve.CacheScopeEntity,
+				TypeName:   "Product",
+				Candidates: upcCandidate(),
+			},
+		}, fetch.Cache)
+	})
+
+	t.Run("zero TTLs keep L1 eligibility with L2 off", func(t *testing.T) {
+		configurator := newEntityConfigurator(t, productProviders(cacheconfig.EntityCachePolicy{
+			TypeName:  "Product",
+			CacheName: "products",
+		}))
+		fetch := &resolve.EntityFetch{Info: productEntityInfo()}
+		tree := &resolve.FetchTreeNode{Kind: resolve.FetchTreeNodeKindSingle, Item: &resolve.FetchItem{Fetch: fetch}}
+		configurator.configureTree(&resolve.GraphQLResponse{}, tree)
+
+		require.NotNil(t, fetch.Cache)
+		assert.True(t, fetch.Cache.L1)
+		assert.False(t, fetch.Cache.L2)
+	})
+
+	nilRows := []struct {
+		name  string
+		fetch resolve.Fetch
+		cfg   func(t *testing.T) *fetchCacheConfigurator
+	}{
+		{
+			name:  "single fetch stays uncached until task 13",
+			fetch: &resolve.SingleFetch{Info: productEntityInfo()},
+			cfg: func(t *testing.T) *fetchCacheConfigurator {
+				return newEntityConfigurator(t, productProviders(fullPolicy))
+			},
+		},
+		{
+			name:  "no provider for the datasource",
+			fetch: &resolve.EntityFetch{Info: productEntityInfo()},
+			cfg: func(t *testing.T) *fetchCacheConfigurator {
+				return newEntityConfigurator(t, map[string]cacheconfig.CacheConfigProvider{})
+			},
+		},
+		{
+			name:  "no entity policy for the type",
+			fetch: &resolve.EntityFetch{Info: productEntityInfo()},
+			cfg: func(t *testing.T) *fetchCacheConfigurator {
+				return newEntityConfigurator(t, map[string]cacheconfig.CacheConfigProvider{
+					"products": &cacheconfig.CachingConfiguration{},
+				})
+			},
+		},
+		{
+			name:  "no usable key",
+			fetch: &resolve.EntityFetch{Info: productEntityInfo()},
+			cfg: func(t *testing.T) *fetchCacheConfigurator {
+				return &fetchCacheConfigurator{
+					providers:  productProviders(fullPolicy),
+					keyBuilder: newKeyBuilder(t, parseKeyBuilderDefinition(t), newKeyBuilderFederation(t)),
+				}
+			},
+		},
+		{
+			name:  "nil fetch info",
+			fetch: &resolve.EntityFetch{},
+			cfg: func(t *testing.T) *fetchCacheConfigurator {
+				return newEntityConfigurator(t, productProviders(fullPolicy))
+			},
+		},
+	}
+	for _, row := range nilRows {
+		t.Run(row.name, func(t *testing.T) {
+			tree := &resolve.FetchTreeNode{Kind: resolve.FetchTreeNodeKindSingle, Item: &resolve.FetchItem{Fetch: row.fetch}}
+			row.cfg(t).configureTree(&resolve.GraphQLResponse{}, tree)
+			assert.Nil(t, row.fetch.CacheConfig())
+		})
+	}
+}

--- a/v2/pkg/engine/cache/fetch_cache_configurator_test.go
+++ b/v2/pkg/engine/cache/fetch_cache_configurator_test.go
@@ -201,6 +201,22 @@ func TestFetchCacheConfiguratorEntityArm(t *testing.T) {
 				return newEntityConfigurator(t, productProviders(fullPolicy))
 			},
 		},
+		{
+			// An abstract-path entity fetch can collect one root coordinate
+			// per enclosing concrete type; policy and key spec both derive
+			// from RootFields[0].TypeName, so mixed types decline entirely.
+			name: "mixed entity types decline caching",
+			fetch: &resolve.EntityFetch{Info: &resolve.FetchInfo{
+				DataSourceID: "products",
+				RootFields: []resolve.GraphCoordinate{
+					{TypeName: "Product", FieldName: "name"},
+					{TypeName: "User", FieldName: "username"},
+				},
+			}},
+			cfg: func(t *testing.T) *fetchCacheConfigurator {
+				return newEntityConfigurator(t, productProviders(fullPolicy))
+			},
+		},
 	}
 	for _, row := range nilRows {
 		t.Run(row.name, func(t *testing.T) {

--- a/v2/pkg/engine/cache/multikey.go
+++ b/v2/pkg/engine/cache/multikey.go
@@ -1,0 +1,150 @@
+package cache
+
+import (
+	"cmp"
+	"time"
+
+	"github.com/wundergraph/astjson"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// selectMultiCandidateCacheValue is the multi-candidate selection ladder over
+// freshest-first candidates (parsed[i] pairs state.FromCacheCandidates[i]):
+//  1. the freshest value covers on its own → serve it;
+//  2. no single value covers, but the union does → serve the merge, freshest
+//     winning on conflicts, and mark NeedsWriteback so the canonical entry is
+//     rewritten with the synthesized value;
+//  3. an older single value covers → serve it and mark NeedsWriteback (the
+//     freshest entry is stale in shape and owes a refresh);
+//  4. nothing covers → miss.
+//
+// It fills FromCache and SelectedRemainingTTL and reports whether a value was
+// selected.
+func selectMultiCandidateCacheValue(tx *resolve.CacheTransaction, state *resolve.ItemCacheState, parsed []*astjson.Value, providesData *resolve.Object) bool {
+	if len(parsed) == 0 || providesData == nil {
+		return false
+	}
+	if parsed[0] != nil && covers(parsed[0], providesData) {
+		state.FromCache = parsed[0]
+		state.SelectedRemainingTTL = state.FromCacheCandidates[0].RemainingTTL
+		return true
+	}
+	if len(parsed) <= 1 {
+		return false
+	}
+
+	// Merge synthesis: build the union OLDEST first so the freshest value wins
+	// every conflicting field.
+	var merged *astjson.Value
+	for i := len(parsed) - 1; i >= 0; i-- {
+		if parsed[i] == nil {
+			continue
+		}
+		current := tx.StructuralCopy(parsed[i])
+		if merged == nil {
+			merged = current
+			continue
+		}
+		if _, err := tx.MergeValues(merged, current); err != nil {
+			// A merge failure (e.g. type conflicts) voids the synthesis; fall
+			// through to the older-single ladder rung instead of serving a
+			// half-merged value.
+			merged = nil
+			break
+		}
+	}
+	if merged != nil && covers(merged, providesData) {
+		state.FromCache = merged
+		state.SelectedRemainingTTL = state.FromCacheCandidates[0].RemainingTTL
+		state.NeedsWriteback = true
+		return true
+	}
+
+	for i := 1; i < len(parsed); i++ {
+		if parsed[i] == nil {
+			continue
+		}
+		if covers(parsed[i], providesData) {
+			state.FromCache = parsed[i]
+			state.SelectedRemainingTTL = state.FromCacheCandidates[i].RemainingTTL
+			state.NeedsWriteback = true
+			return true
+		}
+	}
+	return false
+}
+
+// compareCacheCandidateFreshness orders candidates freshest first: a known
+// remaining TTL always beats an unknown (non-positive) one, larger beats
+// smaller.
+func compareCacheCandidateFreshness(a, b time.Duration) int {
+	aKnown := a > 0
+	bKnown := b > 0
+	switch {
+	case aKnown && bKnown:
+		return cmp.Compare(b, a)
+	case aKnown:
+		return -1
+	case bKnown:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// reorderToSelectionOrder rebuilds the value with its fields in the
+// ProvidesData selection order (recursively), appending cached-only extras
+// after the selected fields, so a spliced value renders byte-identically to a
+// fetched one.
+func reorderToSelectionOrder(tx *resolve.CacheTransaction, value *astjson.Value, node resolve.Node) *astjson.Value {
+	if value == nil || node == nil {
+		return value
+	}
+	switch typed := node.(type) {
+	case *resolve.Object:
+		if value.Type() != astjson.TypeObject {
+			return value
+		}
+		reordered := tx.NewObject()
+		seen := make(map[string]struct{}, len(typed.Fields))
+		for _, field := range typed.Fields {
+			fieldName := string(field.Name)
+			fieldValue := value.Get(fieldName)
+			if fieldValue == nil {
+				continue
+			}
+			reordered.Set(nil, fieldName, reorderToSelectionOrder(tx, fieldValue, field.Value))
+			seen[fieldName] = struct{}{}
+		}
+		obj, err := value.Object()
+		if err != nil {
+			return value
+		}
+		// Keep fields the cache carries beyond the selection (e.g. key fields
+		// another fetch needed) so a write-back never loses data.
+		obj.Visit(func(key []byte, fieldValue *astjson.Value) {
+			fieldName := string(key)
+			if _, ok := seen[fieldName]; ok {
+				return
+			}
+			reordered.Set(nil, fieldName, fieldValue)
+		})
+		return reordered
+	case *resolve.Array:
+		if value.Type() != astjson.TypeArray {
+			return value
+		}
+		items, err := value.Array()
+		if err != nil {
+			return value
+		}
+		reordered := tx.NewArray()
+		for i, item := range items {
+			reordered.SetArrayItem(nil, i, reorderToSelectionOrder(tx, item, typed.Item))
+		}
+		return reordered
+	default:
+		return value
+	}
+}

--- a/v2/pkg/engine/cache/multikey.go
+++ b/v2/pkg/engine/cache/multikey.go
@@ -21,11 +21,11 @@ import (
 //
 // It fills FromCache and SelectedRemainingTTL and reports whether a value was
 // selected.
-func selectMultiCandidateCacheValue(tx *resolve.CacheTransaction, state *resolve.ItemCacheState, parsed []*astjson.Value, providesData *resolve.Object) bool {
+func selectMultiCandidateCacheValue(tx *resolve.CacheTransaction, ctx *resolve.Context, state *resolve.ItemCacheState, parsed []*astjson.Value, providesData *resolve.Object) bool {
 	if len(parsed) == 0 || providesData == nil {
 		return false
 	}
-	if parsed[0] != nil && covers(parsed[0], providesData) {
+	if parsed[0] != nil && covers(ctx, parsed[0], providesData) {
 		state.FromCache = parsed[0]
 		state.SelectedRemainingTTL = state.FromCacheCandidates[0].RemainingTTL
 		return true
@@ -54,7 +54,7 @@ func selectMultiCandidateCacheValue(tx *resolve.CacheTransaction, state *resolve
 			break
 		}
 	}
-	if merged != nil && covers(merged, providesData) {
+	if merged != nil && covers(ctx, merged, providesData) {
 		state.FromCache = merged
 		state.SelectedRemainingTTL = state.FromCacheCandidates[0].RemainingTTL
 		state.NeedsWriteback = true
@@ -65,7 +65,7 @@ func selectMultiCandidateCacheValue(tx *resolve.CacheTransaction, state *resolve
 		if parsed[i] == nil {
 			continue
 		}
-		if covers(parsed[i], providesData) {
+		if covers(ctx, parsed[i], providesData) {
 			state.FromCache = parsed[i]
 			state.SelectedRemainingTTL = state.FromCacheCandidates[i].RemainingTTL
 			state.NeedsWriteback = true
@@ -90,61 +90,5 @@ func compareCacheCandidateFreshness(a, b time.Duration) int {
 		return 1
 	default:
 		return 0
-	}
-}
-
-// reorderToSelectionOrder rebuilds the value with its fields in the
-// ProvidesData selection order (recursively), appending cached-only extras
-// after the selected fields, so a spliced value renders byte-identically to a
-// fetched one.
-func reorderToSelectionOrder(tx *resolve.CacheTransaction, value *astjson.Value, node resolve.Node) *astjson.Value {
-	if value == nil || node == nil {
-		return value
-	}
-	switch typed := node.(type) {
-	case *resolve.Object:
-		if value.Type() != astjson.TypeObject {
-			return value
-		}
-		reordered := tx.NewObject()
-		seen := make(map[string]struct{}, len(typed.Fields))
-		for _, field := range typed.Fields {
-			fieldName := string(field.Name)
-			fieldValue := value.Get(fieldName)
-			if fieldValue == nil {
-				continue
-			}
-			reordered.Set(nil, fieldName, reorderToSelectionOrder(tx, fieldValue, field.Value))
-			seen[fieldName] = struct{}{}
-		}
-		obj, err := value.Object()
-		if err != nil {
-			return value
-		}
-		// Keep fields the cache carries beyond the selection (e.g. key fields
-		// another fetch needed) so a write-back never loses data.
-		obj.Visit(func(key []byte, fieldValue *astjson.Value) {
-			fieldName := string(key)
-			if _, ok := seen[fieldName]; ok {
-				return
-			}
-			reordered.Set(nil, fieldName, fieldValue)
-		})
-		return reordered
-	case *resolve.Array:
-		if value.Type() != astjson.TypeArray {
-			return value
-		}
-		items, err := value.Array()
-		if err != nil {
-			return value
-		}
-		reordered := tx.NewArray()
-		for i, item := range items {
-			reordered.SetArrayItem(nil, i, reorderToSelectionOrder(tx, item, typed.Item))
-		}
-		return reordered
-	default:
-		return value
 	}
 }

--- a/v2/pkg/engine/cache/multikey_test.go
+++ b/v2/pkg/engine/cache/multikey_test.go
@@ -1,0 +1,357 @@
+package cache
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/astjson"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// multiKeyConfig builds a two-candidate entity config over the shared fixture:
+// candidates sorted by selection set — index 0 is "sku", index 1 is "upc".
+func multiKeyConfig(t *testing.T) *resolve.FetchCacheConfig {
+	t.Helper()
+	builder := newKeyBuilder(t, parseKeyBuilderDefinition(t), newKeyBuilderFederation(t, "upc", "sku"))
+	spec, ok := builder.buildEntitySpec(productEntityInfo())
+	require.True(t, ok)
+	require.Len(t, spec.Candidates, 2)
+	return &resolve.FetchCacheConfig{
+		L1:           true,
+		L2:           true,
+		CacheName:    "entities",
+		TTL:          time.Minute,
+		KeySpec:      spec,
+		ProvidesData: productProvidesData(),
+	}
+}
+
+// fullProductItem carries BOTH key fields, so both candidates render.
+func fullProductItem(t *testing.T) *astjson.Value {
+	t.Helper()
+	return astjson.MustParseBytes([]byte(`{"__typename":"Product","upc":"1","sku":"S1"}`))
+}
+
+// deriveMultiKeys returns (skuKey, upcKey) for the full item by rendering
+// through a throwaway request cache — the same templates production uses.
+func deriveMultiKeys(t *testing.T, cfg *resolve.FetchCacheConfig) (string, string) {
+	t.Helper()
+	rc := NewController(newTestStore(), nil).BeginRequest(nil)
+	_, handle := prepare(t, rc, cfg, fullProductItem(t))
+	require.NotNil(t, handle)
+	require.Len(t, handle.Items[0].RenderedKeys, 2)
+	return handle.Items[0].RenderedKeys[0], handle.Items[0].RenderedKeys[1]
+}
+
+func newMultiKeyRC(store Store) resolve.RequestCache {
+	return NewController(store, nil).BeginRequest(nil)
+}
+
+// TestMultiKeyRenderRows covers E1/E3/E4/E7: best-effort rendering into
+// RenderedKeys vs PendingCandidates and the write-side refresh/backfill split,
+// each with the EXACT ordered store-op log.
+func TestMultiKeyRenderRows(t *testing.T) {
+	t.Run("[E1] both candidates render; write refreshes both keys", func(t *testing.T) {
+		cfg := multiKeyConfig(t)
+		skuKey, upcKey := deriveMultiKeys(t, cfg)
+		store := newTestStore()
+		rc := newMultiKeyRC(store)
+		item := fullProductItem(t)
+		decision, handle := prepare(t, rc, cfg, item)
+		require.Equal(t, resolve.DecisionFetch, decision)
+		assert.Equal(t, []string{skuKey, upcKey}, handle.Items[0].RenderedKeys)
+		assert.Nil(t, handle.Items[0].PendingCandidates)
+
+		require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+			Items:        []*astjson.Value{item},
+			ResponseData: astjson.MustParseBytes([]byte(`{"__typename":"Product","name":"Table","price":100}`)),
+			Arena:        beginner(),
+		}))
+		rc.EndRequest()
+		assert.Equal(t, []testStoreOp{
+			{Kind: "Get", Key: skuKey},
+			{Kind: "Get", Key: upcKey},
+			{Kind: "Set", Key: skuKey, Value: `{"__typename":"Product","name":"Table","price":100}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
+			{Kind: "Set", Key: upcKey, Value: `{"__typename":"Product","name":"Table","price":100}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
+		}, store.ops)
+	})
+
+	t.Run("[E3] unrenderable candidate backfills from the fresh response", func(t *testing.T) {
+		cfg := multiKeyConfig(t)
+		skuKey, upcKey := deriveMultiKeys(t, cfg)
+		store := newTestStore()
+		rc := newMultiKeyRC(store)
+		// The request item lacks sku: the sku candidate is pending, only upc renders.
+		item := productItem(t, "1")
+		decision, handle := prepare(t, rc, cfg, item)
+		require.Equal(t, resolve.DecisionFetch, decision)
+		assert.Equal(t, []string{upcKey}, handle.Items[0].RenderedKeys)
+		require.Len(t, handle.Items[0].PendingCandidates, 1)
+
+		// The FRESH data carries sku, so the pending candidate now renders.
+		require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+			Items:        []*astjson.Value{item},
+			ResponseData: astjson.MustParseBytes([]byte(`{"__typename":"Product","name":"Table","price":100,"sku":"S1"}`)),
+			Arena:        beginner(),
+		}))
+		rc.EndRequest()
+		assert.Equal(t, []testStoreOp{
+			{Kind: "Get", Key: upcKey},
+			{Kind: "Set", Key: upcKey, Value: `{"__typename":"Product","name":"Table","price":100,"sku":"S1"}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
+			{Kind: "Set", Key: skuKey, Value: `{"__typename":"Product","name":"Table","price":100,"sku":"S1"}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonBackfill},
+		}, store.ops)
+	})
+
+	t.Run("[E4] no candidate renderable: zero lookups, write-only post fetch", func(t *testing.T) {
+		cfg := multiKeyConfig(t)
+		skuKey, upcKey := deriveMultiKeys(t, cfg)
+		store := newTestStore()
+		rc := newMultiKeyRC(store)
+		item := astjson.MustParseBytes([]byte(`{"__typename":"Product"}`))
+		decision, handle := prepare(t, rc, cfg, item)
+		require.Equal(t, resolve.DecisionFetch, decision)
+		assert.Nil(t, handle.Items[0].RenderedKeys)
+		require.Len(t, handle.Items[0].PendingCandidates, 2)
+
+		require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+			Items:        []*astjson.Value{item},
+			ResponseData: astjson.MustParseBytes([]byte(`{"__typename":"Product","name":"Table","price":100,"sku":"S1","upc":"1"}`)),
+			Arena:        beginner(),
+		}))
+		rc.EndRequest()
+		assert.Equal(t, []testStoreOp{
+			{Kind: "Set", Key: skuKey, Value: `{"__typename":"Product","name":"Table","price":100,"sku":"S1","upc":"1"}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonBackfill},
+			{Kind: "Set", Key: upcKey, Value: `{"__typename":"Product","name":"Table","price":100,"sku":"S1","upc":"1"}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonBackfill},
+		}, store.ops)
+	})
+
+	t.Run("[E7] single-@key degenerate stays a one-element list", func(t *testing.T) {
+		cfg := entityConfig(t, time.Minute)
+		store := newTestStore()
+		rc := newMultiKeyRC(store)
+		_, handle := prepare(t, rc, cfg, productItem(t, "1"))
+		require.NotNil(t, handle)
+		assert.Len(t, handle.Items[0].RenderedKeys, 1)
+		assert.Nil(t, handle.Items[0].PendingCandidates)
+	})
+}
+
+// TestMultiKeyHitRows covers E2/E5/E6: cross-key hits and the read-hit
+// write-back paths through OnFetchSkipped.
+func TestMultiKeyHitRows(t *testing.T) {
+	t.Run("[E2] hit on the non-primary key serves and backfills the missed key", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			cfg := multiKeyConfig(t)
+			skuKey, upcKey := deriveMultiKeys(t, cfg)
+			store := newTestStore()
+			// Only the upc (second) candidate is primed.
+			store.seed(upcKey, []byte(`{"__typename":"Product","name":"Table","price":100}`), 30*time.Second)
+
+			rc := newMultiKeyRC(store)
+			item := fullProductItem(t)
+			decision, handle := prepare(t, rc, cfg, item)
+			require.Equal(t, resolve.DecisionSkipFullHit, decision)
+			assert.True(t, handle.MustWriteBack)
+			require.Len(t, handle.Items, 1)
+			assert.Equal(t, 30*time.Second, handle.Items[0].SelectedRemainingTTL)
+			assert.False(t, handle.Items[0].NeedsWriteback)
+
+			target := astjson.MustParseBytes([]byte(`{}`))
+			handle.Items[0].Item = target
+			require.NoError(t, rc.OnFetchSkipped(handle, resolve.MergeInput{
+				Items: []*astjson.Value{target},
+				Arena: beginner(),
+			}))
+			rc.EndRequest()
+			assert.Equal(t, `{"name":"Table","price":100,"__typename":"Product"}`, string(target.MarshalTo(nil)))
+			assert.Equal(t, []testStoreOp{
+				{Kind: "Get", Key: skuKey},
+				{Kind: "Get", Key: upcKey},
+				{Kind: "Set", Key: skuKey, Value: `{"name":"Table","price":100,"__typename":"Product"}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonBackfill},
+			}, store.ops)
+		})
+	})
+
+	t.Run("[E5] pending candidate renders from the SERVED value on a hit", func(t *testing.T) {
+		cfg := multiKeyConfig(t)
+		skuKey, upcKey := deriveMultiKeys(t, cfg)
+		store := newTestStore()
+		// The cached value itself carries sku, so the pending sku candidate can
+		// render from it at write-back time.
+		store.seed(upcKey, []byte(`{"__typename":"Product","name":"Table","price":100,"sku":"S1"}`), time.Minute)
+
+		rc := newMultiKeyRC(store)
+		item := productItem(t, "1") // no sku: sku candidate pending
+		decision, handle := prepare(t, rc, cfg, item)
+		require.Equal(t, resolve.DecisionSkipFullHit, decision)
+		require.Len(t, handle.Items[0].PendingCandidates, 1)
+
+		require.NoError(t, rc.OnFetchSkipped(handle, resolve.MergeInput{
+			Items: []*astjson.Value{item},
+			Arena: beginner(),
+		}))
+		rc.EndRequest()
+		assert.Equal(t, []testStoreOp{
+			{Kind: "Get", Key: upcKey},
+			{Kind: "Set", Key: skuKey, Value: `{"name":"Table","price":100,"__typename":"Product","sku":"S1"}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonBackfill},
+		}, store.ops)
+	})
+}
+
+// TestMultiKeyFreshnessRows covers the D7–D13 selection ladder.
+func TestMultiKeyFreshnessRows(t *testing.T) {
+	t.Run("[D7] the freshest covering value wins", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			cfg := multiKeyConfig(t)
+			skuKey, upcKey := deriveMultiKeys(t, cfg)
+			store := newTestStore()
+			store.seed(skuKey, []byte(`{"__typename":"Product","name":"Fresh","price":1}`), time.Minute)
+			store.seed(upcKey, []byte(`{"__typename":"Product","name":"Stale","price":2}`), 10*time.Second)
+
+			rc := newMultiKeyRC(store)
+			decision, handle := prepare(t, rc, cfg, fullProductItem(t))
+			require.Equal(t, resolve.DecisionSkipFullHit, decision)
+			assert.Equal(t, `{"name":"Fresh","price":1,"__typename":"Product"}`, string(handle.Items[0].FromCache.MarshalTo(nil)))
+			assert.Equal(t, time.Minute, handle.Items[0].SelectedRemainingTTL)
+			assert.False(t, handle.Items[0].NeedsWriteback)
+			// Candidates are recorded freshest first.
+			assert.Equal(t, []resolve.CacheCandidate{
+				{Value: []byte(`{"__typename":"Product","name":"Fresh","price":1}`), RemainingTTL: time.Minute},
+				{Value: []byte(`{"__typename":"Product","name":"Stale","price":2}`), RemainingTTL: 10 * time.Second},
+			}, handle.Items[0].FromCacheCandidates)
+		})
+	})
+
+	t.Run("[D8] a known TTL beats an unknown one", func(t *testing.T) {
+		cfg := multiKeyConfig(t)
+		skuKey, upcKey := deriveMultiKeys(t, cfg)
+		store := newTestStore()
+		store.seedNoTTL(skuKey, []byte(`{"__typename":"Product","name":"Unknown","price":1}`))
+		store.seed(upcKey, []byte(`{"__typename":"Product","name":"Known","price":2}`), 10*time.Second)
+
+		rc := newMultiKeyRC(store)
+		decision, handle := prepare(t, rc, cfg, fullProductItem(t))
+		require.Equal(t, resolve.DecisionSkipFullHit, decision)
+		assert.Equal(t, `{"name":"Known","price":2,"__typename":"Product"}`, string(handle.Items[0].FromCache.MarshalTo(nil)))
+	})
+
+	t.Run("[D9] merge synthesis: the union covers, freshest wins conflicts, canonical rewritten", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			cfg := multiKeyConfig(t)
+			skuKey, upcKey := deriveMultiKeys(t, cfg)
+			store := newTestStore()
+			// Fresher value has name (and a conflicting price=1); older has price only.
+			store.seed(skuKey, []byte(`{"__typename":"Product","name":"Table","price":1}`), time.Minute)
+			store.seed(upcKey, []byte(`{"__typename":"Product","price":2}`), 10*time.Second)
+			// Neither covers alone: make name non-nullable and REQUIRE a field
+			// only the union has.
+			cfg.ProvidesData = &resolve.Object{
+				Fields: []*resolve.Field{
+					{Name: []byte("name"), Value: &resolve.Scalar{Nullable: false, Path: []string{"name"}}},
+					{Name: []byte("price"), Value: &resolve.Scalar{Nullable: false, Path: []string{"price"}}},
+					{Name: []byte("weight"), Value: &resolve.Scalar{Nullable: true, Path: []string{"weight"}}},
+				},
+			}
+			store.seed(skuKey, []byte(`{"__typename":"Product","name":"Table","weight":9}`), time.Minute)
+			store.seed(upcKey, []byte(`{"__typename":"Product","price":2,"weight":1}`), 10*time.Second)
+
+			rc := newMultiKeyRC(store)
+			decision, handle := prepare(t, rc, cfg, fullProductItem(t))
+			require.Equal(t, resolve.DecisionSkipFullHit, decision)
+			require.NotNil(t, handle.Items[0].FromCache)
+			// Union serves; the fresher value's weight=9 wins the conflict.
+			assert.Equal(t, `{"name":"Table","price":2,"weight":9,"__typename":"Product"}`, string(handle.Items[0].FromCache.MarshalTo(nil)))
+			assert.True(t, handle.Items[0].NeedsWriteback)
+			assert.True(t, handle.MustWriteBack)
+
+			// The read-hit write-back REFRESHES both canonical keys with the
+			// synthesized value.
+			require.NoError(t, rc.OnFetchSkipped(handle, resolve.MergeInput{
+				Items: []*astjson.Value{handle.Items[0].Item},
+				Arena: beginner(),
+			}))
+			rc.EndRequest()
+			assert.Equal(t, []testStoreOp{
+				{Kind: "Get", Key: skuKey},
+				{Kind: "Get", Key: upcKey},
+				{Kind: "Set", Key: skuKey, Value: `{"name":"Table","price":2,"weight":9,"__typename":"Product"}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
+				{Kind: "Set", Key: upcKey, Value: `{"name":"Table","price":2,"weight":9,"__typename":"Product"}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
+			}, store.ops)
+		})
+	})
+
+	t.Run("[D10] older single covering value is the fallback and owes a refresh", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			cfg := multiKeyConfig(t)
+			skuKey, upcKey := deriveMultiKeys(t, cfg)
+			store := newTestStore()
+			// Fresher value is shape-stale (missing non-nullable name; extra
+			// conflicting garbage that breaks the union too).
+			store.seed(skuKey, []byte(`{"__typename":"Product","price":null}`), time.Minute)
+			store.seed(upcKey, []byte(`{"__typename":"Product","name":"Older","price":2}`), 10*time.Second)
+			// Union fails: merged value has price=null from the fresher entry.
+			cfg.ProvidesData = &resolve.Object{
+				Fields: []*resolve.Field{
+					{Name: []byte("name"), Value: &resolve.Scalar{Nullable: false, Path: []string{"name"}}},
+					{Name: []byte("price"), Value: &resolve.Scalar{Nullable: false, Path: []string{"price"}}},
+				},
+			}
+
+			rc := newMultiKeyRC(store)
+			decision, handle := prepare(t, rc, cfg, fullProductItem(t))
+			require.Equal(t, resolve.DecisionSkipFullHit, decision)
+			assert.Equal(t, `{"name":"Older","price":2,"__typename":"Product"}`, string(handle.Items[0].FromCache.MarshalTo(nil)))
+			assert.Equal(t, 10*time.Second, handle.Items[0].SelectedRemainingTTL)
+			assert.True(t, handle.Items[0].NeedsWriteback)
+		})
+	})
+
+	t.Run("[adversarial] empty union: nothing covers, nothing served", func(t *testing.T) {
+		cfg := multiKeyConfig(t)
+		skuKey, upcKey := deriveMultiKeys(t, cfg)
+		store := newTestStore()
+		store.seed(skuKey, []byte(`{}`), time.Minute)
+		store.seed(upcKey, []byte(`{}`), time.Minute)
+
+		rc := newMultiKeyRC(store)
+		decision, handle := prepare(t, rc, cfg, fullProductItem(t))
+		require.Equal(t, resolve.DecisionFetch, decision)
+		assert.Nil(t, handle.Items[0].FromCache)
+		assert.Len(t, handle.Items[0].FromCacheCandidates, 2)
+	})
+
+	t.Run("[adversarial] all candidates stale even merged: miss", func(t *testing.T) {
+		cfg := multiKeyConfig(t)
+		skuKey, upcKey := deriveMultiKeys(t, cfg)
+		store := newTestStore()
+		// Both lack the non-nullable name; the union does too.
+		store.seed(skuKey, []byte(`{"__typename":"Product","price":1}`), time.Minute)
+		store.seed(upcKey, []byte(`{"__typename":"Product","price":2}`), 30*time.Second)
+
+		rc := newMultiKeyRC(store)
+		decision, handle := prepare(t, rc, cfg, fullProductItem(t))
+		require.Equal(t, resolve.DecisionFetch, decision)
+		assert.Nil(t, handle.Items[0].FromCache)
+	})
+
+	t.Run("[D12/D13] AND-reduction across items with multi-key states", func(t *testing.T) {
+		cfg := multiKeyConfig(t)
+		_, upcKey := deriveMultiKeys(t, cfg)
+		store := newTestStore()
+		store.seed(upcKey, []byte(`{"__typename":"Product","name":"Table","price":100}`), time.Minute)
+
+		rc := newMultiKeyRC(store)
+		itemCovered := fullProductItem(t)
+		itemMiss := astjson.MustParseBytes([]byte(`{"__typename":"Product","upc":"2","sku":"S2"}`))
+		decision, handle := prepare(t, rc, cfg, itemCovered, itemMiss)
+		require.Equal(t, resolve.DecisionFetch, decision)
+		assert.NotNil(t, handle.Items[0].FromCache)
+		assert.Nil(t, handle.Items[1].FromCache)
+		assert.False(t, handle.MustWriteBack) // not a full hit
+	})
+}

--- a/v2/pkg/engine/cache/multikey_test.go
+++ b/v2/pkg/engine/cache/multikey_test.go
@@ -355,3 +355,39 @@ func TestMultiKeyFreshnessRows(t *testing.T) {
 		assert.False(t, handle.MustWriteBack) // not a full hit
 	})
 }
+
+// TestMultiKeyNegativeSentinelAuthority pins that ONLY the freshest candidate
+// decides a negative hit: a staler negative sentinel on a sibling @key must
+// never override a fresher positive value (and the freshest sentinel still
+// wins over staler positives).
+func TestMultiKeyNegativeSentinelAuthority(t *testing.T) {
+	t.Run("stale sentinel loses to a fresher positive sibling", func(t *testing.T) {
+		store := newTestStore()
+		cfg := multiKeyConfig(t)
+		skuKey, upcKey := deriveMultiKeys(t, cfg)
+		// sku: negative sentinel with 55s left; upc: positive value with 295s.
+		store.seed(skuKey, []byte(negativeCacheSentinel), 55*time.Second)
+		store.seed(upcKey, []byte(`{"__typename":"Product","name":"Table","price":100}`), 295*time.Second)
+
+		rc := NewController(store, nil).BeginRequest(nil)
+		decision, handle := prepare(t, rc, cfg, fullProductItem(t))
+		assert.Equal(t, resolve.DecisionSkipFullHit, decision)
+		require.NotNil(t, handle.Items[0].FromCache)
+		assert.False(t, handle.Items[0].NegativeHit)
+		assert.Equal(t, `{"__typename":"Product","name":"Table","price":100}`,
+			string(handle.Items[0].FromCache.MarshalTo(nil)))
+	})
+
+	t.Run("the freshest sentinel still wins over a staler positive", func(t *testing.T) {
+		store := newTestStore()
+		cfg := multiKeyConfig(t)
+		skuKey, upcKey := deriveMultiKeys(t, cfg)
+		store.seed(skuKey, []byte(negativeCacheSentinel), 295*time.Second)
+		store.seed(upcKey, []byte(`{"__typename":"Product","name":"Table","price":100}`), 55*time.Second)
+
+		rc := NewController(store, nil).BeginRequest(nil)
+		decision, handle := prepare(t, rc, cfg, fullProductItem(t))
+		assert.Equal(t, resolve.DecisionSkipFullHit, decision)
+		assert.True(t, handle.Items[0].NegativeHit)
+	})
+}

--- a/v2/pkg/engine/cache/multikey_test.go
+++ b/v2/pkg/engine/cache/multikey_test.go
@@ -172,7 +172,7 @@ func TestMultiKeyHitRows(t *testing.T) {
 			assert.Equal(t, []testStoreOp{
 				{Kind: "Get", Key: skuKey},
 				{Kind: "Get", Key: upcKey},
-				{Kind: "Set", Key: skuKey, Value: `{"name":"Table","price":100,"__typename":"Product"}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonBackfill},
+				{Kind: "Set", Key: skuKey, Value: `{"__typename":"Product","name":"Table","price":100}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonBackfill},
 			}, store.ops)
 		})
 	})
@@ -198,7 +198,7 @@ func TestMultiKeyHitRows(t *testing.T) {
 		rc.EndRequest()
 		assert.Equal(t, []testStoreOp{
 			{Kind: "Get", Key: upcKey},
-			{Kind: "Set", Key: skuKey, Value: `{"name":"Table","price":100,"__typename":"Product","sku":"S1"}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonBackfill},
+			{Kind: "Set", Key: skuKey, Value: `{"__typename":"Product","name":"Table","price":100,"sku":"S1"}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonBackfill},
 		}, store.ops)
 	})
 }
@@ -216,7 +216,7 @@ func TestMultiKeyFreshnessRows(t *testing.T) {
 			rc := newMultiKeyRC(store)
 			decision, handle := prepare(t, rc, cfg, fullProductItem(t))
 			require.Equal(t, resolve.DecisionSkipFullHit, decision)
-			assert.Equal(t, `{"name":"Fresh","price":1,"__typename":"Product"}`, string(handle.Items[0].FromCache.MarshalTo(nil)))
+			assert.Equal(t, `{"__typename":"Product","name":"Fresh","price":1}`, string(handle.Items[0].FromCache.MarshalTo(nil)))
 			assert.Equal(t, time.Minute, handle.Items[0].SelectedRemainingTTL)
 			assert.False(t, handle.Items[0].NeedsWriteback)
 			// Candidates are recorded freshest first.
@@ -237,7 +237,7 @@ func TestMultiKeyFreshnessRows(t *testing.T) {
 		rc := newMultiKeyRC(store)
 		decision, handle := prepare(t, rc, cfg, fullProductItem(t))
 		require.Equal(t, resolve.DecisionSkipFullHit, decision)
-		assert.Equal(t, `{"name":"Known","price":2,"__typename":"Product"}`, string(handle.Items[0].FromCache.MarshalTo(nil)))
+		assert.Equal(t, `{"__typename":"Product","name":"Known","price":2}`, string(handle.Items[0].FromCache.MarshalTo(nil)))
 	})
 
 	t.Run("[D9] merge synthesis: the union covers, freshest wins conflicts, canonical rewritten", func(t *testing.T) {
@@ -265,7 +265,7 @@ func TestMultiKeyFreshnessRows(t *testing.T) {
 			require.Equal(t, resolve.DecisionSkipFullHit, decision)
 			require.NotNil(t, handle.Items[0].FromCache)
 			// Union serves; the fresher value's weight=9 wins the conflict.
-			assert.Equal(t, `{"name":"Table","price":2,"weight":9,"__typename":"Product"}`, string(handle.Items[0].FromCache.MarshalTo(nil)))
+			assert.Equal(t, `{"__typename":"Product","price":2,"weight":9,"name":"Table"}`, string(handle.Items[0].FromCache.MarshalTo(nil)))
 			assert.True(t, handle.Items[0].NeedsWriteback)
 			assert.True(t, handle.MustWriteBack)
 
@@ -279,8 +279,8 @@ func TestMultiKeyFreshnessRows(t *testing.T) {
 			assert.Equal(t, []testStoreOp{
 				{Kind: "Get", Key: skuKey},
 				{Kind: "Get", Key: upcKey},
-				{Kind: "Set", Key: skuKey, Value: `{"name":"Table","price":2,"weight":9,"__typename":"Product"}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
-				{Kind: "Set", Key: upcKey, Value: `{"name":"Table","price":2,"weight":9,"__typename":"Product"}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
+				{Kind: "Set", Key: skuKey, Value: `{"__typename":"Product","price":2,"weight":9,"name":"Table"}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
+				{Kind: "Set", Key: upcKey, Value: `{"__typename":"Product","price":2,"weight":9,"name":"Table"}`, TTL: time.Minute, Reason: resolve.CacheWriteReasonRefresh},
 			}, store.ops)
 		})
 	})
@@ -305,7 +305,7 @@ func TestMultiKeyFreshnessRows(t *testing.T) {
 			rc := newMultiKeyRC(store)
 			decision, handle := prepare(t, rc, cfg, fullProductItem(t))
 			require.Equal(t, resolve.DecisionSkipFullHit, decision)
-			assert.Equal(t, `{"name":"Older","price":2,"__typename":"Product"}`, string(handle.Items[0].FromCache.MarshalTo(nil)))
+			assert.Equal(t, `{"__typename":"Product","name":"Older","price":2}`, string(handle.Items[0].FromCache.MarshalTo(nil)))
 			assert.Equal(t, 10*time.Second, handle.Items[0].SelectedRemainingTTL)
 			assert.True(t, handle.Items[0].NeedsWriteback)
 		})

--- a/v2/pkg/engine/cache/multikey_test.go
+++ b/v2/pkg/engine/cache/multikey_test.go
@@ -390,4 +390,56 @@ func TestMultiKeyNegativeSentinelAuthority(t *testing.T) {
 		assert.Equal(t, resolve.DecisionSkipFullHit, decision)
 		assert.True(t, handle.Items[0].NegativeHit)
 	})
+
+	t.Run("a mid-fresh sentinel keeps candidate alignment: the older-single rung reports ITS OWN TTL", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			// THREE candidates so a sentinel can sit BETWEEN a fresher
+			// non-covering positive and an older covering one: the ladder must
+			// pair each parsed value with its own candidate, never the
+			// sentinel's neighbor.
+			builder := newKeyBuilder(t, parseKeyBuilderDefinition(t), newKeyBuilderFederation(t, "upc", "sku", "name"))
+			spec, ok := builder.buildEntitySpec(productEntityInfo())
+			require.True(t, ok)
+			require.Len(t, spec.Candidates, 3)
+			cfg := &resolve.FetchCacheConfig{
+				L1:        true,
+				L2:        true,
+				CacheName: "entities",
+				TTL:       time.Minute,
+				KeySpec:   spec,
+				// Both fields non-nullable: the fresher value's null name breaks
+				// single-serve AND the union (freshest wins the merge conflict).
+				ProvidesData: &resolve.Object{
+					Fields: []*resolve.Field{
+						{Name: []byte("name"), Value: &resolve.Scalar{Nullable: false, Path: []string{"name"}}},
+						{Name: []byte("price"), Value: &resolve.Scalar{Nullable: false, Path: []string{"price"}}},
+					},
+				},
+			}
+			throwaway := NewController(newTestStore(), nil).BeginRequest(nil)
+			_, keysHandle := prepare(t, throwaway, cfg, astjson.MustParseBytes([]byte(`{"__typename":"Product","upc":"1","sku":"S1","name":"X"}`)))
+			require.Len(t, keysHandle.Items[0].RenderedKeys, 3)
+			keys := keysHandle.Items[0].RenderedKeys
+
+			store := newTestStore()
+			store.seed(keys[0], []byte(`{"__typename":"Product","name":null,"price":1}`), 10*time.Second)
+			store.seed(keys[1], []byte(negativeCacheSentinel), 5*time.Second)
+			store.seed(keys[2], []byte(`{"__typename":"Product","name":"Older","price":2}`), 2*time.Second)
+
+			rc := NewController(store, nil).BeginRequest(nil)
+			decision, handle := prepare(t, rc, cfg, astjson.MustParseBytes([]byte(`{"__typename":"Product","upc":"1","sku":"S1","name":"X"}`)))
+			require.Equal(t, resolve.DecisionSkipFullHit, decision)
+			require.NotNil(t, handle.Items[0].FromCache)
+			assert.False(t, handle.Items[0].NegativeHit)
+			assert.Equal(t, `{"__typename":"Product","name":"Older","price":2}`, string(handle.Items[0].FromCache.MarshalTo(nil)))
+			assert.True(t, handle.Items[0].NeedsWriteback)
+			// The older value's OWN 2s — not the mid sentinel's 5s.
+			assert.Equal(t, 2*time.Second, handle.Items[0].SelectedRemainingTTL)
+			assert.Equal(t, []resolve.CacheCandidate{
+				{Value: []byte(`{"__typename":"Product","name":null,"price":1}`), RemainingTTL: 10 * time.Second},
+				{Value: []byte(negativeCacheSentinel), RemainingTTL: 5 * time.Second},
+				{Value: []byte(`{"__typename":"Product","name":"Older","price":2}`), RemainingTTL: 2 * time.Second},
+			}, handle.Items[0].FromCacheCandidates)
+		})
+	})
 }

--- a/v2/pkg/engine/cache/observer.go
+++ b/v2/pkg/engine/cache/observer.go
@@ -1,6 +1,8 @@
 package cache
 
 import (
+	"maps"
+	"slices"
 	"sync"
 
 	"github.com/wundergraph/astjson"
@@ -46,7 +48,8 @@ func (o *TraceObserver) CompareShadow(h *resolve.FetchCacheHandle, fresh *astjso
 		batch = fresh.GetArray()
 	}
 	compares := make([]resolve.CacheShadowCompareTrace, 0, len(h.ShadowStash))
-	for itemIndex, entry := range h.ShadowStash {
+	for _, itemIndex := range slices.Sorted(maps.Keys(h.ShadowStash)) {
+		entry := h.ShadowStash[itemIndex]
 		freshValue := fresh
 		if h.BatchEntityKey {
 			freshValue = nil

--- a/v2/pkg/engine/cache/observer.go
+++ b/v2/pkg/engine/cache/observer.go
@@ -1,0 +1,125 @@
+package cache
+
+import (
+	"sync"
+
+	"github.com/wundergraph/astjson"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// TraceObserver is the production CacheObserver: it accumulates per-fetch
+// cache trace from the opaque FetchCacheHandle and attaches the assembled
+// CacheTrace to the fetch's ART trace at request end. The observer is
+// composed INSIDE the controller — the loader never calls it — and a nil
+// observer on the controller records nothing at zero cost. Metrics/analytics
+// export and the walker-inlined per-field hooks stay follow-ups (the scope
+// guard); OnEntity/OnFieldValue are deliberate no-ops.
+type TraceObserver struct {
+	// mu guards compares: CompareShadow runs inside per-request hook
+	// transactions, and one TraceObserver instance serves MANY concurrent
+	// requests.
+	mu       sync.Mutex
+	compares map[*resolve.FetchCacheHandle][]resolve.CacheShadowCompareTrace
+}
+
+// NewTraceObserver builds the ART trace observer.
+func NewTraceObserver() *TraceObserver {
+	return &TraceObserver{
+		compares: make(map[*resolve.FetchCacheHandle][]resolve.CacheShadowCompareTrace),
+	}
+}
+
+func (o *TraceObserver) BeginRequest(*resolve.Context) {}
+func (o *TraceObserver) EndRequest(*resolve.Context)   {}
+
+// CompareShadow materializes the shadow staleness probe: cached-vs-fresh byte
+// equality per stashed entry, with the entry's age (CacheTTL - RemainingTTL).
+// Results are computed EAGERLY into plain values — nothing arena-owned
+// survives the transaction — and drained by OnFetchObserved.
+func (o *TraceObserver) CompareShadow(h *resolve.FetchCacheHandle, fresh *astjson.Value, tx *resolve.CacheTransaction) {
+	if h == nil || len(h.ShadowStash) == 0 {
+		return
+	}
+	var batch []*astjson.Value
+	if h.BatchEntityKey && fresh != nil {
+		batch = fresh.GetArray()
+	}
+	compares := make([]resolve.CacheShadowCompareTrace, 0, len(h.ShadowStash))
+	for itemIndex, entry := range h.ShadowStash {
+		freshValue := fresh
+		if h.BatchEntityKey {
+			freshValue = nil
+			if itemIndex >= 0 && itemIndex < len(h.Items) {
+				if batchIndex := h.Items[itemIndex].BatchIndex; batchIndex >= 0 && batchIndex < len(batch) {
+					freshValue = batch[batchIndex]
+				}
+			}
+		}
+		freshBytes := []byte("null")
+		if freshValue != nil {
+			freshBytes = freshValue.MarshalTo(nil)
+		}
+		compares = append(compares, resolve.CacheShadowCompareTrace{
+			Key:          traceKey(entry.CacheKey, h.HashAnalyticsKeys),
+			IsFresh:      string(entry.CachedValue.MarshalTo(nil)) == string(freshBytes),
+			CacheAgeNano: int64(entry.CacheTTL - entry.RemainingTTL),
+		})
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.compares[h] = append(o.compares[h], compares...)
+}
+
+// OnFetchObserved assembles the finished handle's CacheTrace and attaches it
+// to the fetch's ART trace. It runs at EndRequest — single-threaded per
+// request, no lock (beyond draining the cross-request compare map), no arena.
+func (o *TraceObserver) OnFetchObserved(h *resolve.FetchCacheHandle) {
+	if h == nil {
+		return
+	}
+	o.mu.Lock()
+	compares := o.compares[h]
+	delete(o.compares, h)
+	o.mu.Unlock()
+	if h.Trace == nil {
+		// Tracing disabled: the drain above still prevents cross-request
+		// accumulation; nothing is emitted.
+		return
+	}
+	trace := &resolve.CacheTrace{
+		Decision:       h.Decision.String(),
+		Hit:            h.WasHit,
+		Shadow:         h.Shadow,
+		ShadowCompares: compares,
+	}
+	for i := range h.Items {
+		item := &h.Items[i]
+		keys := make([]string, 0, len(item.RenderedKeys))
+		for _, key := range item.RenderedKeys {
+			keys = append(keys, traceKey(key, h.HashAnalyticsKeys))
+		}
+		trace.Items = append(trace.Items, resolve.CacheItemTrace{
+			Keys:              keys,
+			ServedFrom:        item.ServedFromLayer,
+			Hit:               item.FromCache != nil,
+			NegativeHit:       item.NegativeHit,
+			RemainingTTLNano:  int64(item.SelectedRemainingTTL),
+			WriteReason:       string(item.WriteReason),
+			PendingCandidates: len(item.PendingCandidates),
+		})
+	}
+	h.Trace.CacheTrace = trace
+}
+
+func (o *TraceObserver) OnEntity(*resolve.FetchCacheHandle, *astjson.Value)       {}
+func (o *TraceObserver) OnFieldValue(resolve.GraphCoordinate, resolve.FieldValue) {}
+
+// traceKey returns the key as-is, or its 16-hex xxhash64 when the policy asks
+// for hashed key material in analytics/trace output.
+func traceKey(key string, hash bool) string {
+	if !hash || key == "" {
+		return key
+	}
+	return hashHex([]byte(key))
+}

--- a/v2/pkg/engine/cache/observer_test.go
+++ b/v2/pkg/engine/cache/observer_test.go
@@ -252,3 +252,54 @@ func writeNegativeThrough(t *testing.T, store *testStore, cfg *resolve.FetchCach
 	rc.EndRequest()
 	return handle.Items[0].RenderedKeys[0]
 }
+
+// countingObserver counts OnFetchObserved calls around the real TraceObserver.
+type countingObserver struct {
+	*TraceObserver
+
+	observed int
+}
+
+func (c *countingObserver) OnFetchObserved(h *resolve.FetchCacheHandle) {
+	c.observed++
+	c.TraceObserver.OnFetchObserved(h)
+}
+
+// TestFlushTracesBeforeEndRequest: the resolver flushes cache traces BEFORE
+// the response renders (extensions.trace serializes during Resolve, EndRequest
+// runs after the response is written). The trace must be attached by
+// FlushTraces, and the handle observed exactly ONCE — EndRequest skips
+// already-flushed handles.
+func TestFlushTracesBeforeEndRequest(t *testing.T) {
+	obs := &countingObserver{TraceObserver: NewTraceObserver()}
+	rc := NewController(newTestStore(), obs).BeginRequest(nil)
+	cfg := entityConfig(t, time.Minute)
+	item := productItem(t, "1")
+	in, trace := tracedInput(cfg, item)
+	decision, handle := rc.PrepareFetch(in)
+	require.Equal(t, resolve.DecisionFetch, decision)
+	require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+		Items:        []*astjson.Value{item},
+		ResponseData: astjson.MustParseBytes([]byte(`{"__typename":"Product","name":"Table","price":100}`)),
+		Arena:        beginner(),
+	}))
+
+	flusher, ok := rc.(resolve.CacheTraceFlusher)
+	require.True(t, ok, "requestCache must implement CacheTraceFlusher")
+	flusher.FlushTraces()
+	assert.Equal(t, &resolve.CacheTrace{
+		Decision: "Fetch",
+		Hit:      false,
+		Items: []resolve.CacheItemTrace{
+			{
+				Keys:        handle.Items[0].RenderedKeys,
+				Hit:         false,
+				WriteReason: "refresh",
+			},
+		},
+	}, trace.CacheTrace)
+	assert.Equal(t, 1, obs.observed)
+
+	rc.EndRequest()
+	assert.Equal(t, 1, obs.observed)
+}

--- a/v2/pkg/engine/cache/observer_test.go
+++ b/v2/pkg/engine/cache/observer_test.go
@@ -1,0 +1,254 @@
+package cache
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/astjson"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// tracedInput wires a fetch with an ART trace destination into the prepare
+// input, exactly as the loader does when tracing is enabled.
+func tracedInput(cfg *resolve.FetchCacheConfig, items ...*astjson.Value) (resolve.PrepareFetchInput, *resolve.DataSourceLoadTrace) {
+	trace := &resolve.DataSourceLoadTrace{}
+	in := prepareInput(cfg, items...)
+	in.Item = &resolve.FetchItem{Fetch: &resolve.EntityFetch{Trace: trace}}
+	return in, trace
+}
+
+// TestTraceObserverRows pins the COMPLETE assembled CacheTrace per scenario.
+func TestTraceObserverRows(t *testing.T) {
+	fresh := `{"__typename":"Product","name":"Table","price":100}`
+
+	t.Run("miss + fetch: decision, keys, refresh write", func(t *testing.T) {
+		obs := NewTraceObserver()
+		rc := NewController(newTestStore(), obs).BeginRequest(nil)
+		cfg := entityConfig(t, time.Minute)
+		item := productItem(t, "1")
+		in, trace := tracedInput(cfg, item)
+		decision, handle := rc.PrepareFetch(in)
+		require.Equal(t, resolve.DecisionFetch, decision)
+		require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+			Items:        []*astjson.Value{item},
+			ResponseData: astjson.MustParseBytes([]byte(fresh)),
+			Arena:        beginner(),
+		}))
+		rc.EndRequest()
+		assert.Equal(t, &resolve.CacheTrace{
+			Decision: "Fetch",
+			Hit:      false,
+			Items: []resolve.CacheItemTrace{
+				{
+					Keys:        handle.Items[0].RenderedKeys,
+					Hit:         false,
+					WriteReason: "refresh",
+				},
+			},
+		}, trace.CacheTrace)
+	})
+
+	t.Run("L2 hit: served_from l2 with the EXACT remaining TTL", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			store := newTestStore()
+			cfg := entityConfig(t, time.Minute)
+			key := writeThrough(t, NewController(store, nil).BeginRequest(nil), cfg, productItem(t, "1"), fresh)
+
+			time.Sleep(20 * time.Second) // age inside the bubble
+
+			obs := NewTraceObserver()
+			rc := NewController(store, obs).BeginRequest(nil)
+			item := productItem(t, "1")
+			in, trace := tracedInput(cfg, item)
+			decision, handle := rc.PrepareFetch(in)
+			require.Equal(t, resolve.DecisionSkipFullHit, decision)
+			require.NoError(t, rc.OnFetchSkipped(handle, resolve.MergeInput{
+				Items: []*astjson.Value{item},
+				Arena: beginner(),
+			}))
+			rc.EndRequest()
+			assert.Equal(t, &resolve.CacheTrace{
+				Decision: "SkipFullHit",
+				Hit:      true,
+				Items: []resolve.CacheItemTrace{
+					{
+						Keys:             []string{key},
+						ServedFrom:       "l2",
+						Hit:              true,
+						RemainingTTLNano: int64(40 * time.Second),
+					},
+				},
+			}, trace.CacheTrace)
+		})
+	})
+
+	t.Run("L1 hit: served_from l1, no TTL", func(t *testing.T) {
+		obs := NewTraceObserver()
+		rc := NewController(newTestStore(), obs).BeginRequest(nil)
+		cfg := entityConfig(t, time.Minute)
+		l1Fetch(t, rc, cfg, productItem(t, "1"), astjson.MustParseBytes([]byte(fresh)))
+
+		item := productItem(t, "1")
+		in, trace := tracedInput(cfg, item)
+		decision, handle := rc.PrepareFetch(in)
+		require.Equal(t, resolve.DecisionSkipFullHit, decision)
+		require.NoError(t, rc.OnFetchSkipped(handle, resolve.MergeInput{
+			Items: []*astjson.Value{item},
+			Arena: beginner(),
+		}))
+		rc.EndRequest()
+		assert.Equal(t, &resolve.CacheTrace{
+			Decision: "SkipFullHit",
+			Hit:      true,
+			Items: []resolve.CacheItemTrace{
+				{
+					Keys:       handle.Items[0].RenderedKeys,
+					ServedFrom: "l1",
+					Hit:        true,
+				},
+			},
+		}, trace.CacheTrace)
+	})
+
+	t.Run("backfill: a hit with a missed sibling key records the backfill write", func(t *testing.T) {
+		store := newTestStore()
+		cfg := multiKeyConfig(t)
+		skuKey, upcKey := entityWriteKeys(t, cfg.CacheName, `{"__typename":"Product","upc":"1","sku":"S1"}`)
+		store.seed(skuKey, []byte(`{"__typename":"Product","name":"Table","price":100,"upc":"1","sku":"S1"}`), time.Minute)
+
+		obs := NewTraceObserver()
+		rc := NewController(store, obs).BeginRequest(nil)
+		item := astjson.MustParseBytes([]byte(`{"__typename":"Product","upc":"1","sku":"S1"}`))
+		in, trace := tracedInput(cfg, item)
+		decision, handle := rc.PrepareFetch(in)
+		require.Equal(t, resolve.DecisionSkipFullHit, decision)
+		require.NoError(t, rc.OnFetchSkipped(handle, resolve.MergeInput{
+			Items: []*astjson.Value{item},
+			Arena: beginner(),
+		}))
+		rc.EndRequest()
+		require.NotNil(t, trace.CacheTrace)
+		require.Len(t, trace.CacheTrace.Items, 1)
+		got := trace.CacheTrace.Items[0]
+		assert.Equal(t, []string{skuKey, upcKey}, got.Keys)
+		assert.Equal(t, "l2", got.ServedFrom)
+		assert.Equal(t, "backfill", got.WriteReason)
+	})
+
+	t.Run("negative hit is marked", func(t *testing.T) {
+		store := newTestStore()
+		cfg := negativeConfig(t, 5*time.Second)
+		key := writeNegativeThrough(t, store, cfg, "404")
+
+		obs := NewTraceObserver()
+		rc := NewController(store, obs).BeginRequest(nil)
+		item := productItem(t, "404")
+		in, trace := tracedInput(cfg, item)
+		decision, handle := rc.PrepareFetch(in)
+		require.Equal(t, resolve.DecisionSkipFullHit, decision)
+		require.NoError(t, rc.OnFetchSkipped(handle, resolve.MergeInput{
+			Items: []*astjson.Value{item},
+			Arena: beginner(),
+		}))
+		rc.EndRequest()
+		require.NotNil(t, trace.CacheTrace)
+		require.Len(t, trace.CacheTrace.Items, 1)
+		assert.True(t, trace.CacheTrace.Items[0].NegativeHit)
+		assert.True(t, trace.CacheTrace.Items[0].Hit)
+		assert.Equal(t, []string{key}, trace.CacheTrace.Items[0].Keys)
+		_ = handle
+	})
+
+	t.Run("shadow: compares recorded with the EXACT cache age", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			store := newTestStore()
+			cfg := shadowConfig(t)
+			key := writeThrough(t, NewController(store, nil).BeginRequest(nil), cfg, productItem(t, "1"), fresh)
+
+			time.Sleep(15 * time.Second)
+
+			obs := NewTraceObserver()
+			rc := NewController(store, obs).BeginRequest(nil)
+			item := productItem(t, "1")
+			in, trace := tracedInput(cfg, item)
+			decision, handle := rc.PrepareFetch(in)
+			require.Equal(t, resolve.DecisionFetchShadow, decision)
+			require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+				Items:        []*astjson.Value{item},
+				ResponseData: astjson.MustParseBytes([]byte(fresh)),
+				Arena:        beginner(),
+			}))
+			rc.EndRequest()
+			require.NotNil(t, trace.CacheTrace)
+			assert.Equal(t, "FetchShadow", trace.CacheTrace.Decision)
+			assert.True(t, trace.CacheTrace.Shadow)
+			assert.Equal(t, []resolve.CacheShadowCompareTrace{
+				{Key: key, IsFresh: true, CacheAgeNano: int64(15 * time.Second)},
+			}, trace.CacheTrace.ShadowCompares)
+		})
+	})
+
+	t.Run("HashAnalyticsKeys hashes key material in trace output", func(t *testing.T) {
+		obs := NewTraceObserver()
+		rc := NewController(newTestStore(), obs).BeginRequest(nil)
+		cfg := entityConfig(t, time.Minute)
+		cfg.HashAnalyticsKeys = true
+		item := productItem(t, "1")
+		in, trace := tracedInput(cfg, item)
+		_, handle := rc.PrepareFetch(in)
+		require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+			Items:        []*astjson.Value{item},
+			ResponseData: astjson.MustParseBytes([]byte(fresh)),
+			Arena:        beginner(),
+		}))
+		rc.EndRequest()
+		require.NotNil(t, trace.CacheTrace)
+		require.Len(t, trace.CacheTrace.Items[0].Keys, 1)
+		hashed := trace.CacheTrace.Items[0].Keys[0]
+		raw := handle.Items[0].RenderedKeys[0]
+		assert.NotEqual(t, raw, hashed)
+		assert.Equal(t, hashHex([]byte(raw)), hashed)
+		assert.Len(t, hashed, 16)
+	})
+
+	t.Run("tracing off: nothing attached, compares drained", func(t *testing.T) {
+		obs := NewTraceObserver()
+		rc := NewController(newTestStore(), obs).BeginRequest(nil)
+		cfg := entityConfig(t, time.Minute)
+		item := productItem(t, "1")
+		// No Item on the input: the loader with tracing disabled leaves
+		// handle.Trace nil.
+		decision, handle := prepare(t, rc, cfg, item)
+		require.Equal(t, resolve.DecisionFetch, decision)
+		require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+			Items:        []*astjson.Value{item},
+			ResponseData: astjson.MustParseBytes([]byte(fresh)),
+			Arena:        beginner(),
+		}))
+		rc.EndRequest()
+		assert.Nil(t, handle.Trace)
+		assert.Empty(t, obs.compares)
+	})
+}
+
+// writeNegativeThrough primes the negative sentinel for one item and returns
+// its key.
+func writeNegativeThrough(t *testing.T, store *testStore, cfg *resolve.FetchCacheConfig, upc string) string {
+	t.Helper()
+	rc := NewController(store, nil).BeginRequest(nil)
+	item := productItem(t, upc)
+	_, handle := prepare(t, rc, cfg, item)
+	require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+		Items:        []*astjson.Value{item},
+		ResponseData: astjson.MustParseBytes([]byte(`null`)),
+		EmptyEntity:  true,
+		Arena:        beginner(),
+	}))
+	rc.EndRequest()
+	return handle.Items[0].RenderedKeys[0]
+}

--- a/v2/pkg/engine/cache/optimize_l1_cache.go
+++ b/v2/pkg/engine/cache/optimize_l1_cache.go
@@ -34,7 +34,13 @@ type entityFetchInfo struct {
 // provider/consumer pairs span trees).
 func (o *optimizeL1Cache) optimize(trees []*resolve.FetchTreeNode) {
 	var entities []*entityFetchInfo
+	// dependencies indexes EVERY fetch in the trees (cached or not): a
+	// provider/consumer chain routinely passes THROUGH unconfigured fetches
+	// (products -> reviews -> products), and a chain walk restricted to cached
+	// entity fetches would break at the middle hop.
+	dependencies := make(map[int][]int)
 	for treeIndex, tree := range trees {
+		collectFetchDependencies(tree, dependencies)
 		collected := o.collectEntityFetches(tree)
 		for _, entity := range collected {
 			entity.treeIndex = treeIndex
@@ -60,7 +66,7 @@ func (o *optimizeL1Cache) optimize(trees []*resolve.FetchTreeNode) {
 	}
 
 	for _, entity := range eligible {
-		if o.hasValidProvider(entity, eligible, entities) || o.hasValidConsumer(entity, eligible, entities) {
+		if o.hasValidProvider(entity, eligible, dependencies) || o.hasValidConsumer(entity, eligible, dependencies) {
 			continue
 		}
 		cfg := entity.fetch.CacheConfig()
@@ -122,7 +128,7 @@ func (o *optimizeL1Cache) extractEntityFetchInfo(fetch resolve.Fetch) *entityFet
 
 // hasValidProvider reports canRead: a prior fetch of the same entity type (or
 // the union of all priors) provides a SUPERSET of this fetch's tree.
-func (o *optimizeL1Cache) hasValidProvider(consumer *entityFetchInfo, candidates, allFetches []*entityFetchInfo) bool {
+func (o *optimizeL1Cache) hasValidProvider(consumer *entityFetchInfo, candidates []*entityFetchInfo, dependencies map[int][]int) bool {
 	for _, provider := range candidates {
 		if provider.fetchID == consumer.fetchID {
 			continue
@@ -130,14 +136,14 @@ func (o *optimizeL1Cache) hasValidProvider(consumer *entityFetchInfo, candidates
 		if provider.entityType != consumer.entityType {
 			continue
 		}
-		if !o.executesBefore(provider, consumer, allFetches) {
+		if !o.executesBefore(provider, consumer, dependencies) {
 			continue
 		}
 		if objectProvidesAllFields(provider.providesData, consumer.providesData) {
 			return true
 		}
 	}
-	union := o.collectAncestorUnion(consumer, candidates, allFetches)
+	union := o.collectAncestorUnion(consumer, candidates, dependencies)
 	return union != nil && objectProvidesAllFields(union, consumer.providesData)
 }
 
@@ -147,7 +153,7 @@ func (o *optimizeL1Cache) hasValidProvider(consumer *entityFetchInfo, candidates
 // OLD union-fallback flaw: without it, a provider sharing a consumer with
 // other, sufficient providers stayed L1-eligible although nothing ever reused
 // its cached data.
-func (o *optimizeL1Cache) hasValidConsumer(provider *entityFetchInfo, candidates, allFetches []*entityFetchInfo) bool {
+func (o *optimizeL1Cache) hasValidConsumer(provider *entityFetchInfo, candidates []*entityFetchInfo, dependencies map[int][]int) bool {
 	for _, consumer := range candidates {
 		if consumer.fetchID == provider.fetchID {
 			continue
@@ -155,7 +161,7 @@ func (o *optimizeL1Cache) hasValidConsumer(provider *entityFetchInfo, candidates
 		if consumer.entityType != provider.entityType {
 			continue
 		}
-		if !o.executesBefore(provider, consumer, allFetches) {
+		if !o.executesBefore(provider, consumer, dependencies) {
 			continue
 		}
 		if objectProvidesAllFields(provider.providesData, consumer.providesData) {
@@ -164,7 +170,7 @@ func (o *optimizeL1Cache) hasValidConsumer(provider *entityFetchInfo, candidates
 		if !objectSharesAnyField(provider.providesData, consumer.providesData) {
 			continue
 		}
-		union := o.collectAncestorUnion(consumer, candidates, allFetches)
+		union := o.collectAncestorUnion(consumer, candidates, dependencies)
 		if union != nil && objectProvidesAllFields(union, consumer.providesData) {
 			return true
 		}
@@ -178,18 +184,15 @@ func (o *optimizeL1Cache) hasValidConsumer(provider *entityFetchInfo, candidates
 // before every defer-group fetch even across branches with no dependency
 // edge. Defer groups among themselves stay unordered (conservative: they may
 // run in parallel).
-func (o *optimizeL1Cache) executesBefore(a, b *entityFetchInfo, allFetches []*entityFetchInfo) bool {
+func (o *optimizeL1Cache) executesBefore(a, b *entityFetchInfo, dependencies map[int][]int) bool {
 	if a.treeIndex == 0 && b.treeIndex > 0 {
 		return true
 	}
-	if slices.Contains(b.dependsOn, a.fetchID) {
-		return true
-	}
 	visited := make(map[int]bool)
-	return o.isInDependencyChain(b.dependsOn, a.fetchID, allFetches, visited)
+	return o.isInDependencyChain(b.dependsOn, a.fetchID, dependencies, visited)
 }
 
-func (o *optimizeL1Cache) isInDependencyChain(dependsOn []int, targetID int, allFetches []*entityFetchInfo, visited map[int]bool) bool {
+func (o *optimizeL1Cache) isInDependencyChain(dependsOn []int, targetID int, dependencies map[int][]int, visited map[int]bool) bool {
 	for _, depID := range dependsOn {
 		if depID == targetID {
 			return true
@@ -198,21 +201,32 @@ func (o *optimizeL1Cache) isInDependencyChain(dependsOn []int, targetID int, all
 			continue
 		}
 		visited[depID] = true
-		for _, fetch := range allFetches {
-			if fetch.fetchID == depID {
-				if o.isInDependencyChain(fetch.dependsOn, targetID, allFetches, visited) {
-					return true
-				}
-				break
-			}
+		if o.isInDependencyChain(dependencies[depID], targetID, dependencies, visited) {
+			return true
 		}
 	}
 	return false
 }
 
+// collectFetchDependencies records fetchID -> DependsOnFetchIDs for every
+// fetch under node.
+func collectFetchDependencies(node *resolve.FetchTreeNode, out map[int][]int) {
+	if node == nil {
+		return
+	}
+	if node.Item != nil && node.Item.Fetch != nil {
+		if deps := node.Item.Fetch.Dependencies(); deps != nil {
+			out[deps.FetchID] = deps.DependsOnFetchIDs
+		}
+	}
+	for _, child := range node.ChildNodes {
+		collectFetchDependencies(child, out)
+	}
+}
+
 // collectAncestorUnion unions the trees of every same-type provider executing
 // before the consumer.
-func (o *optimizeL1Cache) collectAncestorUnion(consumer *entityFetchInfo, candidates, allFetches []*entityFetchInfo) *resolve.Object {
+func (o *optimizeL1Cache) collectAncestorUnion(consumer *entityFetchInfo, candidates []*entityFetchInfo, dependencies map[int][]int) *resolve.Object {
 	var union *resolve.Object
 	for _, provider := range candidates {
 		if provider.fetchID == consumer.fetchID {
@@ -221,7 +235,7 @@ func (o *optimizeL1Cache) collectAncestorUnion(consumer *entityFetchInfo, candid
 		if provider.entityType != consumer.entityType {
 			continue
 		}
-		if !o.executesBefore(provider, consumer, allFetches) {
+		if !o.executesBefore(provider, consumer, dependencies) {
 			continue
 		}
 		if provider.providesData != nil {

--- a/v2/pkg/engine/cache/optimize_l1_cache.go
+++ b/v2/pkg/engine/cache/optimize_l1_cache.go
@@ -213,11 +213,20 @@ func (o *optimizeL1Cache) executesBefore(a, b *entityFetchInfo, dependencies map
 // resolver resolves a parent defer group fully before its children (and the
 // initial tree before every group), so ancestor-tree fetches execute before
 // every descendant-tree fetch. SIBLING groups stay unordered (parallel).
+// The walk is bounded by the tree count: treeParents crosses the public
+// ConfigureCaching API, and a malformed parent cycle must terminate, never
+// hang. Within such a cycle direct parent edges may still report enclosure —
+// harmless: L1 is only an eligibility hint, and the runtime still gates every
+// serve on key and coverage matches against actually-cached values.
 func (o *optimizeL1Cache) treeEncloses(a, b int) bool {
 	if a == b {
 		return false
 	}
-	for cur := b; cur >= 0 && cur < len(o.treeParents); {
+	cur := b
+	for range o.treeParents {
+		if cur < 0 || cur >= len(o.treeParents) {
+			return false
+		}
 		parent := o.treeParents[cur]
 		if parent == a {
 			return true

--- a/v2/pkg/engine/cache/optimize_l1_cache.go
+++ b/v2/pkg/engine/cache/optimize_l1_cache.go
@@ -342,17 +342,36 @@ func objectProvidesAllFields(provider, consumer *resolve.Object) bool {
 }
 
 // objectSharesAnyField reports whether the provider supplies at least one
-// field the consumer needs — the union-fallback contribution gate.
+// field PATH the consumer needs — the union-fallback contribution gate. The
+// walk is recursive: sharing only a nested object's NAME while providing none
+// of its leaves the consumer reads is not a contribution.
 func objectSharesAnyField(provider, consumer *resolve.Object) bool {
 	if provider == nil || consumer == nil {
 		return false
 	}
 	for _, consumerField := range consumer.Fields {
-		if findFieldByNarrowingName(provider.Fields, fieldNarrowingName(consumerField)) != nil {
+		providerField := findFieldByNarrowingName(provider.Fields, fieldNarrowingName(consumerField))
+		if providerField != nil && nodeSharesAnyField(providerField.Value, consumerField.Value) {
 			return true
 		}
 	}
 	return false
+}
+
+func nodeSharesAnyField(provider, consumer resolve.Node) bool {
+	if provider == nil || consumer == nil {
+		return false
+	}
+	switch consumerNode := consumer.(type) {
+	case *resolve.Object:
+		providerObj, ok := provider.(*resolve.Object)
+		return ok && objectSharesAnyField(providerObj, consumerNode)
+	case *resolve.Array:
+		providerArr, ok := provider.(*resolve.Array)
+		return ok && nodeSharesAnyField(providerArr.Item, consumerNode.Item)
+	default:
+		return true
+	}
 }
 
 func nodeProvidesAllFields(provider, consumer resolve.Node) bool {

--- a/v2/pkg/engine/cache/optimize_l1_cache.go
+++ b/v2/pkg/engine/cache/optimize_l1_cache.go
@@ -1,0 +1,17 @@
+package cache
+
+import (
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// optimizeL1Cache narrows cfg.L1 CROSS-TREE after all fetch configs are set:
+// L1 stays enabled only where a value written by one fetch can actually be
+// reused by another within the same request.
+//
+// Skeleton only — the narrowing pass lands with task 16.
+type optimizeL1Cache struct{}
+
+// optimize runs the cross-tree narrowing over all fetch trees of one response.
+// Inert until task 16.
+func (o *optimizeL1Cache) optimize(trees []*resolve.FetchTreeNode) {
+}

--- a/v2/pkg/engine/cache/optimize_l1_cache.go
+++ b/v2/pkg/engine/cache/optimize_l1_cache.go
@@ -14,7 +14,11 @@ import (
 // fetch can serve (canRead) drops its eligibility. The configurator is the
 // SOLE eligibility setter; this pass NEVER turns L1 on. Wrong narrowing costs
 // only a missed hit, never correctness.
-type optimizeL1Cache struct{}
+type optimizeL1Cache struct {
+	// treeParents is the per-run tree ancestry (index of the enclosing tree,
+	// -1 for roots); see optimize.
+	treeParents []int
+}
 
 // entityFetchInfo is the narrowing view of one L1-relevant entity fetch.
 type entityFetchInfo struct {
@@ -32,7 +36,20 @@ type entityFetchInfo struct {
 // optimize runs the cross-tree narrowing over ALL fetch trees of one response
 // (the root tree and every defer group — the L1 store is request-lifetime, so
 // provider/consumer pairs span trees).
-func (o *optimizeL1Cache) optimize(trees []*resolve.FetchTreeNode) {
+func (o *optimizeL1Cache) optimize(trees []*resolve.FetchTreeNode, treeParents []int) {
+	// treeParents encodes the defer-group ancestry (parent tree index per
+	// tree, -1 for roots); nil defaults to "tree 0 encloses every other
+	// tree" — the plain root-before-defers rule.
+	o.treeParents = treeParents
+	if len(o.treeParents) != len(trees) {
+		o.treeParents = make([]int, len(trees))
+		for i := range o.treeParents {
+			o.treeParents[i] = 0
+		}
+		if len(o.treeParents) > 0 {
+			o.treeParents[0] = -1
+		}
+	}
 	var entities []*entityFetchInfo
 	// dependencies indexes EVERY fetch in the trees (cached or not): a
 	// provider/consumer chain routinely passes THROUGH unconfigured fetches
@@ -185,11 +202,32 @@ func (o *optimizeL1Cache) hasValidConsumer(provider *entityFetchInfo, candidates
 // edge. Defer groups among themselves stay unordered (conservative: they may
 // run in parallel).
 func (o *optimizeL1Cache) executesBefore(a, b *entityFetchInfo, dependencies map[int][]int) bool {
-	if a.treeIndex == 0 && b.treeIndex > 0 {
+	if o.treeEncloses(a.treeIndex, b.treeIndex) {
 		return true
 	}
 	visited := make(map[int]bool)
 	return o.isInDependencyChain(b.dependsOn, a.fetchID, dependencies, visited)
+}
+
+// treeEncloses reports whether tree a is a strict ancestor of tree b: the
+// resolver resolves a parent defer group fully before its children (and the
+// initial tree before every group), so ancestor-tree fetches execute before
+// every descendant-tree fetch. SIBLING groups stay unordered (parallel).
+func (o *optimizeL1Cache) treeEncloses(a, b int) bool {
+	if a == b {
+		return false
+	}
+	for cur := b; cur >= 0 && cur < len(o.treeParents); {
+		parent := o.treeParents[cur]
+		if parent == a {
+			return true
+		}
+		if parent == cur {
+			return false
+		}
+		cur = parent
+	}
+	return false
 }
 
 func (o *optimizeL1Cache) isInDependencyChain(dependsOn []int, targetID int, dependencies map[int][]int, visited map[int]bool) bool {

--- a/v2/pkg/engine/cache/optimize_l1_cache.go
+++ b/v2/pkg/engine/cache/optimize_l1_cache.go
@@ -1,17 +1,362 @@
 package cache
 
 import (
+	"cmp"
+	"slices"
+	"strings"
+
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 )
 
 // optimizeL1Cache narrows cfg.L1 CROSS-TREE after all fetch configs are set:
-// L1 stays enabled only where a value written by one fetch can actually be
-// reused by another within the same request.
-//
-// Skeleton only — the narrowing pass lands with task 16.
+// L1 stays enabled only where a request-lifetime provider/consumer pair exists
+// — a fetch whose value no later fetch can reuse (canWrite) and that no prior
+// fetch can serve (canRead) drops its eligibility. The configurator is the
+// SOLE eligibility setter; this pass NEVER turns L1 on. Wrong narrowing costs
+// only a missed hit, never correctness.
 type optimizeL1Cache struct{}
 
-// optimize runs the cross-tree narrowing over all fetch trees of one response.
-// Inert until task 16.
+// entityFetchInfo is the narrowing view of one L1-relevant entity fetch.
+type entityFetchInfo struct {
+	fetchID    int
+	coordinate string
+	entityType string
+	// treeIndex is the fetch's tree position in the facade's execution-ordered
+	// tree list: 0 is the initial response tree, 1+ are defer groups.
+	treeIndex    int
+	providesData *resolve.Object
+	dependsOn    []int
+	fetch        resolve.Fetch
+}
+
+// optimize runs the cross-tree narrowing over ALL fetch trees of one response
+// (the root tree and every defer group — the L1 store is request-lifetime, so
+// provider/consumer pairs span trees).
 func (o *optimizeL1Cache) optimize(trees []*resolve.FetchTreeNode) {
+	var entities []*entityFetchInfo
+	for treeIndex, tree := range trees {
+		collected := o.collectEntityFetches(tree)
+		for _, entity := range collected {
+			entity.treeIndex = treeIndex
+		}
+		entities = append(entities, collected...)
+	}
+	if len(entities) == 0 {
+		return
+	}
+
+	slices.SortFunc(entities, func(a, b *entityFetchInfo) int {
+		return cmp.Or(
+			cmp.Compare(a.fetchID, b.fetchID),
+			cmp.Compare(a.coordinate, b.coordinate),
+		)
+	})
+
+	eligible := make([]*entityFetchInfo, 0, len(entities))
+	for _, entity := range entities {
+		if cfg := entity.fetch.CacheConfig(); cfg != nil && cfg.L1 {
+			eligible = append(eligible, entity)
+		}
+	}
+
+	for _, entity := range eligible {
+		if o.hasValidProvider(entity, eligible, entities) || o.hasValidConsumer(entity, eligible, entities) {
+			continue
+		}
+		cfg := entity.fetch.CacheConfig()
+		cfg.L1 = false
+		if !cfg.L2 && !cfg.ShadowMode {
+			// The config enables nothing anymore: re-nil it so the loader's
+			// per-fetch gate skips the fetch entirely (tidy, not correctness).
+			entity.fetch.SetCacheConfig(nil)
+		}
+	}
+}
+
+func (o *optimizeL1Cache) collectEntityFetches(node *resolve.FetchTreeNode) []*entityFetchInfo {
+	if node == nil {
+		return nil
+	}
+	switch node.Kind {
+	case resolve.FetchTreeNodeKindSingle:
+		if node.Item == nil {
+			return nil
+		}
+		if entity := o.extractEntityFetchInfo(node.Item.Fetch); entity != nil {
+			return []*entityFetchInfo{entity}
+		}
+	case resolve.FetchTreeNodeKindParallel, resolve.FetchTreeNodeKindSequence:
+		var result []*entityFetchInfo
+		for _, child := range node.ChildNodes {
+			result = append(result, o.collectEntityFetches(child)...)
+		}
+		return result
+	}
+	return nil
+}
+
+func (o *optimizeL1Cache) extractEntityFetchInfo(fetch resolve.Fetch) *entityFetchInfo {
+	if fetch == nil || fetch.CacheConfig() == nil {
+		return nil
+	}
+	if !fetch.IsEntityFetch() && !fetch.IsBatchEntityFetch() {
+		return nil
+	}
+	info := fetch.FetchInfo()
+	if info == nil || len(info.RootFields) == 0 || info.RootFields[0].TypeName == "" {
+		return nil
+	}
+	deps := fetch.Dependencies()
+	if deps == nil {
+		return nil
+	}
+	return &entityFetchInfo{
+		fetchID:      deps.FetchID,
+		coordinate:   info.RootFields[0].TypeName + "." + info.RootFields[0].FieldName,
+		entityType:   info.RootFields[0].TypeName,
+		providesData: fetch.CacheConfig().ProvidesData,
+		dependsOn:    deps.DependsOnFetchIDs,
+		fetch:        fetch,
+	}
+}
+
+// hasValidProvider reports canRead: a prior fetch of the same entity type (or
+// the union of all priors) provides a SUPERSET of this fetch's tree.
+func (o *optimizeL1Cache) hasValidProvider(consumer *entityFetchInfo, candidates, allFetches []*entityFetchInfo) bool {
+	for _, provider := range candidates {
+		if provider.fetchID == consumer.fetchID {
+			continue
+		}
+		if provider.entityType != consumer.entityType {
+			continue
+		}
+		if !o.executesBefore(provider, consumer, allFetches) {
+			continue
+		}
+		if objectProvidesAllFields(provider.providesData, consumer.providesData) {
+			return true
+		}
+	}
+	union := o.collectAncestorUnion(consumer, candidates, allFetches)
+	return union != nil && objectProvidesAllFields(union, consumer.providesData)
+}
+
+// hasValidConsumer reports canWrite: a later fetch of the same entity type
+// needs a SUBSET of this fetch's tree, either from this fetch alone or from a
+// union THIS FETCH CONTRIBUTES TO. The contribution gate is the fix for the
+// OLD union-fallback flaw: without it, a provider sharing a consumer with
+// other, sufficient providers stayed L1-eligible although nothing ever reused
+// its cached data.
+func (o *optimizeL1Cache) hasValidConsumer(provider *entityFetchInfo, candidates, allFetches []*entityFetchInfo) bool {
+	for _, consumer := range candidates {
+		if consumer.fetchID == provider.fetchID {
+			continue
+		}
+		if consumer.entityType != provider.entityType {
+			continue
+		}
+		if !o.executesBefore(provider, consumer, allFetches) {
+			continue
+		}
+		if objectProvidesAllFields(provider.providesData, consumer.providesData) {
+			return true
+		}
+		if !objectSharesAnyField(provider.providesData, consumer.providesData) {
+			continue
+		}
+		union := o.collectAncestorUnion(consumer, candidates, allFetches)
+		if union != nil && objectProvidesAllFields(union, consumer.providesData) {
+			return true
+		}
+	}
+	return false
+}
+
+// executesBefore resolves ordering from two sources: the dependency edges
+// (direct or transitive), and TREE order — the initial response tree always
+// completes before any defer group starts, so an initial-tree fetch executes
+// before every defer-group fetch even across branches with no dependency
+// edge. Defer groups among themselves stay unordered (conservative: they may
+// run in parallel).
+func (o *optimizeL1Cache) executesBefore(a, b *entityFetchInfo, allFetches []*entityFetchInfo) bool {
+	if a.treeIndex == 0 && b.treeIndex > 0 {
+		return true
+	}
+	if slices.Contains(b.dependsOn, a.fetchID) {
+		return true
+	}
+	visited := make(map[int]bool)
+	return o.isInDependencyChain(b.dependsOn, a.fetchID, allFetches, visited)
+}
+
+func (o *optimizeL1Cache) isInDependencyChain(dependsOn []int, targetID int, allFetches []*entityFetchInfo, visited map[int]bool) bool {
+	for _, depID := range dependsOn {
+		if depID == targetID {
+			return true
+		}
+		if visited[depID] {
+			continue
+		}
+		visited[depID] = true
+		for _, fetch := range allFetches {
+			if fetch.fetchID == depID {
+				if o.isInDependencyChain(fetch.dependsOn, targetID, allFetches, visited) {
+					return true
+				}
+				break
+			}
+		}
+	}
+	return false
+}
+
+// collectAncestorUnion unions the trees of every same-type provider executing
+// before the consumer.
+func (o *optimizeL1Cache) collectAncestorUnion(consumer *entityFetchInfo, candidates, allFetches []*entityFetchInfo) *resolve.Object {
+	var union *resolve.Object
+	for _, provider := range candidates {
+		if provider.fetchID == consumer.fetchID {
+			continue
+		}
+		if provider.entityType != consumer.entityType {
+			continue
+		}
+		if !o.executesBefore(provider, consumer, allFetches) {
+			continue
+		}
+		if provider.providesData != nil {
+			union = unionObjects(union, provider.providesData)
+		}
+	}
+	return union
+}
+
+// fieldNarrowingName identifies a field for provider/consumer matching: the
+// SCHEMA name (alias-independent — the L1 store holds normalized values) plus
+// the argument bindings (fields selected with different arguments are
+// different cache fields). CacheArgs are sorted at capture time (task 05), so
+// plain concatenation is deterministic.
+func fieldNarrowingName(field *resolve.Field) string {
+	name := string(field.Name)
+	if len(field.OriginalName) > 0 {
+		name = string(field.OriginalName)
+	}
+	if len(field.CacheArgs) == 0 {
+		return name
+	}
+	var b strings.Builder
+	b.WriteString(name)
+	b.WriteByte('(')
+	for i, arg := range field.CacheArgs {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(arg.Name)
+		b.WriteByte(':')
+		b.WriteString(arg.VariableName)
+	}
+	b.WriteByte(')')
+	return b.String()
+}
+
+func findFieldByNarrowingName(fields []*resolve.Field, name string) *resolve.Field {
+	for _, field := range fields {
+		if fieldNarrowingName(field) == name {
+			return field
+		}
+	}
+	return nil
+}
+
+// objectProvidesAllFields reports whether the provider tree contains EVERY
+// field of the consumer tree, recursively.
+func objectProvidesAllFields(provider, consumer *resolve.Object) bool {
+	if consumer == nil {
+		return true
+	}
+	if provider == nil {
+		return len(consumer.Fields) == 0
+	}
+	for _, consumerField := range consumer.Fields {
+		providerField := findFieldByNarrowingName(provider.Fields, fieldNarrowingName(consumerField))
+		if providerField == nil {
+			return false
+		}
+		if !nodeProvidesAllFields(providerField.Value, consumerField.Value) {
+			return false
+		}
+	}
+	return true
+}
+
+// objectSharesAnyField reports whether the provider supplies at least one
+// field the consumer needs — the union-fallback contribution gate.
+func objectSharesAnyField(provider, consumer *resolve.Object) bool {
+	if provider == nil || consumer == nil {
+		return false
+	}
+	for _, consumerField := range consumer.Fields {
+		if findFieldByNarrowingName(provider.Fields, fieldNarrowingName(consumerField)) != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func nodeProvidesAllFields(provider, consumer resolve.Node) bool {
+	if consumer == nil {
+		return true
+	}
+	if provider == nil {
+		return false
+	}
+	switch consumerNode := consumer.(type) {
+	case *resolve.Object:
+		providerObj, ok := provider.(*resolve.Object)
+		if !ok {
+			return false
+		}
+		return objectProvidesAllFields(providerObj, consumerNode)
+	case *resolve.Array:
+		providerArr, ok := provider.(*resolve.Array)
+		if !ok {
+			return false
+		}
+		return nodeProvidesAllFields(providerArr.Item, consumerNode.Item)
+	default:
+		return true
+	}
+}
+
+// unionObjects merges two trees into a NEW object. Overlapping object fields
+// merge recursively into COPIED field structs — the inputs are live
+// ProvidesData trees on the fetch configs, and mutating them here would
+// corrupt the configs (a first-pass aliasing bug this port fixes).
+func unionObjects(a, b *resolve.Object) *resolve.Object {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	merged := make([]*resolve.Field, 0, len(a.Fields)+len(b.Fields))
+	merged = append(merged, a.Fields...)
+	for _, bField := range b.Fields {
+		name := fieldNarrowingName(bField)
+		existingIdx := slices.IndexFunc(merged, func(f *resolve.Field) bool {
+			return fieldNarrowingName(f) == name
+		})
+		if existingIdx < 0 {
+			merged = append(merged, bField)
+			continue
+		}
+		existingObj, existingIsObj := merged[existingIdx].Value.(*resolve.Object)
+		bObj, bIsObj := bField.Value.(*resolve.Object)
+		if existingIsObj && bIsObj {
+			fieldCopy := *merged[existingIdx]
+			fieldCopy.Value = unionObjects(existingObj, bObj)
+			merged[existingIdx] = &fieldCopy
+		}
+	}
+	return &resolve.Object{Fields: merged}
 }

--- a/v2/pkg/engine/cache/optimize_l1_cache_test.go
+++ b/v2/pkg/engine/cache/optimize_l1_cache_test.go
@@ -54,27 +54,27 @@ func TestOptimizeL1CacheRows(t *testing.T) {
 	t.Run("provider/consumer pair via a dependency edge keeps both", func(t *testing.T) {
 		provider := narrowingFetch(1, nil, "Product", narrowingTree("name", "price"), true, true)
 		consumer := narrowingFetch(2, []int{1}, "Product", narrowingTree("name"), true, true)
-		pass.optimize([]*resolve.FetchTreeNode{tree(provider, consumer)})
+		pass.optimize([]*resolve.FetchTreeNode{tree(provider, consumer)}, nil)
 		assert.True(t, l1Of(provider))
 		assert.True(t, l1Of(consumer))
 	})
 
 	t.Run("a lone fetch is narrowed off", func(t *testing.T) {
 		lone := narrowingFetch(1, nil, "Product", narrowingTree("name"), true, true)
-		pass.optimize([]*resolve.FetchTreeNode{tree(lone)})
+		pass.optimize([]*resolve.FetchTreeNode{tree(lone)}, nil)
 		assert.False(t, l1Of(lone))
 	})
 
 	t.Run("narrowing a lone L1-only fetch re-nils the inert config", func(t *testing.T) {
 		lone := narrowingFetch(1, nil, "Product", narrowingTree("name"), true, false)
-		pass.optimize([]*resolve.FetchTreeNode{tree(lone)})
+		pass.optimize([]*resolve.FetchTreeNode{tree(lone)}, nil)
 		assert.Nil(t, lone.Item.Fetch.CacheConfig())
 	})
 
 	t.Run("never turns L1 on: a configurator-false fetch stays false despite a pair", func(t *testing.T) {
 		provider := narrowingFetch(1, nil, "Product", narrowingTree("name", "price"), false, true)
 		consumer := narrowingFetch(2, []int{1}, "Product", narrowingTree("name"), true, true)
-		pass.optimize([]*resolve.FetchTreeNode{tree(provider, consumer)})
+		pass.optimize([]*resolve.FetchTreeNode{tree(provider, consumer)}, nil)
 		assert.False(t, l1Of(provider))
 		// The consumer's only candidate provider is ineligible: no pair, off.
 		assert.False(t, l1Of(consumer))
@@ -84,7 +84,7 @@ func TestOptimizeL1CacheRows(t *testing.T) {
 		providerA := narrowingFetch(1, nil, "Product", narrowingTree("name"), true, true)
 		providerB := narrowingFetch(2, nil, "Product", narrowingTree("price"), true, true)
 		consumer := narrowingFetch(3, []int{1, 2}, "Product", narrowingTree("name", "price"), true, true)
-		pass.optimize([]*resolve.FetchTreeNode{tree(providerA, providerB, consumer)})
+		pass.optimize([]*resolve.FetchTreeNode{tree(providerA, providerB, consumer)}, nil)
 		assert.True(t, l1Of(providerA))
 		assert.True(t, l1Of(providerB))
 		assert.True(t, l1Of(consumer))
@@ -94,7 +94,7 @@ func TestOptimizeL1CacheRows(t *testing.T) {
 		relevant := narrowingFetch(1, nil, "Product", narrowingTree("name"), true, true)
 		irrelevant := narrowingFetch(2, nil, "Product", narrowingTree("weight"), true, true)
 		consumer := narrowingFetch(3, []int{1, 2}, "Product", narrowingTree("name"), true, true)
-		pass.optimize([]*resolve.FetchTreeNode{tree(relevant, irrelevant, consumer)})
+		pass.optimize([]*resolve.FetchTreeNode{tree(relevant, irrelevant, consumer)}, nil)
 		assert.True(t, l1Of(relevant))
 		// Shares NO field with the consumer: the union fallback must not keep
 		// it merely because the OTHER provider covers the consumer.
@@ -105,7 +105,7 @@ func TestOptimizeL1CacheRows(t *testing.T) {
 	t.Run("partial overlap without full coverage narrows both off", func(t *testing.T) {
 		provider := narrowingFetch(1, nil, "Product", narrowingTree("name", "price"), true, true)
 		consumer := narrowingFetch(2, []int{1}, "Product", narrowingTree("price", "weight"), true, true)
-		pass.optimize([]*resolve.FetchTreeNode{tree(provider, consumer)})
+		pass.optimize([]*resolve.FetchTreeNode{tree(provider, consumer)}, nil)
 		assert.False(t, l1Of(provider))
 		assert.False(t, l1Of(consumer))
 	})
@@ -113,7 +113,7 @@ func TestOptimizeL1CacheRows(t *testing.T) {
 	t.Run("empty union: a consumer with no prior providers is narrowed off", func(t *testing.T) {
 		later := narrowingFetch(2, nil, "Product", narrowingTree("name"), true, true)
 		unrelated := narrowingFetch(1, nil, "User", narrowingTree("name"), true, true)
-		pass.optimize([]*resolve.FetchTreeNode{tree(unrelated, later)})
+		pass.optimize([]*resolve.FetchTreeNode{tree(unrelated, later)}, nil)
 		assert.False(t, l1Of(later))
 		assert.False(t, l1Of(unrelated))
 	})
@@ -122,7 +122,7 @@ func TestOptimizeL1CacheRows(t *testing.T) {
 		provider := narrowingFetch(1, nil, "Product", narrowingTree("name", "price"), true, true)
 		bridge := narrowingFetch(2, []int{1}, "User", narrowingTree("id"), true, true)
 		consumer := narrowingFetch(3, []int{2}, "Product", narrowingTree("name"), true, true)
-		pass.optimize([]*resolve.FetchTreeNode{tree(provider, bridge, consumer)})
+		pass.optimize([]*resolve.FetchTreeNode{tree(provider, bridge, consumer)}, nil)
 		assert.True(t, l1Of(provider))
 		assert.True(t, l1Of(consumer))
 		assert.False(t, l1Of(bridge))
@@ -133,21 +133,30 @@ func TestOptimizeL1CacheRows(t *testing.T) {
 		// order relates them.
 		provider := narrowingFetch(1, nil, "Product", narrowingTree("name", "price"), true, true)
 		consumer := narrowingFetch(7, []int{5}, "Product", narrowingTree("name"), true, true)
-		pass.optimize([]*resolve.FetchTreeNode{tree(provider), tree(consumer)})
+		pass.optimize([]*resolve.FetchTreeNode{tree(provider), tree(consumer)}, nil)
 		assert.True(t, l1Of(provider))
 		assert.True(t, l1Of(consumer))
 
 		// Per-tree-only behavior is rejected: the SAME shapes narrowed off when
 		// the pass only sees the root tree.
 		soloProvider := narrowingFetch(1, nil, "Product", narrowingTree("name", "price"), true, true)
-		pass.optimize([]*resolve.FetchTreeNode{tree(soloProvider)})
+		pass.optimize([]*resolve.FetchTreeNode{tree(soloProvider)}, nil)
 		assert.False(t, l1Of(soloProvider))
+	})
+
+	t.Run("a parent defer group orders before its NESTED child group", func(t *testing.T) {
+		provider := narrowingFetch(3, nil, "Product", narrowingTree("name", "price"), true, true)
+		consumer := narrowingFetch(4, nil, "Product", narrowingTree("name"), true, true)
+		// treeParents: tree 1 (outer group) encloses tree 2 (nested group).
+		pass.optimize([]*resolve.FetchTreeNode{tree(), tree(provider), tree(consumer)}, []int{-1, 0, 1})
+		assert.True(t, l1Of(provider))
+		assert.True(t, l1Of(consumer))
 	})
 
 	t.Run("defer groups among themselves stay unordered", func(t *testing.T) {
 		deferA := narrowingFetch(3, nil, "Product", narrowingTree("name", "price"), true, true)
 		deferB := narrowingFetch(4, nil, "Product", narrowingTree("name"), true, true)
-		pass.optimize([]*resolve.FetchTreeNode{tree(), tree(deferA), tree(deferB)})
+		pass.optimize([]*resolve.FetchTreeNode{tree(), tree(deferA), tree(deferB)}, nil)
 		assert.False(t, l1Of(deferA))
 		assert.False(t, l1Of(deferB))
 	})
@@ -157,9 +166,9 @@ func TestOptimizeL1CacheRows(t *testing.T) {
 		consumer := narrowingFetch(2, []int{1}, "Product", narrowingTree("name"), true, true)
 		lone := narrowingFetch(3, nil, "User", narrowingTree("id"), true, true)
 		trees := []*resolve.FetchTreeNode{tree(provider, consumer, lone)}
-		pass.optimize(trees)
+		pass.optimize(trees, nil)
 		first := []bool{l1Of(provider), l1Of(consumer), l1Of(lone)}
-		pass.optimize(trees)
+		pass.optimize(trees, nil)
 		assert.Equal(t, first, []bool{l1Of(provider), l1Of(consumer), l1Of(lone)})
 		assert.Equal(t, []bool{true, true, false}, first)
 	})
@@ -181,7 +190,7 @@ func TestOptimizeL1CacheRows(t *testing.T) {
 				{Name: []byte("location"), Value: &resolve.Scalar{Path: []string{"location"}}},
 			}}},
 		}}, true, true)
-		pass.optimize([]*resolve.FetchTreeNode{tree(providerA, providerB, consumer)})
+		pass.optimize([]*resolve.FetchTreeNode{tree(providerA, providerB, consumer)}, nil)
 		assert.True(t, l1Of(consumer)) // served by the recursive union
 		// The FIRST-PASS aliasing bug: the union merged INTO provider A's live
 		// tree. A's brand object must still have exactly its own field.

--- a/v2/pkg/engine/cache/optimize_l1_cache_test.go
+++ b/v2/pkg/engine/cache/optimize_l1_cache_test.go
@@ -181,6 +181,19 @@ func TestOptimizeL1CacheRows(t *testing.T) {
 		assert.False(t, l1Of(deferB))
 	})
 
+	t.Run("a malformed treeParents cycle degrades to unordered, never hangs", func(t *testing.T) {
+		// treeParents crosses the public ConfigureCaching API: probing whether
+		// the ROOT tree encloses a member of a 1<->2 parent cycle must
+		// terminate (the walk never reaches -1), leaving root and cycle
+		// unordered — the root provider loses its only consumer and both
+		// narrow off.
+		provider := narrowingFetch(1, nil, "Product", narrowingTree("name", "price"), true, true)
+		consumer := narrowingFetch(4, nil, "Product", narrowingTree("name"), true, true)
+		pass.optimize([]*resolve.FetchTreeNode{tree(provider), tree(consumer), tree()}, []int{-1, 2, 1})
+		assert.False(t, l1Of(provider))
+		assert.False(t, l1Of(consumer))
+	})
+
 	t.Run("determinism: a second run leaves the narrowed state unchanged", func(t *testing.T) {
 		provider := narrowingFetch(1, nil, "Product", narrowingTree("name", "price"), true, true)
 		consumer := narrowingFetch(2, []int{1}, "Product", narrowingTree("name"), true, true)

--- a/v2/pkg/engine/cache/optimize_l1_cache_test.go
+++ b/v2/pkg/engine/cache/optimize_l1_cache_test.go
@@ -102,6 +102,26 @@ func TestOptimizeL1CacheRows(t *testing.T) {
 		assert.True(t, l1Of(consumer))
 	})
 
+	t.Run("[flaw pin] nested NAME-only overlap is not a contribution", func(t *testing.T) {
+		// The irrelevant provider shares the OBJECT NAME "warehouse" but none
+		// of the leaves the consumer reads; the relevant provider covers the
+		// consumer alone. The contribution gate must recurse past the name.
+		warehouseWith := func(leaf string) *resolve.Object {
+			return &resolve.Object{Fields: []*resolve.Field{
+				{Name: []byte("warehouse"), Value: &resolve.Object{Fields: []*resolve.Field{
+					{Name: []byte(leaf), Value: &resolve.Scalar{Path: []string{leaf}}},
+				}}},
+			}}
+		}
+		relevant := narrowingFetch(1, nil, "Product", warehouseWith("location"), true, true)
+		irrelevant := narrowingFetch(2, nil, "Product", warehouseWith("id"), true, true)
+		consumer := narrowingFetch(3, []int{1, 2}, "Product", warehouseWith("location"), true, true)
+		pass.optimize([]*resolve.FetchTreeNode{tree(relevant, irrelevant, consumer)}, nil)
+		assert.True(t, l1Of(relevant))
+		assert.False(t, l1Of(irrelevant))
+		assert.True(t, l1Of(consumer))
+	})
+
 	t.Run("partial overlap without full coverage narrows both off", func(t *testing.T) {
 		provider := narrowingFetch(1, nil, "Product", narrowingTree("name", "price"), true, true)
 		consumer := narrowingFetch(2, []int{1}, "Product", narrowingTree("price", "weight"), true, true)

--- a/v2/pkg/engine/cache/optimize_l1_cache_test.go
+++ b/v2/pkg/engine/cache/optimize_l1_cache_test.go
@@ -1,0 +1,192 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// narrowingTree builds an entity tree with the given scalar fields (nested
+// object fields expressed as "parent.child").
+func narrowingTree(fieldNames ...string) *resolve.Object {
+	obj := &resolve.Object{}
+	for _, name := range fieldNames {
+		obj.Fields = append(obj.Fields, &resolve.Field{
+			Name:  []byte(name),
+			Value: &resolve.Scalar{Path: []string{name}},
+		})
+	}
+	return obj
+}
+
+// narrowingFetch builds one entity fetch node for the pass.
+func narrowingFetch(fetchID int, dependsOn []int, typeName string, provides *resolve.Object, l1, l2 bool) *resolve.FetchTreeNode {
+	fetch := &resolve.EntityFetch{
+		FetchDependencies: resolve.FetchDependencies{FetchID: fetchID, DependsOnFetchIDs: dependsOn},
+		Info:              &resolve.FetchInfo{RootFields: []resolve.GraphCoordinate{{TypeName: typeName}}},
+		Cache: &resolve.FetchCacheConfig{
+			L1:           l1,
+			L2:           l2,
+			CacheName:    "entities",
+			ProvidesData: provides,
+		},
+	}
+	return &resolve.FetchTreeNode{Kind: resolve.FetchTreeNodeKindSingle, Item: &resolve.FetchItem{Fetch: fetch}}
+}
+
+func tree(nodes ...*resolve.FetchTreeNode) *resolve.FetchTreeNode {
+	return &resolve.FetchTreeNode{Kind: resolve.FetchTreeNodeKindSequence, ChildNodes: nodes}
+}
+
+func l1Of(node *resolve.FetchTreeNode) bool {
+	cfg := node.Item.Fetch.CacheConfig()
+	return cfg != nil && cfg.L1
+}
+
+// TestOptimizeL1CacheRows covers the narrowing rows, including the adversarial
+// ones the OLD test set lacked.
+func TestOptimizeL1CacheRows(t *testing.T) {
+	pass := &optimizeL1Cache{}
+
+	t.Run("provider/consumer pair via a dependency edge keeps both", func(t *testing.T) {
+		provider := narrowingFetch(1, nil, "Product", narrowingTree("name", "price"), true, true)
+		consumer := narrowingFetch(2, []int{1}, "Product", narrowingTree("name"), true, true)
+		pass.optimize([]*resolve.FetchTreeNode{tree(provider, consumer)})
+		assert.True(t, l1Of(provider))
+		assert.True(t, l1Of(consumer))
+	})
+
+	t.Run("a lone fetch is narrowed off", func(t *testing.T) {
+		lone := narrowingFetch(1, nil, "Product", narrowingTree("name"), true, true)
+		pass.optimize([]*resolve.FetchTreeNode{tree(lone)})
+		assert.False(t, l1Of(lone))
+	})
+
+	t.Run("narrowing a lone L1-only fetch re-nils the inert config", func(t *testing.T) {
+		lone := narrowingFetch(1, nil, "Product", narrowingTree("name"), true, false)
+		pass.optimize([]*resolve.FetchTreeNode{tree(lone)})
+		assert.Nil(t, lone.Item.Fetch.CacheConfig())
+	})
+
+	t.Run("never turns L1 on: a configurator-false fetch stays false despite a pair", func(t *testing.T) {
+		provider := narrowingFetch(1, nil, "Product", narrowingTree("name", "price"), false, true)
+		consumer := narrowingFetch(2, []int{1}, "Product", narrowingTree("name"), true, true)
+		pass.optimize([]*resolve.FetchTreeNode{tree(provider, consumer)})
+		assert.False(t, l1Of(provider))
+		// The consumer's only candidate provider is ineligible: no pair, off.
+		assert.False(t, l1Of(consumer))
+	})
+
+	t.Run("union of two partial providers covers the consumer: all three keep L1", func(t *testing.T) {
+		providerA := narrowingFetch(1, nil, "Product", narrowingTree("name"), true, true)
+		providerB := narrowingFetch(2, nil, "Product", narrowingTree("price"), true, true)
+		consumer := narrowingFetch(3, []int{1, 2}, "Product", narrowingTree("name", "price"), true, true)
+		pass.optimize([]*resolve.FetchTreeNode{tree(providerA, providerB, consumer)})
+		assert.True(t, l1Of(providerA))
+		assert.True(t, l1Of(providerB))
+		assert.True(t, l1Of(consumer))
+	})
+
+	t.Run("[flaw pin] an irrelevant provider sharing a consumer is narrowed off", func(t *testing.T) {
+		relevant := narrowingFetch(1, nil, "Product", narrowingTree("name"), true, true)
+		irrelevant := narrowingFetch(2, nil, "Product", narrowingTree("weight"), true, true)
+		consumer := narrowingFetch(3, []int{1, 2}, "Product", narrowingTree("name"), true, true)
+		pass.optimize([]*resolve.FetchTreeNode{tree(relevant, irrelevant, consumer)})
+		assert.True(t, l1Of(relevant))
+		// Shares NO field with the consumer: the union fallback must not keep
+		// it merely because the OTHER provider covers the consumer.
+		assert.False(t, l1Of(irrelevant))
+		assert.True(t, l1Of(consumer))
+	})
+
+	t.Run("partial overlap without full coverage narrows both off", func(t *testing.T) {
+		provider := narrowingFetch(1, nil, "Product", narrowingTree("name", "price"), true, true)
+		consumer := narrowingFetch(2, []int{1}, "Product", narrowingTree("price", "weight"), true, true)
+		pass.optimize([]*resolve.FetchTreeNode{tree(provider, consumer)})
+		assert.False(t, l1Of(provider))
+		assert.False(t, l1Of(consumer))
+	})
+
+	t.Run("empty union: a consumer with no prior providers is narrowed off", func(t *testing.T) {
+		later := narrowingFetch(2, nil, "Product", narrowingTree("name"), true, true)
+		unrelated := narrowingFetch(1, nil, "User", narrowingTree("name"), true, true)
+		pass.optimize([]*resolve.FetchTreeNode{tree(unrelated, later)})
+		assert.False(t, l1Of(later))
+		assert.False(t, l1Of(unrelated))
+	})
+
+	t.Run("transitive dependency chains order fetches", func(t *testing.T) {
+		provider := narrowingFetch(1, nil, "Product", narrowingTree("name", "price"), true, true)
+		bridge := narrowingFetch(2, []int{1}, "User", narrowingTree("id"), true, true)
+		consumer := narrowingFetch(3, []int{2}, "Product", narrowingTree("name"), true, true)
+		pass.optimize([]*resolve.FetchTreeNode{tree(provider, bridge, consumer)})
+		assert.True(t, l1Of(provider))
+		assert.True(t, l1Of(consumer))
+		assert.False(t, l1Of(bridge))
+	})
+
+	t.Run("cross-tree: a root provider is kept because its only consumer is deferred", func(t *testing.T) {
+		// NO dependency edge between the two — different branches; only tree
+		// order relates them.
+		provider := narrowingFetch(1, nil, "Product", narrowingTree("name", "price"), true, true)
+		consumer := narrowingFetch(7, []int{5}, "Product", narrowingTree("name"), true, true)
+		pass.optimize([]*resolve.FetchTreeNode{tree(provider), tree(consumer)})
+		assert.True(t, l1Of(provider))
+		assert.True(t, l1Of(consumer))
+
+		// Per-tree-only behavior is rejected: the SAME shapes narrowed off when
+		// the pass only sees the root tree.
+		soloProvider := narrowingFetch(1, nil, "Product", narrowingTree("name", "price"), true, true)
+		pass.optimize([]*resolve.FetchTreeNode{tree(soloProvider)})
+		assert.False(t, l1Of(soloProvider))
+	})
+
+	t.Run("defer groups among themselves stay unordered", func(t *testing.T) {
+		deferA := narrowingFetch(3, nil, "Product", narrowingTree("name", "price"), true, true)
+		deferB := narrowingFetch(4, nil, "Product", narrowingTree("name"), true, true)
+		pass.optimize([]*resolve.FetchTreeNode{tree(), tree(deferA), tree(deferB)})
+		assert.False(t, l1Of(deferA))
+		assert.False(t, l1Of(deferB))
+	})
+
+	t.Run("determinism: a second run leaves the narrowed state unchanged", func(t *testing.T) {
+		provider := narrowingFetch(1, nil, "Product", narrowingTree("name", "price"), true, true)
+		consumer := narrowingFetch(2, []int{1}, "Product", narrowingTree("name"), true, true)
+		lone := narrowingFetch(3, nil, "User", narrowingTree("id"), true, true)
+		trees := []*resolve.FetchTreeNode{tree(provider, consumer, lone)}
+		pass.optimize(trees)
+		first := []bool{l1Of(provider), l1Of(consumer), l1Of(lone)}
+		pass.optimize(trees)
+		assert.Equal(t, first, []bool{l1Of(provider), l1Of(consumer), l1Of(lone)})
+		assert.Equal(t, []bool{true, true, false}, first)
+	})
+
+	t.Run("union computation never mutates the provider trees", func(t *testing.T) {
+		providerA := narrowingFetch(1, nil, "Product", &resolve.Object{Fields: []*resolve.Field{
+			{Name: []byte("brand"), Value: &resolve.Object{Fields: []*resolve.Field{
+				{Name: []byte("id"), Value: &resolve.Scalar{Path: []string{"id"}}},
+			}}},
+		}}, true, true)
+		providerB := narrowingFetch(2, nil, "Product", &resolve.Object{Fields: []*resolve.Field{
+			{Name: []byte("brand"), Value: &resolve.Object{Fields: []*resolve.Field{
+				{Name: []byte("location"), Value: &resolve.Scalar{Path: []string{"location"}}},
+			}}},
+		}}, true, true)
+		consumer := narrowingFetch(3, []int{1, 2}, "Product", &resolve.Object{Fields: []*resolve.Field{
+			{Name: []byte("brand"), Value: &resolve.Object{Fields: []*resolve.Field{
+				{Name: []byte("id"), Value: &resolve.Scalar{Path: []string{"id"}}},
+				{Name: []byte("location"), Value: &resolve.Scalar{Path: []string{"location"}}},
+			}}},
+		}}, true, true)
+		pass.optimize([]*resolve.FetchTreeNode{tree(providerA, providerB, consumer)})
+		assert.True(t, l1Of(consumer)) // served by the recursive union
+		// The FIRST-PASS aliasing bug: the union merged INTO provider A's live
+		// tree. A's brand object must still have exactly its own field.
+		brandA := providerA.Item.Fetch.CacheConfig().ProvidesData.Fields[0].Value.(*resolve.Object)
+		require.Len(t, brandA.Fields, 1)
+		assert.Equal(t, "id", string(brandA.Fields[0].Name))
+	})
+}

--- a/v2/pkg/engine/cache/partial.go
+++ b/v2/pkg/engine/cache/partial.go
@@ -65,7 +65,8 @@ func filterBatchInput(input []byte, keep []bool) ([]byte, bool) {
 // signals the covered splice still happens (the cached data is valid; the
 // loader has already rendered the fetch errors) and only the fetched subset's
 // merge and writes are skipped.
-func (r *requestCache) onPartialBatchResult(h *resolve.FetchCacheHandle, in resolve.MergeInput, cfg *resolve.FetchCacheConfig) error {
+func (r *requestCache) onPartialBatchResult(h *resolve.FetchCacheHandle, in resolve.MergeInput, state *handleState) error {
+	cfg := state.cfg
 	tx := in.Arena.Begin()
 	defer tx.Commit()
 
@@ -78,8 +79,8 @@ func (r *requestCache) onPartialBatchResult(h *resolve.FetchCacheHandle, in reso
 		}
 	}
 
-	prefix := r.prefixes[h]
-	missedByItem := r.missedKeys[h]
+	prefix := state.prefix
+	missedByItem := state.missedKeys
 	fetchedIndex := 0
 	for i := range h.Items {
 		item := &h.Items[i]

--- a/v2/pkg/engine/cache/partial.go
+++ b/v2/pkg/engine/cache/partial.go
@@ -1,0 +1,124 @@
+package cache
+
+import (
+	"github.com/wundergraph/astjson"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// Partial fetching (task 19): a batch entity fetch with SOME buckets covered
+// and some not serves the covered ones from cache and sends the subgraph a
+// REDUCED representations list; the response then realigns to the original
+// bucket positions via ItemCacheState.BatchIndex. Everything lives here — the
+// loader only swaps in the reduced input and leaves the data merge to the
+// partial arm of OnFetchResult (one hook, one lock acquisition).
+
+// filterBatchInput builds the reduced fetch input: the original rendered
+// input with the representations of COVERED buckets removed. keep[i] mirrors
+// the BatchStats bucket order (which is the representations order). Returns
+// ok=false when the input does not have the expected
+// body.variables.representations shape — the caller then falls back to a
+// plain full fetch (never an error, never a wrong request).
+func filterBatchInput(input []byte, keep []bool) ([]byte, bool) {
+	parsed, err := astjson.ParseBytes(input)
+	if err != nil {
+		return nil, false
+	}
+	representations := parsed.Get("body", "variables", "representations")
+	if representations == nil || representations.Type() != astjson.TypeArray {
+		return nil, false
+	}
+	all := representations.GetArray()
+	if len(all) != len(keep) {
+		return nil, false
+	}
+	reduced := astjson.ArrayValue(nil)
+	kept := 0
+	for i, representation := range all {
+		if !keep[i] {
+			continue
+		}
+		reduced.SetArrayItem(nil, kept, representation)
+		kept++
+	}
+	if kept == 0 || kept == len(all) {
+		// Nothing to filter (degenerate cases are handled by Fetch /
+		// SkipFullHit before this point; guard anyway).
+		return nil, false
+	}
+	parsed.Get("body", "variables").Set(nil, "representations", reduced)
+	return parsed.MarshalTo(nil), true
+}
+
+// onPartialBatchResult is the FetchPartial merge arm: within ONE transaction
+// it splices every covered bucket from cache (denormalized per merge target)
+// and realigns the REDUCED response — fetched buckets consume the _entities
+// array in order — merging and cache-writing the fresh values. On failure
+// signals the covered splice still happens (the cached data is valid; the
+// loader has already rendered the fetch errors) and only the fetched subset's
+// merge and writes are skipped.
+func (r *requestCache) onPartialBatchResult(h *resolve.FetchCacheHandle, in resolve.MergeInput, cfg *resolve.FetchCacheConfig) error {
+	tx := in.Arena.Begin()
+	defer tx.Commit()
+
+	fetchFailed := in.FetchFailed || in.HasErrors || in.ResponseData == nil
+	var batch []*astjson.Value
+	if !fetchFailed {
+		batch = in.ResponseData.GetArray()
+		if batch == nil {
+			fetchFailed = true
+		}
+	}
+
+	prefix := r.prefixes[h]
+	missedByItem := r.missedKeys[h]
+	fetchedIndex := 0
+	for i, item := range h.Items {
+		var targets []*astjson.Value
+		if item.BatchIndex >= 0 && item.BatchIndex < len(in.BatchStats) {
+			targets = in.BatchStats[item.BatchIndex]
+		}
+		if item.FromCache != nil {
+			// Covered bucket: identical duties to OnFetchSkipped — splice
+			// (nothing for a negative sentinel) plus the best-effort
+			// refresh/backfill write-backs.
+			var missed []string
+			if i < len(missedByItem) {
+				missed = missedByItem[i]
+			}
+			if err := r.spliceCachedItem(tx, cfg, prefix, cfg.ProvidesData, item, missed, targets, in.MergePath); err != nil {
+				return err
+			}
+			continue
+		}
+		// Fetched bucket: consume the reduced response in order.
+		if fetchFailed {
+			continue
+		}
+		if fetchedIndex >= len(batch) {
+			continue
+		}
+		src := batch[fetchedIndex]
+		fetchedIndex++
+		if src == nil || src.Type() == astjson.TypeNull {
+			// A legitimately missing entity: nothing to merge, nothing to
+			// write (negative caching needs the loader's EmptyEntity signal,
+			// which is whole-response scoped — out of the partial path).
+			continue
+		}
+		for _, target := range targets {
+			if target == nil {
+				continue
+			}
+			if len(in.MergePath) > 0 {
+				if _, err := tx.MergeValuesWithPath(target, tx.StructuralCopy(src), in.MergePath...); err != nil {
+					return err
+				}
+			} else if _, err := tx.MergeValues(target, tx.StructuralCopy(src)); err != nil {
+				return err
+			}
+		}
+		r.writeFetchedValue(tx, cfg, h, item, src, cfg.ProvidesData)
+	}
+	return nil
+}

--- a/v2/pkg/engine/cache/partial.go
+++ b/v2/pkg/engine/cache/partial.go
@@ -1,10 +1,18 @@
 package cache
 
 import (
+	"errors"
+
 	"github.com/wundergraph/astjson"
 
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 )
+
+// errPartialBatchEntityCountMismatch surfaces a subgraph contract violation:
+// the reduced _entities response must contain exactly one element per sent
+// representation (nulls included), like the loader's own full-batch
+// invalidBatchItemCount check.
+var errPartialBatchEntityCountMismatch = errors.New("partial batch _entities count does not match the reduced representations")
 
 // Partial fetching (task 19): a batch entity fetch with SOME buckets covered
 // and some not serves the covered ones from cache and sends the subgraph a
@@ -97,7 +105,7 @@ func (r *requestCache) onPartialBatchResult(h *resolve.FetchCacheHandle, in reso
 			continue
 		}
 		if fetchedIndex >= len(batch) {
-			continue
+			return errPartialBatchEntityCountMismatch
 		}
 		src := batch[fetchedIndex]
 		fetchedIndex++
@@ -120,6 +128,9 @@ func (r *requestCache) onPartialBatchResult(h *resolve.FetchCacheHandle, in reso
 			}
 		}
 		r.writeFetchedValue(tx, cfg, h, item, src, cfg.ProvidesData)
+	}
+	if !fetchFailed && fetchedIndex != len(batch) {
+		return errPartialBatchEntityCountMismatch
 	}
 	return nil
 }

--- a/v2/pkg/engine/cache/partial.go
+++ b/v2/pkg/engine/cache/partial.go
@@ -73,7 +73,8 @@ func (r *requestCache) onPartialBatchResult(h *resolve.FetchCacheHandle, in reso
 	prefix := r.prefixes[h]
 	missedByItem := r.missedKeys[h]
 	fetchedIndex := 0
-	for i, item := range h.Items {
+	for i := range h.Items {
+		item := &h.Items[i]
 		var targets []*astjson.Value
 		if item.BatchIndex >= 0 && item.BatchIndex < len(in.BatchStats) {
 			targets = in.BatchStats[item.BatchIndex]

--- a/v2/pkg/engine/cache/partial.go
+++ b/v2/pkg/engine/cache/partial.go
@@ -17,46 +17,11 @@ var errPartialBatchEntityCountMismatch = errors.New("partial batch _entities cou
 // Partial fetching (task 19): a batch entity fetch with SOME buckets covered
 // and some not serves the covered ones from cache and sends the subgraph a
 // REDUCED representations list; the response then realigns to the original
-// bucket positions via ItemCacheState.BatchIndex. Everything lives here — the
-// loader only swaps in the reduced input and leaves the data merge to the
-// partial arm of OnFetchResult (one hook, one lock acquisition).
-
-// filterBatchInput builds the reduced fetch input: the original rendered
-// input with the representations of COVERED buckets removed. keep[i] mirrors
-// the BatchStats bucket order (which is the representations order). Returns
-// ok=false when the input does not have the expected
-// body.variables.representations shape — the caller then falls back to a
-// plain full fetch (never an error, never a wrong request).
-func filterBatchInput(input []byte, keep []bool) ([]byte, bool) {
-	parsed, err := astjson.ParseBytes(input)
-	if err != nil {
-		return nil, false
-	}
-	representations := parsed.Get("body", "variables", "representations")
-	if representations == nil || representations.Type() != astjson.TypeArray {
-		return nil, false
-	}
-	all := representations.GetArray()
-	if len(all) != len(keep) {
-		return nil, false
-	}
-	reduced := astjson.ArrayValue(nil)
-	kept := 0
-	for i, representation := range all {
-		if !keep[i] {
-			continue
-		}
-		reduced.SetArrayItem(nil, kept, representation)
-		kept++
-	}
-	if kept == 0 || kept == len(all) {
-		// Nothing to filter (degenerate cases are handled by Fetch /
-		// SkipFullHit before this point; guard anyway).
-		return nil, false
-	}
-	parsed.Get("body", "variables").Set(nil, "representations", reduced)
-	return parsed.MarshalTo(nil), true
-}
+// bucket positions via ItemCacheState.BatchIndex. The controller marks the
+// missing buckets on handle.BatchFetchKeep and the LOADER assembles the
+// reduced input from the already-rendered representation segments (before any
+// bytes are parsed back); the data merge lives in the partial arm of
+// OnFetchResult (one hook, one lock acquisition).
 
 // onPartialBatchResult is the FetchPartial merge arm: within ONE transaction
 // it splices every covered bucket from cache (denormalized per merge target)

--- a/v2/pkg/engine/cache/partial_test.go
+++ b/v2/pkg/engine/cache/partial_test.go
@@ -13,36 +13,6 @@ import (
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 )
 
-// TestFilterBatchInput pins the reduced-input bytes and the fallback cases.
-func TestFilterBatchInput(t *testing.T) {
-	input := []byte(`{"method":"POST","url":"http://x","body":{"query":"...","variables":{"representations":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"},{"__typename":"Product","upc":"3"}]}}}`)
-
-	t.Run("filters covered representations, keeping order", func(t *testing.T) {
-		reduced, ok := filterBatchInput(input, []bool{true, false, true})
-		require.True(t, ok)
-		assert.Equal(t,
-			`{"method":"POST","url":"http://x","body":{"query":"...","variables":{"representations":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"3"}]}}}`,
-			string(reduced))
-	})
-
-	t.Run("unexpected shape falls back", func(t *testing.T) {
-		_, ok := filterBatchInput([]byte(`{"body":{"variables":{}}}`), []bool{true})
-		assert.False(t, ok)
-	})
-
-	t.Run("length mismatch falls back", func(t *testing.T) {
-		_, ok := filterBatchInput(input, []bool{true, false})
-		assert.False(t, ok)
-	})
-
-	t.Run("degenerate all-keep and none-keep fall back", func(t *testing.T) {
-		_, ok := filterBatchInput(input, []bool{true, true, true})
-		assert.False(t, ok)
-		_, ok = filterBatchInput(input, []bool{false, false, false})
-		assert.False(t, ok)
-	})
-}
-
 // partialConfig is the batch entity config with partial loading enabled.
 func partialConfig(t *testing.T) *resolve.FetchCacheConfig {
 	t.Helper()
@@ -93,10 +63,9 @@ func TestPartialBatchRows(t *testing.T) {
 		require.NotNil(t, handle.Items[1].FromCache)
 		assert.Equal(t, fresh("2"), string(handle.Items[1].FromCache.MarshalTo(nil)))
 		assert.Nil(t, handle.Items[2].FromCache)
-		// The reduced input carries EXACTLY the missing representations.
-		assert.Equal(t,
-			`{"body":{"query":"...","variables":{"representations":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"3"}]}}}`,
-			string(handle.PartialInput))
+		// The keep mask marks EXACTLY the missing buckets (the loader then
+		// assembles the reduced input from the pre-rendered segments).
+		assert.Equal(t, []bool{true, false, true}, handle.BatchFetchKeep)
 		// Lookups ran for ALL buckets (three Gets; key1 among them).
 		require.Len(t, store.ops, 3)
 		assert.Equal(t, "Get", store.ops[0].Kind)
@@ -171,12 +140,12 @@ func TestPartialBatchRows(t *testing.T) {
 		inHit, _ := batchPrepareInput(t, cfg, "1", "2")
 		decision, handle := rc.PrepareFetch(inHit)
 		assert.Equal(t, resolve.DecisionSkipFullHit, decision)
-		assert.Nil(t, handle.PartialInput)
+		assert.Nil(t, handle.BatchFetchKeep)
 
 		inMiss, _ := batchPrepareInput(t, cfg, "8", "9")
 		decision, handle = rc.PrepareFetch(inMiss)
 		assert.Equal(t, resolve.DecisionFetch, decision)
-		assert.Nil(t, handle.PartialInput)
+		assert.Nil(t, handle.BatchFetchKeep)
 	})
 
 	t.Run("single-element batch never goes partial", func(t *testing.T) {
@@ -186,7 +155,7 @@ func TestPartialBatchRows(t *testing.T) {
 		in, _ := batchPrepareInput(t, cfg, "1")
 		decision, handle := rc.PrepareFetch(in)
 		assert.Equal(t, resolve.DecisionFetch, decision)
-		assert.Nil(t, handle.PartialInput)
+		assert.Nil(t, handle.BatchFetchKeep)
 	})
 
 	t.Run("failure in the fetched subset: spliced subset intact, zero writes", func(t *testing.T) {
@@ -256,7 +225,7 @@ func TestPartialBatchRows(t *testing.T) {
 		in, _ := batchPrepareInput(t, cfg, "1", "2")
 		decision, handle := rc.PrepareFetch(in)
 		assert.Equal(t, resolve.DecisionFetch, decision)
-		assert.Nil(t, handle.PartialInput)
+		assert.Nil(t, handle.BatchFetchKeep)
 	})
 
 	t.Run("shadow wins over partial", func(t *testing.T) {
@@ -272,6 +241,6 @@ func TestPartialBatchRows(t *testing.T) {
 		in, _ := batchPrepareInput(t, cfg, "1", "2")
 		decision, handle := rc.PrepareFetch(in)
 		assert.Equal(t, resolve.DecisionFetchShadow, decision)
-		assert.Nil(t, handle.PartialInput)
+		assert.Nil(t, handle.BatchFetchKeep)
 	})
 }

--- a/v2/pkg/engine/cache/partial_test.go
+++ b/v2/pkg/engine/cache/partial_test.go
@@ -214,6 +214,40 @@ func TestPartialBatchRows(t *testing.T) {
 		}
 	})
 
+	t.Run("a short reduced response is a contract violation, not a silent skip", func(t *testing.T) {
+		store := newTestStore()
+		cfg := partialConfig(t)
+		writeThrough(t, NewController(store, nil).BeginRequest(nil), cfg, productItem(t, "2"), fresh("2"))
+
+		rc := NewController(store, nil).BeginRequest(nil)
+		in, buckets := batchPrepareInput(t, cfg, "1", "2", "3")
+		decision, handle := rc.PrepareFetch(in)
+		require.Equal(t, resolve.DecisionFetchPartial, decision)
+		// TWO representations were sent; only ONE entity came back.
+		err := rc.OnFetchResult(handle, resolve.MergeInput{
+			BatchStats:   buckets,
+			ResponseData: astjson.MustParseBytes([]byte(`[` + fresh("1") + `]`)),
+			Arena:        beginner(),
+		})
+		assert.ErrorIs(t, err, errPartialBatchEntityCountMismatch)
+	})
+
+	t.Run("an over-long reduced response is a contract violation too", func(t *testing.T) {
+		store := newTestStore()
+		cfg := partialConfig(t)
+		writeThrough(t, NewController(store, nil).BeginRequest(nil), cfg, productItem(t, "2"), fresh("2"))
+
+		rc := NewController(store, nil).BeginRequest(nil)
+		in, buckets := batchPrepareInput(t, cfg, "1", "2")
+		_, handle := rc.PrepareFetch(in)
+		err := rc.OnFetchResult(handle, resolve.MergeInput{
+			BatchStats:   buckets,
+			ResponseData: astjson.MustParseBytes([]byte(`[` + fresh("1") + `,` + fresh("9") + `]`)),
+			Arena:        beginner(),
+		})
+		assert.ErrorIs(t, err, errPartialBatchEntityCountMismatch)
+	})
+
 	t.Run("config gate: partial disabled keeps all-or-nothing", func(t *testing.T) {
 		store := newTestStore()
 		cfg := entityConfig(t, time.Minute) // EnablePartialCacheLoad false

--- a/v2/pkg/engine/cache/partial_test.go
+++ b/v2/pkg/engine/cache/partial_test.go
@@ -81,7 +81,7 @@ func TestPartialBatchRows(t *testing.T) {
 		store := newTestStore()
 		cfg := partialConfig(t)
 		key1 := writeThrough(t, NewController(store, nil).BeginRequest(nil), cfg, productItem(t, "2"), fresh("2"))
-		storeOpsBefore := len(store.ops)
+		store.ops = nil // the partial request's ops assert in isolation
 
 		rc := NewController(store, nil).BeginRequest(nil)
 		in, _ := batchPrepareInput(t, cfg, "1", "2", "3")
@@ -98,10 +98,9 @@ func TestPartialBatchRows(t *testing.T) {
 			`{"body":{"query":"...","variables":{"representations":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"3"}]}}}`,
 			string(handle.PartialInput))
 		// Lookups ran for ALL buckets (three Gets; key1 among them).
-		gets := store.ops[storeOpsBefore:]
-		require.Len(t, gets, 3)
-		assert.Equal(t, "Get", gets[0].Kind)
-		assert.Equal(t, key1, gets[1].Key)
+		require.Len(t, store.ops, 3)
+		assert.Equal(t, "Get", store.ops[0].Kind)
+		assert.Equal(t, key1, store.ops[1].Key)
 	})
 
 	t.Run("realign: fetched entities land at their ORIGINAL positions; writes only for fetched", func(t *testing.T) {

--- a/v2/pkg/engine/cache/partial_test.go
+++ b/v2/pkg/engine/cache/partial_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -55,18 +56,16 @@ func partialConfig(t *testing.T) *resolve.FetchCacheConfig {
 func batchPrepareInput(t *testing.T, cfg *resolve.FetchCacheConfig, upcs ...string) (resolve.PrepareFetchInput, [][]*astjson.Value) {
 	t.Helper()
 	buckets := make([][]*astjson.Value, 0, len(upcs))
-	representations := ""
-	for i, upc := range upcs {
-		if i > 0 {
-			representations += ","
-		}
-		representations += `{"__typename":"Product","upc":"` + upc + `"}`
-		buckets = append(buckets, []*astjson.Value{astjson.MustParseBytes([]byte(`{"__typename":"Product","upc":"` + upc + `"}`))})
+	representations := make([]string, 0, len(upcs))
+	for _, upc := range upcs {
+		representation := `{"__typename":"Product","upc":"` + upc + `"}`
+		representations = append(representations, representation)
+		buckets = append(buckets, []*astjson.Value{astjson.MustParseBytes([]byte(representation))})
 	}
 	in := resolve.PrepareFetchInput{
 		Config:     cfg,
 		BatchStats: buckets,
-		Input:      []byte(`{"body":{"query":"...","variables":{"representations":[` + representations + `]}}}`),
+		Input:      []byte(`{"body":{"query":"...","variables":{"representations":[` + strings.Join(representations, ",") + `]}}}`),
 		Arena:      beginner(),
 	}
 	return in, buckets

--- a/v2/pkg/engine/cache/partial_test.go
+++ b/v2/pkg/engine/cache/partial_test.go
@@ -1,0 +1,245 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/astjson"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// TestFilterBatchInput pins the reduced-input bytes and the fallback cases.
+func TestFilterBatchInput(t *testing.T) {
+	input := []byte(`{"method":"POST","url":"http://x","body":{"query":"...","variables":{"representations":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"},{"__typename":"Product","upc":"3"}]}}}`)
+
+	t.Run("filters covered representations, keeping order", func(t *testing.T) {
+		reduced, ok := filterBatchInput(input, []bool{true, false, true})
+		require.True(t, ok)
+		assert.Equal(t,
+			`{"method":"POST","url":"http://x","body":{"query":"...","variables":{"representations":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"3"}]}}}`,
+			string(reduced))
+	})
+
+	t.Run("unexpected shape falls back", func(t *testing.T) {
+		_, ok := filterBatchInput([]byte(`{"body":{"variables":{}}}`), []bool{true})
+		assert.False(t, ok)
+	})
+
+	t.Run("length mismatch falls back", func(t *testing.T) {
+		_, ok := filterBatchInput(input, []bool{true, false})
+		assert.False(t, ok)
+	})
+
+	t.Run("degenerate all-keep and none-keep fall back", func(t *testing.T) {
+		_, ok := filterBatchInput(input, []bool{true, true, true})
+		assert.False(t, ok)
+		_, ok = filterBatchInput(input, []bool{false, false, false})
+		assert.False(t, ok)
+	})
+}
+
+// partialConfig is the batch entity config with partial loading enabled.
+func partialConfig(t *testing.T) *resolve.FetchCacheConfig {
+	t.Helper()
+	cfg := entityConfig(t, time.Minute)
+	cfg.EnablePartialCacheLoad = true
+	return cfg
+}
+
+// batchPrepareInput builds a PrepareFetchInput with BatchStats buckets (one
+// target per bucket) and the rendered representations input matching them.
+func batchPrepareInput(t *testing.T, cfg *resolve.FetchCacheConfig, upcs ...string) (resolve.PrepareFetchInput, [][]*astjson.Value) {
+	t.Helper()
+	buckets := make([][]*astjson.Value, 0, len(upcs))
+	representations := ""
+	for i, upc := range upcs {
+		if i > 0 {
+			representations += ","
+		}
+		representations += `{"__typename":"Product","upc":"` + upc + `"}`
+		buckets = append(buckets, []*astjson.Value{astjson.MustParseBytes([]byte(`{"__typename":"Product","upc":"` + upc + `"}`))})
+	}
+	in := resolve.PrepareFetchInput{
+		Config:     cfg,
+		BatchStats: buckets,
+		Input:      []byte(`{"body":{"query":"...","variables":{"representations":[` + representations + `]}}}`),
+		Arena:      beginner(),
+	}
+	return in, buckets
+}
+
+// TestPartialBatchRows covers the split, realign, adversarial, and failure rows.
+func TestPartialBatchRows(t *testing.T) {
+	fresh := func(upc string) string {
+		return `{"__typename":"Product","name":"P` + upc + `","price":100}`
+	}
+
+	t.Run("partial split: exact partition, reduced input, lookups for all", func(t *testing.T) {
+		store := newTestStore()
+		cfg := partialConfig(t)
+		key1 := writeThrough(t, NewController(store, nil).BeginRequest(nil), cfg, productItem(t, "2"), fresh("2"))
+		storeOpsBefore := len(store.ops)
+
+		rc := NewController(store, nil).BeginRequest(nil)
+		in, _ := batchPrepareInput(t, cfg, "1", "2", "3")
+		decision, handle := rc.PrepareFetch(in)
+		assert.Equal(t, resolve.DecisionFetchPartial, decision)
+		require.NotNil(t, handle)
+		// Exact partition: bucket 1 covered, buckets 0 and 2 missing.
+		assert.Nil(t, handle.Items[0].FromCache)
+		require.NotNil(t, handle.Items[1].FromCache)
+		assert.Equal(t, fresh("2"), string(handle.Items[1].FromCache.MarshalTo(nil)))
+		assert.Nil(t, handle.Items[2].FromCache)
+		// The reduced input carries EXACTLY the missing representations.
+		assert.Equal(t,
+			`{"body":{"query":"...","variables":{"representations":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"3"}]}}}`,
+			string(handle.PartialInput))
+		// Lookups ran for ALL buckets (three Gets; key1 among them).
+		gets := store.ops[storeOpsBefore:]
+		require.Len(t, gets, 3)
+		assert.Equal(t, "Get", gets[0].Kind)
+		assert.Equal(t, key1, gets[1].Key)
+	})
+
+	t.Run("realign: fetched entities land at their ORIGINAL positions; writes only for fetched", func(t *testing.T) {
+		store := newTestStore()
+		cfg := partialConfig(t)
+		writeThrough(t, NewController(store, nil).BeginRequest(nil), cfg, productItem(t, "2"), fresh("2"))
+		store.ops = nil
+
+		rc := NewController(store, nil).BeginRequest(nil)
+		in, buckets := batchPrepareInput(t, cfg, "1", "2", "3")
+		decision, handle := rc.PrepareFetch(in)
+		require.Equal(t, resolve.DecisionFetchPartial, decision)
+
+		// The REDUCED response: entities for upc 1 and 3 only, in order.
+		require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+			BatchStats:   buckets,
+			ResponseData: astjson.MustParseBytes([]byte(`[` + fresh("1") + `,` + fresh("3") + `]`)),
+			Arena:        beginner(),
+		}))
+		// Full merged targets: cached bucket 1 spliced, fetched 0 and 2 merged
+		// at their original positions.
+		assert.Equal(t, `{"__typename":"Product","upc":"1","name":"P1","price":100}`, string(buckets[0][0].MarshalTo(nil)))
+		assert.Equal(t, `{"__typename":"Product","upc":"2","name":"P2","price":100}`, string(buckets[1][0].MarshalTo(nil)))
+		assert.Equal(t, `{"__typename":"Product","upc":"3","name":"P3","price":100}`, string(buckets[2][0].MarshalTo(nil)))
+
+		rc.EndRequest()
+		// Writes ONLY for the fetched buckets (0 and 2), none for the covered one.
+		var sets []testStoreOp
+		for _, op := range store.ops {
+			if op.Kind == "Set" {
+				sets = append(sets, op)
+			}
+		}
+		require.Len(t, sets, 2)
+		assert.Equal(t, fresh("1"), sets[0].Value)
+		assert.Equal(t, fresh("3"), sets[1].Value)
+	})
+
+	t.Run("duplicated representations: one bucket, many targets, all served", func(t *testing.T) {
+		store := newTestStore()
+		cfg := partialConfig(t)
+		writeThrough(t, NewController(store, nil).BeginRequest(nil), cfg, productItem(t, "2"), fresh("2"))
+
+		rc := NewController(store, nil).BeginRequest(nil)
+		in, buckets := batchPrepareInput(t, cfg, "1", "2")
+		// The "1" bucket has TWO merge targets (a duplicated representation).
+		buckets[0] = append(buckets[0], astjson.MustParseBytes([]byte(`{"__typename":"Product","upc":"1"}`)))
+		in.BatchStats = buckets
+		decision, handle := rc.PrepareFetch(in)
+		require.Equal(t, resolve.DecisionFetchPartial, decision)
+		require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+			BatchStats:   buckets,
+			ResponseData: astjson.MustParseBytes([]byte(`[` + fresh("1") + `]`)),
+			Arena:        beginner(),
+		}))
+		assert.Equal(t, `{"__typename":"Product","upc":"1","name":"P1","price":100}`, string(buckets[0][0].MarshalTo(nil)))
+		assert.Equal(t, `{"__typename":"Product","upc":"1","name":"P1","price":100}`, string(buckets[0][1].MarshalTo(nil)))
+		assert.Equal(t, `{"__typename":"Product","upc":"2","name":"P2","price":100}`, string(buckets[1][0].MarshalTo(nil)))
+	})
+
+	t.Run("all-hit degenerates to SkipFullHit; all-miss to Fetch", func(t *testing.T) {
+		store := newTestStore()
+		cfg := partialConfig(t)
+		writeThrough(t, NewController(store, nil).BeginRequest(nil), cfg, productItem(t, "1"), fresh("1"))
+		writeThrough(t, NewController(store, nil).BeginRequest(nil), cfg, productItem(t, "2"), fresh("2"))
+
+		rc := NewController(store, nil).BeginRequest(nil)
+		inHit, _ := batchPrepareInput(t, cfg, "1", "2")
+		decision, handle := rc.PrepareFetch(inHit)
+		assert.Equal(t, resolve.DecisionSkipFullHit, decision)
+		assert.Nil(t, handle.PartialInput)
+
+		inMiss, _ := batchPrepareInput(t, cfg, "8", "9")
+		decision, handle = rc.PrepareFetch(inMiss)
+		assert.Equal(t, resolve.DecisionFetch, decision)
+		assert.Nil(t, handle.PartialInput)
+	})
+
+	t.Run("single-element batch never goes partial", func(t *testing.T) {
+		store := newTestStore()
+		cfg := partialConfig(t)
+		rc := NewController(store, nil).BeginRequest(nil)
+		in, _ := batchPrepareInput(t, cfg, "1")
+		decision, handle := rc.PrepareFetch(in)
+		assert.Equal(t, resolve.DecisionFetch, decision)
+		assert.Nil(t, handle.PartialInput)
+	})
+
+	t.Run("failure in the fetched subset: spliced subset intact, zero writes", func(t *testing.T) {
+		store := newTestStore()
+		cfg := partialConfig(t)
+		writeThrough(t, NewController(store, nil).BeginRequest(nil), cfg, productItem(t, "2"), fresh("2"))
+		store.ops = nil
+
+		rc := NewController(store, nil).BeginRequest(nil)
+		in, buckets := batchPrepareInput(t, cfg, "1", "2")
+		decision, handle := rc.PrepareFetch(in)
+		require.Equal(t, resolve.DecisionFetchPartial, decision)
+		require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+			BatchStats:  buckets,
+			FetchFailed: true,
+			Arena:       beginner(),
+		}))
+		rc.EndRequest()
+		// The covered bucket is spliced; the failed bucket's target untouched.
+		assert.Equal(t, `{"__typename":"Product","upc":"1"}`, string(buckets[0][0].MarshalTo(nil)))
+		assert.Equal(t, `{"__typename":"Product","upc":"2","name":"P2","price":100}`, string(buckets[1][0].MarshalTo(nil)))
+		for _, op := range store.ops {
+			assert.NotEqual(t, "Set", op.Kind)
+		}
+	})
+
+	t.Run("config gate: partial disabled keeps all-or-nothing", func(t *testing.T) {
+		store := newTestStore()
+		cfg := entityConfig(t, time.Minute) // EnablePartialCacheLoad false
+		writeThrough(t, NewController(store, nil).BeginRequest(nil), cfg, productItem(t, "2"), fresh("2"))
+
+		rc := NewController(store, nil).BeginRequest(nil)
+		in, _ := batchPrepareInput(t, cfg, "1", "2")
+		decision, handle := rc.PrepareFetch(in)
+		assert.Equal(t, resolve.DecisionFetch, decision)
+		assert.Nil(t, handle.PartialInput)
+	})
+
+	t.Run("shadow wins over partial", func(t *testing.T) {
+		store := newTestStore()
+		cfg := partialConfig(t)
+		cfg.ShadowMode = true
+		writeThrough(t, NewController(store, nil).BeginRequest(nil), func() *resolve.FetchCacheConfig {
+			plain := partialConfig(t)
+			return plain
+		}(), productItem(t, "2"), fresh("2"))
+
+		rc := NewController(store, nil).BeginRequest(nil)
+		in, _ := batchPrepareInput(t, cfg, "1", "2")
+		decision, handle := rc.PrepareFetch(in)
+		assert.Equal(t, resolve.DecisionFetchShadow, decision)
+		assert.Nil(t, handle.PartialInput)
+	})
+}

--- a/v2/pkg/engine/cache/transform.go
+++ b/v2/pkg/engine/cache/transform.go
@@ -1,0 +1,186 @@
+package cache
+
+import (
+	"cmp"
+	"slices"
+
+	"github.com/wundergraph/astjson"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/pool"
+)
+
+// The transform module: values are cached in NORMALIZED form — schema field
+// names (aliases resolved via Field.OriginalName) with a deterministic
+// argument suffix folded into the object key (from Field.CacheArgs and the
+// request's variable values) — and DENORMALIZED back to the requesting
+// operation's aliases at serve time. Normalization is what makes a value
+// cached by one operation reusable by another with different aliases, and the
+// argument suffix is what keeps `friends(first:5)` from ever serving
+// `friends(first:20)`. Partial fetching (task 19) reuses these walks per field.
+
+// normalizedFieldName is the SINGLE derivation of a field's cache-side key:
+// the schema name (OriginalName when aliased) plus the argument suffix. The
+// write path, the coverage walk, and the read path all go through it, so the
+// key spaces cannot diverge.
+func normalizedFieldName(ctx *resolve.Context, field *resolve.Field) string {
+	name := string(field.Name)
+	if len(field.OriginalName) > 0 {
+		name = string(field.OriginalName)
+	}
+	if len(field.CacheArgs) == 0 {
+		return name
+	}
+	return name + computeArgSuffix(ctx, field.CacheArgs)
+}
+
+// computeArgSuffix hashes the field's variable-bound argument values into a
+// deterministic "_<16-hex xxhash64>" suffix: args sorted by name, each value
+// taken from the request variables (through the remap that normalization may
+// have applied), absent values hashed as null.
+func computeArgSuffix(ctx *resolve.Context, args []resolve.CacheFieldArg) string {
+	sorted := args
+	if !slices.IsSortedFunc(sorted, func(a, b resolve.CacheFieldArg) int {
+		return cmp.Compare(a.Name, b.Name)
+	}) {
+		sorted = slices.Clone(args)
+		slices.SortFunc(sorted, func(a, b resolve.CacheFieldArg) int {
+			return cmp.Compare(a.Name, b.Name)
+		})
+	}
+	h := pool.Hash64.Get()
+	for i, arg := range sorted {
+		if i > 0 {
+			_, _ = h.WriteString(",")
+		}
+		_, _ = h.WriteString(arg.Name)
+		_, _ = h.WriteString(":")
+		var value *astjson.Value
+		if ctx != nil && ctx.Variables != nil {
+			variableName := arg.VariableName
+			if mapped, ok := ctx.RemapVariables[variableName]; ok {
+				variableName = mapped
+			}
+			value = ctx.Variables.Get(variableName)
+		}
+		if value == nil {
+			_, _ = h.WriteString("null")
+		} else {
+			_, _ = h.Write(value.MarshalTo(nil))
+		}
+	}
+	sum := h.Sum64()
+	pool.Hash64.Put(h)
+	return "_" + hex64(sum)
+}
+
+// normalizeToSchema rewrites a fetched (alias-shaped) value into the stored
+// form: object keys become normalized field names, recursively; fields the
+// tree does not select (e.g. __typename, key fields) are preserved as-is. The
+// caller gates on HasAliases — a tree without aliases or args stores the raw
+// value unchanged.
+func normalizeToSchema(tx *resolve.CacheTransaction, ctx *resolve.Context, value *astjson.Value, node resolve.Node) *astjson.Value {
+	if value == nil || node == nil {
+		return value
+	}
+	switch typed := node.(type) {
+	case *resolve.Object:
+		if value.Type() != astjson.TypeObject {
+			return value
+		}
+		out := tx.NewObject()
+		seen := make(map[string]struct{}, len(typed.Fields))
+		for _, field := range typed.Fields {
+			responseKey := string(field.Name)
+			fieldValue := value.Get(responseKey)
+			if fieldValue == nil {
+				continue
+			}
+			out.Set(nil, normalizedFieldName(ctx, field), normalizeToSchema(tx, ctx, fieldValue, field.Value))
+			seen[responseKey] = struct{}{}
+		}
+		obj, err := value.Object()
+		if err != nil {
+			return value
+		}
+		obj.Visit(func(key []byte, fieldValue *astjson.Value) {
+			responseKey := string(key)
+			if _, ok := seen[responseKey]; ok {
+				return
+			}
+			out.Set(nil, responseKey, fieldValue)
+		})
+		return out
+	case *resolve.Array:
+		if value.Type() != astjson.TypeArray {
+			return value
+		}
+		items, err := value.Array()
+		if err != nil {
+			return value
+		}
+		out := tx.NewArray()
+		for i, item := range items {
+			out.SetArrayItem(nil, i, normalizeToSchema(tx, ctx, item, typed.Item))
+		}
+		return out
+	default:
+		return value
+	}
+}
+
+// denormalizeToSelection rewrites a cached (normalized) value into the
+// REQUESTING operation's shape: fields come out under their aliases, in
+// selection order, with cached-only extras appended after (so a write-back or
+// resolver never loses data the selection did not name). It always builds a
+// fresh transaction-owned value, which also serves as the aliasing-safe copy
+// for the splice.
+func denormalizeToSelection(tx *resolve.CacheTransaction, ctx *resolve.Context, value *astjson.Value, node resolve.Node) *astjson.Value {
+	if value == nil || node == nil {
+		return value
+	}
+	switch typed := node.(type) {
+	case *resolve.Object:
+		if value.Type() != astjson.TypeObject {
+			return value
+		}
+		out := tx.NewObject()
+		seen := make(map[string]struct{}, len(typed.Fields))
+		for _, field := range typed.Fields {
+			storedKey := normalizedFieldName(ctx, field)
+			fieldValue := value.Get(storedKey)
+			if fieldValue == nil {
+				continue
+			}
+			out.Set(nil, string(field.Name), denormalizeToSelection(tx, ctx, fieldValue, field.Value))
+			seen[storedKey] = struct{}{}
+		}
+		obj, err := value.Object()
+		if err != nil {
+			return value
+		}
+		obj.Visit(func(key []byte, fieldValue *astjson.Value) {
+			storedKey := string(key)
+			if _, ok := seen[storedKey]; ok {
+				return
+			}
+			out.Set(nil, storedKey, fieldValue)
+		})
+		return out
+	case *resolve.Array:
+		if value.Type() != astjson.TypeArray {
+			return value
+		}
+		items, err := value.Array()
+		if err != nil {
+			return value
+		}
+		out := tx.NewArray()
+		for i, item := range items {
+			out.SetArrayItem(nil, i, denormalizeToSelection(tx, ctx, item, typed.Item))
+		}
+		return out
+	default:
+		return value
+	}
+}

--- a/v2/pkg/engine/cache/transform_test.go
+++ b/v2/pkg/engine/cache/transform_test.go
@@ -1,0 +1,232 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/astjson"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// variableContext builds a resolve.Context carrying the given variables JSON.
+func variableContext(t *testing.T, variables string) *resolve.Context {
+	t.Helper()
+	ctx := resolve.NewContext(t.Context())
+	if variables != "" {
+		ctx.Variables = astjson.MustParseBytes([]byte(variables))
+	}
+	return ctx
+}
+
+func testTx() *resolve.CacheTransaction {
+	return resolve.NewTransactionBeginner(nil, &resolve.DataBuffer{}).Begin()
+}
+
+// aliasedTree is a ProvidesData tree with an aliased scalar, an arg-suffixed
+// list field, and a nested object with an aliased leaf.
+func aliasedTree() *resolve.Object {
+	tree := &resolve.Object{
+		Fields: []*resolve.Field{
+			{
+				Name:         []byte("productName"),
+				OriginalName: []byte("name"),
+				Value:        &resolve.Scalar{Nullable: false, Path: []string{"productName"}},
+			},
+			{
+				Name:      []byte("friends"),
+				CacheArgs: []resolve.CacheFieldArg{{Name: "first", VariableName: "first"}},
+				Value: &resolve.Array{
+					Nullable: true,
+					Path:     []string{"friends"},
+					Item: &resolve.Object{
+						Nullable: true,
+						Fields: []*resolve.Field{
+							{
+								Name:         []byte("handle"),
+								OriginalName: []byte("username"),
+								Value:        &resolve.Scalar{Nullable: true, Path: []string{"handle"}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	resolve.ComputeHasAliases(tree)
+	return tree
+}
+
+func TestNormalizedFieldName(t *testing.T) {
+	ctx := variableContext(t, `{"first":5}`)
+
+	t.Run("plain field", func(t *testing.T) {
+		assert.Equal(t, "name", normalizedFieldName(ctx, &resolve.Field{Name: []byte("name")}))
+	})
+
+	t.Run("aliased field uses the schema name", func(t *testing.T) {
+		assert.Equal(t, "name", normalizedFieldName(ctx, &resolve.Field{Name: []byte("productName"), OriginalName: []byte("name")}))
+	})
+
+	t.Run("argument suffix is deterministic and order-independent", func(t *testing.T) {
+		ctxAB := variableContext(t, `{"a":1,"b":2}`)
+		args := []resolve.CacheFieldArg{{Name: "x", VariableName: "a"}, {Name: "y", VariableName: "b"}}
+		reversed := []resolve.CacheFieldArg{{Name: "y", VariableName: "b"}, {Name: "x", VariableName: "a"}}
+		nameA := normalizedFieldName(ctxAB, &resolve.Field{Name: []byte("f"), CacheArgs: args})
+		nameB := normalizedFieldName(ctxAB, &resolve.Field{Name: []byte("f"), CacheArgs: reversed})
+		assert.Equal(t, nameA, nameB)
+		assert.Equal(t, "f"+computeArgSuffix(ctxAB, args), nameA)
+	})
+
+	t.Run("different argument values produce different suffixes", func(t *testing.T) {
+		field := &resolve.Field{Name: []byte("friends"), CacheArgs: []resolve.CacheFieldArg{{Name: "first", VariableName: "first"}}}
+		name5 := normalizedFieldName(variableContext(t, `{"first":5}`), field)
+		name20 := normalizedFieldName(variableContext(t, `{"first":20}`), field)
+		assert.NotEqual(t, name5, name20)
+	})
+
+	t.Run("remapped variables resolve through the remap", func(t *testing.T) {
+		ctx := variableContext(t, `{"a":5}`)
+		ctx.RemapVariables = map[string]string{"first": "a"}
+		field := &resolve.Field{Name: []byte("friends"), CacheArgs: []resolve.CacheFieldArg{{Name: "first", VariableName: "first"}}}
+		direct := normalizedFieldName(variableContext(t, `{"first":5}`), field)
+		assert.Equal(t, direct, normalizedFieldName(ctx, field))
+	})
+
+	t.Run("absent variables hash as null", func(t *testing.T) {
+		field := &resolve.Field{Name: []byte("friends"), CacheArgs: []resolve.CacheFieldArg{{Name: "first", VariableName: "first"}}}
+		noVars := normalizedFieldName(variableContext(t, ""), field)
+		nilCtx := normalizedFieldName(nil, field)
+		assert.Equal(t, noVars, nilCtx)
+	})
+}
+
+// TestNormalizeDenormalizeRoundTrip proves the transform pair: an alias-shaped
+// response normalizes to schema names + arg suffixes (full stored form
+// asserted) and denormalizes back under a DIFFERENT alias set.
+func TestNormalizeDenormalizeRoundTrip(t *testing.T) {
+	ctx := variableContext(t, `{"first":5}`)
+	tx := testTx()
+	defer tx.Commit()
+
+	suffix := computeArgSuffix(ctx, []resolve.CacheFieldArg{{Name: "first", VariableName: "first"}})
+	response := astjson.MustParseBytes([]byte(`{"__typename":"User","productName":"Table","friends":[{"handle":"alice"},{"handle":"bob"}]}`))
+
+	stored := normalizeToSchema(tx, ctx, response, aliasedTree())
+	assert.Equal(t,
+		`{"name":"Table","friends`+suffix+`":[{"username":"alice"},{"username":"bob"}],"__typename":"User"}`,
+		string(stored.MarshalTo(nil)))
+
+	// A DIFFERENT operation selects the same data under other aliases.
+	otherTree := &resolve.Object{
+		Fields: []*resolve.Field{
+			{
+				Name:         []byte("title"),
+				OriginalName: []byte("name"),
+				Value:        &resolve.Scalar{Nullable: false, Path: []string{"title"}},
+			},
+			{
+				Name:         []byte("buddies"),
+				OriginalName: []byte("friends"),
+				CacheArgs:    []resolve.CacheFieldArg{{Name: "first", VariableName: "first"}},
+				Value: &resolve.Array{
+					Nullable: true,
+					Path:     []string{"buddies"},
+					Item: &resolve.Object{
+						Nullable: true,
+						Fields: []*resolve.Field{
+							{
+								Name:         []byte("nick"),
+								OriginalName: []byte("username"),
+								Value:        &resolve.Scalar{Nullable: true, Path: []string{"nick"}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	resolve.ComputeHasAliases(otherTree)
+	require.True(t, covers(ctx, stored, otherTree))
+
+	served := denormalizeToSelection(tx, ctx, stored, otherTree)
+	assert.Equal(t,
+		`{"title":"Table","buddies":[{"nick":"alice"},{"nick":"bob"}],"__typename":"User"}`,
+		string(served.MarshalTo(nil)))
+}
+
+// TestArgumentMismatchIsMiss is the D6 coverage rule: a value cached under one
+// argument suffix does not satisfy the same field with different arguments.
+func TestArgumentMismatchIsMiss(t *testing.T) {
+	writeCtx := variableContext(t, `{"first":5}`)
+	readCtx := variableContext(t, `{"first":20}`)
+	tx := testTx()
+	defer tx.Commit()
+
+	tree := aliasedTree()
+	response := astjson.MustParseBytes([]byte(`{"__typename":"User","productName":"Table","friends":[{"handle":"alice"}]}`))
+	stored := normalizeToSchema(tx, writeCtx, response, tree)
+
+	assert.True(t, covers(writeCtx, stored, tree))
+	assert.False(t, covers(readCtx, stored, tree))
+}
+
+// TestControllerAliasRoundTrip drives the transforms through the controller:
+// an alias-shaped response is STORED normalized, and a second request with a
+// different alias set is served, spliced under ITS aliases.
+func TestControllerAliasRoundTrip(t *testing.T) {
+	store := newTestStore()
+
+	writeCfg := entityConfig(t, time.Minute)
+	writeCfg.ProvidesData = &resolve.Object{
+		Fields: []*resolve.Field{
+			{
+				Name:         []byte("productName"),
+				OriginalName: []byte("name"),
+				Value:        &resolve.Scalar{Nullable: false, Path: []string{"productName"}},
+			},
+		},
+	}
+	resolve.ComputeHasAliases(writeCfg.ProvidesData)
+
+	rc := NewController(store, nil).BeginRequest(variableContext(t, ""))
+	item := productItem(t, "1")
+	_, handle := prepare(t, rc, writeCfg, item)
+	require.NoError(t, rc.OnFetchResult(handle, resolve.MergeInput{
+		Items:        []*astjson.Value{item},
+		ResponseData: astjson.MustParseBytes([]byte(`{"__typename":"Product","productName":"Table"}`)),
+		Arena:        beginner(),
+	}))
+	rc.EndRequest()
+	key := handle.Items[0].RenderedKeys[0]
+	// The STORED form carries the schema name.
+	value, _, ok := store.Get(key)
+	require.True(t, ok)
+	assert.Equal(t, `{"name":"Table","__typename":"Product"}`, string(value))
+
+	// A second operation selects the same field under ANOTHER alias.
+	readCfg := entityConfig(t, time.Minute)
+	readCfg.ProvidesData = &resolve.Object{
+		Fields: []*resolve.Field{
+			{
+				Name:         []byte("label"),
+				OriginalName: []byte("name"),
+				Value:        &resolve.Scalar{Nullable: false, Path: []string{"label"}},
+			},
+		},
+	}
+	resolve.ComputeHasAliases(readCfg.ProvidesData)
+
+	rc2 := NewController(store, nil).BeginRequest(variableContext(t, ""))
+	item2 := productItem(t, "1")
+	decision, handle2 := prepare(t, rc2, readCfg, item2)
+	require.Equal(t, resolve.DecisionSkipFullHit, decision)
+	require.NoError(t, rc2.OnFetchSkipped(handle2, resolve.MergeInput{
+		Items: []*astjson.Value{item2},
+		Arena: beginner(),
+	}))
+	assert.Equal(t, `{"__typename":"Product","upc":"1","label":"Table"}`, string(item2.MarshalTo(nil)))
+}

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
@@ -29,6 +29,7 @@ import (
 	grpcdatasource "github.com/wundergraph/graphql-go-tools/v2/pkg/engine/datasource/grpc_datasource"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/datasource/httpclient"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/representationvariable"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/internal/quotes"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/internal/unsafebytes"
@@ -852,7 +853,7 @@ func (p *Planner[T]) addRepresentationsVariable() {
 func (p *Planner[T]) buildRepresentationsVariable() resolve.Variable {
 	objects := make([]*resolve.Object, 0, len(p.dataSourcePlannerConfig.RequiredFields))
 	for _, cfg := range p.dataSourcePlannerConfig.RequiredFields {
-		node, err := buildRepresentationVariableNode(p.visitor.Definition, cfg, p.dataSourceConfig.FederationConfiguration())
+		node, err := representationvariable.BuildRepresentationVariableNode(p.visitor.Definition, cfg, p.dataSourceConfig.FederationConfiguration())
 		if err != nil {
 			p.stopWithError(errors.WithStack(fmt.Errorf("buildRepresentationsVariable: failed to build representation variable node: %w", err)))
 			return nil
@@ -862,7 +863,7 @@ func (p *Planner[T]) buildRepresentationsVariable() resolve.Variable {
 	}
 
 	return resolve.NewResolvableObjectVariable(
-		mergeRepresentationVariableNodes(objects),
+		representationvariable.MergeRepresentationVariableNodes(objects),
 	)
 }
 

--- a/v2/pkg/engine/plan/cache_provides_data_visitor.go
+++ b/v2/pkg/engine/plan/cache_provides_data_visitor.go
@@ -1,28 +1,475 @@
 package plan
 
 import (
+	"bytes"
+	"cmp"
+	"fmt"
+	"maps"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/astvisitor"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/lexer/literal"
 )
 
 // cacheProvidesDataVisitor is the P1 caching walk (PLAN.md D9): a gated
 // SECOND, filter-free walk over the operation, run on the planningWalker AFTER
-// the main planning walk, building the per-fetch ProvidesData tree
-// (alias → OriginalName, CacheArgs, entity boundaries). It never re-runs the
-// planning visitor and never rebuilds the plan; it only produces the
-// side-table attachTo hands to the plan's response.
-//
-// This is the registration SKELETON — the visitor body lands with task 05.
+// the main planning walk. Per planner (i.e. per fetch) it builds the exact
+// field tree that fetch RETURNS — alias-aware (Field.OriginalName),
+// argument-aware (Field.CacheArgs), with inline-fragment OnTypeNames and the
+// entity-boundary reset (a nested entity fetch provides the ENTITY's fields,
+// not the path down to it). It reads planningVisitor.fieldPlanners, which the
+// main walk populates in LeaveField, so it must never run before the main
+// walk; it never re-runs the planning visitor and never rebuilds the plan.
 type cacheProvidesDataVisitor struct {
-	walker *astvisitor.Walker
+	*astvisitor.Walker
+
+	operation, definition *ast.Document
+	config                Configuration
+	// planners / fieldPlanners are the main walk's outputs: the per-planner
+	// configurations and the field→planner-IDs attribution.
+	planners      []PlannerConfiguration
+	fieldPlanners map[int][]int
+	// objects is the per-planner tree under construction; currentFields the
+	// per-planner frame stack; entityBoundaryPaths remembers where a nested
+	// entity fetch's tree was reset so its direct children get OnTypeNames.
+	objects             map[int]*resolve.Object
+	currentFields       map[int][]objectFields
+	entityBoundaryPaths map[int]string
 }
 
+// cacheProvidesDataFragmentMarkerRegex strips normalization fragment markers
+// (e.g. ".$0User") from walker paths so they compare against fetch response
+// paths.
+var cacheProvidesDataFragmentMarkerRegex = regexp.MustCompile(`\.\$\d+\w+`)
+
 // reset clears all per-plan state so a Planner can be reused across Plan calls.
-func (v *cacheProvidesDataVisitor) reset() {}
+func (v *cacheProvidesDataVisitor) reset() {
+	v.objects = map[int]*resolve.Object{}
+	v.currentFields = map[int][]objectFields{}
+	v.entityBoundaryPaths = map[int]string{}
+}
 
-func (v *cacheProvidesDataVisitor) EnterField(ref int) {}
+func (v *cacheProvidesDataVisitor) EnterField(ref int) {
+	for _, plannerID := range v.fieldPlanners[ref] {
+		v.trackField(plannerID, ref)
+	}
+}
 
-func (v *cacheProvidesDataVisitor) LeaveField(ref int) {}
+func (v *cacheProvidesDataVisitor) LeaveField(ref int) {
+	for _, plannerID := range v.fieldPlanners[ref] {
+		v.popFields(plannerID, ref)
+	}
+}
 
-// attachTo hands the collected ProvidesData side-table to the plan's response
-// via resolve.GraphQLResponse.SetCacheProvidesData (task 05).
-func (v *cacheProvidesDataVisitor) attachTo(pl Plan) {}
+// attachTo resolves each planner to its fetch's *FetchInfo (the
+// identity-stable key across dedup, fetchID-append, and concrete-type
+// conversion, which all copy Info by reference) and stashes the side-table on
+// the plan's response. Planner IDs are walked in sorted order for determinism.
+func (v *cacheProvidesDataVisitor) attachTo(p Plan) {
+	resp := responseOf(p)
+	if resp == nil {
+		return
+	}
+	out := make(map[*resolve.FetchInfo]*resolve.Object, len(v.objects))
+	for _, plannerID := range slices.Sorted(maps.Keys(v.objects)) {
+		if plannerID < 0 || plannerID >= len(v.planners) {
+			continue
+		}
+		fetchConfig := v.planners[plannerID].ObjectFetchConfiguration()
+		if fetchConfig == nil || fetchConfig.fetchItem == nil || fetchConfig.fetchItem.Fetch == nil {
+			continue
+		}
+		info := fetchConfig.fetchItem.Fetch.FetchInfo()
+		if info == nil {
+			continue
+		}
+		out[info] = v.objects[plannerID]
+	}
+	resp.SetCacheProvidesData(out)
+}
+
+// trackField appends the field to the planner's current frame; on the
+// planner's entity boundary it RESETS the tree instead, so a nested entity
+// fetch's ProvidesData starts at the entity, not at the query root.
+func (v *cacheProvidesDataVisitor) trackField(plannerID, fieldRef int) {
+	if !v.ensurePlanner(plannerID) {
+		return
+	}
+
+	fieldName := v.operation.FieldNameBytes(fieldRef)
+	fetchResponseKey := v.operation.FieldAliasOrNameString(fieldRef)
+
+	if v.isEntityBoundaryField(plannerID, fieldRef) {
+		entityObj := &resolve.Object{
+			Fields: []*resolve.Field{},
+		}
+		v.Walker.RunAfterEnterField(func() {
+			v.currentFields[plannerID] = append(v.currentFields[plannerID], objectFields{
+				popOnField: fieldRef,
+				fields:     &entityObj.Fields,
+			})
+		})
+		v.objects[plannerID] = entityObj
+		return
+	}
+
+	// __typename dedup: normalization can leave the same __typename selection
+	// twice in one frame; a second entry would double-count coverage.
+	if bytes.Equal(fieldName, literal.TYPENAME) && len(v.currentFields[plannerID]) > 0 {
+		currentFields := v.currentFields[plannerID][len(v.currentFields[plannerID])-1]
+		for _, existingField := range *currentFields.fields {
+			if !bytes.Equal(existingField.Name, []byte(fetchResponseKey)) {
+				continue
+			}
+			existingValue, ok := existingField.Value.(*resolve.Scalar)
+			if ok && len(existingValue.Path) > 0 && existingValue.Path[0] == fetchResponseKey {
+				return
+			}
+		}
+	}
+
+	fieldDefinition, ok := v.Walker.FieldDefinition(fieldRef)
+	if !ok {
+		return
+	}
+	fieldType := v.definition.FieldDefinitionType(fieldDefinition)
+	fieldValue := v.createFieldValue(fieldType, []string{fetchResponseKey})
+	field := &resolve.Field{
+		Name:        []byte(fetchResponseKey),
+		Value:       fieldValue,
+		OnTypeNames: v.resolveEntityOnTypeNames(plannerID, fieldRef, fieldName),
+	}
+	if fetchResponseKey != string(fieldName) {
+		field.OriginalName = v.operation.FieldNameBytes(fieldRef)
+	}
+	if v.operation.FieldHasArguments(fieldRef) {
+		// Root-operation-field arguments are part of the ROOT-FIELD cache key
+		// (rendered from the fetch input), not per-field CacheArgs.
+		enclosingType := v.Walker.EnclosingTypeDefinition.NameString(v.definition)
+		if !v.definition.Index.IsRootOperationTypeNameString(enclosingType) {
+			field.CacheArgs = v.captureFieldCacheArgs(fieldRef)
+		}
+	}
+
+	currentFields := v.currentFields[plannerID][len(v.currentFields[plannerID])-1]
+	*currentFields.fields = append(*currentFields.fields, field)
+
+	// Descend through list nesting to the object node (if any) and push its
+	// field slice as the new frame for this planner.
+	for {
+		switch node := fieldValue.(type) {
+		case *resolve.Array:
+			fieldValue = node.Item
+		case *resolve.Object:
+			v.Walker.RunAfterEnterField(func() {
+				v.currentFields[plannerID] = append(v.currentFields[plannerID], objectFields{
+					popOnField: fieldRef,
+					fields:     &node.Fields,
+				})
+			})
+			return
+		default:
+			return
+		}
+	}
+}
+
+// ensurePlanner lazily creates the planner's root object and frame stack.
+func (v *cacheProvidesDataVisitor) ensurePlanner(plannerID int) bool {
+	if plannerID < 0 || plannerID >= len(v.planners) {
+		return false
+	}
+	if _, ok := v.objects[plannerID]; ok {
+		return true
+	}
+	v.objects[plannerID] = &resolve.Object{
+		Fields: []*resolve.Field{},
+	}
+	v.currentFields[plannerID] = []objectFields{
+		{
+			popOnField: -1,
+			fields:     &v.objects[plannerID].Fields,
+		},
+	}
+	return true
+}
+
+// captureFieldCacheArgs records the field's variable-bound arguments, sorted
+// by argument name so cache keys are order-independent. Literal (inline)
+// argument values are intentionally skipped: they are part of the normalized
+// operation and thus already part of the fetch input the key derives from.
+func (v *cacheProvidesDataVisitor) captureFieldCacheArgs(fieldRef int) []resolve.CacheFieldArg {
+	argRefs := v.operation.FieldArguments(fieldRef)
+	if len(argRefs) == 0 {
+		return nil
+	}
+
+	args := make([]resolve.CacheFieldArg, 0, len(argRefs))
+	for _, argRef := range argRefs {
+		argName := v.operation.ArgumentNameString(argRef)
+		argValue := v.operation.ArgumentValue(argRef)
+		if argValue.Kind != ast.ValueKindVariable {
+			continue
+		}
+		args = append(args, resolve.CacheFieldArg{
+			Name:         argName,
+			VariableName: v.operation.VariableValueNameString(argValue.Ref),
+		})
+	}
+	if len(args) == 0 {
+		return nil
+	}
+	slices.SortFunc(args, func(a, b resolve.CacheFieldArg) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+	return args
+}
+
+// createFieldValue maps a schema type to the resolve node shape the coverage
+// walk consumes: scalars/enums to Scalar, composites to Object, lists to
+// Array; nullability follows the schema.
+func (v *cacheProvidesDataVisitor) createFieldValue(typeRef int, path []string) resolve.Node {
+	ofType := v.definition.Types[typeRef].OfType
+
+	switch v.definition.Types[typeRef].TypeKind {
+	case ast.TypeKindNonNull:
+		node := v.createFieldValue(ofType, path)
+		switch n := node.(type) {
+		case *resolve.Scalar:
+			n.Nullable = false
+		case *resolve.Object:
+			n.Nullable = false
+		case *resolve.Array:
+			n.Nullable = false
+		}
+		return node
+	case ast.TypeKindList:
+		return &resolve.Array{
+			Nullable: true,
+			Path:     path,
+			Item:     v.createFieldValue(ofType, nil),
+		}
+	case ast.TypeKindNamed:
+		typeName := v.definition.ResolveTypeNameString(typeRef)
+		typeDefinitionNode, ok := v.definition.Index.FirstNodeByNameStr(typeName)
+		if !ok {
+			return &resolve.Null{}
+		}
+		switch typeDefinitionNode.Kind {
+		case ast.NodeKindScalarTypeDefinition, ast.NodeKindEnumTypeDefinition:
+			return &resolve.Scalar{
+				Nullable: true,
+				Path:     path,
+			}
+		case ast.NodeKindObjectTypeDefinition, ast.NodeKindInterfaceTypeDefinition, ast.NodeKindUnionTypeDefinition:
+			return &resolve.Object{
+				Nullable: true,
+				Path:     path,
+				Fields:   []*resolve.Field{},
+			}
+		default:
+			return &resolve.Null{}
+		}
+	default:
+		return &resolve.Null{}
+	}
+}
+
+// isEntityBoundaryField reports whether the field is exactly the planner's
+// fetch response path, i.e. the point where a nested entity fetch's own data
+// begins.
+func (v *cacheProvidesDataVisitor) isEntityBoundaryField(plannerID, fieldRef int) bool {
+	fetchConfig := v.planners[plannerID].ObjectFetchConfiguration()
+	if fetchConfig == nil || fetchConfig.fetchItem == nil || fetchConfig.fetchItem.ResponsePath == "" {
+		return false
+	}
+
+	currentPath := v.currentFullPath(fieldRef)
+	rootPrefix := "query"
+	if idx := strings.IndexByte(currentPath, '.'); idx > 0 {
+		rootPrefix = currentPath[:idx]
+	}
+	responsePath := strings.ReplaceAll(rootPrefix+"."+fetchConfig.fetchItem.ResponsePath, ".@", "")
+	normalizedFieldPath := v.normalizePathRemovingFragments(currentPath)
+	if normalizedFieldPath == responsePath {
+		v.entityBoundaryPaths[plannerID] = normalizedFieldPath
+		return true
+	}
+	return false
+}
+
+// isEntityRootField reports whether the field is a DIRECT child of the
+// planner's entity boundary; those fields carry the entity type condition.
+func (v *cacheProvidesDataVisitor) isEntityRootField(plannerID, fieldRef int) bool {
+	boundaryPath, ok := v.entityBoundaryPaths[plannerID]
+	if !ok {
+		return false
+	}
+	return v.isEntityRootPath(boundaryPath, v.currentFullPath(fieldRef))
+}
+
+func (v *cacheProvidesDataVisitor) isEntityRootPath(boundaryPath, fullFieldPath string) bool {
+	normalized := v.normalizePathRemovingFragments(fullFieldPath)
+	rest, ok := strings.CutPrefix(normalized, boundaryPath+".")
+	if !ok {
+		return false
+	}
+	return !strings.Contains(rest, ".")
+}
+
+func (v *cacheProvidesDataVisitor) currentFullPath(fieldRef int) string {
+	path := v.Walker.Path.DotDelimitedString()
+	if v.Walker.CurrentKind == ast.NodeKindField {
+		path += "." + v.operation.FieldAliasOrNameString(fieldRef)
+	}
+	return path
+}
+
+func (v *cacheProvidesDataVisitor) normalizePathRemovingFragments(path string) string {
+	return cacheProvidesDataFragmentMarkerRegex.ReplaceAllString(path, "")
+}
+
+func (v *cacheProvidesDataVisitor) popFields(plannerID, fieldRef int) {
+	fields, ok := v.currentFields[plannerID]
+	if !ok || len(fields) == 0 {
+		return
+	}
+
+	last := len(fields) - 1
+	if fields[last].popOnField == fieldRef {
+		v.currentFields[plannerID] = fields[:last]
+	}
+}
+
+// resolveEntityOnTypeNames gives the entity boundary's direct children the
+// enclosing entity type as their type condition (an _entities response is
+// polymorphic); everything else falls through to the inline-fragment rules.
+func (v *cacheProvidesDataVisitor) resolveEntityOnTypeNames(plannerID, fieldRef int, fieldName ast.ByteSlice) (onTypeNames [][]byte) {
+	if v.isEntityRootField(plannerID, fieldRef) {
+		enclosingTypeName := v.Walker.EnclosingTypeDefinition.NameBytes(v.definition)
+		if enclosingTypeName != nil {
+			return [][]byte{enclosingTypeName}
+		}
+	}
+	return v.resolveOnTypeNames(fieldRef, fieldName)
+}
+
+// resolveOnTypeNames derives the field's type conditions from its enclosing
+// inline fragment: concrete conditions pass through (plus a possible
+// interfaceObject remap); abstract conditions expand to the implementing /
+// member types, narrowed by the grandparent type where fragments nest.
+func (v *cacheProvidesDataVisitor) resolveOnTypeNames(fieldRef int, fieldName ast.ByteSlice) (onTypeNames [][]byte) {
+	if len(v.Walker.Ancestors) < 2 {
+		return nil
+	}
+	inlineFragment := v.Walker.Ancestors[len(v.Walker.Ancestors)-2]
+	if inlineFragment.Kind != ast.NodeKindInlineFragment {
+		return nil
+	}
+	typeName := v.operation.InlineFragmentTypeConditionName(inlineFragment.Ref)
+	if typeName == nil {
+		typeName = v.Walker.EnclosingTypeDefinition.NameBytes(v.definition)
+	}
+	node, exists := v.definition.NodeByName(typeName)
+	if !exists || !node.Kind.IsAbstractType() {
+		return v.addInterfaceObjectNameToTypeNames(fieldRef, typeName, [][]byte{v.config.Types.RenameTypeNameOnMatchBytes(typeName)})
+	}
+
+	if node.Kind == ast.NodeKindUnionTypeDefinition {
+		if !bytes.Equal(fieldName, literal.TYPENAME) {
+			// Only __typename can be selected directly on a union.
+			v.Walker.StopWithInternalErr(fmt.Errorf("resolveOnTypeNames called with a union type and field %s", fieldName))
+			return nil
+		}
+
+		typeNames, ok := v.definition.UnionTypeDefinitionMemberTypeNamesAsBytes(node.Ref)
+		if ok {
+			onTypeNames = typeNames
+		}
+	} else {
+		typeNames, ok := v.definition.InterfaceTypeDefinitionImplementedByObjectWithNamesAsBytes(node.Ref)
+		if ok {
+			onTypeNames = typeNames
+		}
+	}
+
+	// Narrow the expansion by the grandparent scope where fragments nest.
+	if len(v.Walker.TypeDefinitions) > 1 {
+		grandParent := v.Walker.TypeDefinitions[len(v.Walker.TypeDefinitions)-2]
+		switch grandParent.Kind {
+		case ast.NodeKindUnionTypeDefinition:
+			for i := 0; i < len(onTypeNames); i++ {
+				possibleMember, exists := v.definition.Index.FirstNodeByNameStr(string(onTypeNames[i]))
+				if !exists {
+					continue
+				}
+				if !v.definition.NodeIsUnionMember(possibleMember, grandParent) {
+					onTypeNames = append(onTypeNames[:i], onTypeNames[i+1:]...)
+					i--
+				}
+			}
+		case ast.NodeKindInterfaceTypeDefinition:
+			objectTypesImplementingGrandParent, _ := v.definition.InterfaceTypeDefinitionImplementedByObjectWithNames(grandParent.Ref)
+			for i := 0; i < len(onTypeNames); i++ {
+				if !slices.Contains(objectTypesImplementingGrandParent, string(onTypeNames[i])) {
+					onTypeNames = append(onTypeNames[:i], onTypeNames[i+1:]...)
+					i--
+				}
+			}
+		case ast.NodeKindObjectTypeDefinition:
+			grandParentTypeName := grandParent.NameBytes(v.definition)
+			for i := 0; i < len(onTypeNames); i++ {
+				if !bytes.Equal(onTypeNames[i], grandParentTypeName) {
+					onTypeNames = append(onTypeNames[:i], onTypeNames[i+1:]...)
+					i--
+				}
+			}
+		default:
+		}
+	}
+
+	return onTypeNames
+}
+
+// addInterfaceObjectNameToTypeNames appends the interfaceObject interface name
+// when a planner resolving this field declares the concrete type as an
+// interfaceObject member, mirroring how such subgraphs respond with the
+// interface type name.
+func (v *cacheProvidesDataVisitor) addInterfaceObjectNameToTypeNames(fieldRef int, typeName []byte, onTypeNames [][]byte) [][]byte {
+	for i := range v.planners {
+		if !v.planners[i].HasPathWithFieldRef(fieldRef) {
+			continue
+		}
+
+		for _, interfaceObjCfg := range v.planners[i].DataSourceConfiguration().FederationConfiguration().InterfaceObjects {
+			if slices.Contains(interfaceObjCfg.ConcreteTypeNames, string(typeName)) {
+				return append(onTypeNames, []byte(interfaceObjCfg.InterfaceTypeName))
+			}
+		}
+	}
+	return onTypeNames
+}
+
+// responseOf extracts the GraphQLResponse the side-table attaches to.
+func responseOf(p Plan) *resolve.GraphQLResponse {
+	switch t := p.(type) {
+	case *SynchronousResponsePlan:
+		return t.Response
+	case *DeferResponsePlan:
+		if t.Response == nil {
+			return nil
+		}
+		return t.Response.Response
+	case *SubscriptionResponsePlan:
+		if t.Response == nil {
+			return nil
+		}
+		return t.Response.Response
+	default:
+		return nil
+	}
+}

--- a/v2/pkg/engine/plan/cache_provides_data_visitor.go
+++ b/v2/pkg/engine/plan/cache_provides_data_visitor.go
@@ -1,0 +1,28 @@
+package plan
+
+import (
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astvisitor"
+)
+
+// cacheProvidesDataVisitor is the P1 caching walk (PLAN.md D9): a gated
+// SECOND, filter-free walk over the operation, run on the planningWalker AFTER
+// the main planning walk, building the per-fetch ProvidesData tree
+// (alias → OriginalName, CacheArgs, entity boundaries). It never re-runs the
+// planning visitor and never rebuilds the plan; it only produces the
+// side-table attachTo hands to the plan's response.
+//
+// This is the registration SKELETON — the visitor body lands with task 05.
+type cacheProvidesDataVisitor struct {
+	walker *astvisitor.Walker
+}
+
+// reset clears all per-plan state so a Planner can be reused across Plan calls.
+func (v *cacheProvidesDataVisitor) reset() {}
+
+func (v *cacheProvidesDataVisitor) EnterField(ref int) {}
+
+func (v *cacheProvidesDataVisitor) LeaveField(ref int) {}
+
+// attachTo hands the collected ProvidesData side-table to the plan's response
+// via resolve.GraphQLResponse.SetCacheProvidesData (task 05).
+func (v *cacheProvidesDataVisitor) attachTo(pl Plan) {}

--- a/v2/pkg/engine/plan/cache_provides_data_visitor.go
+++ b/v2/pkg/engine/plan/cache_provides_data_visitor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/astvisitor"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/lexer/literal"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/operationreport"
 )
 
 // cacheProvidesDataVisitor is the P1 caching walk (PLAN.md D9): a gated
@@ -24,6 +25,24 @@ import (
 // not the path down to it). It reads planningVisitor.fieldPlanners, which the
 // main walk populates in LeaveField, so it must never run before the main
 // walk; it never re-runs the planning visitor and never rebuilds the plan.
+// walk runs the P1 caching walk on a DEDICATED walker after every planning
+// walk has finished — fieldPlanners (populated by the main walk's LeaveField)
+// is complete by then, and the planning walker's visitor set and filter stay
+// untouched. One call carries all the state the walk needs.
+func (v *cacheProvidesDataVisitor) walk(operation, definition *ast.Document, config Configuration, planners []PlannerConfiguration, fieldPlanners map[int][]int, report *operationreport.Report) {
+	walker := astvisitor.NewWalker(48)
+	v.Walker = &walker
+	v.operation = operation
+	v.definition = definition
+	v.config = config
+	v.planners = planners
+	v.fieldPlanners = fieldPlanners
+	v.reset()
+	walker.RegisterEnterFieldVisitor(v)
+	walker.RegisterLeaveFieldVisitor(v)
+	walker.Walk(operation, definition, report)
+}
+
 type cacheProvidesDataVisitor struct {
 	*astvisitor.Walker
 

--- a/v2/pkg/engine/plan/cache_provides_data_visitor.go
+++ b/v2/pkg/engine/plan/cache_provides_data_visitor.go
@@ -144,7 +144,7 @@ func (v *cacheProvidesDataVisitor) trackField(plannerID, fieldRef int) {
 		OnTypeNames: v.resolveEntityOnTypeNames(plannerID, fieldRef, fieldName),
 	}
 	if fetchResponseKey != string(fieldName) {
-		field.OriginalName = v.operation.FieldNameBytes(fieldRef)
+		field.OriginalName = fieldName
 	}
 	if v.operation.FieldHasArguments(fieldRef) {
 		// Root-operation-field arguments are part of the ROOT-FIELD cache key

--- a/v2/pkg/engine/plan/cache_provides_data_visitor_port_test.go
+++ b/v2/pkg/engine/plan/cache_provides_data_visitor_port_test.go
@@ -1,0 +1,790 @@
+package plan
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astnormalization"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/asttransform"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astvalidation"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astvisitor"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/internal/unsafeparser"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/operationreport"
+)
+
+// The FIDELITY GATE rows: ported 1:1 from the first-pass/OLD ProvidesData
+// builder test set, asserting the FULL per-fetch tree map. Planner 0 is the
+// root fetch (accountDS), planner 1 the nested entity fetch at "user"
+// (profileDS).
+func TestCacheProvidesDataVisitor(t *testing.T) {
+	tests := []struct {
+		name string
+		op   string
+		want func(t *testing.T, pd map[*resolve.FetchInfo]*resolve.Object) map[*resolve.FetchInfo]*resolve.Object
+	}{
+		{
+			name: "single key entity selection",
+			op: `
+				query {
+					user(id: "1") {
+						id
+						username
+					}
+				}`,
+			want: func(t *testing.T, pd map[*resolve.FetchInfo]*resolve.Object) map[*resolve.FetchInfo]*resolve.Object {
+				accountInfo := requireProvidesDataInfo(t, pd, "accountDS")
+				profileInfo := requireProvidesDataInfo(t, pd, "profileDS")
+				return map[*resolve.FetchInfo]*resolve.Object{
+					accountInfo: {
+						Fields: []*resolve.Field{
+							{
+								Name: []byte("user"),
+								Value: &resolve.Object{
+									Nullable: true,
+									Path:     []string{"user"},
+									Fields: []*resolve.Field{
+										{
+											Name: []byte("id"),
+											Value: &resolve.Scalar{
+												Nullable: false,
+												Path:     []string{"id"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					profileInfo: {
+						Fields: []*resolve.Field{
+							{
+								Name: []byte("username"),
+								Value: &resolve.Scalar{
+									Nullable: true,
+									Path:     []string{"username"},
+								},
+								OnTypeNames: [][]byte{[]byte("User")},
+							},
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "multi field entity with nested object",
+			op: `
+				query {
+					user(id: "1") {
+						id
+						username
+						profile {
+							displayName
+						}
+					}
+				}`,
+			want: func(t *testing.T, pd map[*resolve.FetchInfo]*resolve.Object) map[*resolve.FetchInfo]*resolve.Object {
+				accountInfo := requireProvidesDataInfo(t, pd, "accountDS")
+				profileInfo := requireProvidesDataInfo(t, pd, "profileDS")
+				return map[*resolve.FetchInfo]*resolve.Object{
+					accountInfo: {
+						Fields: []*resolve.Field{
+							{
+								Name: []byte("user"),
+								Value: &resolve.Object{
+									Nullable: true,
+									Path:     []string{"user"},
+									Fields: []*resolve.Field{
+										{
+											Name: []byte("id"),
+											Value: &resolve.Scalar{
+												Nullable: false,
+												Path:     []string{"id"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					profileInfo: {
+						Fields: []*resolve.Field{
+							{
+								Name: []byte("username"),
+								Value: &resolve.Scalar{
+									Nullable: true,
+									Path:     []string{"username"},
+								},
+								OnTypeNames: [][]byte{[]byte("User")},
+							},
+							{
+								Name: []byte("profile"),
+								Value: &resolve.Object{
+									Nullable: true,
+									Path:     []string{"profile"},
+									Fields: []*resolve.Field{
+										{
+											Name: []byte("displayName"),
+											Value: &resolve.Scalar{
+												Nullable: true,
+												Path:     []string{"displayName"},
+											},
+										},
+									},
+								},
+								OnTypeNames: [][]byte{[]byte("User")},
+							},
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "aliased field stores original name",
+			op: `
+				query {
+					user(id: "1") {
+						id
+						handle: username
+					}
+				}`,
+			want: func(t *testing.T, pd map[*resolve.FetchInfo]*resolve.Object) map[*resolve.FetchInfo]*resolve.Object {
+				accountInfo := requireProvidesDataInfo(t, pd, "accountDS")
+				profileInfo := requireProvidesDataInfo(t, pd, "profileDS")
+				return map[*resolve.FetchInfo]*resolve.Object{
+					accountInfo: {
+						Fields: []*resolve.Field{
+							{
+								Name: []byte("user"),
+								Value: &resolve.Object{
+									Nullable: true,
+									Path:     []string{"user"},
+									Fields: []*resolve.Field{
+										{
+											Name: []byte("id"),
+											Value: &resolve.Scalar{
+												Nullable: false,
+												Path:     []string{"id"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					profileInfo: {
+						Fields: []*resolve.Field{
+							{
+								Name:         []byte("handle"),
+								OriginalName: []byte("username"),
+								Value: &resolve.Scalar{
+									Nullable: true,
+									Path:     []string{"handle"},
+								},
+								OnTypeNames: [][]byte{[]byte("User")},
+							},
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "variable arguments are captured except on root operation fields",
+			op: `
+				query($id: ID!, $first: Int, $after: String) {
+					user(id: $id) {
+						id
+						friends(first: $first, after: $after) {
+							username
+						}
+					}
+				}`,
+			want: func(t *testing.T, pd map[*resolve.FetchInfo]*resolve.Object) map[*resolve.FetchInfo]*resolve.Object {
+				accountInfo := requireProvidesDataInfo(t, pd, "accountDS")
+				profileInfo := requireProvidesDataInfo(t, pd, "profileDS")
+				return map[*resolve.FetchInfo]*resolve.Object{
+					accountInfo: {
+						Fields: []*resolve.Field{
+							{
+								Name: []byte("user"),
+								Value: &resolve.Object{
+									Nullable: true,
+									Path:     []string{"user"},
+									Fields: []*resolve.Field{
+										{
+											Name: []byte("id"),
+											Value: &resolve.Scalar{
+												Nullable: false,
+												Path:     []string{"id"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					profileInfo: {
+						Fields: []*resolve.Field{
+							{
+								Name: []byte("friends"),
+								Value: &resolve.Array{
+									Nullable: true,
+									Path:     []string{"friends"},
+									Item: &resolve.Object{
+										Nullable: true,
+										Fields: []*resolve.Field{
+											{
+												Name: []byte("username"),
+												Value: &resolve.Scalar{
+													Nullable: true,
+													Path:     []string{"username"},
+												},
+											},
+										},
+									},
+								},
+								OnTypeNames: [][]byte{[]byte("User")},
+								CacheArgs: []resolve.CacheFieldArg{
+									{Name: "after", VariableName: "after"},
+									{Name: "first", VariableName: "first"},
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "typename is deduplicated in one frame",
+			op: `
+				query {
+					user(id: "1") {
+						id
+						__typename
+						__typename
+						username
+					}
+				}`,
+			want: func(t *testing.T, pd map[*resolve.FetchInfo]*resolve.Object) map[*resolve.FetchInfo]*resolve.Object {
+				accountInfo := requireProvidesDataInfo(t, pd, "accountDS")
+				profileInfo := requireProvidesDataInfo(t, pd, "profileDS")
+				return map[*resolve.FetchInfo]*resolve.Object{
+					accountInfo: {
+						Fields: []*resolve.Field{
+							{
+								Name: []byte("user"),
+								Value: &resolve.Object{
+									Nullable: true,
+									Path:     []string{"user"},
+									Fields: []*resolve.Field{
+										{
+											Name: []byte("id"),
+											Value: &resolve.Scalar{
+												Nullable: false,
+												Path:     []string{"id"},
+											},
+										},
+										{
+											Name: []byte("__typename"),
+											Value: &resolve.Scalar{
+												Nullable: false,
+												Path:     []string{"__typename"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					profileInfo: {
+						Fields: []*resolve.Field{
+							{
+								Name: []byte("__typename"),
+								Value: &resolve.Scalar{
+									Nullable: false,
+									Path:     []string{"__typename"},
+								},
+								OnTypeNames: [][]byte{[]byte("User")},
+							},
+							{
+								Name: []byte("username"),
+								Value: &resolve.Scalar{
+									Nullable: true,
+									Path:     []string{"username"},
+								},
+								OnTypeNames: [][]byte{[]byte("User")},
+							},
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "inline fragment fields carry the concrete type condition",
+			op: `
+				query {
+					user(id: "1") {
+						id
+						pet {
+							name
+							... on Dog {
+								barks
+							}
+						}
+					}
+				}`,
+			want: func(t *testing.T, pd map[*resolve.FetchInfo]*resolve.Object) map[*resolve.FetchInfo]*resolve.Object {
+				accountInfo := requireProvidesDataInfo(t, pd, "accountDS")
+				profileInfo := requireProvidesDataInfo(t, pd, "profileDS")
+				return map[*resolve.FetchInfo]*resolve.Object{
+					accountInfo: {
+						Fields: []*resolve.Field{
+							{
+								Name: []byte("user"),
+								Value: &resolve.Object{
+									Nullable: true,
+									Path:     []string{"user"},
+									Fields: []*resolve.Field{
+										{
+											Name: []byte("id"),
+											Value: &resolve.Scalar{
+												Nullable: false,
+												Path:     []string{"id"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					profileInfo: {
+						Fields: []*resolve.Field{
+							{
+								Name: []byte("pet"),
+								Value: &resolve.Object{
+									Nullable: true,
+									Path:     []string{"pet"},
+									Fields: []*resolve.Field{
+										{
+											Name: []byte("name"),
+											Value: &resolve.Scalar{
+												Nullable: true,
+												Path:     []string{"name"},
+											},
+										},
+										{
+											Name: []byte("barks"),
+											Value: &resolve.Scalar{
+												Nullable: true,
+												Path:     []string{"barks"},
+											},
+											OnTypeNames: [][]byte{[]byte("Dog")},
+										},
+									},
+								},
+								OnTypeNames: [][]byte{[]byte("User")},
+							},
+						},
+					},
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pd := planCacheProvidesData(t, tt.op)
+
+			assert.Equal(t, tt.want(t, pd), pd)
+		})
+	}
+}
+
+// TestCacheProvidesDataVisitorAdversarial goes beyond the OLD test set (a
+// verbatim port would carry latent OLD bugs): per-fetch attribution with an
+// irrelevant provider sharing the consumer query, partial overlap of two
+// entity fetches on the same field, and a planner with no attributed fields.
+func TestCacheProvidesDataVisitorAdversarial(t *testing.T) {
+	t.Run("irrelevant provider does not leak into sibling trees", func(t *testing.T) {
+		planners := defaultProvidesDataPlanners()
+		planners = append(planners, newTestProvidesDataPlanner("", &resolve.FetchInfo{DataSourceID: "statsDS"}))
+		routes := func(path string, ref int, out map[int][]int) {
+			switch {
+			case path == "query.stats":
+				out[ref] = []int{2}
+			case path == "query.user":
+				out[ref] = []int{0, 1}
+			case path == "query.user.id":
+				out[ref] = []int{0}
+			case strings.HasPrefix(path, "query.user."):
+				out[ref] = []int{1}
+			}
+		}
+		pd := planCacheProvidesDataWith(t, `
+			query {
+				user(id: "1") { id username }
+				stats
+			}`, planners, routes)
+
+		accountInfo := requireProvidesDataInfo(t, pd, "accountDS")
+		profileInfo := requireProvidesDataInfo(t, pd, "profileDS")
+		gotStatsInfo := requireProvidesDataInfo(t, pd, "statsDS")
+		assert.Equal(t, map[*resolve.FetchInfo]*resolve.Object{
+			accountInfo: {
+				Fields: []*resolve.Field{
+					{
+						Name: []byte("user"),
+						Value: &resolve.Object{
+							Nullable: true,
+							Path:     []string{"user"},
+							Fields: []*resolve.Field{
+								{
+									Name: []byte("id"),
+									Value: &resolve.Scalar{
+										Nullable: false,
+										Path:     []string{"id"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			profileInfo: {
+				Fields: []*resolve.Field{
+					{
+						Name: []byte("username"),
+						Value: &resolve.Scalar{
+							Nullable: true,
+							Path:     []string{"username"},
+						},
+						OnTypeNames: [][]byte{[]byte("User")},
+					},
+				},
+			},
+			gotStatsInfo: {
+				Fields: []*resolve.Field{
+					{
+						Name: []byte("stats"),
+						Value: &resolve.Scalar{
+							Nullable: true,
+							Path:     []string{"stats"},
+						},
+					},
+				},
+			},
+		}, pd)
+	})
+
+	t.Run("partial overlap: two entity fetches sharing one field get their own trees", func(t *testing.T) {
+		planners := defaultProvidesDataPlanners()
+		planners = append(planners, newTestProvidesDataPlanner("user", &resolve.FetchInfo{DataSourceID: "secondEntityDS"}))
+		routes := func(path string, ref int, out map[int][]int) {
+			switch {
+			case path == "query.user":
+				out[ref] = []int{0, 1, 2}
+			case path == "query.user.id":
+				out[ref] = []int{0}
+			case path == "query.user.username":
+				out[ref] = []int{1, 2}
+			case strings.HasPrefix(path, "query.user."):
+				out[ref] = []int{1}
+			}
+		}
+		pd := planCacheProvidesDataWith(t, `
+			query {
+				user(id: "1") { id username profile { displayName } }
+			}`, planners, routes)
+
+		accountInfo := requireProvidesDataInfo(t, pd, "accountDS")
+		profileInfo := requireProvidesDataInfo(t, pd, "profileDS")
+		gotSecondInfo := requireProvidesDataInfo(t, pd, "secondEntityDS")
+		assert.Equal(t, map[*resolve.FetchInfo]*resolve.Object{
+			accountInfo: {
+				Fields: []*resolve.Field{
+					{
+						Name: []byte("user"),
+						Value: &resolve.Object{
+							Nullable: true,
+							Path:     []string{"user"},
+							Fields: []*resolve.Field{
+								{
+									Name: []byte("id"),
+									Value: &resolve.Scalar{
+										Nullable: false,
+										Path:     []string{"id"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			profileInfo: {
+				Fields: []*resolve.Field{
+					{
+						Name: []byte("username"),
+						Value: &resolve.Scalar{
+							Nullable: true,
+							Path:     []string{"username"},
+						},
+						OnTypeNames: [][]byte{[]byte("User")},
+					},
+					{
+						Name: []byte("profile"),
+						Value: &resolve.Object{
+							Nullable: true,
+							Path:     []string{"profile"},
+							Fields: []*resolve.Field{
+								{
+									Name: []byte("displayName"),
+									Value: &resolve.Scalar{
+										Nullable: true,
+										Path:     []string{"displayName"},
+									},
+								},
+							},
+						},
+						OnTypeNames: [][]byte{[]byte("User")},
+					},
+				},
+			},
+			gotSecondInfo: {
+				Fields: []*resolve.Field{
+					{
+						Name: []byte("username"),
+						Value: &resolve.Scalar{
+							Nullable: true,
+							Path:     []string{"username"},
+						},
+						OnTypeNames: [][]byte{[]byte("User")},
+					},
+				},
+			},
+		}, pd)
+	})
+
+	t.Run("empty selections: unrouted planner absent, boundary-only entity planner empty", func(t *testing.T) {
+		planners := defaultProvidesDataPlanners()
+		planners = append(planners, newTestProvidesDataPlanner("", &resolve.FetchInfo{DataSourceID: "unusedDS"}))
+		pd := planCacheProvidesDataWith(t, `
+			query {
+				user(id: "1") { id }
+			}`, planners, defaultProvidesDataRoutes)
+
+		accountInfo := requireProvidesDataInfo(t, pd, "accountDS")
+		// profileDS is attributed the boundary field but nothing below it, so
+		// its tree exists and is EMPTY (zero coverage); unusedDS was never
+		// attributed any field and is absent entirely.
+		profileInfo := requireProvidesDataInfo(t, pd, "profileDS")
+		assert.Equal(t, map[*resolve.FetchInfo]*resolve.Object{
+			accountInfo: {
+				Fields: []*resolve.Field{
+					{
+						Name: []byte("user"),
+						Value: &resolve.Object{
+							Nullable: true,
+							Path:     []string{"user"},
+							Fields: []*resolve.Field{
+								{
+									Name: []byte("id"),
+									Value: &resolve.Scalar{
+										Nullable: false,
+										Path:     []string{"id"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			profileInfo: {
+				Fields: []*resolve.Field{},
+			},
+		}, pd)
+	})
+}
+
+// TestCacheProvidesDataVisitorDeterminism plans the same operation twice and
+// asserts identical side-tables (compared by datasource, since *FetchInfo keys
+// differ per run).
+func TestCacheProvidesDataVisitorDeterminism(t *testing.T) {
+	op := `
+		query {
+			user(id: "1") {
+				id
+				handle: username
+				profile { displayName }
+			}
+		}`
+	first := rekeyProvidesDataByDataSource(t, planCacheProvidesData(t, op))
+	second := rekeyProvidesDataByDataSource(t, planCacheProvidesData(t, op))
+	assert.Equal(t, first, second)
+}
+
+func rekeyProvidesDataByDataSource(t *testing.T, pd map[*resolve.FetchInfo]*resolve.Object) map[string]*resolve.Object {
+	t.Helper()
+	out := make(map[string]*resolve.Object, len(pd))
+	for info, obj := range pd {
+		require.NotContains(t, out, info.DataSourceID)
+		out[info.DataSourceID] = obj
+	}
+	return out
+}
+
+func defaultProvidesDataPlanners() []PlannerConfiguration {
+	return []PlannerConfiguration{
+		newTestProvidesDataPlanner("", &resolve.FetchInfo{DataSourceID: "accountDS"}),
+		newTestProvidesDataPlanner("user", &resolve.FetchInfo{DataSourceID: "profileDS"}),
+	}
+}
+
+// newTestProvidesDataPlanner builds the minimal planner configuration the
+// visitor dereferences: a fetch item (with the entity-boundary response path),
+// an empty datasource configuration (for the federation lookup), and an empty
+// paths configuration (for HasPathWithFieldRef).
+func newTestProvidesDataPlanner(responsePath string, info *resolve.FetchInfo) PlannerConfiguration {
+	return &plannerConfiguration[any]{
+		plannerPathsConfiguration: &plannerPathsConfiguration{},
+		dataSourceConfiguration: &dataSourceConfiguration[any]{
+			DataSourceMetadata: &DataSourceMetadata{},
+		},
+		objectFetchConfiguration: &objectFetchConfiguration{
+			fetchItem: &resolve.FetchItem{
+				ResponsePath: responsePath,
+				Fetch:        &resolve.SingleFetch{Info: info},
+			},
+		},
+	}
+}
+
+// defaultProvidesDataRoutes emulates the main walk's field→planner attribution
+// for the two-planner fixture: the root fetch resolves user+id, the entity
+// fetch at "user" everything below it.
+func defaultProvidesDataRoutes(path string, ref int, out map[int][]int) {
+	switch {
+	case path == "query.user":
+		out[ref] = []int{0, 1}
+	case path == "query.user.__typename":
+		out[ref] = []int{0, 1}
+	case path == "query.user.id":
+		out[ref] = []int{0}
+	case strings.HasPrefix(path, "query.user."):
+		out[ref] = []int{1}
+	}
+}
+
+func planCacheProvidesData(t *testing.T, operation string) map[*resolve.FetchInfo]*resolve.Object {
+	t.Helper()
+	return planCacheProvidesDataWith(t, operation, defaultProvidesDataPlanners(), defaultProvidesDataRoutes)
+}
+
+func planCacheProvidesDataWith(t *testing.T, operation string, planners []PlannerConfiguration, routes func(path string, ref int, out map[int][]int)) map[*resolve.FetchInfo]*resolve.Object {
+	t.Helper()
+
+	definition := unsafeparser.ParseGraphqlDocumentString(cacheProvidesDataDefinition)
+	require.NoError(t, asttransform.MergeDefinitionWithBaseSchema(&definition))
+
+	op := unsafeparser.ParseGraphqlDocumentString(operation)
+	var report operationreport.Report
+	norm := astnormalization.NewNormalizer(true, true)
+	norm.NormalizeOperation(&op, &definition, &report)
+	require.False(t, report.HasErrors(), report.Error())
+
+	valid := astvalidation.DefaultOperationValidator()
+	valid.Validate(&op, &definition, &report)
+	require.False(t, report.HasErrors(), report.Error())
+
+	walker := astvisitor.NewWalkerWithID(48, "CacheProvidesDataVisitorTest")
+	visitor := &cacheProvidesDataVisitor{
+		Walker:        &walker,
+		operation:     &op,
+		definition:    &definition,
+		planners:      planners,
+		fieldPlanners: collectFieldPlanners(&op, &definition, routes),
+	}
+	visitor.reset()
+	walker.RegisterEnterFieldVisitor(visitor)
+	walker.RegisterLeaveFieldVisitor(visitor)
+	walker.Walk(&op, &definition, &report)
+	require.False(t, report.HasErrors(), report.Error())
+
+	pre := &SynchronousResponsePlan{
+		Response: &resolve.GraphQLResponse{},
+	}
+	visitor.attachTo(pre)
+	return pre.Response.CacheProvidesData()
+}
+
+func requireProvidesDataInfo(t *testing.T, pd map[*resolve.FetchInfo]*resolve.Object, dataSourceID string) *resolve.FetchInfo {
+	t.Helper()
+
+	for info := range pd {
+		if info != nil && info.DataSourceID == dataSourceID {
+			return info
+		}
+	}
+	require.Failf(t, "missing provides data info", "data source %q in %#v", dataSourceID, pd)
+	return nil
+}
+
+// collectFieldPlanners emulates the main walk's fieldPlanners output using the
+// row's path-based routing.
+func collectFieldPlanners(operation, definition *ast.Document, routes func(path string, ref int, out map[int][]int)) map[int][]int {
+	fieldPlanners := make(map[int][]int)
+	walker := astvisitor.NewWalkerWithID(48, "CacheProvidesDataFieldPlannerCollector")
+	collector := &cacheProvidesDataFieldPlannerCollector{
+		walker:        &walker,
+		operation:     operation,
+		fieldPlanners: fieldPlanners,
+		routes:        routes,
+	}
+	walker.RegisterEnterFieldVisitor(collector)
+	var report operationreport.Report
+	walker.Walk(operation, definition, &report)
+	return fieldPlanners
+}
+
+const cacheProvidesDataDefinition = `
+	type Query {
+		user(id: ID!): User
+		stats: Int
+	}
+	type User {
+		id: ID!
+		username: String
+		profile: Profile
+		friends(first: Int, after: String): [User]
+		pet: Pet
+	}
+	type Profile {
+		displayName: String
+	}
+	interface Pet {
+		name: String
+	}
+	type Dog implements Pet {
+		name: String
+		barks: Boolean
+	}
+	type Cat implements Pet {
+		name: String
+		meows: Boolean
+	}
+`
+
+type cacheProvidesDataFieldPlannerCollector struct {
+	walker        *astvisitor.Walker
+	operation     *ast.Document
+	fieldPlanners map[int][]int
+	routes        func(path string, ref int, out map[int][]int)
+}
+
+func (c *cacheProvidesDataFieldPlannerCollector) EnterField(ref int) {
+	path := c.walker.Path.DotDelimitedString() + "." + c.operation.FieldAliasOrNameString(ref)
+	c.routes(cacheProvidesDataFragmentMarkerRegex.ReplaceAllString(path, ""), ref, c.fieldPlanners)
+}

--- a/v2/pkg/engine/plan/cache_provides_data_visitor_test.go
+++ b/v2/pkg/engine/plan/cache_provides_data_visitor_test.go
@@ -1,0 +1,114 @@
+package plan
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astnormalization"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/asttransform"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astvalidation"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/internal/unsafeparser"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/operationreport"
+)
+
+// TestCacheProvidesDataVisitorGating pins the planner no-op gate: the P1
+// visitor is constructed only when caching providers are configured.
+func TestCacheProvidesDataVisitorGating(t *testing.T) {
+	t.Run("not constructed without providers", func(t *testing.T) {
+		p, err := NewPlanner(Configuration{
+			DataSources: []DataSource{testDefinitionDSConfiguration},
+		})
+		require.NoError(t, err)
+		assert.Nil(t, p.cacheProvidesData)
+	})
+
+	t.Run("constructed with providers", func(t *testing.T) {
+		p, err := NewPlanner(Configuration{
+			DataSources: []DataSource{testDefinitionDSConfiguration},
+			CacheConfigProviders: map[string]cacheconfig.CacheConfigProvider{
+				"testDefinitionDSConfiguration": &cacheconfig.CachingConfiguration{},
+			},
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, p.cacheProvidesData)
+	})
+}
+
+// TestCacheProvidesDataSecondWalkKeepsPlanIdentical proves the P1 second-walk
+// seam never re-runs the planning visitor and never rebuilds the plan: with
+// the (task-03 inert) visitor enabled, the produced plan is identical to the
+// plan produced without any caching configuration.
+func TestCacheProvidesDataSecondWalkKeepsPlanIdentical(t *testing.T) {
+	planOnce := func(t *testing.T, config Configuration) Plan {
+		t.Helper()
+
+		def := unsafeparser.ParseGraphqlDocumentString(testDefinition)
+		op := unsafeparser.ParseGraphqlDocumentString(`
+			query SearchResults {
+				searchResults {
+					... on Character {
+						name
+					}
+					... on Vehicle {
+						length
+					}
+				}
+			}
+		`)
+		err := asttransform.MergeDefinitionWithBaseSchema(&def)
+		require.NoError(t, err)
+		var report operationreport.Report
+		norm := astnormalization.NewNormalizer(true, true)
+		norm.NormalizeOperation(&op, &def, &report)
+		valid := astvalidation.DefaultOperationValidator()
+		valid.Validate(&op, &def, &report)
+		require.False(t, report.HasErrors(), "unexpected report errors: %s", report.Error())
+
+		p, err := NewPlanner(config)
+		require.NoError(t, err)
+		result := p.Plan(&op, &def, "SearchResults", &report)
+		require.False(t, report.HasErrors(), "unexpected report errors: %s", report.Error())
+		return result
+	}
+
+	baseConfig := func() Configuration {
+		return Configuration{
+			DisableResolveFieldPositions: true,
+			DisableIncludeInfo:           true,
+			DataSources:                  []DataSource{testDefinitionDSConfiguration},
+		}
+	}
+
+	withoutCaching := planOnce(t, baseConfig())
+
+	cachingConfig := baseConfig()
+	cachingConfig.CacheConfigProviders = map[string]cacheconfig.CacheConfigProvider{
+		"testDefinitionDSConfiguration": &cacheconfig.CachingConfiguration{},
+	}
+	withCaching := planOnce(t, cachingConfig)
+
+	formatterConfig := map[reflect.Type]any{
+		reflect.TypeFor[[]byte](): func(b []byte) string { return fmt.Sprintf(`"%s"`, string(b)) },
+		reflect.TypeOf(map[string]struct{}{}): func(m map[string]struct{}) string {
+			keys := slices.Sorted(maps.Keys(m))
+			keysPrinted, _ := json.Marshal(keys)
+			return string(keysPrinted)
+		},
+	}
+	prettyCfg := &pretty.Config{
+		Diffable:          true,
+		IncludeUnexported: false,
+		Formatter:         formatterConfig,
+	}
+
+	assert.Equal(t, prettyCfg.Sprint(withoutCaching), prettyCfg.Sprint(withCaching))
+}

--- a/v2/pkg/engine/plan/cacheconfig/cacheconfig.go
+++ b/v2/pkg/engine/plan/cacheconfig/cacheconfig.go
@@ -39,6 +39,17 @@ type RootFieldCachePolicy struct {
 	ShadowMode, PartialBatchLoad   bool
 }
 
+// EnablesCaching reports whether the policy enables ANY cache behavior for its
+// root field: L2 is derived from the TTL (see the package doc) and root fields
+// never carry L1, so only a positive TTL or shadow mode makes the policy
+// effective. An ineffective policy yields no FetchCacheConfig (the
+// configurator's all-flags-false safety net), so consumers that change plans
+// for cached fields — the per-root-field isolation gate — must treat it as
+// "not cached".
+func (p RootFieldCachePolicy) EnablesCaching() bool {
+	return p.TTL > 0 || p.ShadowMode
+}
+
 // MutationCachePolicy declares how a mutation root field interacts with the
 // cache (invalidation / L2 population inheritance).
 type MutationCachePolicy struct {

--- a/v2/pkg/engine/plan/cacheconfig/cacheconfig.go
+++ b/v2/pkg/engine/plan/cacheconfig/cacheconfig.go
@@ -1,0 +1,109 @@
+// Package cacheconfig is the LEAF caching policy package on the plan side: the
+// declarative per-datasource cache policies an integrator supplies, and the
+// CacheConfigProvider port the caching planner passes consume. It carries no
+// cache logic and imports no engine packages, so plan and engine/cache can both
+// depend on it without a cycle. L2 enablement is DERIVED from the TTLs
+// (TTL > 0 || NegativeCacheTTL > 0 for entities, TTL > 0 for root fields);
+// the policy structs deliberately carry no explicit L1/L2 switches.
+package cacheconfig
+
+import (
+	"time"
+)
+
+// CachingConfiguration is the declarative caching policy set for ONE
+// datasource. It implements CacheConfigProvider by lookup, so it can be handed
+// to the engine directly.
+type CachingConfiguration struct {
+	Entities      []EntityCachePolicy
+	RootFields    []RootFieldCachePolicy
+	Mutations     []MutationCachePolicy
+	Subscriptions []SubscriptionCachePolicy
+}
+
+// EntityCachePolicy caches an entity type resolved via _entities fetches.
+type EntityCachePolicy struct {
+	TypeName, CacheName         string
+	TTL, NegativeCacheTTL       time.Duration
+	IncludeSubgraphHeaderPrefix bool
+	EnablePartialCacheLoad      bool
+	HashAnalyticsKeys           bool
+	ShadowMode                  bool
+}
+
+// RootFieldCachePolicy caches one query root field.
+type RootFieldCachePolicy struct {
+	TypeName, FieldName, CacheName string
+	TTL                            time.Duration
+	IncludeSubgraphHeaderPrefix    bool
+	ShadowMode, PartialBatchLoad   bool
+}
+
+// MutationCachePolicy declares how a mutation root field interacts with the
+// cache (invalidation / L2 population inheritance).
+type MutationCachePolicy struct {
+	FieldName              string
+	Invalidate, PopulateL2 bool
+	TTLOverride            time.Duration
+}
+
+// SubscriptionCachePolicy declares caching for a subscription root field.
+// Subscription caching itself is an out-of-core follow-up; the policy shape is
+// part of the provider contract.
+type SubscriptionCachePolicy struct {
+	TypeName, FieldName, CacheName string
+	TTL                            time.Duration
+	IncludeSubgraphHeaderPrefix    bool
+	EnableInvalidationOnKeyOnly    bool
+}
+
+// CacheConfigProvider is the lookup port the caching planner passes use: given
+// a coordinate, return the policy and whether one is configured. A nil
+// provider means no caching for that datasource; a (zero, false) return means
+// no caching for that coordinate.
+type CacheConfigProvider interface {
+	EntityPolicy(typeName string) (EntityCachePolicy, bool)
+	RootFieldPolicy(typeName, fieldName string) (RootFieldCachePolicy, bool)
+	MutationPolicy(fieldName string) (MutationCachePolicy, bool)
+	SubscriptionPolicy(typeName, fieldName string) (SubscriptionCachePolicy, bool)
+}
+
+// EntityPolicy returns the policy for an entity type name.
+func (c *CachingConfiguration) EntityPolicy(typeName string) (EntityCachePolicy, bool) {
+	for _, p := range c.Entities {
+		if p.TypeName == typeName {
+			return p, true
+		}
+	}
+	return EntityCachePolicy{}, false
+}
+
+// RootFieldPolicy returns the policy for a root-field coordinate.
+func (c *CachingConfiguration) RootFieldPolicy(typeName, fieldName string) (RootFieldCachePolicy, bool) {
+	for _, p := range c.RootFields {
+		if p.TypeName == typeName && p.FieldName == fieldName {
+			return p, true
+		}
+	}
+	return RootFieldCachePolicy{}, false
+}
+
+// MutationPolicy returns the policy for a mutation root field.
+func (c *CachingConfiguration) MutationPolicy(fieldName string) (MutationCachePolicy, bool) {
+	for _, p := range c.Mutations {
+		if p.FieldName == fieldName {
+			return p, true
+		}
+	}
+	return MutationCachePolicy{}, false
+}
+
+// SubscriptionPolicy returns the policy for a subscription root field.
+func (c *CachingConfiguration) SubscriptionPolicy(typeName, fieldName string) (SubscriptionCachePolicy, bool) {
+	for _, p := range c.Subscriptions {
+		if p.TypeName == typeName && p.FieldName == fieldName {
+			return p, true
+		}
+	}
+	return SubscriptionCachePolicy{}, false
+}

--- a/v2/pkg/engine/plan/cacheconfig/cacheconfig_test.go
+++ b/v2/pkg/engine/plan/cacheconfig/cacheconfig_test.go
@@ -1,0 +1,154 @@
+package cacheconfig
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func testConfiguration() *CachingConfiguration {
+	return &CachingConfiguration{
+		Entities: []EntityCachePolicy{
+			{
+				TypeName:                    "Product",
+				CacheName:                   "products",
+				TTL:                         30 * time.Second,
+				NegativeCacheTTL:            5 * time.Second,
+				IncludeSubgraphHeaderPrefix: true,
+				EnablePartialCacheLoad:      true,
+				HashAnalyticsKeys:           true,
+				ShadowMode:                  true,
+			},
+		},
+		RootFields: []RootFieldCachePolicy{
+			{
+				TypeName:                    "Query",
+				FieldName:                   "topProducts",
+				CacheName:                   "top-products",
+				TTL:                         time.Minute,
+				IncludeSubgraphHeaderPrefix: true,
+				ShadowMode:                  true,
+				PartialBatchLoad:            true,
+			},
+		},
+		Mutations: []MutationCachePolicy{
+			{
+				FieldName:   "updateProduct",
+				Invalidate:  true,
+				PopulateL2:  true,
+				TTLOverride: 10 * time.Second,
+			},
+		},
+		Subscriptions: []SubscriptionCachePolicy{
+			{
+				TypeName:                    "Subscription",
+				FieldName:                   "productUpdated",
+				CacheName:                   "product-updates",
+				TTL:                         15 * time.Second,
+				IncludeSubgraphHeaderPrefix: true,
+				EnableInvalidationOnKeyOnly: true,
+			},
+		},
+	}
+}
+
+// TestCachingConfigurationProvider pins the CacheConfigProvider lookup
+// semantics of CachingConfiguration: exact-match hit with the full policy, and
+// the (zero, false) miss that gates caching off per coordinate.
+func TestCachingConfigurationProvider(t *testing.T) {
+	cfg := testConfiguration()
+
+	t.Run("entity policy found", func(t *testing.T) {
+		policy, ok := cfg.EntityPolicy("Product")
+		assert.True(t, ok)
+		assert.Equal(t, EntityCachePolicy{
+			TypeName:                    "Product",
+			CacheName:                   "products",
+			TTL:                         30 * time.Second,
+			NegativeCacheTTL:            5 * time.Second,
+			IncludeSubgraphHeaderPrefix: true,
+			EnablePartialCacheLoad:      true,
+			HashAnalyticsKeys:           true,
+			ShadowMode:                  true,
+		}, policy)
+	})
+
+	t.Run("entity policy not found", func(t *testing.T) {
+		policy, ok := cfg.EntityPolicy("Review")
+		assert.False(t, ok)
+		assert.Equal(t, EntityCachePolicy{}, policy)
+	})
+
+	t.Run("root field policy found", func(t *testing.T) {
+		policy, ok := cfg.RootFieldPolicy("Query", "topProducts")
+		assert.True(t, ok)
+		assert.Equal(t, RootFieldCachePolicy{
+			TypeName:                    "Query",
+			FieldName:                   "topProducts",
+			CacheName:                   "top-products",
+			TTL:                         time.Minute,
+			IncludeSubgraphHeaderPrefix: true,
+			ShadowMode:                  true,
+			PartialBatchLoad:            true,
+		}, policy)
+	})
+
+	t.Run("root field policy requires both coordinates", func(t *testing.T) {
+		policy, ok := cfg.RootFieldPolicy("Query", "topReviews")
+		assert.False(t, ok)
+		assert.Equal(t, RootFieldCachePolicy{}, policy)
+
+		policy, ok = cfg.RootFieldPolicy("Mutation", "topProducts")
+		assert.False(t, ok)
+		assert.Equal(t, RootFieldCachePolicy{}, policy)
+	})
+
+	t.Run("mutation policy found", func(t *testing.T) {
+		policy, ok := cfg.MutationPolicy("updateProduct")
+		assert.True(t, ok)
+		assert.Equal(t, MutationCachePolicy{
+			FieldName:   "updateProduct",
+			Invalidate:  true,
+			PopulateL2:  true,
+			TTLOverride: 10 * time.Second,
+		}, policy)
+	})
+
+	t.Run("mutation policy not found", func(t *testing.T) {
+		policy, ok := cfg.MutationPolicy("deleteProduct")
+		assert.False(t, ok)
+		assert.Equal(t, MutationCachePolicy{}, policy)
+	})
+
+	t.Run("subscription policy found", func(t *testing.T) {
+		policy, ok := cfg.SubscriptionPolicy("Subscription", "productUpdated")
+		assert.True(t, ok)
+		assert.Equal(t, SubscriptionCachePolicy{
+			TypeName:                    "Subscription",
+			FieldName:                   "productUpdated",
+			CacheName:                   "product-updates",
+			TTL:                         15 * time.Second,
+			IncludeSubgraphHeaderPrefix: true,
+			EnableInvalidationOnKeyOnly: true,
+		}, policy)
+	})
+
+	t.Run("subscription policy not found", func(t *testing.T) {
+		policy, ok := cfg.SubscriptionPolicy("Subscription", "reviewAdded")
+		assert.False(t, ok)
+		assert.Equal(t, SubscriptionCachePolicy{}, policy)
+	})
+
+	t.Run("empty configuration misses everywhere", func(t *testing.T) {
+		empty := &CachingConfiguration{}
+		_, ok := empty.EntityPolicy("Product")
+		assert.False(t, ok)
+		_, ok = empty.RootFieldPolicy("Query", "topProducts")
+		assert.False(t, ok)
+		_, ok = empty.MutationPolicy("updateProduct")
+		assert.False(t, ok)
+		_, ok = empty.SubscriptionPolicy("Subscription", "productUpdated")
+		assert.False(t, ok)
+	})
+}

--- a/v2/pkg/engine/plan/configuration.go
+++ b/v2/pkg/engine/plan/configuration.go
@@ -3,6 +3,7 @@ package plan
 import (
 	"github.com/jensneuse/abstractlogger"
 
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 )
 
@@ -14,6 +15,13 @@ type Configuration struct {
 	Fields                             FieldConfigurations
 	Types                              TypeConfigurations
 	EntityInterfaceNames               []string
+
+	// CacheConfigProviders holds the per-datasource caching policy providers,
+	// keyed by datasource ID. A non-empty map gates the cacheProvidesDataVisitor
+	// second walk; the same map feeds postprocess.EnableCaching. Populated by
+	// the engine Configuration's SetCaching — the engine entry point is the only
+	// public producer.
+	CacheConfigProviders map[string]cacheconfig.CacheConfigProvider
 	// DisableResolveFieldPositions should be set to true for testing purposes
 	// This setting removes position information from all fields
 	// In production, this should be set to false so that error messages are easier to understand

--- a/v2/pkg/engine/plan/datasource_configuration.go
+++ b/v2/pkg/engine/plan/datasource_configuration.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/astvisitor"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 )
 
@@ -244,6 +245,10 @@ type dataSourceConfiguration[T any] struct {
 	factory PlannerFactory[T] // factory is the factory for the creation of the concrete DataSourcePlanner
 	custom  T                 // custom is the datasource specific configuration
 
+	// caching is the optional per-datasource cache policy provider; nil means
+	// no caching for this datasource.
+	caching cacheconfig.CacheConfigProvider
+
 	hash DSHash // hash is a unique hash for the dataSourceConfiguration used to match datasources
 }
 
@@ -348,6 +353,12 @@ func (d *dataSourceConfiguration[T]) Name() string {
 
 func (d *dataSourceConfiguration[T]) FederationConfiguration() FederationMetaData {
 	return d.FederationMetaData
+}
+
+// Caching returns the per-datasource cache policy provider; nil means no
+// caching is configured for this datasource.
+func (d *dataSourceConfiguration[T]) Caching() cacheconfig.CacheConfigProvider {
+	return d.caching
 }
 
 func (d *dataSourceConfiguration[T]) Hash() DSHash {

--- a/v2/pkg/engine/plan/path_builder_visitor.go
+++ b/v2/pkg/engine/plan/path_builder_visitor.go
@@ -123,6 +123,10 @@ type objectFetchConfiguration struct {
 	rootFields         []resolve.GraphCoordinate
 	operationType      ast.OperationType
 	deferID            int
+	// isolatedRootField marks a planner created by the per-root-field cache
+	// isolation gate (root_field_isolation.go): it owns exactly ONE query root
+	// field and never accepts another top-level operation field.
+	isolatedRootField bool
 }
 
 type currentFieldInfo struct {
@@ -655,6 +659,7 @@ func (c *pathBuilderVisitor) handlePlanningField(field *currentFieldInfo) {
 	}
 
 	isMutationRoot := c.isMutationRoot(field.currentPath)
+	isolateRootField := shouldIsolateRootField(c.plannerConfiguration.CacheConfigProviders, field, field.parentPath)
 
 	var (
 		plannerIdx int
@@ -662,9 +667,14 @@ func (c *pathBuilderVisitor) handlePlanningField(field *currentFieldInfo) {
 	)
 
 	// mutation root fields should always be planned on a new planner
-	// because mutations must be executed sequentially
-	if isMutationRoot {
+	// because mutations must be executed sequentially;
+	// cache-isolated query root fields get their own planner so each keeps
+	// its own cache policy and L2 key (root_field_isolation.go)
+	if isMutationRoot || isolateRootField {
 		plannerIdx, planned = c.addNewPlanner(field, isMutationRoot)
+		if planned && isolateRootField {
+			c.planners[plannerIdx].ObjectFetchConfiguration().isolatedRootField = true
+		}
 	} else {
 		plannerIdx, planned = c.planWithExistingPlanners(field)
 		if !planned {
@@ -833,6 +843,15 @@ func (c *pathBuilderVisitor) planWithExistingPlanners(field *currentFieldInfo) (
 		currentPlannerDSHash := dsConfiguration.Hash()
 
 		if field.suggestion.DataSourceHash != currentPlannerDSHash {
+			continue
+		}
+
+		if plannerConfig.ObjectFetchConfiguration().isolatedRootField && c.isParentPathIsRootOperationPath(field.parentPath) {
+			// an isolated planner owns exactly one root field: never fold
+			// another TOP-LEVEL operation field into it. The guard keys off
+			// the parent path, NOT IsRootNode — entity types are root nodes
+			// too, and an IsRootNode guard would tear the isolated field's
+			// own nested entity subtree apart.
 			continue
 		}
 

--- a/v2/pkg/engine/plan/planner.go
+++ b/v2/pkg/engine/plan/planner.go
@@ -241,7 +241,14 @@ func (p *Planner) Plan(operation, definition *ast.Document, operationName string
 	if p.cacheProvidesData != nil {
 		p.planningWalker.ResetVisitors()
 		p.planningWalker.SetVisitorFilter(nil)
-		p.cacheProvidesData.walker = p.planningWalker
+		p.cacheProvidesData.Walker = p.planningWalker
+		p.cacheProvidesData.operation = operation
+		p.cacheProvidesData.definition = definition
+		p.cacheProvidesData.config = p.config
+		p.cacheProvidesData.planners = plannersConfigurations
+		// fieldPlanners is populated by the main walk's LeaveField; it is
+		// complete here because the main walk has finished.
+		p.cacheProvidesData.fieldPlanners = p.planningVisitor.fieldPlanners
 		p.cacheProvidesData.reset()
 		p.planningWalker.RegisterEnterFieldVisitor(p.cacheProvidesData)
 		p.planningWalker.RegisterLeaveFieldVisitor(p.cacheProvidesData)

--- a/v2/pkg/engine/plan/planner.go
+++ b/v2/pkg/engine/plan/planner.go
@@ -20,6 +20,10 @@ type Planner struct {
 	planningVisitor *Visitor
 	costVisitor     *CostVisitor
 
+	// cacheProvidesData is the P1 caching walk; constructed only when caching
+	// is configured (nil otherwise, the planner no-op gate).
+	cacheProvidesData *cacheProvidesDataVisitor
+
 	nodeSelectionBuilder *NodeSelectionBuilder
 	planningPathBuilder  *PathBuilder
 
@@ -66,10 +70,16 @@ func NewPlanner(config Configuration) (*Planner, error) {
 	planningVisitor := NewVisitor(&planningWalker)
 	planningVisitor.disableResolveFieldPositions = config.DisableResolveFieldPositions
 
+	var cacheProvidesData *cacheProvidesDataVisitor
+	if len(config.CacheConfigProviders) > 0 {
+		cacheProvidesData = &cacheProvidesDataVisitor{}
+	}
+
 	p := &Planner{
 		config:                 config,
 		planningWalker:         &planningWalker,
 		planningVisitor:        planningVisitor,
+		cacheProvidesData:      cacheProvidesData,
 		prepareOperationWalker: &prepareOperationWalker,
 		deferInfoCollector:     deferInfoCollector,
 	}
@@ -222,6 +232,24 @@ func (p *Planner) Plan(operation, definition *ast.Document, operationName string
 		costCalc := NewCostCalculator(p.planningVisitor.Config)
 		costCalc.tree = p.costVisitor.finalCostTree()
 		p.planningVisitor.plan.SetCostCalculator(costCalc)
+	}
+
+	// P1 caching walk (D9): a gated SECOND, filter-free walk on the finished
+	// planningWalker. ResetVisitors drops every planning visitor (the plan is
+	// already built and is never rebuilt), the filter is cleared so P1 sees
+	// every field, and only P1 is registered for the walk.
+	if p.cacheProvidesData != nil {
+		p.planningWalker.ResetVisitors()
+		p.planningWalker.SetVisitorFilter(nil)
+		p.cacheProvidesData.walker = p.planningWalker
+		p.cacheProvidesData.reset()
+		p.planningWalker.RegisterEnterFieldVisitor(p.cacheProvidesData)
+		p.planningWalker.RegisterLeaveFieldVisitor(p.cacheProvidesData)
+		p.planningWalker.Walk(operation, definition, report)
+		if report.HasErrors() {
+			return
+		}
+		p.cacheProvidesData.attachTo(p.planningVisitor.plan)
 	}
 
 	// Step 5. Plan is handed over to postprocess.Processor. It checks fetch dependencies and

--- a/v2/pkg/engine/plan/planner.go
+++ b/v2/pkg/engine/plan/planner.go
@@ -234,25 +234,11 @@ func (p *Planner) Plan(operation, definition *ast.Document, operationName string
 		p.planningVisitor.plan.SetCostCalculator(costCalc)
 	}
 
-	// P1 caching walk (D9): a gated SECOND, filter-free walk on the finished
-	// planningWalker. ResetVisitors drops every planning visitor (the plan is
-	// already built and is never rebuilt), the filter is cleared so P1 sees
-	// every field, and only P1 is registered for the walk.
+	// P1 caching walk (D9): a gated SECOND, filter-free walk on a DEDICATED
+	// walker, after all planning walks are done — the planning walker keeps
+	// its visitors and filter, and fieldPlanners is complete here.
 	if p.cacheProvidesData != nil {
-		p.planningWalker.ResetVisitors()
-		p.planningWalker.SetVisitorFilter(nil)
-		p.cacheProvidesData.Walker = p.planningWalker
-		p.cacheProvidesData.operation = operation
-		p.cacheProvidesData.definition = definition
-		p.cacheProvidesData.config = p.config
-		p.cacheProvidesData.planners = plannersConfigurations
-		// fieldPlanners is populated by the main walk's LeaveField; it is
-		// complete here because the main walk has finished.
-		p.cacheProvidesData.fieldPlanners = p.planningVisitor.fieldPlanners
-		p.cacheProvidesData.reset()
-		p.planningWalker.RegisterEnterFieldVisitor(p.cacheProvidesData)
-		p.planningWalker.RegisterLeaveFieldVisitor(p.cacheProvidesData)
-		p.planningWalker.Walk(operation, definition, report)
+		p.cacheProvidesData.walk(operation, definition, p.config, plannersConfigurations, p.planningVisitor.fieldPlanners, report)
 		if report.HasErrors() {
 			return
 		}

--- a/v2/pkg/engine/plan/representationvariable/representation_variable.go
+++ b/v2/pkg/engine/plan/representationvariable/representation_variable.go
@@ -1,4 +1,9 @@
-package graphql_datasource
+// Package representationvariable builds the resolve-node representation of a federation
+// entity key: it turns one `@key` selection set into a federation-pointer-free
+// *resolve.Object used to render the `representations` variable for entity fetches.
+// It is shared between the graphql datasource planner and cache-key construction,
+// so that both derive representation nodes from a single walker and can never skew.
+package representationvariable
 
 import (
 	"bytes"
@@ -18,7 +23,10 @@ type objectFields struct {
 
 // TODO: add support for remapping path
 
-func buildRepresentationVariableNode(definition *ast.Document, cfg plan.FederationFieldConfiguration, federationCfg plan.FederationMetaData) (*resolve.Object, error) {
+// BuildRepresentationVariableNode turns one `@key` selection set (cfg.SelectionSet on
+// cfg.TypeName) into a federation-pointer-free *resolve.Object, with the
+// interfaceObject/entityInterface `__typename` remap from federationCfg baked in.
+func BuildRepresentationVariableNode(definition *ast.Document, cfg plan.FederationFieldConfiguration, federationCfg plan.FederationMetaData) (*resolve.Object, error) {
 	key, report := plan.RequiredFieldsFragment(cfg.TypeName, cfg.SelectionSet, false)
 	if report.HasErrors() {
 		return nil, report
@@ -120,7 +128,10 @@ func fieldsHasField(fields []*resolve.Field, field *resolve.Field) (int, bool) {
 	return -1, false
 }
 
-func mergeRepresentationVariableNodes(objects []*resolve.Object) *resolve.Object {
+// MergeRepresentationVariableNodes merges the per-key representation objects into the
+// single nullable object the graphql datasource renders as its `representations`
+// variable; fields with the same name and type conditions are deep-merged.
+func MergeRepresentationVariableNodes(objects []*resolve.Object) *resolve.Object {
 	fieldCount := 0
 	for _, object := range objects {
 		fieldCount += len(object.Fields)
@@ -144,6 +155,8 @@ func mergeRepresentationVariableNodes(objects []*resolve.Object) *resolve.Object
 	}
 }
 
+// representationVariableVisitor walks one `@key` selection set against the schema
+// definition and assembles the corresponding resolve-node tree.
 type representationVariableVisitor struct {
 	*astvisitor.Walker
 

--- a/v2/pkg/engine/plan/representationvariable/representation_variable_test.go
+++ b/v2/pkg/engine/plan/representationvariable/representation_variable_test.go
@@ -1,4 +1,4 @@
-package graphql_datasource
+package representationvariable
 
 import (
 	"testing"
@@ -18,7 +18,7 @@ func TestBuildRepresentationVariableNode(t *testing.T) {
 			SelectionSet: keyStr,
 		}
 
-		node, err := buildRepresentationVariableNode(&definition, cfg, federationMeta)
+		node, err := BuildRepresentationVariableNode(&definition, cfg, federationMeta)
 		require.NoError(t, err)
 
 		require.Equal(t, expectedNode, node)
@@ -27,7 +27,7 @@ func TestBuildRepresentationVariableNode(t *testing.T) {
 	t.Run("simple", func(t *testing.T) {
 		runTest(t, `
 			scalar String
-	
+
 			type User {
 				id: String!
 				name: String!
@@ -66,7 +66,7 @@ func TestBuildRepresentationVariableNode(t *testing.T) {
 	t.Run("with interface object", func(t *testing.T) {
 		runTest(t, `
 			scalar String
-	
+
 			type User {
 				id: String!
 				name: String!
@@ -110,12 +110,58 @@ func TestBuildRepresentationVariableNode(t *testing.T) {
 			})
 	})
 
+	t.Run("with entity interface", func(t *testing.T) {
+		runTest(t, `
+			scalar String
+
+			type User {
+				id: String!
+				name: String!
+			}
+		`,
+			`id name`,
+			plan.FederationMetaData{
+				EntityInterfaces: []plan.EntityInterfaceConfiguration{
+					{
+						InterfaceTypeName: "Account",
+						ConcreteTypeNames: []string{"User", "Admin"},
+					},
+				},
+			},
+			&resolve.Object{
+				Nullable: true,
+				Fields: []*resolve.Field{
+					{
+						Name: []byte("__typename"),
+						Value: &resolve.String{
+							Path: []string{"__typename"},
+						},
+						OnTypeNames: [][]byte{[]byte("User"), []byte("Account")},
+					},
+					{
+						Name: []byte("id"),
+						Value: &resolve.String{
+							Path: []string{"id"},
+						},
+						OnTypeNames: [][]byte{[]byte("User"), []byte("Account")},
+					},
+					{
+						Name: []byte("name"),
+						Value: &resolve.String{
+							Path: []string{"name"},
+						},
+						OnTypeNames: [][]byte{[]byte("User"), []byte("Account")},
+					},
+				},
+			})
+	})
+
 	t.Run("deeply nested", func(t *testing.T) {
 		runTest(t, `
 			scalar String
 			scalar Int
 			scalar Float
-	
+
 			type User {
 				id: String!
 				name: String!
@@ -130,7 +176,7 @@ func TestBuildRepresentationVariableNode(t *testing.T) {
 			type Address {
 				zip: Float!
 			}
-				
+
 		`,
 			`id name account { accoundID address(home: true) { zip } }`,
 			plan.FederationMetaData{},
@@ -313,7 +359,7 @@ func TestMergeRepresentationVariableNodes(t *testing.T) {
 			},
 		}
 
-		merged := mergeRepresentationVariableNodes([]*resolve.Object{userRepresentation, adminRepresentation})
+		merged := MergeRepresentationVariableNodes([]*resolve.Object{userRepresentation, adminRepresentation})
 		require.Equal(t, expected, merged)
 	})
 
@@ -362,7 +408,7 @@ func TestMergeRepresentationVariableNodes(t *testing.T) {
 			},
 		}
 
-		merged := mergeRepresentationVariableNodes([]*resolve.Object{userKeyRepresentation, userRequiresRepresentation})
+		merged := MergeRepresentationVariableNodes([]*resolve.Object{userKeyRepresentation, userRequiresRepresentation})
 		require.Equal(t, expected, merged)
 	})
 
@@ -413,7 +459,7 @@ func TestMergeRepresentationVariableNodes(t *testing.T) {
 			},
 		}
 
-		merged := mergeRepresentationVariableNodes([]*resolve.Object{userKeyRepresentation, userRequiresRepresentation})
+		merged := MergeRepresentationVariableNodes([]*resolve.Object{userKeyRepresentation, userRequiresRepresentation})
 		require.Equal(t, expected, merged)
 	})
 
@@ -567,7 +613,7 @@ func TestMergeRepresentationVariableNodes(t *testing.T) {
 			},
 		}
 
-		merged := mergeRepresentationVariableNodes([]*resolve.Object{userKeyRepresentation, userRequiresRepresentation})
+		merged := MergeRepresentationVariableNodes([]*resolve.Object{userKeyRepresentation, userRequiresRepresentation})
 		require.Equal(t, expected, merged)
 	})
 
@@ -793,7 +839,7 @@ func TestMergeRepresentationVariableNodes(t *testing.T) {
 			},
 		}
 
-		merged := mergeRepresentationVariableNodes([]*resolve.Object{userKeyRepresentation, userRequiresRepresentation})
+		merged := MergeRepresentationVariableNodes([]*resolve.Object{userKeyRepresentation, userRequiresRepresentation})
 		require.Equal(t, expected, merged)
 	})
 }

--- a/v2/pkg/engine/plan/root_field_isolation.go
+++ b/v2/pkg/engine/plan/root_field_isolation.go
@@ -17,7 +17,10 @@ import (
 //   - the field is a DIRECT child of the QUERY operation root (mutation roots
 //     are already one-planner-per-root; subscriptions are out of core);
 //   - the field's datasource has a provider AND that provider has a
-//     RootFieldPolicy for the exact (typeName, fieldName) coordinate.
+//     RootFieldPolicy for the exact (typeName, fieldName) coordinate AND that
+//     policy actually enables caching (an inert policy — no TTL, no shadow —
+//     yields no FetchCacheConfig via the configurator's all-flags-false safety
+//     net, so isolating for it would change the plan without caching anything).
 //
 // The decision reads the CacheConfigProvider ONLY — never FederationMetaData.
 func shouldIsolateRootField(providers map[string]cacheconfig.CacheConfigProvider, field *currentFieldInfo, parentPath string) bool {
@@ -31,6 +34,6 @@ func shouldIsolateRootField(providers map[string]cacheconfig.CacheConfigProvider
 	if provider == nil {
 		return false
 	}
-	_, ok := provider.RootFieldPolicy(field.typeName, field.fieldName)
-	return ok
+	policy, ok := provider.RootFieldPolicy(field.typeName, field.fieldName)
+	return ok && policy.EnablesCaching()
 }

--- a/v2/pkg/engine/plan/root_field_isolation.go
+++ b/v2/pkg/engine/plan/root_field_isolation.go
@@ -1,0 +1,36 @@
+package plan
+
+import (
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
+)
+
+// shouldIsolateRootField is the per-root-field cache isolation gate (RFC-3, in
+// core): a QUERY root field whose exact coordinate carries a RootFieldPolicy
+// gets its OWN planner during path building, so sibling root fields with
+// different (or no) cache policies never merge into one fetch — each cached
+// field keeps its own L2 key and TTL, and the task-13 all-or-nothing decline
+// stays a rare residual safety net.
+//
+// The gate holds when ALL of:
+//   - caching is configured (non-empty providers — with caching off the
+//     isolation branches are provably dead and plans stay byte-identical);
+//   - the field is a DIRECT child of the QUERY operation root (mutation roots
+//     are already one-planner-per-root; subscriptions are out of core);
+//   - the field's datasource has a provider AND that provider has a
+//     RootFieldPolicy for the exact (typeName, fieldName) coordinate.
+//
+// The decision reads the CacheConfigProvider ONLY — never FederationMetaData.
+func shouldIsolateRootField(providers map[string]cacheconfig.CacheConfigProvider, field *currentFieldInfo, parentPath string) bool {
+	if len(providers) == 0 {
+		return false
+	}
+	if parentPath != "query" {
+		return false
+	}
+	provider := providers[field.ds.Id()]
+	if provider == nil {
+		return false
+	}
+	_, ok := provider.RootFieldPolicy(field.typeName, field.fieldName)
+	return ok
+}

--- a/v2/pkg/engine/plan/root_field_isolation_test.go
+++ b/v2/pkg/engine/plan/root_field_isolation_test.go
@@ -1,0 +1,63 @@
+package plan
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
+)
+
+// TestShouldIsolateRootField pins the gate predicate directly: every condition
+// that must hold, and every one that must decline. The plan-level behavior
+// (two parallel fetches, the entity-root-node trap, defer composition, the
+// byte-identical no-op) is pinned over REAL plans in
+// execution/cachingtesting/isolation_e2e_test.go.
+func TestShouldIsolateRootField(t *testing.T) {
+	providers := map[string]cacheconfig.CacheConfigProvider{
+		"products": &cacheconfig.CachingConfiguration{
+			RootFields: []cacheconfig.RootFieldCachePolicy{
+				{TypeName: "Query", FieldName: "products", CacheName: "products-cache", TTL: time.Minute},
+			},
+		},
+	}
+	productsField := &currentFieldInfo{
+		typeName:  "Query",
+		fieldName: "products",
+		ds:        &dataSourceConfiguration[any]{id: "products"},
+	}
+
+	t.Run("cached query root field isolates", func(t *testing.T) {
+		assert.True(t, shouldIsolateRootField(providers, productsField, "query"))
+	})
+
+	t.Run("no caching configured never isolates (the provable no-op)", func(t *testing.T) {
+		assert.False(t, shouldIsolateRootField(nil, productsField, "query"))
+		assert.False(t, shouldIsolateRootField(map[string]cacheconfig.CacheConfigProvider{}, productsField, "query"))
+	})
+
+	t.Run("only DIRECT children of the QUERY root isolate", func(t *testing.T) {
+		assert.False(t, shouldIsolateRootField(providers, productsField, "mutation"))
+		assert.False(t, shouldIsolateRootField(providers, productsField, "subscription"))
+		assert.False(t, shouldIsolateRootField(providers, productsField, "query.products"))
+	})
+
+	t.Run("a datasource without a provider never isolates", func(t *testing.T) {
+		otherDS := &currentFieldInfo{
+			typeName:  "Query",
+			fieldName: "products",
+			ds:        &dataSourceConfiguration[any]{id: "reviews"},
+		}
+		assert.False(t, shouldIsolateRootField(providers, otherDS, "query"))
+	})
+
+	t.Run("a coordinate without a RootFieldPolicy never isolates", func(t *testing.T) {
+		uncachedField := &currentFieldInfo{
+			typeName:  "Query",
+			fieldName: "promotions",
+			ds:        &dataSourceConfiguration[any]{id: "products"},
+		}
+		assert.False(t, shouldIsolateRootField(providers, uncachedField, "query"))
+	})
+}

--- a/v2/pkg/engine/plan/root_field_isolation_test.go
+++ b/v2/pkg/engine/plan/root_field_isolation_test.go
@@ -60,4 +60,29 @@ func TestShouldIsolateRootField(t *testing.T) {
 		}
 		assert.False(t, shouldIsolateRootField(providers, uncachedField, "query"))
 	})
+
+	t.Run("an INERT policy (no TTL, no shadow) never isolates", func(t *testing.T) {
+		// The configurator's all-flags-false safety net drops such a policy's
+		// config entirely; isolating for it would change the plan without
+		// enabling any caching.
+		inertProviders := map[string]cacheconfig.CacheConfigProvider{
+			"products": &cacheconfig.CachingConfiguration{
+				RootFields: []cacheconfig.RootFieldCachePolicy{
+					{TypeName: "Query", FieldName: "products", CacheName: "products-cache"},
+				},
+			},
+		}
+		assert.False(t, shouldIsolateRootField(inertProviders, productsField, "query"))
+	})
+
+	t.Run("a shadow-only policy isolates", func(t *testing.T) {
+		shadowProviders := map[string]cacheconfig.CacheConfigProvider{
+			"products": &cacheconfig.CachingConfiguration{
+				RootFields: []cacheconfig.RootFieldCachePolicy{
+					{TypeName: "Query", FieldName: "products", CacheName: "products-cache", ShadowMode: true},
+				},
+			},
+		}
+		assert.True(t, shouldIsolateRootField(shadowProviders, productsField, "query"))
+	})
 }

--- a/v2/pkg/engine/postprocess/postprocess.go
+++ b/v2/pkg/engine/postprocess/postprocess.go
@@ -217,7 +217,7 @@ func (p *Processor) Process(pre plan.Plan) {
 		p.createFetchTree(t.Response)
 		p.fetchTreeProcessors.processFlatFetchTree(t.Response.Fetches)
 		// caching passes run on the flat tree, after the concrete fetch types exist
-		p.caching.ConfigureCaching(t.Response, t.Response.Fetches)
+		p.caching.ConfigureCaching(t.Response, nil, t.Response.Fetches)
 		p.fetchTreeProcessors.organizeFetchTree(t.Response.Fetches)
 
 	case *plan.DeferResponsePlan:
@@ -230,7 +230,7 @@ func (p *Processor) Process(pre plan.Plan) {
 
 		// caching passes run over the initial tree AND every defer-group tree,
 		// before the trees are organized and the defer tree is built
-		p.caching.ConfigureCaching(t.Response.Response, deferTrees(t)...)
+		p.caching.ConfigureCaching(t.Response.Response, deferTreeParents(t), deferTrees(t)...)
 
 		// process the initial response fetch tree
 		p.fetchTreeProcessors.organizeFetchTree(t.Response.Response.Fetches)
@@ -251,7 +251,7 @@ func (p *Processor) Process(pre plan.Plan) {
 		p.appendTriggerToFetchTree(t.Response)
 
 		p.fetchTreeProcessors.processFlatFetchTree(t.Response.Response.Fetches)
-		p.caching.ConfigureCaching(t.Response.Response, t.Response.Response.Fetches)
+		p.caching.ConfigureCaching(t.Response.Response, nil, t.Response.Response.Fetches)
 
 		// resolve input template for the root query in the subscription trigger
 		p.fetchTreeProcessors.resolveInputTemplates.ProcessTrigger(&t.Response.Trigger)
@@ -263,6 +263,28 @@ func (p *Processor) Process(pre plan.Plan) {
 // deferTrees collects the initial response fetch tree plus every defer-group
 // tree of a defer plan, so the caching passes see all trees of one response
 // (cross-tree passes like optimizeL1Cache need the full set).
+// deferTreeParents mirrors deferTrees: for each tree, the index of the tree
+// whose @defer group ENCLOSES it (-1 for the initial tree), derived from the
+// DeferDescriptors' ParentID chain. The narrowing pass uses it as an ordering
+// source (a parent group resolves fully before its children).
+func deferTreeParents(d *plan.DeferResponsePlan) []int {
+	deferIDToTree := make(map[int]int, len(d.Response.Defers))
+	for i, g := range d.Response.Defers {
+		deferIDToTree[g.DeferID] = i + 1
+	}
+	parents := make([]int, 1+len(d.Response.Defers))
+	parents[0] = -1
+	for i, g := range d.Response.Defers {
+		parents[i+1] = 0
+		if descriptor, ok := d.Response.DeferDescriptors[g.DeferID]; ok && descriptor.ParentID != 0 {
+			if parentTree, ok := deferIDToTree[descriptor.ParentID]; ok {
+				parents[i+1] = parentTree
+			}
+		}
+	}
+	return parents
+}
+
 func deferTrees(d *plan.DeferResponsePlan) []*resolve.FetchTreeNode {
 	trees := make([]*resolve.FetchTreeNode, 0, 1+len(d.Response.Defers))
 	trees = append(trees, d.Response.Response.Fetches)

--- a/v2/pkg/engine/postprocess/postprocess.go
+++ b/v2/pkg/engine/postprocess/postprocess.go
@@ -3,7 +3,10 @@ package postprocess
 import (
 	"slices"
 
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/cache"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 )
 
@@ -25,6 +28,9 @@ type Processor struct {
 	responseTreeProcessors *ResponseTreeProcessors
 	extractDeferFetches    *extractDeferFetches
 	buildDeferTree         *buildDeferTree
+	// caching orchestrates the caching passes; with no EnableCaching option it
+	// is a guaranteed no-op (the planner no-op gate lives inside it).
+	caching *cache.Configurator
 }
 
 type FetchTreeProcessors struct {
@@ -71,6 +77,9 @@ type processorOptions struct {
 	collectDataSourceInfo                 bool
 	disableExtractDeferFetches            bool
 	disableBuildDeferTree                 bool
+	cacheProviders                        map[string]cacheconfig.CacheConfigProvider
+	cacheFederation                       map[string]plan.FederationMetaData
+	cacheDefinition                       *ast.Document
 }
 
 type ProcessorOption func(*processorOptions)
@@ -136,6 +145,18 @@ func DisableBuildDeferTree() ProcessorOption {
 	}
 }
 
+// EnableCaching wires the caching postprocess passes. It is an INTERNAL
+// detail: the public entry point is the engine Configuration's SetCaching,
+// which builds these inputs (providers and federation keyed by datasource ID,
+// plus the composed schema) and passes them through.
+func EnableCaching(providers map[string]cacheconfig.CacheConfigProvider, federation map[string]plan.FederationMetaData, definition *ast.Document) ProcessorOption {
+	return func(o *processorOptions) {
+		o.cacheProviders = providers
+		o.cacheFederation = federation
+		o.cacheDefinition = definition
+	}
+}
+
 func NewProcessor(options ...ProcessorOption) *Processor {
 	opts := &processorOptions{}
 	for _, o := range options {
@@ -180,6 +201,7 @@ func NewProcessor(options ...ProcessorOption) *Processor {
 		buildDeferTree: &buildDeferTree{
 			disable: opts.disableBuildDeferTree,
 		},
+		caching: cache.NewConfigurator(opts.cacheProviders, opts.cacheFederation, opts.cacheDefinition),
 	}
 }
 
@@ -194,6 +216,8 @@ func (p *Processor) Process(pre plan.Plan) {
 		// initialize the fetch tree
 		p.createFetchTree(t.Response)
 		p.fetchTreeProcessors.processFlatFetchTree(t.Response.Fetches)
+		// caching passes run on the flat tree, after the concrete fetch types exist
+		p.caching.ConfigureCaching(t.Response, t.Response.Fetches)
 		p.fetchTreeProcessors.organizeFetchTree(t.Response.Fetches)
 
 	case *plan.DeferResponsePlan:
@@ -203,6 +227,10 @@ func (p *Processor) Process(pre plan.Plan) {
 
 		// extract deferred fetches into their own fetch trees
 		p.extractDeferFetches.Process(t)
+
+		// caching passes run over the initial tree AND every defer-group tree,
+		// before the trees are organized and the defer tree is built
+		p.caching.ConfigureCaching(t.Response.Response, deferTrees(t)...)
 
 		// process the initial response fetch tree
 		p.fetchTreeProcessors.organizeFetchTree(t.Response.Response.Fetches)
@@ -223,12 +251,25 @@ func (p *Processor) Process(pre plan.Plan) {
 		p.appendTriggerToFetchTree(t.Response)
 
 		p.fetchTreeProcessors.processFlatFetchTree(t.Response.Response.Fetches)
+		p.caching.ConfigureCaching(t.Response.Response, t.Response.Response.Fetches)
 
 		// resolve input template for the root query in the subscription trigger
 		p.fetchTreeProcessors.resolveInputTemplates.ProcessTrigger(&t.Response.Trigger)
 
 		p.fetchTreeProcessors.organizeFetchTree(t.Response.Response.Fetches)
 	}
+}
+
+// deferTrees collects the initial response fetch tree plus every defer-group
+// tree of a defer plan, so the caching passes see all trees of one response
+// (cross-tree passes like optimizeL1Cache need the full set).
+func deferTrees(d *plan.DeferResponsePlan) []*resolve.FetchTreeNode {
+	trees := make([]*resolve.FetchTreeNode, 0, 1+len(d.Response.Defers))
+	trees = append(trees, d.Response.Response.Fetches)
+	for _, g := range d.Response.Defers {
+		trees = append(trees, g.Fetches)
+	}
+	return trees
 }
 
 // createFetchTree creates an initial fetch tree from the raw fetches in the GraphQL response.

--- a/v2/pkg/engine/postprocess/postprocess.go
+++ b/v2/pkg/engine/postprocess/postprocess.go
@@ -228,10 +228,6 @@ func (p *Processor) Process(pre plan.Plan) {
 		// extract deferred fetches into their own fetch trees
 		p.extractDeferFetches.Process(t)
 
-		// caching passes run over the initial tree AND every defer-group tree,
-		// before the trees are organized and the defer tree is built
-		p.caching.ConfigureCaching(t.Response.Response, deferTreeParents(t), deferTrees(t)...)
-
 		// process the initial response fetch tree
 		p.fetchTreeProcessors.organizeFetchTree(t.Response.Response.Fetches)
 
@@ -242,6 +238,13 @@ func (p *Processor) Process(pre plan.Plan) {
 
 		// order defer fetches into parallel/sequence groups
 		p.buildDeferTree.Process(t.Response)
+
+		// caching passes run AFTER the defer tree is built: the group trees
+		// and their ancestry come from the AUTHORITATIVE DeferTree the
+		// resolver executes (a parent group resolves fully before its
+		// children), not from a parallel derivation
+		cachingTrees, cachingTreeParents := collectDeferCachingTrees(t.Response)
+		p.caching.ConfigureCaching(t.Response.Response, cachingTreeParents, cachingTrees...)
 		// emptily defers, as they are now ordered in a separate tree
 		t.Response.Defers = nil
 
@@ -263,35 +266,62 @@ func (p *Processor) Process(pre plan.Plan) {
 // deferTrees collects the initial response fetch tree plus every defer-group
 // tree of a defer plan, so the caching passes see all trees of one response
 // (cross-tree passes like optimizeL1Cache need the full set).
-// deferTreeParents mirrors deferTrees: for each tree, the index of the tree
-// whose @defer group ENCLOSES it (-1 for the initial tree), derived from the
-// DeferDescriptors' ParentID chain. The narrowing pass uses it as an ordering
-// source (a parent group resolves fully before its children).
-func deferTreeParents(d *plan.DeferResponsePlan) []int {
-	deferIDToTree := make(map[int]int, len(d.Response.Defers))
-	for i, g := range d.Response.Defers {
-		deferIDToTree[g.DeferID] = i + 1
+// collectDeferCachingTrees gathers the fetch trees the caching passes run
+// over — the initial tree plus every defer group — with each tree's parent
+// index for the L1 narrowing pass's ancestry ordering. Both come from the
+// BUILT DeferTree: a Sequence node's first child is the parent group and the
+// remaining children are its nested groups; Parallel children share their
+// enclosing parent. A group without fetches contributes no tree, and its
+// children attach to the nearest fetch-bearing ancestor (a weaker but still
+// sound ordering). Falls back to the flat Defers list (all parented to the
+// initial tree) when the defer tree was not built (disableBuildDeferTree).
+func collectDeferCachingTrees(response *resolve.GraphQLDeferResponse) ([]*resolve.FetchTreeNode, []int) {
+	trees := []*resolve.FetchTreeNode{response.Response.Fetches}
+	parents := []int{-1}
+	if response.DeferTree == nil {
+		for _, group := range response.Defers {
+			if group.Fetches == nil {
+				continue
+			}
+			trees = append(trees, group.Fetches)
+			parents = append(parents, 0)
+		}
+		return trees, parents
 	}
-	parents := make([]int, 1+len(d.Response.Defers))
-	parents[0] = -1
-	for i, g := range d.Response.Defers {
-		parents[i+1] = 0
-		if descriptor, ok := d.Response.DeferDescriptors[g.DeferID]; ok && descriptor.ParentID != 0 {
-			if parentTree, ok := deferIDToTree[descriptor.ParentID]; ok {
-				parents[i+1] = parentTree
+	var walk func(node *resolve.DeferTreeNode, parentIndex int)
+	walk = func(node *resolve.DeferTreeNode, parentIndex int) {
+		if node == nil {
+			return
+		}
+		switch node.Kind {
+		case resolve.DeferTreeNodeKindSingle:
+			if node.Item != nil && node.Item.Fetches != nil {
+				trees = append(trees, node.Item.Fetches)
+				parents = append(parents, parentIndex)
+			}
+		case resolve.DeferTreeNodeKindSequence:
+			if len(node.ChildNodes) == 0 {
+				return
+			}
+			// buildDeferTree shape: ChildNodes[0] is the parent group, the
+			// rest is its child subtree.
+			before := len(trees)
+			walk(node.ChildNodes[0], parentIndex)
+			childParent := parentIndex
+			if len(trees) == before+1 {
+				childParent = before
+			}
+			for _, child := range node.ChildNodes[1:] {
+				walk(child, childParent)
+			}
+		case resolve.DeferTreeNodeKindParallel:
+			for _, child := range node.ChildNodes {
+				walk(child, parentIndex)
 			}
 		}
 	}
-	return parents
-}
-
-func deferTrees(d *plan.DeferResponsePlan) []*resolve.FetchTreeNode {
-	trees := make([]*resolve.FetchTreeNode, 0, 1+len(d.Response.Defers))
-	trees = append(trees, d.Response.Response.Fetches)
-	for _, g := range d.Response.Defers {
-		trees = append(trees, g.Fetches)
-	}
-	return trees
+	walk(response.DeferTree, 0)
+	return trees, parents
 }
 
 // createFetchTree creates an initial fetch tree from the raw fetches in the GraphQL response.

--- a/v2/pkg/engine/postprocess/postprocess_caching_test.go
+++ b/v2/pkg/engine/postprocess/postprocess_caching_test.go
@@ -1,0 +1,334 @@
+package postprocess
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astparser"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan/cacheconfig"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// The postprocess-level caching suite: the FULL Processor pipeline over
+// synthetic plans, pinning that EnableCaching configures fetches in the sync
+// arm AND in the defer arm (where ConfigureCaching runs AFTER buildDeferTree
+// and derives group ancestry from the built DeferTree), plus direct rows for
+// collectDeferCachingTrees. The plan-driven end-to-end equivalents live in
+// execution/cachingtesting.
+
+func cachingTestDefinition(t *testing.T) *ast.Document {
+	t.Helper()
+	definition, report := astparser.ParseGraphqlDocumentString(`
+		scalar String
+		scalar Int
+
+		type Query {
+			products: [Product]
+		}
+
+		type Product {
+			upc: String!
+			name: String!
+			price: Int
+		}
+	`)
+	require.False(t, report.HasErrors(), "parse definition: %v", report)
+	return &definition
+}
+
+func cachingTestFederation(t *testing.T) map[string]plan.FederationMetaData {
+	t.Helper()
+	// The metadata needs Init (entity index + parsed key selection sets) —
+	// exactly what the engine wiring provides in production.
+	metadata := &plan.DataSourceMetadata{
+		FederationMetaData: plan.FederationMetaData{
+			Keys: plan.FederationFieldConfigurations{
+				{TypeName: "Product", SelectionSet: "upc"},
+			},
+		},
+	}
+	require.NoError(t, metadata.Init())
+	return map[string]plan.FederationMetaData{"products": metadata.FederationMetaData}
+}
+
+func cachingTestProviders(ttl time.Duration) map[string]cacheconfig.CacheConfigProvider {
+	return map[string]cacheconfig.CacheConfigProvider{
+		"products": &cacheconfig.CachingConfiguration{
+			Entities: []cacheconfig.EntityCachePolicy{
+				{TypeName: "Product", CacheName: "products", TTL: ttl},
+			},
+		},
+	}
+}
+
+// productTree builds an entity coverage tree with the given scalar fields.
+func productTree(fields ...string) *resolve.Object {
+	obj := &resolve.Object{}
+	for _, name := range fields {
+		obj.Fields = append(obj.Fields, &resolve.Field{
+			Name:  []byte(name),
+			Value: &resolve.Scalar{Nullable: true, Path: []string{name}},
+		})
+	}
+	return obj
+}
+
+// entityRawFetch builds a raw SingleFetch that createConcreteSingleFetchTypes
+// converts into an EntityFetch (RequiresEntityFetch + a representations
+// variable segment), attributed to the products datasource.
+func entityRawFetch(fetchID, deferID int) (*resolve.FetchItem, *resolve.FetchInfo) {
+	info := &resolve.FetchInfo{
+		DataSourceID: "products",
+		RootFields:   []resolve.GraphCoordinate{{TypeName: "Product"}},
+	}
+	fetch := &resolve.SingleFetch{
+		FetchDependencies: resolve.FetchDependencies{FetchID: fetchID, DeferID: deferID},
+		FetchConfiguration: resolve.FetchConfiguration{
+			RequiresEntityFetch: true,
+			Input:               `{"method":"POST","url":"http://products","body":{"query":"...","variables":{"representations":[$$0$$]}}}`,
+			Variables: resolve.Variables{
+				resolve.NewResolvableObjectVariable(&resolve.Object{
+					Fields: []*resolve.Field{
+						{Name: []byte("__typename"), Value: &resolve.String{Path: []string{"__typename"}}},
+						{Name: []byte("upc"), Value: &resolve.String{Path: []string{"upc"}}},
+					},
+				}),
+			},
+		},
+		Info: info,
+	}
+	return &resolve.FetchItem{Fetch: fetch, ResponsePath: "products"}, info
+}
+
+func minimalData() *resolve.Object {
+	return &resolve.Object{
+		Fields: []*resolve.Field{
+			{Name: []byte("products"), Value: &resolve.String{Path: []string{"products"}, Nullable: true}},
+		},
+	}
+}
+
+// findCacheConfigs walks a fetch tree collecting each fetch's cache config
+// string (nil-safe), depth-first.
+func findCacheConfigs(node *resolve.FetchTreeNode) []string {
+	if node == nil {
+		return nil
+	}
+	var out []string
+	if node.Item != nil && node.Item.Fetch != nil {
+		out = append(out, node.Item.Fetch.CacheConfig().String())
+	}
+	for _, child := range node.ChildNodes {
+		out = append(out, findCacheConfigs(child)...)
+	}
+	return out
+}
+
+// TestPostprocessCachingSyncArm: the full pipeline configures an entity fetch
+// in a synchronous plan; a lone entity fetch has no L1 partner, so the
+// narrowing pass turns L1 off and L2 remains.
+func TestPostprocessCachingSyncArm(t *testing.T) {
+	entityItem, info := entityRawFetch(2, 0)
+	response := &resolve.GraphQLResponse{
+		RawFetches: []*resolve.FetchItem{
+			{Fetch: &resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 1}}},
+			entityItem,
+		},
+		Data: minimalData(),
+	}
+	response.SetCacheProvidesData(map[*resolve.FetchInfo]*resolve.Object{
+		info: productTree("name", "price"),
+	})
+
+	processor := NewProcessor(EnableCaching(cachingTestProviders(time.Minute), cachingTestFederation(t), cachingTestDefinition(t)))
+	processor.Process(&plan.SynchronousResponsePlan{Response: response})
+
+	assert.Equal(t, []string{
+		`<nil>`,
+		`{l1:false l2:true cacheName:products ttl:1m0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:Entity type:Product field: candidates:1 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}`,
+	}, findCacheConfigs(response.Fetches))
+}
+
+// TestPostprocessCachingNoOp: a processor with EnableCaching over EMPTY
+// providers produces a plan equal to a plain processor's — the no-op gate at
+// the postprocess level.
+func TestPostprocessCachingNoOp(t *testing.T) {
+	build := func() *plan.SynchronousResponsePlan {
+		entityItem, _ := entityRawFetch(2, 0)
+		return &plan.SynchronousResponsePlan{Response: &resolve.GraphQLResponse{
+			RawFetches: []*resolve.FetchItem{
+				{Fetch: &resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 1}}},
+				entityItem,
+			},
+			Data: minimalData(),
+		}}
+	}
+
+	plain := build()
+	NewProcessor().Process(plain)
+
+	withEmptyCaching := build()
+	NewProcessor(EnableCaching(map[string]cacheconfig.CacheConfigProvider{}, nil, nil)).Process(withEmptyCaching)
+
+	assert.Equal(t, plain, withEmptyCaching)
+	assert.Equal(t, []string{`<nil>`, `<nil>`}, findCacheConfigs(withEmptyCaching.Response.Fetches))
+}
+
+// deferCachingPlan builds a DeferResponsePlan with one uncached initial fetch
+// and two ENTITY fetches in defer groups 1 and 2, whose coverage trees form a
+// provider/consumer pair ({name,price} ⊇ {name}). The descriptors decide
+// whether group 2 is NESTED under group 1 or its SIBLING.
+func deferCachingPlan(t *testing.T, descriptors map[int]resolve.DeferDescriptor) (*plan.DeferResponsePlan, *resolve.GraphQLDeferResponse) {
+	t.Helper()
+	providerItem, providerInfo := entityRawFetch(2, 1)
+	consumerItem, consumerInfo := entityRawFetch(3, 2)
+	response := &resolve.GraphQLResponse{
+		RawFetches: []*resolve.FetchItem{
+			{Fetch: &resolve.SingleFetch{FetchDependencies: resolve.FetchDependencies{FetchID: 1}}},
+			providerItem,
+			consumerItem,
+		},
+		Data: minimalData(),
+	}
+	response.SetCacheProvidesData(map[*resolve.FetchInfo]*resolve.Object{
+		providerInfo: productTree("name", "price"),
+		consumerInfo: productTree("name"),
+	})
+	deferResponse := &resolve.GraphQLDeferResponse{
+		Response:         response,
+		DeferDescriptors: descriptors,
+	}
+	return &plan.DeferResponsePlan{Response: deferResponse}, deferResponse
+}
+
+// deferGroupCacheConfigs walks the BUILT DeferTree in execution order and
+// returns each group's fetch cache configs.
+func deferGroupCacheConfigs(node *resolve.DeferTreeNode) []string {
+	if node == nil {
+		return nil
+	}
+	var out []string
+	if node.Item != nil {
+		out = append(out, findCacheConfigs(node.Item.Fetches)...)
+	}
+	for _, child := range node.ChildNodes {
+		out = append(out, deferGroupCacheConfigs(child)...)
+	}
+	return out
+}
+
+// TestPostprocessCachingDeferAncestry pins the reason ConfigureCaching runs
+// AFTER buildDeferTree: the L1 narrowing pass orders defer groups by the
+// AUTHORITATIVE tree's ancestry. The same provider/consumer pair keeps L1
+// when the consumer's group is NESTED under the provider's (a parent group
+// resolves fully before its children) and is narrowed off — configs re-nil'd,
+// the policies being L1-only — when the groups are unordered SIBLINGS.
+func TestPostprocessCachingDeferAncestry(t *testing.T) {
+	l1OnlyConfig := `{l1:true l2:false cacheName:products ttl:0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:Entity type:Product field: candidates:1 entityKeyMappings:0 providesData:true populateL2OnMutation:false mutationTTL:0s}`
+
+	t.Run("nested groups keep the L1 pair", func(t *testing.T) {
+		deferPlan, deferResponse := deferCachingPlan(t, map[int]resolve.DeferDescriptor{
+			1: {ID: 1, ParentID: 0},
+			2: {ID: 2, ParentID: 1},
+		})
+		NewProcessor(EnableCaching(cachingTestProviders(0), cachingTestFederation(t), cachingTestDefinition(t))).Process(deferPlan)
+		require.NotNil(t, deferResponse.DeferTree)
+		assert.Equal(t, []string{l1OnlyConfig, l1OnlyConfig}, deferGroupCacheConfigs(deferResponse.DeferTree))
+	})
+
+	t.Run("sibling groups are unordered: both narrowed off and re-nil'd", func(t *testing.T) {
+		deferPlan, deferResponse := deferCachingPlan(t, map[int]resolve.DeferDescriptor{
+			1: {ID: 1, ParentID: 0},
+			2: {ID: 2, ParentID: 0},
+		})
+		NewProcessor(EnableCaching(cachingTestProviders(0), cachingTestFederation(t), cachingTestDefinition(t))).Process(deferPlan)
+		require.NotNil(t, deferResponse.DeferTree)
+		assert.Equal(t, []string{`<nil>`, `<nil>`}, deferGroupCacheConfigs(deferResponse.DeferTree))
+	})
+}
+
+// TestCollectDeferCachingTrees pins the tree/ancestry collection directly
+// over BUILT defer trees (and the not-built fallback).
+func TestCollectDeferCachingTrees(t *testing.T) {
+	groupFetches := func(response *resolve.GraphQLDeferResponse) map[int]*resolve.FetchTreeNode {
+		out := make(map[int]*resolve.FetchTreeNode)
+		var walk func(node *resolve.DeferTreeNode)
+		walk = func(node *resolve.DeferTreeNode) {
+			if node == nil {
+				return
+			}
+			if node.Item != nil {
+				out[node.Item.DeferID] = node.Item.Fetches
+			}
+			for _, child := range node.ChildNodes {
+				walk(child)
+			}
+		}
+		walk(response.DeferTree)
+		return out
+	}
+
+	t.Run("single root group", func(t *testing.T) {
+		p := makeDeferPlan(map[int]resolve.DeferDescriptor{1: {ID: 1, ParentID: 0}}, 1)
+		runBuildDeferTree(p)
+		trees, parents := collectDeferCachingTrees(p.Response)
+		byID := groupFetches(p.Response)
+		assert.Equal(t, []*resolve.FetchTreeNode{p.Response.Response.Fetches, byID[1]}, trees)
+		assert.Equal(t, []int{-1, 0}, parents)
+	})
+
+	t.Run("two siblings share the initial parent", func(t *testing.T) {
+		p := makeDeferPlan(map[int]resolve.DeferDescriptor{
+			1: {ID: 1, ParentID: 0},
+			2: {ID: 2, ParentID: 0},
+		}, 1, 2)
+		runBuildDeferTree(p)
+		_, parents := collectDeferCachingTrees(p.Response)
+		assert.Equal(t, []int{-1, 0, 0}, parents)
+	})
+
+	t.Run("a nested chain parents each group to its enclosing group", func(t *testing.T) {
+		p := makeDeferPlan(map[int]resolve.DeferDescriptor{
+			1: {ID: 1, ParentID: 0},
+			3: {ID: 3, ParentID: 1},
+			5: {ID: 5, ParentID: 3},
+		}, 1, 3, 5)
+		runBuildDeferTree(p)
+		trees, parents := collectDeferCachingTrees(p.Response)
+		byID := groupFetches(p.Response)
+		assert.Equal(t, []*resolve.FetchTreeNode{p.Response.Response.Fetches, byID[1], byID[3], byID[5]}, trees)
+		assert.Equal(t, []int{-1, 0, 1, 2}, parents)
+	})
+
+	t.Run("without a built tree every group falls back to the initial parent", func(t *testing.T) {
+		p := makeDeferPlan(map[int]resolve.DeferDescriptor{
+			1: {ID: 1, ParentID: 0},
+			3: {ID: 3, ParentID: 1},
+		}, 1, 3)
+		// extract only — DeferTree stays nil (the disableBuildDeferTree shape).
+		ext := &extractDeferFetches{}
+		ext.Process(p)
+		require.Nil(t, p.Response.DeferTree)
+		_, parents := collectDeferCachingTrees(p.Response)
+		assert.Equal(t, []int{-1, 0, 0}, parents)
+	})
+
+	t.Run("a fetchless parent group attaches its children to the nearest ancestor", func(t *testing.T) {
+		child := &resolve.DeferFetchGroup{DeferID: 2, Fetches: resolve.Sequence()}
+		response := &resolve.GraphQLDeferResponse{
+			Response: &resolve.GraphQLResponse{Fetches: resolve.Sequence()},
+			DeferTree: resolve.DeferSequence(
+				resolve.DeferSingle(&resolve.DeferFetchGroup{DeferID: 1, Fetches: nil}),
+				resolve.DeferSingle(child),
+			),
+		}
+		trees, parents := collectDeferCachingTrees(response)
+		assert.Equal(t, []*resolve.FetchTreeNode{response.Response.Fetches, child.Fetches}, trees)
+		assert.Equal(t, []int{-1, 0}, parents)
+	})
+}

--- a/v2/pkg/engine/resolve/batch_input_assembly.go
+++ b/v2/pkg/engine/resolve/batch_input_assembly.go
@@ -1,0 +1,48 @@
+package resolve
+
+import (
+	"github.com/pkg/errors"
+
+	arena "github.com/wundergraph/go-arena"
+)
+
+// batchInputAssembly holds the pre-rendered pieces of a batch entity input:
+// header/separator/footer plus one segment per UNIQUE representation (bucket
+// order). All slices live on the fetch's batchEntityTools arena, which stays
+// alive until resolveSingle returns.
+//
+// It exists to defer the final input rendering until AFTER the cache decision:
+// assemble runs exactly once, producing an input that contains only the
+// representations the network fetch still needs (no parse-back filtering).
+type batchInputAssembly struct {
+	header             []byte
+	separator          []byte
+	footer             []byte
+	segments           [][]byte
+	undefinedVariables []string
+}
+
+// assemble renders the FINAL batch input into a fresh buffer on a: the header,
+// the kept segments separator-joined (nil keep = all; a segment index beyond
+// keep's length is dropped), the footer — then the undefined-variables
+// post-processing on the final bytes.
+func (b *batchInputAssembly) assemble(a arena.Arena, keep []bool) ([]byte, error) {
+	buf := arena.NewArenaBuffer(a)
+	_, _ = buf.Write(b.header)
+	wroteItem := false
+	for i, segment := range b.segments {
+		if keep != nil && (i >= len(keep) || !keep[i]) {
+			continue
+		}
+		if wroteItem {
+			_, _ = buf.Write(b.separator)
+		}
+		_, _ = buf.Write(segment)
+		wroteItem = true
+	}
+	_, _ = buf.Write(b.footer)
+	if err := SetInputUndefinedVariables(buf, b.undefinedVariables); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return buf.Bytes(), nil
+}

--- a/v2/pkg/engine/resolve/batch_input_assembly_test.go
+++ b/v2/pkg/engine/resolve/batch_input_assembly_test.go
@@ -1,0 +1,92 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	arena "github.com/wundergraph/go-arena"
+)
+
+// TestBatchInputAssembly pins the exact final input bytes for every keep
+// shape: the header/footer bracket, the separator-joining of kept segments,
+// and the undefined-variables post-processing on the final bytes.
+func TestBatchInputAssembly(t *testing.T) {
+	newAssembly := func() *batchInputAssembly {
+		return &batchInputAssembly{
+			header:    []byte(`{"method":"POST","url":"http://reviews","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations)}","variables":{"representations":[`),
+			separator: []byte(`,`),
+			footer:    []byte(`]}}}`),
+			segments: [][]byte{
+				[]byte(`{"__typename":"Product","upc":"1"}`),
+				[]byte(`{"__typename":"Product","upc":"2"}`),
+				[]byte(`{"__typename":"Product","upc":"3"}`),
+			},
+		}
+	}
+	assemble := func(t *testing.T, b *batchInputAssembly, keep []bool) string {
+		t.Helper()
+		out, err := b.assemble(arena.NewMonotonicArena(), keep)
+		require.NoError(t, err)
+		return string(out)
+	}
+
+	t.Run("nil keep sends every segment", func(t *testing.T) {
+		assert.Equal(t,
+			`{"method":"POST","url":"http://reviews","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations)}","variables":{"representations":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"},{"__typename":"Product","upc":"3"}]}}}`,
+			assemble(t, newAssembly(), nil))
+	})
+
+	t.Run("all-true keep equals nil keep", func(t *testing.T) {
+		assert.Equal(t,
+			assemble(t, newAssembly(), nil),
+			assemble(t, newAssembly(), []bool{true, true, true}))
+	})
+
+	t.Run("dropping the middle segment keeps exactly one separator", func(t *testing.T) {
+		assert.Equal(t,
+			`{"method":"POST","url":"http://reviews","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations)}","variables":{"representations":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"3"}]}}}`,
+			assemble(t, newAssembly(), []bool{true, false, true}))
+	})
+
+	t.Run("keeping only the first segment writes no separator", func(t *testing.T) {
+		assert.Equal(t,
+			`{"method":"POST","url":"http://reviews","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations)}","variables":{"representations":[{"__typename":"Product","upc":"1"}]}}}`,
+			assemble(t, newAssembly(), []bool{true, false, false}))
+	})
+
+	t.Run("keeping only the last segment writes no separator", func(t *testing.T) {
+		assert.Equal(t,
+			`{"method":"POST","url":"http://reviews","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations)}","variables":{"representations":[{"__typename":"Product","upc":"3"}]}}}`,
+			assemble(t, newAssembly(), []bool{false, false, true}))
+	})
+
+	t.Run("all-false keep leaves an empty representations list", func(t *testing.T) {
+		assert.Equal(t,
+			`{"method":"POST","url":"http://reviews","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations)}","variables":{"representations":[]}}}`,
+			assemble(t, newAssembly(), []bool{false, false, false}))
+	})
+
+	t.Run("a keep shorter than the segments drops the unmarked tail", func(t *testing.T) {
+		assert.Equal(t,
+			`{"method":"POST","url":"http://reviews","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations)}","variables":{"representations":[{"__typename":"Product","upc":"1"}]}}}`,
+			assemble(t, newAssembly(), []bool{true}))
+	})
+
+	t.Run("undefined variables are set on the FINAL bytes", func(t *testing.T) {
+		b := newAssembly()
+		b.undefinedVariables = []string{"first", "second"}
+		assert.Equal(t,
+			`{"undefined":["first","second"],"method":"POST","url":"http://reviews","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations)}","variables":{"representations":[{"__typename":"Product","upc":"2"}]}}}`,
+			assemble(t, b, []bool{false, true, false}))
+	})
+
+	t.Run("no segments renders the bare bracket", func(t *testing.T) {
+		b := newAssembly()
+		b.segments = nil
+		assert.Equal(t,
+			`{"method":"POST","url":"http://reviews","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations)}","variables":{"representations":[]}}}`,
+			assemble(t, b, nil))
+	})
+}

--- a/v2/pkg/engine/resolve/cache_config.go
+++ b/v2/pkg/engine/resolve/cache_config.go
@@ -43,6 +43,12 @@ type FetchCacheConfig struct {
 
 // Equals deep-compares two configs so plan dedup can never lose or conflate
 // cache policy. It is nil-safe: two nils are equal, nil never equals non-nil.
+// ProvidesData is compared by response SHAPE (Object.Equals); the cache alias
+// metadata on it (OriginalName / CacheArgs / HasAliases) is not compared.
+// That is sound because fetch dedup additionally requires byte-identical
+// rendered Input (FetchConfiguration.Equals), which pins the alias/argument
+// structure — and the production dedup pass runs before configs are attached
+// (postprocess: dedupe precedes ConfigureCaching).
 func (c *FetchCacheConfig) Equals(other *FetchCacheConfig) bool {
 	if c == nil || other == nil {
 		return c == other

--- a/v2/pkg/engine/resolve/cache_config.go
+++ b/v2/pkg/engine/resolve/cache_config.go
@@ -1,0 +1,203 @@
+package resolve
+
+import (
+	"fmt"
+	"slices"
+	"time"
+)
+
+// FetchCacheConfig is the self-contained, federation-free per-fetch cache
+// config the caching planner passes set onto SingleFetch / EntityFetch /
+// BatchEntityFetch. The loader carries it forward-only (it never reads a field
+// beyond the L1/L2 gate, it hands it to the controller); the cache package
+// interprets it. A nil *FetchCacheConfig means caching is disabled for this
+// fetch — the gate that makes a not-run planner pass behave as a NO-OP. It
+// imports NO federation types: federation @key selection sets are a plan-time
+// input only, frozen into KeySpec by the cache key builder.
+type FetchCacheConfig struct {
+	L1 bool // participate in the request-lifetime shared L1 cache
+	L2 bool // participate in the cross-request L2 cache
+
+	CacheName                   string
+	TTL                         time.Duration
+	NegativeCacheTTL            time.Duration // > 0 enables negative caching
+	IncludeSubgraphHeaderPrefix bool          // fold the subgraph header hash into the L2 key
+	EnablePartialCacheLoad      bool          // partial cache load (serve covered items, fetch the rest)
+	PartialBatchLoad            bool          // partial batch realign
+	ShadowMode                  bool          // L2 read-but-never-serve probe
+	HashAnalyticsKeys           bool
+
+	// KeySpec is the frozen multi-key derivation, data only.
+	KeySpec CacheKeySpec
+
+	// ProvidesData is the field tree the fetch returns. It is request-independent
+	// plan data, but it is consumed at RUNTIME by the coverage walk in
+	// PrepareFetch. Folding it here keeps the loader from referencing *Object for
+	// caching.
+	ProvidesData *Object
+
+	// Mutation populate inheritance (request-lifetime carry).
+	PopulateL2OnMutation bool
+	MutationTTLOverride  time.Duration
+}
+
+// Equals deep-compares two configs so plan dedup can never lose or conflate
+// cache policy. It is nil-safe: two nils are equal, nil never equals non-nil.
+func (c *FetchCacheConfig) Equals(other *FetchCacheConfig) bool {
+	if c == nil || other == nil {
+		return c == other
+	}
+	if c.L1 != other.L1 ||
+		c.L2 != other.L2 ||
+		c.CacheName != other.CacheName ||
+		c.TTL != other.TTL ||
+		c.NegativeCacheTTL != other.NegativeCacheTTL ||
+		c.IncludeSubgraphHeaderPrefix != other.IncludeSubgraphHeaderPrefix ||
+		c.EnablePartialCacheLoad != other.EnablePartialCacheLoad ||
+		c.PartialBatchLoad != other.PartialBatchLoad ||
+		c.ShadowMode != other.ShadowMode ||
+		c.HashAnalyticsKeys != other.HashAnalyticsKeys ||
+		c.PopulateL2OnMutation != other.PopulateL2OnMutation ||
+		c.MutationTTLOverride != other.MutationTTLOverride {
+		return false
+	}
+	if !c.KeySpec.Equals(other.KeySpec) {
+		return false
+	}
+	if (c.ProvidesData == nil) != (other.ProvidesData == nil) {
+		return false
+	}
+	if c.ProvidesData != nil && !c.ProvidesData.Equals(other.ProvidesData) {
+		return false
+	}
+	return true
+}
+
+// String renders a compact, nil-safe summary for the plan pretty-printer and
+// for logs.
+func (c *FetchCacheConfig) String() string {
+	if c == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf(
+		"{l1:%t l2:%t cacheName:%s ttl:%s negativeTTL:%s includeHeaders:%t partial:%t partialBatch:%t shadow:%t hashAnalytics:%t scope:%s type:%s field:%s candidates:%d entityKeyMappings:%d providesData:%t populateL2OnMutation:%t mutationTTL:%s}",
+		c.L1,
+		c.L2,
+		c.CacheName,
+		c.TTL,
+		c.NegativeCacheTTL,
+		c.IncludeSubgraphHeaderPrefix,
+		c.EnablePartialCacheLoad,
+		c.PartialBatchLoad,
+		c.ShadowMode,
+		c.HashAnalyticsKeys,
+		c.KeySpec.Scope,
+		c.KeySpec.TypeName,
+		c.KeySpec.FieldName,
+		len(c.KeySpec.Candidates),
+		len(c.KeySpec.EntityKeyMappings),
+		c.ProvidesData != nil,
+		c.PopulateL2OnMutation,
+		c.MutationTTLOverride,
+	)
+}
+
+// CacheScope says whether a config caches a root field or an entity.
+type CacheScope uint8
+
+const (
+	CacheScopeRootField CacheScope = iota
+	CacheScopeEntity
+)
+
+// String renders the CacheScope for logs and test assertions.
+func (s CacheScope) String() string {
+	switch s {
+	case CacheScopeRootField:
+		return "RootField"
+	case CacheScopeEntity:
+		return "Entity"
+	default:
+		return fmt.Sprintf("CacheScope(%d)", s)
+	}
+}
+
+// CacheKeySpec is DATA ONLY (no renderer, no federation types). It models the
+// MULTI-KEY identity of an entity / root field: an entity type may declare
+// more than one @key set, so Candidates is a list. None is required — each
+// candidate is independently and best-effort renderable from whatever data is
+// available at the moment it is rendered: render what you can at lookup,
+// backfill the rest at write. Frozen once from @key at plan time.
+type CacheKeySpec struct {
+	Scope     CacheScope
+	TypeName  string
+	FieldName string
+
+	// Candidates is the list of candidate key templates, one per @key set.
+	Candidates []CacheKeyCandidate
+
+	// EntityKeyMappings (root-arg <-> @key) contribute additional candidates
+	// rather than a separate key space: a key derivable from root-field args is
+	// renderable at lookup, one derivable only from returned entity data becomes
+	// renderable at write.
+	EntityKeyMappings []EntityKeyMapping
+}
+
+// Equals structurally compares two specs, walking Candidates and
+// EntityKeyMappings by value.
+func (c CacheKeySpec) Equals(other CacheKeySpec) bool {
+	if c.Scope != other.Scope || c.TypeName != other.TypeName || c.FieldName != other.FieldName {
+		return false
+	}
+	if !slices.EqualFunc(c.Candidates, other.Candidates, func(a, b CacheKeyCandidate) bool {
+		if (a.Representation == nil) != (b.Representation == nil) {
+			return false
+		}
+		if a.Representation == nil {
+			return true
+		}
+		return a.Representation.Equals(b.Representation)
+	}) {
+		return false
+	}
+	return slices.EqualFunc(c.EntityKeyMappings, other.EntityKeyMappings, func(a, b EntityKeyMapping) bool {
+		return a.EntityTypeName == b.EntityTypeName && slices.EqualFunc(a.FieldMappings, b.FieldMappings, func(left, right EntityFieldMapping) bool {
+			return left.EntityKeyField == right.EntityKeyField &&
+				slices.Equal(left.ArgumentPath, right.ArgumentPath) &&
+				left.ArgumentIsEntityKey == right.ArgumentIsEntityKey
+		})
+	})
+}
+
+// CacheKeyCandidate is ONE candidate @key template, frozen from a single @key
+// set at plan time. Representation is the federation-pointer-free key template
+// node tree (built via representationvariable.BuildRepresentationVariableNode)
+// with the interfaceObject / entityInterface __typename remap already baked in.
+// A candidate renders only when every field it references is present in the
+// data at hand; an unrenderable candidate is skipped at lookup and retried at
+// write, never an error.
+type CacheKeyCandidate struct {
+	Representation *Object
+}
+
+// CacheWriteReason is metadata only; it does NOT gate writes.
+type CacheWriteReason string
+
+const (
+	CacheWriteReasonRefresh  CacheWriteReason = "refresh"  // a key already populated, re-written with fresh data
+	CacheWriteReasonBackfill CacheWriteReason = "backfill" // a candidate key unrenderable/absent at lookup, populated now
+)
+
+// EntityKeyMapping maps a by-key root field's arguments onto an entity's @key
+// fields, so the root field can render an entity cache candidate.
+type EntityKeyMapping struct {
+	EntityTypeName string
+	FieldMappings  []EntityFieldMapping
+}
+
+// EntityFieldMapping maps one root-field argument path to one entity @key field.
+type EntityFieldMapping struct {
+	EntityKeyField      string
+	ArgumentPath        []string
+	ArgumentIsEntityKey bool
+}

--- a/v2/pkg/engine/resolve/cache_config_test.go
+++ b/v2/pkg/engine/resolve/cache_config_test.go
@@ -1,0 +1,193 @@
+package resolve
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// fullFetchCacheConfig returns a config with every field populated, so the
+// Equals table can flip one field per row and prove each one participates.
+func fullFetchCacheConfig() *FetchCacheConfig {
+	return &FetchCacheConfig{
+		L1:                          true,
+		L2:                          true,
+		CacheName:                   "products",
+		TTL:                         30 * time.Second,
+		NegativeCacheTTL:            5 * time.Second,
+		IncludeSubgraphHeaderPrefix: true,
+		EnablePartialCacheLoad:      true,
+		PartialBatchLoad:            true,
+		ShadowMode:                  true,
+		HashAnalyticsKeys:           true,
+		KeySpec: CacheKeySpec{
+			Scope:     CacheScopeEntity,
+			TypeName:  "Product",
+			FieldName: "product",
+			Candidates: []CacheKeyCandidate{
+				{
+					Representation: &Object{
+						Nullable: true,
+						Fields: []*Field{
+							{
+								Name:        []byte("upc"),
+								Value:       &String{Path: []string{"upc"}},
+								OnTypeNames: [][]byte{[]byte("Product")},
+							},
+						},
+					},
+				},
+			},
+			EntityKeyMappings: []EntityKeyMapping{
+				{
+					EntityTypeName: "Product",
+					FieldMappings: []EntityFieldMapping{
+						{
+							EntityKeyField:      "upc",
+							ArgumentPath:        []string{"upc"},
+							ArgumentIsEntityKey: true,
+						},
+					},
+				},
+			},
+		},
+		ProvidesData: &Object{
+			Fields: []*Field{
+				{
+					Name:  []byte("name"),
+					Value: &String{Path: []string{"name"}},
+				},
+			},
+		},
+		PopulateL2OnMutation: true,
+		MutationTTLOverride:  10 * time.Second,
+	}
+}
+
+func TestFetchCacheConfigEquals(t *testing.T) {
+	t.Run("nil safety", func(t *testing.T) {
+		var nilCfg *FetchCacheConfig
+		assert.True(t, nilCfg.Equals(nil))
+		assert.False(t, nilCfg.Equals(fullFetchCacheConfig()))
+		assert.False(t, fullFetchCacheConfig().Equals(nil))
+	})
+
+	t.Run("equal when fully populated", func(t *testing.T) {
+		assert.True(t, fullFetchCacheConfig().Equals(fullFetchCacheConfig()))
+	})
+
+	mutations := []struct {
+		name   string
+		mutate func(c *FetchCacheConfig)
+	}{
+		{"L1", func(c *FetchCacheConfig) { c.L1 = false }},
+		{"L2", func(c *FetchCacheConfig) { c.L2 = false }},
+		{"CacheName", func(c *FetchCacheConfig) { c.CacheName = "reviews" }},
+		{"TTL", func(c *FetchCacheConfig) { c.TTL = time.Minute }},
+		{"NegativeCacheTTL", func(c *FetchCacheConfig) { c.NegativeCacheTTL = time.Minute }},
+		{"IncludeSubgraphHeaderPrefix", func(c *FetchCacheConfig) { c.IncludeSubgraphHeaderPrefix = false }},
+		{"EnablePartialCacheLoad", func(c *FetchCacheConfig) { c.EnablePartialCacheLoad = false }},
+		{"PartialBatchLoad", func(c *FetchCacheConfig) { c.PartialBatchLoad = false }},
+		{"ShadowMode", func(c *FetchCacheConfig) { c.ShadowMode = false }},
+		{"HashAnalyticsKeys", func(c *FetchCacheConfig) { c.HashAnalyticsKeys = false }},
+		{"PopulateL2OnMutation", func(c *FetchCacheConfig) { c.PopulateL2OnMutation = false }},
+		{"MutationTTLOverride", func(c *FetchCacheConfig) { c.MutationTTLOverride = time.Minute }},
+		{"KeySpec.Scope", func(c *FetchCacheConfig) { c.KeySpec.Scope = CacheScopeRootField }},
+		{"KeySpec.TypeName", func(c *FetchCacheConfig) { c.KeySpec.TypeName = "Review" }},
+		{"KeySpec.FieldName", func(c *FetchCacheConfig) { c.KeySpec.FieldName = "review" }},
+		{"KeySpec.Candidates length", func(c *FetchCacheConfig) { c.KeySpec.Candidates = nil }},
+		{"KeySpec.Candidates representation", func(c *FetchCacheConfig) {
+			c.KeySpec.Candidates[0].Representation.Fields[0].Name = []byte("sku")
+		}},
+		{"KeySpec.Candidates nil representation", func(c *FetchCacheConfig) {
+			c.KeySpec.Candidates[0].Representation = nil
+		}},
+		{"KeySpec.EntityKeyMappings entity type", func(c *FetchCacheConfig) {
+			c.KeySpec.EntityKeyMappings[0].EntityTypeName = "Review"
+		}},
+		{"KeySpec.EntityKeyMappings key field", func(c *FetchCacheConfig) {
+			c.KeySpec.EntityKeyMappings[0].FieldMappings[0].EntityKeyField = "sku"
+		}},
+		{"KeySpec.EntityKeyMappings argument path", func(c *FetchCacheConfig) {
+			c.KeySpec.EntityKeyMappings[0].FieldMappings[0].ArgumentPath = []string{"sku"}
+		}},
+		{"KeySpec.EntityKeyMappings argument is entity key", func(c *FetchCacheConfig) {
+			c.KeySpec.EntityKeyMappings[0].FieldMappings[0].ArgumentIsEntityKey = false
+		}},
+		{"ProvidesData nil", func(c *FetchCacheConfig) { c.ProvidesData = nil }},
+		{"ProvidesData shape", func(c *FetchCacheConfig) {
+			c.ProvidesData.Fields[0].Name = []byte("title")
+		}},
+	}
+	for _, row := range mutations {
+		t.Run("differ in "+row.name, func(t *testing.T) {
+			mutated := fullFetchCacheConfig()
+			row.mutate(mutated)
+			assert.False(t, fullFetchCacheConfig().Equals(mutated))
+			assert.False(t, mutated.Equals(fullFetchCacheConfig()))
+		})
+	}
+}
+
+// TestFetchConfigurationEqualsCacheClause covers the plan-dedup cache clause,
+// appendix rows P1–P5.
+func TestFetchConfigurationEqualsCacheClause(t *testing.T) {
+	t.Run("[P1] both nil", func(t *testing.T) {
+		a := &FetchConfiguration{}
+		b := &FetchConfiguration{}
+		assert.True(t, a.Equals(b))
+	})
+
+	t.Run("[P2] one nil", func(t *testing.T) {
+		a := &FetchConfiguration{Cache: fullFetchCacheConfig()}
+		b := &FetchConfiguration{}
+		assert.False(t, a.Equals(b))
+		assert.False(t, b.Equals(a))
+	})
+
+	t.Run("[P3] both non-nil, equal", func(t *testing.T) {
+		a := &FetchConfiguration{Cache: fullFetchCacheConfig()}
+		b := &FetchConfiguration{Cache: fullFetchCacheConfig()}
+		assert.True(t, a.Equals(b))
+	})
+
+	t.Run("[P4] differ in one field", func(t *testing.T) {
+		a := &FetchConfiguration{Cache: fullFetchCacheConfig()}
+		b := &FetchConfiguration{Cache: fullFetchCacheConfig()}
+		b.Cache.TTL = time.Minute
+		assert.False(t, a.Equals(b))
+	})
+
+	t.Run("[P5] differ in one candidate representation", func(t *testing.T) {
+		a := &FetchConfiguration{Cache: fullFetchCacheConfig()}
+		b := &FetchConfiguration{Cache: fullFetchCacheConfig()}
+		b.Cache.KeySpec.Candidates[0].Representation.Fields[0].Name = []byte("sku")
+		assert.False(t, a.Equals(b))
+	})
+}
+
+func TestFetchCacheConfigString(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		var cfg *FetchCacheConfig
+		assert.Equal(t, "<nil>", cfg.String())
+	})
+
+	t.Run("populated", func(t *testing.T) {
+		assert.Equal(t,
+			"{l1:true l2:true cacheName:products ttl:30s negativeTTL:5s includeHeaders:true partial:true partialBatch:true shadow:true hashAnalytics:true scope:Entity type:Product field:product candidates:1 entityKeyMappings:1 providesData:true populateL2OnMutation:true mutationTTL:10s}",
+			fullFetchCacheConfig().String())
+	})
+
+	t.Run("zero value", func(t *testing.T) {
+		assert.Equal(t,
+			"{l1:false l2:false cacheName: ttl:0s negativeTTL:0s includeHeaders:false partial:false partialBatch:false shadow:false hashAnalytics:false scope:RootField type: field: candidates:0 entityKeyMappings:0 providesData:false populateL2OnMutation:false mutationTTL:0s}",
+			(&FetchCacheConfig{}).String())
+	})
+}
+
+func TestCacheScopeString(t *testing.T) {
+	assert.Equal(t, "RootField", CacheScopeRootField.String())
+	assert.Equal(t, "Entity", CacheScopeEntity.String())
+	assert.Equal(t, "CacheScope(7)", CacheScope(7).String())
+}

--- a/v2/pkg/engine/resolve/cache_controller.go
+++ b/v2/pkg/engine/resolve/cache_controller.go
@@ -39,14 +39,15 @@ type RequestCache interface {
 	PrepareFetch(in PrepareFetchInput) (Decision, *FetchCacheHandle)
 
 	// OnFetchSkipped runs after the merge phase when PrepareFetch returned
-	// DecisionSkipFullHit (or DecisionFetchPartial). It splices the chosen,
-	// already-reordered cached values into the merge targets and may emit
-	// best-effort multi-key write-back / backfill writes. The fetch did not hit
-	// the network.
+	// DecisionSkipFullHit. It splices the chosen, already-reordered cached
+	// values into the merge targets and may emit best-effort multi-key
+	// write-back / backfill writes. The fetch did not hit the network.
 	OnFetchSkipped(h *FetchCacheHandle, in MergeInput) error
 
 	// OnFetchResult runs after the merge phase following a real network fetch
-	// (DecisionFetch or DecisionFetchShadow). It applies the write gate
+	// (DecisionFetch, DecisionFetchShadow, or DecisionFetchPartial — the
+	// partial arm splices the cached items and realigns + merges the fetched
+	// ones in this same hook). It applies the write gate
 	// (!FetchFailed && !HasErrors && ResponseData != nil && Type() != Null;
 	// EmptyEntity is the one non-failure that still writes the negative
 	// sentinel), re-renders pending candidate keys from the fresh data, and
@@ -56,7 +57,12 @@ type RequestCache interface {
 
 	// EndRequest runs once after the root tree AND every defer group have
 	// resolved, single-threaded. It flushes batched L2 writes and finalizes
-	// analytics/trace. It needs no lock and no arena.
+	// analytics/trace. It needs no lock and no arena — and it MUST NOT touch
+	// one: on the arena entry paths it runs via defer AFTER the request arena
+	// is released back to its pool, so dereferencing any arena-owned
+	// astjson.Value still held on a handle (ItemCacheState.Item / FromCache,
+	// ShadowStash values) reads reset or reused memory. Everything EndRequest
+	// consumes must be plain heap data (strings, durations, copied bytes).
 	EndRequest()
 }
 
@@ -206,6 +212,9 @@ func (h *FetchCacheHandle) String() string {
 // ItemCacheState is the per-item cache payload, one per merge target.
 // PrepareFetch writes every field except NegativeHit / WriteReason (stamped in
 // OnFetchResult from the fresh response); the merge hooks read it.
+// Item and FromCache may be arena-owned: they are valid inside the fetch-phase
+// hooks only and MUST NOT be dereferenced at EndRequest time (a nil-check is
+// fine — see RequestCache.EndRequest).
 type ItemCacheState struct {
 	Item      *astjson.Value // splice target / write source
 	FromCache *astjson.Value // chosen + reordered cached value; nil = miss, TypeNull = negative hit

--- a/v2/pkg/engine/resolve/cache_controller.go
+++ b/v2/pkg/engine/resolve/cache_controller.go
@@ -66,6 +66,17 @@ type RequestCache interface {
 	EndRequest()
 }
 
+// CacheTraceFlusher is the optional RequestCache extension that attaches the
+// per-fetch cache traces AHEAD of EndRequest. The resolver calls it right
+// before the response renders (only when the trace ships in the response
+// extensions), because the trace extension serializes during Resolve while
+// EndRequest runs after the response has been written. Idempotent per handle;
+// EndRequest's own observation pass skips handles already flushed. Same
+// no-arena contract as EndRequest.
+type CacheTraceFlusher interface {
+	FlushTraces()
+}
+
 // Decision is what PrepareFetch tells the loader to do. It is the ONLY cache
 // concept the loader branches on.
 type Decision uint8

--- a/v2/pkg/engine/resolve/cache_controller.go
+++ b/v2/pkg/engine/resolve/cache_controller.go
@@ -1,0 +1,235 @@
+package resolve
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/wundergraph/astjson"
+)
+
+// CacheController is the long-lived, integrator-supplied cache lifecycle port.
+// The router sets one via Context.SetCacheController, exactly as it sets an
+// Authorizer. A nil controller is the global NO-OP and is zero-cost: the loader
+// never enters cache code, never allocates a handle, never takes a lock.
+// NO-OP, L1-only, L2-only, and L1+L2 are not distinguished here; they are all
+// distinguished only by the RequestCache the controller hands back.
+type CacheController interface {
+	// BeginRequest is called once per request, lazily, under DataBuffer.Lock, the
+	// first time a cache-eligible fetch is prepared. It returns the request-lifetime
+	// shared working surface, which is then shared by reference across every
+	// per-defer-group Loader of this request. The returned value owns all
+	// per-request mutable state, so nothing mutable hangs on the long-lived
+	// controller and there is no cross-request sharing.
+	BeginRequest(ctx *Context) RequestCache
+}
+
+// RequestCache is the ONE mode-blind working surface the loader talks to. Its
+// PrepareFetch / OnFetchSkipped / OnFetchResult methods are invoked from
+// resolveSingle with NO loader lock held; each one opens exactly ONE
+// CacheTransaction (which acquires DataBuffer.Lock) for its whole arena
+// sequence and releases it with Commit. EndRequest runs once, single-threaded,
+// after the whole fetch tree (root + every defer group) has resolved, and
+// needs no lock and no arena.
+type RequestCache interface {
+	// PrepareFetch runs after the prepare phase, with no loader lock held. It
+	// best-effort renders every candidate key that CAN be rendered from the data
+	// available now, looks the cache up under all rendered keys, runs the per-item
+	// coverage / freshness / reorder walk, and returns a Decision plus the opaque
+	// handle the merge step reads. A NO-OP returns DecisionFetch and a nil handle.
+	PrepareFetch(in PrepareFetchInput) (Decision, *FetchCacheHandle)
+
+	// OnFetchSkipped runs after the merge phase when PrepareFetch returned
+	// DecisionSkipFullHit (or DecisionFetchPartial). It splices the chosen,
+	// already-reordered cached values into the merge targets and may emit
+	// best-effort multi-key write-back / backfill writes. The fetch did not hit
+	// the network.
+	OnFetchSkipped(h *FetchCacheHandle, in MergeInput) error
+
+	// OnFetchResult runs after the merge phase following a real network fetch
+	// (DecisionFetch or DecisionFetchShadow). It applies the write gate
+	// (!FetchFailed && !HasErrors && ResponseData != nil && Type() != Null;
+	// EmptyEntity is the one non-failure that still writes the negative
+	// sentinel), re-renders pending candidate keys from the fresh data, and
+	// persists or defers the writes. When h.Shadow it runs the shadow compare
+	// before the write-back.
+	OnFetchResult(h *FetchCacheHandle, in MergeInput) error
+
+	// EndRequest runs once after the root tree AND every defer group have
+	// resolved, single-threaded. It flushes batched L2 writes and finalizes
+	// analytics/trace. It needs no lock and no arena.
+	EndRequest()
+}
+
+// Decision is what PrepareFetch tells the loader to do. It is the ONLY cache
+// concept the loader branches on.
+type Decision uint8
+
+const (
+	// DecisionFetch: miss, or caching disabled for this fetch. loadPhase fetches
+	// normally; the handle may be nil.
+	DecisionFetch Decision = iota
+
+	// DecisionSkipFullHit: every item is covered by a covering cache value. The
+	// loader skips the network load. NOT terminal for the cache: OnFetchSkipped
+	// may still emit best-effort multi-key backfill/refresh writes.
+	DecisionSkipFullHit
+
+	// DecisionFetchPartial: some items covered, some not. Fetch only the missed
+	// subset, then splice the cached subset and realign.
+	DecisionFetchPartial
+
+	// DecisionFetchShadow: shadow-mode L2 read hit. The loader treats it exactly
+	// like a miss — skipLoad stays false, full fetch, full merge; the only deltas
+	// live in the handle and the extra compare step inside OnFetchResult.
+	DecisionFetchShadow
+)
+
+// String renders the Decision for logs and test assertions.
+func (d Decision) String() string {
+	switch d {
+	case DecisionFetch:
+		return "Fetch"
+	case DecisionSkipFullHit:
+		return "SkipFullHit"
+	case DecisionFetchPartial:
+		return "FetchPartial"
+	case DecisionFetchShadow:
+		return "FetchShadow"
+	default:
+		return fmt.Sprintf("Decision(%d)", d)
+	}
+}
+
+// PrepareFetchInput carries everything PrepareFetch needs to render candidate
+// keys, look the cache up, and decide. Input is the canonical pre-injection
+// rendered bytes and HeaderHash the subgraph header hash — together the sole
+// key material, so read and write keys derive from the same canonical form.
+type PrepareFetchInput struct {
+	Ctx        *Context
+	Item       *FetchItem
+	Items      []*astjson.Value
+	Config     *FetchCacheConfig
+	BatchStats [][]*astjson.Value
+	Input      []byte
+	HeaderHash uint64
+	Arena      TransactionBeginner
+}
+
+// MergeInput carries the post-merge view of one fetch to OnFetchSkipped /
+// OnFetchResult. It surfaces all five write-gate signals: FetchFailed
+// (transport / empty body / parse failure), HasErrors, EmptyEntity, StatusCode,
+// and ResponseData == nil. FetchFailed and HasErrors block ALL fetched-value
+// writes; EmptyEntity is the one non-failure that still writes (the negative
+// sentinel); ResponseData == nil is the structural backstop for the early
+// failure paths. The gate can never reduce to !HasErrors alone: transport,
+// empty-body, and parse failures reach the merge hook with HasErrors == false.
+type MergeInput struct {
+	Item         *FetchItem
+	Items        []*astjson.Value
+	ResponseData *astjson.Value
+	BatchStats   [][]*astjson.Value
+	// MergePath is the fetch's post-processing merge path, so entity/batch
+	// values splice at the correct target instead of silently at the item root.
+	MergePath   []string
+	HasErrors   bool
+	FetchFailed bool
+	EmptyEntity bool
+	StatusCode  int
+	Arena       TransactionBeginner
+}
+
+// CacheObserver is the optional analytics/trace/shadow-compare port. It is
+// composed INSIDE a RequestCache implementation (the loader never calls it
+// directly), so verbose observability evolves with zero impact on the
+// lookup/write surface. A nil observer means no observability and is zero-cost.
+type CacheObserver interface {
+	BeginRequest(ctx *Context)
+	EndRequest(ctx *Context)
+	// OnFetchObserved derives per-fetch trace + counters from the finished
+	// handle, so trace and analytics read the same opaque state the writer used.
+	OnFetchObserved(h *FetchCacheHandle)
+	// CompareShadow runs the shadow staleness probe; the writer calls it before
+	// overwriting L2, preserving compare -> write-L1 -> write-L2 order. It runs
+	// inside OnFetchResult's already-open CacheTransaction (it does not open its
+	// own).
+	CompareShadow(h *FetchCacheHandle, fresh *astjson.Value, tx *CacheTransaction)
+	// OnEntity / OnFieldValue are the resolvable-walker observability hooks.
+	OnEntity(h *FetchCacheHandle, entity *astjson.Value)
+	OnFieldValue(coordinate GraphCoordinate, value FieldValue)
+}
+
+// FetchCacheHandle is the per-fetch opaque two-level cache state, carried on
+// preparedFetch. It is allocated by PrepareFetch only when the controller
+// actually touches the fetch; the loader stores it, threads it back to the
+// merge hook, and never reads a field beyond Decision.
+type FetchCacheHandle struct {
+	Decision       Decision                 // what PrepareFetch decided (drives the merge dispatch)
+	WasHit         bool                     // a covering cache value was found
+	MustWriteBack  bool                     // a hit still needs best-effort L2 writes
+	BatchEntityKey bool                     // batch-entity-key mode (per-element multi-key render on write)
+	Shadow         bool                     // shadow mode: run compare in OnFetchResult before write-back
+	ShadowStash    map[int]ShadowCacheEntry // stashed L2 reads for the shadow compare, keyed by item index
+	Items          []ItemCacheState         // per-item payload, one per merge target
+	Analytics      any                      // observer-owned accumulators; opaque even here
+}
+
+// String renders a compact, nil-safe summary for logs and panics, e.g.
+// {decision:SkipFullHit items:3 hits:3 writeback:1 shadow:false}.
+func (h *FetchCacheHandle) String() string {
+	if h == nil {
+		return "<nil>"
+	}
+	hits := 0
+	writeback := 0
+	for i := range h.Items {
+		if h.Items[i].FromCache != nil {
+			hits++
+		}
+		if h.Items[i].NeedsWriteback {
+			writeback++
+		}
+	}
+	return fmt.Sprintf("{decision:%s items:%d hits:%d writeback:%d shadow:%t}", h.Decision, len(h.Items), hits, writeback, h.Shadow)
+}
+
+// ItemCacheState is the per-item cache payload, one per merge target.
+// PrepareFetch writes every field except NegativeHit / WriteReason (stamped in
+// OnFetchResult from the fresh response); the merge hooks read it.
+type ItemCacheState struct {
+	Item      *astjson.Value // splice target / write source
+	FromCache *astjson.Value // chosen + reordered cached value; nil = miss, TypeNull = negative hit
+
+	// RenderedKeys are the candidate keys successfully rendered at lookup; looked
+	// up (a hit on ANY serves the item) and the default write set. L1 and L2
+	// SHARE these keys — each key is derived once and reused for both layers.
+	RenderedKeys []string
+
+	// PendingCandidates are the candidates NOT renderable at lookup (fields
+	// absent); re-rendered from fresh data in OnFetchResult and, if now
+	// renderable, added to the write set (best-effort backfill).
+	PendingCandidates []CacheKeyCandidate
+
+	FromCacheCandidates  []CacheCandidate // freshest-first cached entries matched across RenderedKeys
+	SelectedRemainingTTL time.Duration    // remaining TTL of the chosen value, for analytics/trace
+	NeedsWriteback       bool             // merged/older value chosen -> rewrite the canonical entry
+	EntityMergePath      []string         // the fetch's merge path for root<->entity wrap/extract
+	BatchIndex           int              // original batch position for realign
+	NegativeHit          bool             // subgraph-null sentinel routing
+	WriteReason          CacheWriteReason // refresh / backfill (metadata only, never gates writes)
+}
+
+// CacheCandidate is one cached entry matched for an item at lookup, kept as
+// bytes and lazily parsed inside a CacheTransaction.
+type CacheCandidate struct {
+	Value        []byte
+	RemainingTTL time.Duration
+}
+
+// ShadowCacheEntry is one stashed L2 read kept for the shadow compare: the
+// value that WOULD have been served, compared against the fresh fetch before
+// the write-back.
+type ShadowCacheEntry struct {
+	CachedValue  *astjson.Value
+	CacheKey     string
+	RemainingTTL time.Duration
+}

--- a/v2/pkg/engine/resolve/cache_controller.go
+++ b/v2/pkg/engine/resolve/cache_controller.go
@@ -232,4 +232,8 @@ type ShadowCacheEntry struct {
 	CachedValue  *astjson.Value
 	CacheKey     string
 	RemainingTTL time.Duration
+	// CacheTTL is the policy TTL the entry was written with, so the observer
+	// can derive the entry's age (CacheTTL - RemainingTTL) without re-deriving
+	// config.
+	CacheTTL time.Duration
 }

--- a/v2/pkg/engine/resolve/cache_controller.go
+++ b/v2/pkg/engine/resolve/cache_controller.go
@@ -172,10 +172,16 @@ type FetchCacheHandle struct {
 	// the subgraph receives only the missing ones. The loader swaps it in as
 	// the network input (single-flight then dedups on the reduced input).
 	PartialInput []byte
-	Shadow       bool                     // shadow mode: run compare in OnFetchResult before write-back
-	ShadowStash  map[int]ShadowCacheEntry // stashed L2 reads for the shadow compare, keyed by item index
-	Items        []ItemCacheState         // per-item payload, one per merge target
-	Analytics    any                      // observer-owned accumulators; opaque even here
+	// Trace is the fetch's ART trace destination (nil when tracing is off);
+	// the observer attaches the assembled CacheTrace to it at request end.
+	Trace *DataSourceLoadTrace
+	// HashAnalyticsKeys mirrors the policy knob so the observer hashes key
+	// material in trace output when set.
+	HashAnalyticsKeys bool
+	Shadow            bool                     // shadow mode: run compare in OnFetchResult before write-back
+	ShadowStash       map[int]ShadowCacheEntry // stashed L2 reads for the shadow compare, keyed by item index
+	Items             []ItemCacheState         // per-item payload, one per merge target
+	Analytics         any                      // observer-owned accumulators; opaque even here
 }
 
 // String renders a compact, nil-safe summary for logs and panics, e.g.
@@ -217,10 +223,12 @@ type ItemCacheState struct {
 	FromCacheCandidates  []CacheCandidate // freshest-first cached entries matched across RenderedKeys
 	SelectedRemainingTTL time.Duration    // remaining TTL of the chosen value, for analytics/trace
 	NeedsWriteback       bool             // merged/older value chosen -> rewrite the canonical entry
-	EntityMergePath      []string         // the fetch's merge path for root<->entity wrap/extract
-	BatchIndex           int              // original batch position for realign
-	NegativeHit          bool             // subgraph-null sentinel routing
-	WriteReason          CacheWriteReason // refresh / backfill (metadata only, never gates writes)
+	// ServedFromLayer is "l1" or "l2" when FromCache was selected (trace only).
+	ServedFromLayer string
+	EntityMergePath []string         // the fetch's merge path for root<->entity wrap/extract
+	BatchIndex      int              // original batch position for realign
+	NegativeHit     bool             // subgraph-null sentinel routing
+	WriteReason     CacheWriteReason // refresh / backfill (metadata only, never gates writes)
 }
 
 // CacheCandidate is one cached entry matched for an item at lookup, kept as

--- a/v2/pkg/engine/resolve/cache_controller.go
+++ b/v2/pkg/engine/resolve/cache_controller.go
@@ -173,11 +173,12 @@ type FetchCacheHandle struct {
 	WasHit         bool     // a covering cache value was found
 	MustWriteBack  bool     // a hit still needs best-effort L2 writes
 	BatchEntityKey bool     // batch-entity-key mode (per-element multi-key render on write)
-	// PartialInput is the reduced fetch input for DecisionFetchPartial: the
-	// original rendered input with the CACHED representations filtered out, so
-	// the subgraph receives only the missing ones. The loader swaps it in as
-	// the network input (single-flight then dedups on the reduced input).
-	PartialInput []byte
+	// BatchFetchKeep marks, per unique batch bucket, whether the NETWORK fetch
+	// must include its representation (DecisionFetchPartial: true = still
+	// missing, false = served from cache). The loader assembles the reduced
+	// input from the already-rendered representation segments BEFORE any bytes
+	// are parsed back — nil means "fetch all".
+	BatchFetchKeep []bool
 	// Trace is the fetch's ART trace destination (nil when tracing is off);
 	// the observer attaches the assembled CacheTrace to it at request end.
 	Trace *DataSourceLoadTrace

--- a/v2/pkg/engine/resolve/cache_controller.go
+++ b/v2/pkg/engine/resolve/cache_controller.go
@@ -163,14 +163,19 @@ type CacheObserver interface {
 // actually touches the fetch; the loader stores it, threads it back to the
 // merge hook, and never reads a field beyond Decision.
 type FetchCacheHandle struct {
-	Decision       Decision                 // what PrepareFetch decided (drives the merge dispatch)
-	WasHit         bool                     // a covering cache value was found
-	MustWriteBack  bool                     // a hit still needs best-effort L2 writes
-	BatchEntityKey bool                     // batch-entity-key mode (per-element multi-key render on write)
-	Shadow         bool                     // shadow mode: run compare in OnFetchResult before write-back
-	ShadowStash    map[int]ShadowCacheEntry // stashed L2 reads for the shadow compare, keyed by item index
-	Items          []ItemCacheState         // per-item payload, one per merge target
-	Analytics      any                      // observer-owned accumulators; opaque even here
+	Decision       Decision // what PrepareFetch decided (drives the merge dispatch)
+	WasHit         bool     // a covering cache value was found
+	MustWriteBack  bool     // a hit still needs best-effort L2 writes
+	BatchEntityKey bool     // batch-entity-key mode (per-element multi-key render on write)
+	// PartialInput is the reduced fetch input for DecisionFetchPartial: the
+	// original rendered input with the CACHED representations filtered out, so
+	// the subgraph receives only the missing ones. The loader swaps it in as
+	// the network input (single-flight then dedups on the reduced input).
+	PartialInput []byte
+	Shadow       bool                     // shadow mode: run compare in OnFetchResult before write-back
+	ShadowStash  map[int]ShadowCacheEntry // stashed L2 reads for the shadow compare, keyed by item index
+	Items        []ItemCacheState         // per-item payload, one per merge target
+	Analytics    any                      // observer-owned accumulators; opaque even here
 }
 
 // String renders a compact, nil-safe summary for logs and panics, e.g.

--- a/v2/pkg/engine/resolve/cache_controller_test.go
+++ b/v2/pkg/engine/resolve/cache_controller_test.go
@@ -1,0 +1,51 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/wundergraph/astjson"
+)
+
+func TestDecisionString(t *testing.T) {
+	assert.Equal(t, "Fetch", DecisionFetch.String())
+	assert.Equal(t, "SkipFullHit", DecisionSkipFullHit.String())
+	assert.Equal(t, "FetchPartial", DecisionFetchPartial.String())
+	assert.Equal(t, "FetchShadow", DecisionFetchShadow.String())
+	assert.Equal(t, "Decision(9)", Decision(9).String())
+}
+
+func TestFetchCacheHandleString(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		var h *FetchCacheHandle
+		assert.Equal(t, "<nil>", h.String())
+	})
+
+	t.Run("zero value", func(t *testing.T) {
+		assert.Equal(t, "{decision:Fetch items:0 hits:0 writeback:0 shadow:false}", (&FetchCacheHandle{}).String())
+	})
+
+	t.Run("populated", func(t *testing.T) {
+		cached := astjson.MustParseBytes([]byte(`{"__typename":"Product","upc":"1"}`))
+		h := &FetchCacheHandle{
+			Decision: DecisionSkipFullHit,
+			WasHit:   true,
+			Items: []ItemCacheState{
+				{FromCache: cached},
+				{FromCache: cached, NeedsWriteback: true},
+				{},
+			},
+		}
+		assert.Equal(t, "{decision:SkipFullHit items:3 hits:2 writeback:1 shadow:false}", h.String())
+	})
+
+	t.Run("shadow", func(t *testing.T) {
+		h := &FetchCacheHandle{
+			Decision: DecisionFetchShadow,
+			Shadow:   true,
+			Items:    []ItemCacheState{{}},
+		}
+		assert.Equal(t, "{decision:FetchShadow items:1 hits:0 writeback:0 shadow:true}", h.String())
+	})
+}

--- a/v2/pkg/engine/resolve/cache_fetch_test.go
+++ b/v2/pkg/engine/resolve/cache_fetch_test.go
@@ -1,0 +1,63 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestFetchCachePolymorphism proves the Fetch interface cache accessors and
+// shape predicates across ALL concrete fetch types, so caching code never
+// needs a switch over concrete types.
+func TestFetchCachePolymorphism(t *testing.T) {
+	cases := []struct {
+		name               string
+		fetch              Fetch
+		isEntityFetch      bool
+		isBatchEntityFetch bool
+	}{
+		{
+			name:               "SingleFetch",
+			fetch:              &SingleFetch{},
+			isEntityFetch:      false,
+			isBatchEntityFetch: false,
+		},
+		{
+			name:               "EntityFetch",
+			fetch:              &EntityFetch{},
+			isEntityFetch:      true,
+			isBatchEntityFetch: false,
+		},
+		{
+			name:               "BatchEntityFetch",
+			fetch:              &BatchEntityFetch{},
+			isEntityFetch:      false,
+			isBatchEntityFetch: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Nil(t, tc.fetch.CacheConfig())
+
+			cfg := &FetchCacheConfig{L2: true, CacheName: "products"}
+			tc.fetch.SetCacheConfig(cfg)
+			assert.Same(t, cfg, tc.fetch.CacheConfig())
+
+			tc.fetch.SetCacheConfig(nil)
+			assert.Nil(t, tc.fetch.CacheConfig())
+
+			assert.Equal(t, tc.isEntityFetch, tc.fetch.IsEntityFetch())
+			assert.Equal(t, tc.isBatchEntityFetch, tc.fetch.IsBatchEntityFetch())
+		})
+	}
+}
+
+// TestSingleFetchCacheConfigSharesFetchConfiguration pins that the SingleFetch
+// accessor reads/writes the embedded FetchConfiguration.Cache field, which is
+// what plan dedup compares.
+func TestSingleFetchCacheConfigSharesFetchConfiguration(t *testing.T) {
+	f := &SingleFetch{}
+	cfg := &FetchCacheConfig{L1: true}
+	f.SetCacheConfig(cfg)
+	assert.Same(t, cfg, f.FetchConfiguration.Cache)
+}

--- a/v2/pkg/engine/resolve/cache_node_copy_test.go
+++ b/v2/pkg/engine/resolve/cache_node_copy_test.go
@@ -1,0 +1,91 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestObjectCopyCarriesCacheMetadata pins that Object.Copy / Field.Copy carry
+// the caching planner metadata (HasAliases, OriginalName, CacheArgs), so
+// defer's response-tree copies never lose it.
+func TestObjectCopyCarriesCacheMetadata(t *testing.T) {
+	original := &Object{
+		Nullable:   true,
+		Path:       []string{"product"},
+		HasAliases: true,
+		Fields: []*Field{
+			{
+				Name:         []byte("productName"),
+				OriginalName: []byte("name"),
+				Value: &String{
+					Path: []string{"productName"},
+				},
+			},
+			{
+				Name: []byte("price"),
+				CacheArgs: []CacheFieldArg{
+					{Name: "currency", VariableName: "a"},
+					{Name: "region", VariableName: "b"},
+				},
+				Value: &Float{
+					Path: []string{"price"},
+				},
+			},
+		},
+	}
+
+	copied := original.Copy()
+
+	assert.Equal(t, &Object{
+		Nullable:   true,
+		Path:       []string{"product"},
+		HasAliases: true,
+		Fields: []*Field{
+			{
+				Name:         []byte("productName"),
+				OriginalName: []byte("name"),
+				Value: &String{
+					Path: []string{"productName"},
+				},
+			},
+			{
+				Name: []byte("price"),
+				CacheArgs: []CacheFieldArg{
+					{Name: "currency", VariableName: "a"},
+					{Name: "region", VariableName: "b"},
+				},
+				Value: &Float{
+					Path: []string{"price"},
+				},
+			},
+		},
+	}, copied)
+
+	// CacheArgs must be cloned, not aliased: mutating the copy must not reach
+	// the original.
+	copiedObject := copied.(*Object)
+	copiedObject.Fields[1].CacheArgs[0].VariableName = "mutated"
+	assert.Equal(t, "a", original.Fields[1].CacheArgs[0].VariableName)
+}
+
+// TestGraphQLResponseCacheProvidesData pins the ProvidesData side-table
+// accessors on the response.
+func TestGraphQLResponseCacheProvidesData(t *testing.T) {
+	response := &GraphQLResponse{}
+	assert.Nil(t, response.CacheProvidesData())
+
+	info := &FetchInfo{DataSourceID: "products"}
+	providesData := map[*FetchInfo]*Object{
+		info: {
+			Fields: []*Field{
+				{
+					Name:  []byte("name"),
+					Value: &String{Path: []string{"name"}},
+				},
+			},
+		},
+	}
+	response.SetCacheProvidesData(providesData)
+	assert.Equal(t, providesData, response.CacheProvidesData())
+}

--- a/v2/pkg/engine/resolve/cache_noop_test.go
+++ b/v2/pkg/engine/resolve/cache_noop_test.go
@@ -1,0 +1,140 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/wundergraph/astjson"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/fastjsonext"
+)
+
+// countingCacheController records BeginRequest calls so the no-op gates can be
+// asserted observably: with no cache-configured fetch, the loader must never
+// reach the controller at all.
+type countingCacheController struct {
+	beginRequestCalls int
+}
+
+func (c *countingCacheController) BeginRequest(ctx *Context) RequestCache {
+	c.beginRequestCalls++
+	return nil
+}
+
+// TestCacheNoOpGates proves the runtime no-op invariant of the loader seam:
+// with no controller, and with a controller but no per-fetch cache config, the
+// loader output is byte-identical and no cache code runs.
+func TestCacheNoOpGates(t *testing.T) {
+	newResponse := func(ctrl *gomock.Controller) *GraphQLResponse {
+		ds := mockedDS(t, ctrl,
+			`{"method":"POST","url":"http://products","body":{"query":"query{topProducts{name}}"}}`,
+			`{"data":{"topProducts":[{"name":"Table"},{"name":"Couch"}]}}`)
+		return &GraphQLResponse{
+			Fetches: Sequence(
+				Single(&SingleFetch{
+					InputTemplate: InputTemplate{
+						Segments: []TemplateSegment{
+							{
+								Data:        []byte(`{"method":"POST","url":"http://products","body":{"query":"query{topProducts{name}}"}}`),
+								SegmentType: StaticSegmentType,
+							},
+						},
+					},
+					FetchConfiguration: FetchConfiguration{
+						DataSource: ds,
+						PostProcessing: PostProcessingConfiguration{
+							SelectResponseDataPath: []string{"data"},
+						},
+					},
+				}),
+			),
+		}
+	}
+
+	load := func(t *testing.T, ctx *Context, response *GraphQLResponse) string {
+		t.Helper()
+		loader := &Loader{dataBuffer: &DataBuffer{data: astjson.ObjectValue(nil)}}
+		err := loader.LoadGraphQLResponseData(ctx, response)
+		assert.NoError(t, err)
+		return fastjsonext.PrintGraphQLResponse(loader.dataBuffer.Get(), loader.errors)
+	}
+
+	expected := `{"data":{"topProducts":[{"name":"Table"},{"name":"Couch"}]}}`
+
+	t.Run("no controller", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		ctx := NewContext(t.Context())
+		out := load(t, ctx, newResponse(ctrl))
+		assert.Equal(t, expected, out)
+		assert.Nil(t, ctx.requestCache)
+	})
+
+	t.Run("controller set but no fetch is cache-configured", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		controller := &countingCacheController{}
+		ctx := NewContext(t.Context())
+		ctx.SetCacheController(controller)
+		out := load(t, ctx, newResponse(ctrl))
+		assert.Equal(t, expected, out)
+		// The per-fetch gate wins before the controller is ever consulted.
+		assert.Equal(t, 0, controller.beginRequestCalls)
+		assert.Nil(t, ctx.requestCache)
+	})
+}
+
+// TestEndCacheRequestIdempotent pins the request-end lifecycle: EndRequest runs
+// once, the surface is reset, and calling endCacheRequest again is a no-op.
+func TestEndCacheRequestIdempotent(t *testing.T) {
+	ctx := NewContext(t.Context())
+
+	// A Context that never used caching must no-op.
+	ctx.endCacheRequest()
+	assert.Nil(t, ctx.requestCache)
+
+	rc := &countingRequestCache{}
+	ctx.requestCache = rc
+	ctx.endCacheRequest()
+	ctx.endCacheRequest()
+	assert.Equal(t, 1, rc.endRequestCalls)
+	assert.Nil(t, ctx.requestCache)
+}
+
+// TestContextCloneResetsRequestCache pins subscription-event isolation: a
+// cloned resolution keeps the controller port but builds its own per-request
+// cache surface.
+func TestContextCloneResetsRequestCache(t *testing.T) {
+	controller := &countingCacheController{}
+	ctx := NewContext(t.Context())
+	ctx.SetCacheController(controller)
+	ctx.requestCache = &countingRequestCache{}
+
+	cloned := ctx.clone(t.Context())
+	assert.Nil(t, cloned.requestCache)
+	assert.Same(t, controller, cloned.cacheController)
+}
+
+// countingRequestCache is a minimal RequestCache fake recording EndRequest
+// calls for the lifecycle tests.
+type countingRequestCache struct {
+	endRequestCalls int
+}
+
+func (c *countingRequestCache) PrepareFetch(in PrepareFetchInput) (Decision, *FetchCacheHandle) {
+	return DecisionFetch, nil
+}
+
+func (c *countingRequestCache) OnFetchSkipped(h *FetchCacheHandle, in MergeInput) error {
+	return nil
+}
+
+func (c *countingRequestCache) OnFetchResult(h *FetchCacheHandle, in MergeInput) error {
+	return nil
+}
+
+func (c *countingRequestCache) EndRequest() {
+	c.endRequestCalls++
+}

--- a/v2/pkg/engine/resolve/cache_transaction.go
+++ b/v2/pkg/engine/resolve/cache_transaction.go
@@ -1,0 +1,91 @@
+package resolve
+
+import (
+	"github.com/wundergraph/astjson"
+	"github.com/wundergraph/go-arena"
+)
+
+// TransactionBeginner opens CacheTransactions over the loader's shared JSON
+// arena. The loader hands one to every cache hook input; a hook opens exactly
+// ONE transaction via Begin at the top of its arena work and releases it with
+// Commit (via defer). A TransactionBeginner must never be retained past the
+// hook it was handed to, and must never be used from the off-lock load phase.
+type TransactionBeginner interface {
+	// Begin enters the locked merge region and returns the transaction through
+	// which all arena/parser ops run. It acquires DataBuffer.Lock once for the
+	// caller; the matching Commit releases it.
+	Begin() *CacheTransaction
+}
+
+// CacheTransaction is the scoped, lock-held handle for one multi-op arena
+// sequence (candidate parse -> merge synthesis -> reorder, then the splice or
+// write). Every arena/parser op is a method ON the transaction, so the arena
+// cannot be touched without a held transaction. One transaction per hook is
+// one DataBuffer.Lock acquisition; Commit MUST be called (via defer) exactly
+// once.
+type CacheTransaction struct {
+	a  arena.Arena
+	db *DataBuffer
+}
+
+// ParseBytes parses b onto the transaction's arena (lazy candidate parse).
+func (t *CacheTransaction) ParseBytes(b []byte) (*astjson.Value, error) {
+	return astjson.ParseBytesWithArena(t.a, b)
+}
+
+// StructuralCopy deep-copies v onto the arena, avoiding merge aliasing
+// corruption when the same cached value is spliced into multiple targets.
+func (t *CacheTransaction) StructuralCopy(v *astjson.Value) *astjson.Value {
+	return astjson.DeepCopy(t.a, v)
+}
+
+// MergeValues merges src into dst on the arena. The underlying "changed" flag
+// is intentionally discarded, matching how the defer merge path discards it.
+func (t *CacheTransaction) MergeValues(dst, src *astjson.Value) (*astjson.Value, error) {
+	merged, _, err := astjson.MergeValues(t.a, dst, src)
+	return merged, err
+}
+
+// MergeValuesWithPath merges src into dst at path on the arena.
+func (t *CacheTransaction) MergeValuesWithPath(dst, src *astjson.Value, path ...string) (*astjson.Value, error) {
+	merged, _, err := astjson.MergeValuesWithPath(t.a, dst, src, path...)
+	return merged, err
+}
+
+// NewObject allocates an empty object value on the arena.
+func (t *CacheTransaction) NewObject() *astjson.Value {
+	return astjson.ObjectValue(t.a)
+}
+
+// NewArray allocates an empty array value on the arena.
+func (t *CacheTransaction) NewArray() *astjson.Value {
+	return astjson.ArrayValue(t.a)
+}
+
+// String allocates a string value on the arena.
+func (t *CacheTransaction) String(s string) *astjson.Value {
+	return astjson.StringValue(t.a, s)
+}
+
+// Null returns the JSON null value.
+func (t *CacheTransaction) Null() *astjson.Value {
+	return astjson.NullValue
+}
+
+// Commit releases DataBuffer.Lock and ends the transaction; call via defer.
+func (t *CacheTransaction) Commit() {
+	t.db.Unlock()
+}
+
+// cacheTransactionBeginner is the loader-backed TransactionBeginner, bound to
+// the request's shared jsonArena and its DataBuffer guard. It is built only
+// when a cache hook actually runs, never on the no-op path.
+type cacheTransactionBeginner struct {
+	a  arena.Arena
+	db *DataBuffer
+}
+
+func (b cacheTransactionBeginner) Begin() *CacheTransaction {
+	b.db.Lock()
+	return &CacheTransaction{a: b.a, db: b.db}
+}

--- a/v2/pkg/engine/resolve/cache_transaction.go
+++ b/v2/pkg/engine/resolve/cache_transaction.go
@@ -77,6 +77,14 @@ func (t *CacheTransaction) Commit() {
 	t.db.Unlock()
 }
 
+// NewTransactionBeginner builds a TransactionBeginner over an arena and its
+// DataBuffer guard. The loader wires its own internally; this constructor
+// exists for cache-controller unit tests and out-of-loader tooling that must
+// exercise the transaction contract directly.
+func NewTransactionBeginner(a arena.Arena, db *DataBuffer) TransactionBeginner {
+	return cacheTransactionBeginner{a: a, db: db}
+}
+
 // cacheTransactionBeginner is the loader-backed TransactionBeginner, bound to
 // the request's shared jsonArena and its DataBuffer guard. It is built only
 // when a cache hook actually runs, never on the no-op path.

--- a/v2/pkg/engine/resolve/cache_transaction.go
+++ b/v2/pkg/engine/resolve/cache_transaction.go
@@ -35,8 +35,22 @@ func (t *CacheTransaction) ParseBytes(b []byte) (*astjson.Value, error) {
 
 // StructuralCopy deep-copies v onto the arena, avoiding merge aliasing
 // corruption when the same cached value is spliced into multiple targets.
+// Callers rely on VALUE isolation (mutating the source or the copy never
+// affects the other) — in heap mode (nil arena, one production resolve entry
+// runs this way) astjson.DeepCopy is an identity passthrough, so a real copy
+// is forced via a marshal round-trip there.
 func (t *CacheTransaction) StructuralCopy(v *astjson.Value) *astjson.Value {
-	return astjson.DeepCopy(t.a, v)
+	if t.a != nil {
+		return astjson.DeepCopy(t.a, v)
+	}
+	if v == nil {
+		return nil
+	}
+	copied, err := astjson.ParseBytes(v.MarshalTo(nil))
+	if err != nil {
+		return v
+	}
+	return copied
 }
 
 // MergeValues merges src into dst on the arena. The underlying "changed" flag

--- a/v2/pkg/engine/resolve/context.go
+++ b/v2/pkg/engine/resolve/context.go
@@ -213,6 +213,20 @@ func (c *Context) endCacheRequest() {
 	}
 }
 
+// flushCacheTraces asks the request cache to attach the per-fetch cache traces
+// NOW instead of at EndRequest: the trace extension serializes DURING Resolve,
+// while EndRequest runs after the response has been written, so a trace
+// rendered with the response would otherwise never carry the cache sections.
+// A no-op without a cache surface or when the surface doesn't support it.
+func (c *Context) flushCacheTraces() {
+	if c.requestCache == nil {
+		return
+	}
+	if flusher, ok := c.requestCache.(CacheTraceFlusher); ok {
+		flusher.FlushTraces()
+	}
+}
+
 func (c *Context) SetEngineLoaderHooks(hooks LoaderHooks) {
 	c.LoaderHooks = hooks
 }

--- a/v2/pkg/engine/resolve/context.go
+++ b/v2/pkg/engine/resolve/context.go
@@ -43,6 +43,13 @@ type Context struct {
 	rateLimiter   RateLimiter
 	fieldRenderer FieldValueRenderer
 
+	// cacheController is the long-lived caching port (see SetCacheController);
+	// requestCache is the per-request working surface it hands back, created
+	// lazily under DataBuffer.Lock and shared by reference across all
+	// per-defer-group Loaders of this request.
+	cacheController CacheController
+	requestCache    RequestCache
+
 	subgraphErrors map[string]error
 
 	SubgraphHeadersBuilder SubgraphHeadersBuilder
@@ -190,6 +197,22 @@ func (c *Context) SetAuthorizer(authorizer Authorizer) {
 	c.authorizer = authorizer
 }
 
+// SetCacheController wires the caching lifecycle port, mirroring SetAuthorizer.
+// A nil controller (the default) keeps the loader on its cache-free path.
+func (c *Context) SetCacheController(controller CacheController) {
+	c.cacheController = controller
+}
+
+// endCacheRequest finalizes the per-request cache surface (flushing deferred
+// writes) and resets it. It is idempotent and a no-op when caching was never
+// used; deferred at every request entry function.
+func (c *Context) endCacheRequest() {
+	if c.requestCache != nil {
+		c.requestCache.EndRequest()
+		c.requestCache = nil
+	}
+}
+
 func (c *Context) SetEngineLoaderHooks(hooks LoaderHooks) {
 	c.LoaderHooks = hooks
 }
@@ -283,6 +306,10 @@ func (c *Context) WithContext(ctx context.Context) *Context {
 func (c *Context) clone(ctx context.Context) *Context {
 	cpy := *c
 	cpy.ctx = ctx
+	// A cloned resolution (e.g. a subscription event) is a separate request and
+	// must build its own per-request cache surface; the controller port itself
+	// is carried over by the value copy above.
+	cpy.requestCache = nil
 	if c.Variables != nil {
 		variablesData := c.Variables.MarshalTo(nil)
 		cpy.Variables = astjson.MustParseBytes(variablesData)
@@ -305,6 +332,9 @@ func (c *Context) clone(ctx context.Context) *Context {
 }
 
 func (c *Context) Free() {
+	// Defensive: the entry-function defers normally end the cache request; this
+	// covers a Context recycled without passing through one.
+	c.endCacheRequest()
 	c.ctx = nil
 	c.Variables = nil
 	c.Files = nil
@@ -315,6 +345,7 @@ func (c *Context) Free() {
 	c.Extensions = nil
 	c.subgraphErrors = nil
 	c.authorizer = nil
+	c.cacheController = nil
 	c.LoaderHooks = nil
 	c.GetDeduplicationData = nil
 	c.SetDeduplicationData = nil

--- a/v2/pkg/engine/resolve/fetch.go
+++ b/v2/pkg/engine/resolve/fetch.go
@@ -485,7 +485,43 @@ type DataSourceLoadTrace struct {
 	SingleFlightSharedResponse bool            `json:"single_flight_shared_response"`
 	LoadSkipped                bool            `json:"load_skipped"`
 	LoadStats                  *LoadStats      `json:"load_stats,omitempty"`
+	CacheTrace                 *CacheTrace     `json:"cache,omitempty"`
 	Path                       string          `json:"-"`
+}
+
+// CacheTrace is the per-fetch caching section of the ART trace output,
+// assembled by the cache observer at request end from the opaque
+// FetchCacheHandle — no caching internals leak onto the loader surface.
+type CacheTrace struct {
+	Decision       string                    `json:"decision"`
+	Hit            bool                      `json:"hit"`
+	Shadow         bool                      `json:"shadow,omitempty"`
+	Items          []CacheItemTrace          `json:"items,omitempty"`
+	ShadowCompares []CacheShadowCompareTrace `json:"shadow_compares,omitempty"`
+}
+
+// CacheItemTrace traces one item (or batch bucket) of a cached fetch.
+type CacheItemTrace struct {
+	// Keys are the rendered cache keys (shared by L1 and L2); hashed when the
+	// policy sets HashAnalyticsKeys.
+	Keys []string `json:"keys,omitempty"`
+	// ServedFrom is "l1" or "l2" when the item was served from cache.
+	ServedFrom  string `json:"served_from,omitempty"`
+	Hit         bool   `json:"hit"`
+	NegativeHit bool   `json:"negative_hit,omitempty"`
+	// RemainingTTLNano is the selected candidate's remaining TTL (L2 hits).
+	RemainingTTLNano int64 `json:"remaining_ttl_nanoseconds,omitempty"`
+	// WriteReason is "refresh" or "backfill" when the item's value was written.
+	WriteReason string `json:"write_reason,omitempty"`
+	// PendingCandidates counts key candidates that could not render at lookup.
+	PendingCandidates int `json:"pending_candidates,omitempty"`
+}
+
+// CacheShadowCompareTrace is one shadow staleness probe result.
+type CacheShadowCompareTrace struct {
+	Key          string `json:"key,omitempty"`
+	IsFresh      bool   `json:"is_fresh"`
+	CacheAgeNano int64  `json:"cache_age_nanoseconds"`
 }
 
 type LoadStats struct {

--- a/v2/pkg/engine/resolve/fetch.go
+++ b/v2/pkg/engine/resolve/fetch.go
@@ -40,6 +40,11 @@ type Fetch interface {
 	// IsBatchEntityFetch reports whether this is a batched entity fetch (an
 	// _entities fetch over array items).
 	IsBatchEntityFetch() bool
+
+	// SetDataSource replaces the fetch's transport, e.g. to swap in an
+	// in-process fake; it exists so no caller needs a switch over concrete
+	// fetch types.
+	SetDataSource(ds DataSource)
 }
 
 type FetchItem struct {
@@ -144,6 +149,10 @@ func (s *SingleFetch) IsBatchEntityFetch() bool {
 	return false
 }
 
+func (s *SingleFetch) SetDataSource(ds DataSource) {
+	s.FetchConfiguration.DataSource = ds
+}
+
 // FetchDependencies holding current fetch id and ids of fetches that current fetch depends on
 // e.g. should be fetched only after all dependent fetches are fetched
 type FetchDependencies struct {
@@ -232,6 +241,10 @@ func (b *BatchEntityFetch) IsBatchEntityFetch() bool {
 	return true
 }
 
+func (b *BatchEntityFetch) SetDataSource(ds DataSource) {
+	b.DataSource = ds
+}
+
 type BatchInput struct {
 	Header InputTemplate
 	Items  []InputTemplate
@@ -287,6 +300,10 @@ func (e *EntityFetch) IsEntityFetch() bool {
 
 func (e *EntityFetch) IsBatchEntityFetch() bool {
 	return false
+}
+
+func (e *EntityFetch) SetDataSource(ds DataSource) {
+	e.DataSource = ds
 }
 
 type EntityInput struct {

--- a/v2/pkg/engine/resolve/fetch.go
+++ b/v2/pkg/engine/resolve/fetch.go
@@ -23,6 +23,23 @@ type Fetch interface {
 	// FetchInfo returns additional fetch-related information.
 	// Callers must treat FetchInfo as read-only after planning; it may be nil when disabled by planner options.
 	FetchInfo() *FetchInfo
+
+	// CacheConfig returns the per-fetch cache config; nil means "not cached".
+	// All caching code reads it through this method (never via a switch over
+	// concrete fetch types).
+	CacheConfig() *FetchCacheConfig
+
+	// SetCacheConfig sets the per-fetch cache config; the caching planner passes
+	// call it after the concrete fetch types are created.
+	SetCacheConfig(cfg *FetchCacheConfig)
+
+	// IsEntityFetch reports whether this is a single-entity fetch (an _entities
+	// fetch on an object field).
+	IsEntityFetch() bool
+
+	// IsBatchEntityFetch reports whether this is a batched entity fetch (an
+	// _entities fetch over array items).
+	IsBatchEntityFetch() bool
 }
 
 type FetchItem struct {
@@ -111,6 +128,22 @@ func (s *SingleFetch) FetchInfo() *FetchInfo {
 	return s.Info
 }
 
+func (s *SingleFetch) CacheConfig() *FetchCacheConfig {
+	return s.FetchConfiguration.Cache
+}
+
+func (s *SingleFetch) SetCacheConfig(cfg *FetchCacheConfig) {
+	s.FetchConfiguration.Cache = cfg
+}
+
+func (s *SingleFetch) IsEntityFetch() bool {
+	return false
+}
+
+func (s *SingleFetch) IsBatchEntityFetch() bool {
+	return false
+}
+
 // FetchDependencies holding current fetch id and ids of fetches that current fetch depends on
 // e.g. should be fetched only after all dependent fetches are fetched
 type FetchDependencies struct {
@@ -169,6 +202,7 @@ type BatchEntityFetch struct {
 	Input                BatchInput
 	DataSource           DataSource
 	PostProcessing       PostProcessingConfiguration
+	Cache                *FetchCacheConfig
 	DataSourceIdentifier []byte
 	Trace                *DataSourceLoadTrace
 	Info                 *FetchInfo
@@ -180,6 +214,22 @@ func (b *BatchEntityFetch) Dependencies() *FetchDependencies {
 
 func (b *BatchEntityFetch) FetchInfo() *FetchInfo {
 	return b.Info
+}
+
+func (b *BatchEntityFetch) CacheConfig() *FetchCacheConfig {
+	return b.Cache
+}
+
+func (b *BatchEntityFetch) SetCacheConfig(cfg *FetchCacheConfig) {
+	b.Cache = cfg
+}
+
+func (b *BatchEntityFetch) IsEntityFetch() bool {
+	return false
+}
+
+func (b *BatchEntityFetch) IsBatchEntityFetch() bool {
+	return true
 }
 
 type BatchInput struct {
@@ -209,6 +259,7 @@ type EntityFetch struct {
 	Input                EntityInput
 	DataSource           DataSource
 	PostProcessing       PostProcessingConfiguration
+	Cache                *FetchCacheConfig
 	DataSourceIdentifier []byte
 	Trace                *DataSourceLoadTrace
 	Info                 *FetchInfo
@@ -220,6 +271,22 @@ func (e *EntityFetch) Dependencies() *FetchDependencies {
 
 func (e *EntityFetch) FetchInfo() *FetchInfo {
 	return e.Info
+}
+
+func (e *EntityFetch) CacheConfig() *FetchCacheConfig {
+	return e.Cache
+}
+
+func (e *EntityFetch) SetCacheConfig(cfg *FetchCacheConfig) {
+	e.Cache = cfg
+}
+
+func (e *EntityFetch) IsEntityFetch() bool {
+	return true
+}
+
+func (e *EntityFetch) IsBatchEntityFetch() bool {
+	return false
 }
 
 type EntityInput struct {
@@ -278,6 +345,10 @@ type FetchConfiguration struct {
 
 	// OperationName is non-empty when the operation name is propagated to the upstream subgraph fetch.
 	OperationName string
+
+	// Cache is the per-fetch cache config; nil means "not cached". A pointer so
+	// most (uncached) fetches carry no inline struct.
+	Cache *FetchCacheConfig
 }
 
 func (fc *FetchConfiguration) Equals(other *FetchConfiguration) bool {
@@ -302,6 +373,12 @@ func (fc *FetchConfiguration) Equals(other *FetchConfiguration) bool {
 		return false
 	}
 	if fc.SetTemplateOutputToNullOnVariableNull != other.SetTemplateOutputToNullOnVariableNull {
+		return false
+	}
+	if (fc.Cache == nil) != (other.Cache == nil) {
+		return false
+	}
+	if fc.Cache != nil && !fc.Cache.Equals(other.Cache) {
 		return false
 	}
 

--- a/v2/pkg/engine/resolve/fetch.go
+++ b/v2/pkg/engine/resolve/fetch.go
@@ -41,6 +41,11 @@ type Fetch interface {
 	// _entities fetch over array items).
 	IsBatchEntityFetch() bool
 
+	// LoadTrace returns the fetch's ART trace destination; nil when tracing is
+	// disabled for the request. Caching/observability code reads it through
+	// this method (never via a switch over concrete fetch types).
+	LoadTrace() *DataSourceLoadTrace
+
 	// SetDataSource replaces the fetch's transport, e.g. to swap in an
 	// in-process fake; it exists so no caller needs a switch over concrete
 	// fetch types.
@@ -198,6 +203,10 @@ func (ppc *PostProcessingConfiguration) Equals(other *PostProcessingConfiguratio
 	return true
 }
 
+func (f *SingleFetch) LoadTrace() *DataSourceLoadTrace {
+	return f.Trace
+}
+
 func (*SingleFetch) FetchKind() FetchKind {
 	return FetchKindSingle
 }
@@ -260,6 +269,10 @@ type BatchInput struct {
 	Footer       InputTemplate
 }
 
+func (f *BatchEntityFetch) LoadTrace() *DataSourceLoadTrace {
+	return f.Trace
+}
+
 func (*BatchEntityFetch) FetchKind() FetchKind {
 	return FetchKindEntityBatch
 }
@@ -311,6 +324,10 @@ type EntityInput struct {
 	Item        InputTemplate
 	SkipErrItem bool
 	Footer      InputTemplate
+}
+
+func (f *EntityFetch) LoadTrace() *DataSourceLoadTrace {
+	return f.Trace
 }
 
 func (*EntityFetch) FetchKind() FetchKind {

--- a/v2/pkg/engine/resolve/fetchtree.go
+++ b/v2/pkg/engine/resolve/fetchtree.go
@@ -160,6 +160,9 @@ type FetchTreeQueryPlan struct {
 	Representations   []Representation  `json:"representations,omitempty"`
 	Query             string            `json:"query,omitempty"`
 	Dependencies      []FetchDependency `json:"dependencies,omitempty"`
+	// Cache is the fetch's cache config in its canonical one-line form; empty
+	// when the fetch is uncached, so plans without caching are unchanged.
+	Cache string `json:"cache,omitempty"`
 }
 
 func (n *FetchTreeNode) QueryPlan() *FetchTreeQueryPlanNode {
@@ -196,6 +199,14 @@ func (n *FetchTreeNode) queryPlan() *FetchTreeQueryPlanNode {
 	}
 	switch n.Kind {
 	case FetchTreeNodeKindSingle:
+		defer func() {
+			// The cache config reads through the Fetch interface (never a
+			// switch over concrete fetch types); an uncached fetch leaves the
+			// field empty and the plan output unchanged.
+			if queryPlan.Fetch != nil && n.Item.Fetch.CacheConfig() != nil {
+				queryPlan.Fetch.Cache = n.Item.Fetch.CacheConfig().String()
+			}
+		}()
 		switch f := n.Item.Fetch.(type) {
 		case *SingleFetch:
 			queryPlan.Fetch = &FetchTreeQueryPlan{
@@ -345,6 +356,9 @@ func (p *PlanPrinter) printFetchInfo(fetch *FetchTreeQueryPlan) {
 
 	if fetch.Representations != nil {
 		p.printRepresentations(fetch.Representations)
+	}
+	if fetch.Cache != "" {
+		p.print(fmt.Sprintf("Cache: %s", fetch.Cache))
 	}
 	p.printQuery(fetch.Query)
 

--- a/v2/pkg/engine/resolve/loader.go
+++ b/v2/pkg/engine/resolve/loader.go
@@ -414,6 +414,15 @@ func (l *Loader) resolveSingle(ctx context.Context, item *FetchItem) error {
 	// acquisition around its arena work. Both are no-ops when no cache
 	// controller is set.
 	l.cachePrepare(prepared)
+	if prepared.batchAssembly != nil && !prepared.skipLoad {
+		var keep []bool
+		if prepared.cacheHandle != nil {
+			keep = prepared.cacheHandle.BatchFetchKeep
+		}
+		if err := l.assembleBatchInput(prepared, keep); err != nil {
+			return errors.WithStack(err)
+		}
+	}
 	if err := l.loadPhase(ctx, prepared); err != nil {
 		return errors.WithStack(err)
 	}
@@ -432,9 +441,70 @@ type preparedFetch struct {
 	trace      *DataSourceLoadTrace
 	skipLoad   bool
 	batchFetch bool
+	// batchAssembly defers the batch input assembly until AFTER the cache
+	// decision: the final input is rendered exactly once, containing only the
+	// representations the network fetch still needs (no parse-back filtering).
+	batchAssembly *batchInputAssembly
 	// cacheHandle is the opaque per-fetch cache state returned by PrepareFetch,
 	// threaded to the merge hook; nil when the controller did not touch the fetch.
 	cacheHandle *FetchCacheHandle
+}
+
+// batchInputAssembly holds the pre-rendered pieces of a batch entity input:
+// header/separator/footer plus one segment per UNIQUE representation (bucket
+// order). All slices live on the fetch's batchEntityTools arena, which stays
+// alive until resolveSingle returns.
+type batchInputAssembly struct {
+	header             []byte
+	separator          []byte
+	footer             []byte
+	segments           [][]byte
+	undefinedVariables []string
+	info               *FetchInfo
+	fetchItem          *FetchItem
+}
+
+// assembleBatchInput renders the FINAL batch input from the pre-rendered
+// pieces, including only the buckets keep marks (nil keep = all), then runs
+// the undefined-variables post-processing and the pre-fetch validation that
+// operate on the final bytes.
+func (l *Loader) assembleBatchInput(prepared *preparedFetch, keep []bool) error {
+	assembly := prepared.batchAssembly
+	buf := arena.NewArenaBuffer(prepared.res.tools.a)
+	_, _ = buf.Write(assembly.header)
+	wroteItem := false
+	for i, segment := range assembly.segments {
+		if keep != nil && (i >= len(keep) || !keep[i]) {
+			continue
+		}
+		if wroteItem {
+			_, _ = buf.Write(assembly.separator)
+		}
+		_, _ = buf.Write(segment)
+		wroteItem = true
+	}
+	_, _ = buf.Write(assembly.footer)
+	if err := SetInputUndefinedVariables(buf, assembly.undefinedVariables); err != nil {
+		return errors.WithStack(err)
+	}
+	fetchInput := buf.Bytes()
+
+	if l.ctx.TracingOptions.Enable && prepared.res.fetchSkipped {
+		l.setTracingInput(assembly.fetchItem, fetchInput, prepared.trace)
+		prepared.skipLoad = true
+		return nil
+	}
+
+	allowed, err := l.validatePreFetch(fetchInput, assembly.info, prepared.res)
+	if err != nil {
+		return err
+	}
+	if !allowed {
+		prepared.skipLoad = true
+		return nil
+	}
+	prepared.input = fetchInput
+	return nil
 }
 
 // cacheRequest lazily obtains the request-lifetime cache working surface. The
@@ -494,14 +564,12 @@ func (l *Loader) cachePrepare(prepared *preparedFetch) {
 			prepared.trace.LoadSkipped = true
 		}
 	case DecisionFetchPartial:
-		// Partial: the network call carries the REDUCED input (missing
-		// representations only) and the loader's own positional data merge is
-		// skipped — OnFetchResult splices the cached items and realigns +
-		// merges the fetched ones in a single hook (one lock acquisition).
-		// Error/response processing in mergeResult still runs unchanged.
-		if handle != nil && handle.PartialInput != nil {
-			prepared.input = handle.PartialInput
-		}
+		// Partial: the batch input assembly (which runs after this hook)
+		// includes only the buckets handle.BatchFetchKeep marks, and the
+		// loader's own positional data merge is skipped — OnFetchResult
+		// splices the cached items and realigns + merges the fetched ones in
+		// a single hook (one lock acquisition). Error/response processing in
+		// mergeResult still runs unchanged.
 		prepared.res.cachePartial = true
 	default:
 		// DecisionFetch / DecisionFetchShadow leave the load in place; the
@@ -1769,8 +1837,11 @@ func (l *Loader) prepareBatchEntityFetch(fetchItem *FetchItem, fetch *BatchEntit
 	}
 
 	res.tools = batchEntityToolPool.Get(len(items))
-	preparedInput := arena.NewArenaBuffer(res.tools.a)
+	headerInput := arena.NewArenaBuffer(res.tools.a)
+	separatorInput := arena.NewArenaBuffer(res.tools.a)
+	footerInput := arena.NewArenaBuffer(res.tools.a)
 	itemInput := arena.NewArenaBuffer(res.tools.a)
+	segments := arena.AllocateSlice[[]byte](res.tools.a, 0, len(items))
 	batchStats := arena.AllocateSlice[[]*astjson.Value](res.tools.a, 0, len(items))
 	defer func() {
 		// we need to clear the batchStats slice to avoid memory corruption
@@ -1786,12 +1857,14 @@ func (l *Loader) prepareBatchEntityFetch(fetchItem *FetchItem, fetch *BatchEntit
 	// I tried using arena here, but it only worsened the situation
 	var undefinedVariables []string
 
-	err := fetch.Input.Header.RenderAndCollectUndefinedVariables(l.ctx, nil, preparedInput, &undefinedVariables)
+	err := fetch.Input.Header.RenderAndCollectUndefinedVariables(l.ctx, nil, headerInput, &undefinedVariables)
 	if err != nil {
 		return errors.WithStack(err)
 	}
+	if err = fetch.Input.Separator.Render(l.ctx, nil, separatorInput); err != nil {
+		return errors.WithStack(err)
+	}
 	batchItemIndex := 0
-	addSeparator := false
 
 WithNextItem:
 	for i, item := range items {
@@ -1822,14 +1895,13 @@ WithNextItem:
 				batchStats[existingIndex] = arena.SliceAppend(res.tools.a, batchStats[existingIndex], items[i])
 				continue WithNextItem
 			} else {
-				if addSeparator {
-					err = fetch.Input.Separator.Render(l.ctx, nil, preparedInput)
-					if err != nil {
-						return errors.WithStack(err)
-					}
-				}
-				_, _ = itemInput.WriteTo(preparedInput)
-				// new unique representation
+				// New unique representation: keep its rendered SEGMENT — the
+				// final input assembles AFTER the cache decision, so a partial
+				// hit sends only the still-missing representations without
+				// ever parsing the input back.
+				segment := arena.AllocateSlice[byte](res.tools.a, itemInput.Len(), itemInput.Len())
+				copy(segment, itemInput.Bytes())
+				segments = arena.SliceAppend(res.tools.a, segments, segment)
 				res.tools.batchHashToIndex[itemHash] = batchItemIndex
 				// A new targets bucket for the unique index must be allocated on the arena:
 				// a heap-allocated bucket would only be referenced from arena memory,
@@ -1838,7 +1910,6 @@ WithNextItem:
 				bucket[0] = items[i]
 				batchStats = arena.SliceAppend(res.tools.a, batchStats, bucket)
 				batchItemIndex++
-				addSeparator = true
 			}
 		}
 	}
@@ -1854,17 +1925,11 @@ WithNextItem:
 		}
 	}
 
-	err = fetch.Input.Footer.RenderAndCollectUndefinedVariables(l.ctx, nil, preparedInput, &undefinedVariables)
+	err = fetch.Input.Footer.RenderAndCollectUndefinedVariables(l.ctx, nil, footerInput, &undefinedVariables)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	err = SetInputUndefinedVariables(preparedInput, undefinedVariables)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	fetchInput := preparedInput.Bytes()
 	// it's important to copy the *astjson.Value's off the arena to avoid memory corruption
 	res.batchStats = make([][]*astjson.Value, len(batchStats))
 	for i := range batchStats {
@@ -1872,23 +1937,20 @@ WithNextItem:
 		copy(res.batchStats[i], batchStats[i])
 	}
 
-	if l.ctx.TracingOptions.Enable && res.fetchSkipped {
-		l.setTracingInput(fetchItem, fetchInput, fetch.Trace)
-		prepared.skipLoad = true
-		return nil
+	// The final input assembles in resolveSingle AFTER the cache decision
+	// (assembleBatchInput), so a partial hit renders only the still-missing
+	// representations; undefined-variable post-processing and the pre-fetch
+	// validation run there, on the final bytes.
+	prepared.batchAssembly = &batchInputAssembly{
+		header:             headerInput.Bytes(),
+		separator:          separatorInput.Bytes(),
+		footer:             footerInput.Bytes(),
+		segments:           segments,
+		undefinedVariables: undefinedVariables,
+		info:               fetch.Info,
+		fetchItem:          fetchItem,
 	}
-
-	allowed, err := l.validatePreFetch(fetchInput, fetch.Info, res)
-	if err != nil {
-		return err
-	}
-	if !allowed {
-		prepared.skipLoad = true
-		return nil
-	}
-
 	prepared.source = fetch.DataSource
-	prepared.input = fetchInput
 	prepared.trace = fetch.Trace
 	return nil
 }

--- a/v2/pkg/engine/resolve/loader.go
+++ b/v2/pkg/engine/resolve/loader.go
@@ -450,52 +450,22 @@ type preparedFetch struct {
 	cacheHandle *FetchCacheHandle
 }
 
-// batchInputAssembly holds the pre-rendered pieces of a batch entity input:
-// header/separator/footer plus one segment per UNIQUE representation (bucket
-// order). All slices live on the fetch's batchEntityTools arena, which stays
-// alive until resolveSingle returns.
-type batchInputAssembly struct {
-	header             []byte
-	separator          []byte
-	footer             []byte
-	segments           [][]byte
-	undefinedVariables []string
-	info               *FetchInfo
-	fetchItem          *FetchItem
-}
-
-// assembleBatchInput renders the FINAL batch input from the pre-rendered
-// pieces, including only the buckets keep marks (nil keep = all), then runs
-// the undefined-variables post-processing and the pre-fetch validation that
-// operate on the final bytes.
+// assembleBatchInput renders the FINAL batch input (the assembly filtered by
+// keep, nil = all buckets), then runs the tracing-skip branch and the
+// pre-fetch validation that operate on the final bytes.
 func (l *Loader) assembleBatchInput(prepared *preparedFetch, keep []bool) error {
-	assembly := prepared.batchAssembly
-	buf := arena.NewArenaBuffer(prepared.res.tools.a)
-	_, _ = buf.Write(assembly.header)
-	wroteItem := false
-	for i, segment := range assembly.segments {
-		if keep != nil && (i >= len(keep) || !keep[i]) {
-			continue
-		}
-		if wroteItem {
-			_, _ = buf.Write(assembly.separator)
-		}
-		_, _ = buf.Write(segment)
-		wroteItem = true
-	}
-	_, _ = buf.Write(assembly.footer)
-	if err := SetInputUndefinedVariables(buf, assembly.undefinedVariables); err != nil {
+	fetchInput, err := prepared.batchAssembly.assemble(prepared.res.tools.a, keep)
+	if err != nil {
 		return errors.WithStack(err)
 	}
-	fetchInput := buf.Bytes()
 
 	if l.ctx.TracingOptions.Enable && prepared.res.fetchSkipped {
-		l.setTracingInput(assembly.fetchItem, fetchInput, prepared.trace)
+		l.setTracingInput(prepared.item, fetchInput, prepared.trace)
 		prepared.skipLoad = true
 		return nil
 	}
 
-	allowed, err := l.validatePreFetch(fetchInput, assembly.info, prepared.res)
+	allowed, err := l.validatePreFetch(fetchInput, prepared.item.Fetch.FetchInfo(), prepared.res)
 	if err != nil {
 		return err
 	}
@@ -1823,7 +1793,7 @@ var (
 	batchEntityToolPool = _batchEntityToolPool{}
 )
 
-func (l *Loader) prepareBatchEntityFetch(fetchItem *FetchItem, fetch *BatchEntityFetch, items []*astjson.Value, res *result, prepared *preparedFetch) error {
+func (l *Loader) prepareBatchEntityFetch(_ *FetchItem, fetch *BatchEntityFetch, items []*astjson.Value, res *result, prepared *preparedFetch) error {
 	res.init(fetch.PostProcessing, fetch.Info)
 
 	if l.ctx.TracingOptions.Enable {
@@ -1947,8 +1917,6 @@ WithNextItem:
 		footer:             footerInput.Bytes(),
 		segments:           segments,
 		undefinedVariables: undefinedVariables,
-		info:               fetch.Info,
-		fetchItem:          fetchItem,
 	}
 	prepared.source = fetch.DataSource
 	prepared.trace = fetch.Trace

--- a/v2/pkg/engine/resolve/loader.go
+++ b/v2/pkg/engine/resolve/loader.go
@@ -110,7 +110,11 @@ type result struct {
 	//	[item1, item3], // merge response[1] into item1 and item3
 	//
 	// ]
-	batchStats       [][]*astjson.Value
+	batchStats [][]*astjson.Value
+	// cachePartial marks a DecisionFetchPartial fetch: mergeResult stops after
+	// response/error processing and leaves the data merge to the cache hook
+	// (the reduced response is positionally misaligned with batchStats).
+	cachePartial     bool
 	fetchSkipped     bool
 	nestedMergeItems []*result
 
@@ -478,14 +482,26 @@ func (l *Loader) cachePrepare(prepared *preparedFetch) {
 		Arena:      l.cacheTransactions(),
 	})
 	prepared.cacheHandle = handle
-	if decision == DecisionSkipFullHit {
+	switch decision {
+	case DecisionSkipFullHit:
 		// Full hit: skip the network AND the merge. skipLoad makes loadPhase
 		// early-return; fetchSkipped reuses the existing mergeResult early-return
 		// so no spurious "failed to fetch" error is rendered for the empty res.out.
-		// DecisionFetch / DecisionFetchShadow / DecisionFetchPartial leave the
-		// load in place; the handle drives the merge dispatch.
 		prepared.skipLoad = true
 		prepared.res.fetchSkipped = true
+	case DecisionFetchPartial:
+		// Partial: the network call carries the REDUCED input (missing
+		// representations only) and the loader's own positional data merge is
+		// skipped — OnFetchResult splices the cached items and realigns +
+		// merges the fetched ones in a single hook (one lock acquisition).
+		// Error/response processing in mergeResult still runs unchanged.
+		if handle != nil && handle.PartialInput != nil {
+			prepared.input = handle.PartialInput
+		}
+		prepared.res.cachePartial = true
+	default:
+		// DecisionFetch / DecisionFetchShadow leave the load in place; the
+		// handle drives the merge dispatch.
 	}
 }
 
@@ -517,9 +533,11 @@ func (l *Loader) cacheMerge(prepared *preparedFetch) error {
 	}
 	rc := l.cacheRequest() // already created during cachePrepare; non-nil because h != nil
 	switch h.Decision {
-	case DecisionSkipFullHit, DecisionFetchPartial:
+	case DecisionSkipFullHit:
 		return rc.OnFetchSkipped(h, in)
-	default: // DecisionFetch, DecisionFetchShadow
+	default: // DecisionFetch, DecisionFetchShadow, DecisionFetchPartial
+		// The partial arm lives in OnFetchResult too: one hook call splices
+		// the cached items AND realigns + merges + writes the fetched ones.
 		return rc.OnFetchResult(h, in)
 	}
 }
@@ -830,6 +848,13 @@ func (l *Loader) mergeResult(fetchItem *FetchItem, res *result, items []*astjson
 		}
 
 		// no data
+		return nil
+	}
+
+	if res.cachePartial {
+		// Partial fetch: response and errors are fully processed above; the
+		// cache hook owns the data merge (splice + realign), so the positional
+		// merge below must not run against the REDUCED response.
 		return nil
 	}
 

--- a/v2/pkg/engine/resolve/loader.go
+++ b/v2/pkg/engine/resolve/loader.go
@@ -489,6 +489,10 @@ func (l *Loader) cachePrepare(prepared *preparedFetch) {
 		// so no spurious "failed to fetch" error is rendered for the empty res.out.
 		prepared.skipLoad = true
 		prepared.res.fetchSkipped = true
+		if prepared.trace != nil {
+			// The ART trace reports the skipped load like every other skip.
+			prepared.trace.LoadSkipped = true
+		}
 	case DecisionFetchPartial:
 		// Partial: the network call carries the REDUCED input (missing
 		// representations only) and the loader's own positional data merge is

--- a/v2/pkg/engine/resolve/loader.go
+++ b/v2/pkg/engine/resolve/loader.go
@@ -114,6 +114,17 @@ type result struct {
 	fetchSkipped     bool
 	nestedMergeItems []*result
 
+	// response / responseData / responseHasErrors surface what mergeResult
+	// already computes to the cache merge hook: the FULL parsed response (the
+	// input isEmptyEntityFetch needs), the data sub-path (what a cache would
+	// persist), and the GraphQL-errors flag. response is assigned only after a
+	// successful parse, so response == nil is the structural fetch-failed
+	// signal (transport / empty body / parse failure). All three are dead
+	// weight when caching is off (written, never read).
+	response          *astjson.Value
+	responseData      *astjson.Value
+	responseHasErrors bool
+
 	statusCode int
 	err        error
 	// subgraphError is THIS fetch's own subgraph error (errors.Join of res.err and
@@ -394,10 +405,18 @@ func (l *Loader) resolveSingle(ctx context.Context, item *FetchItem) error {
 	if prepared == nil {
 		return nil
 	}
+	// The two cache hooks bracket the network load and run OUTSIDE the phase
+	// locks, so the controller's CacheTransaction is the single DataBuffer.Lock
+	// acquisition around its arena work. Both are no-ops when no cache
+	// controller is set.
+	l.cachePrepare(prepared)
 	if err := l.loadPhase(ctx, prepared); err != nil {
 		return errors.WithStack(err)
 	}
-	return l.mergePhase(prepared)
+	if err := l.mergePhase(prepared); err != nil {
+		return errors.WithStack(err)
+	}
+	return l.cacheMerge(prepared)
 }
 
 type preparedFetch struct {
@@ -409,6 +428,106 @@ type preparedFetch struct {
 	trace      *DataSourceLoadTrace
 	skipLoad   bool
 	batchFetch bool
+	// cacheHandle is the opaque per-fetch cache state returned by PrepareFetch,
+	// threaded to the merge hook; nil when the controller did not touch the fetch.
+	cacheHandle *FetchCacheHandle
+}
+
+// cacheRequest lazily obtains the request-lifetime cache working surface. The
+// once-create runs under DataBuffer.Lock so it is race-free across the
+// parallel fetches of a group and across per-defer-group Loaders (there is
+// exactly one DataBuffer per request). It does NOT hold the lock across the
+// hook: PrepareFetch / OnFetch* open their own CacheTransaction for arena work.
+func (l *Loader) cacheRequest() RequestCache {
+	if l.ctx.cacheController == nil {
+		return nil
+	}
+	l.dataBuffer.Lock()
+	defer l.dataBuffer.Unlock()
+	if l.ctx.requestCache == nil {
+		l.ctx.requestCache = l.ctx.cacheController.BeginRequest(l.ctx)
+	}
+	return l.ctx.requestCache
+}
+
+// cachePrepare is the pre-load cache hook: lookup + coverage + decision. It
+// early-returns on every render-skip (a fetch the loader already decided to
+// skip is not a cache decision) and when the fetch carries no cache config, so
+// the no-controller / no-config path costs nothing.
+func (l *Loader) cachePrepare(prepared *preparedFetch) {
+	if prepared == nil || prepared.skipLoad {
+		return
+	}
+	cfg := prepared.item.Fetch.CacheConfig()
+	if cfg == nil || (!cfg.L1 && !cfg.L2) {
+		return
+	}
+	rc := l.cacheRequest()
+	if rc == nil {
+		return
+	}
+	_, hash := l.ctx.HeadersForSubgraphRequest(prepared.res.ds.Name)
+	decision, handle := rc.PrepareFetch(PrepareFetchInput{
+		Ctx:        l.ctx,
+		Item:       prepared.item,
+		Items:      prepared.items,
+		Config:     cfg,
+		BatchStats: prepared.res.batchStats,
+		Input:      prepared.input,
+		HeaderHash: hash,
+		Arena:      l.cacheTransactions(),
+	})
+	prepared.cacheHandle = handle
+	if decision == DecisionSkipFullHit {
+		// Full hit: skip the network AND the merge. skipLoad makes loadPhase
+		// early-return; fetchSkipped reuses the existing mergeResult early-return
+		// so no spurious "failed to fetch" error is rendered for the empty res.out.
+		// DecisionFetch / DecisionFetchShadow / DecisionFetchPartial leave the
+		// load in place; the handle drives the merge dispatch.
+		prepared.skipLoad = true
+		prepared.res.fetchSkipped = true
+	}
+}
+
+// cacheMerge is the post-merge cache hook: write / skip-splice / shadow. It is
+// gated only on the handle, so it never fires for fetches the controller did
+// not touch.
+func (l *Loader) cacheMerge(prepared *preparedFetch) error {
+	h := prepared.cacheHandle
+	if h == nil {
+		return nil
+	}
+	res := prepared.res
+	in := MergeInput{
+		Item:         prepared.item,
+		Items:        prepared.items,
+		ResponseData: res.responseData,
+		BatchStats:   res.batchStats,
+		MergePath:    res.postProcessing.MergePath,
+		HasErrors:    res.responseHasErrors,
+		FetchFailed:  res.err != nil || len(res.out) == 0 || res.response == nil,
+		StatusCode:   res.statusCode,
+		Arena:        l.cacheTransactions(),
+	}
+	if res.response != nil {
+		// Only meaningful (and only nil-safe) when a response actually parsed;
+		// on a full-hit skip res.response is nil and EmptyEntity is irrelevant
+		// because cacheMerge dispatches to OnFetchSkipped, which ignores it.
+		in.EmptyEntity = isEmptyEntityFetch(prepared.item, res.response)
+	}
+	rc := l.cacheRequest() // already created during cachePrepare; non-nil because h != nil
+	switch h.Decision {
+	case DecisionSkipFullHit, DecisionFetchPartial:
+		return rc.OnFetchSkipped(h, in)
+	default: // DecisionFetch, DecisionFetchShadow
+		return rc.OnFetchResult(h, in)
+	}
+}
+
+// cacheTransactions returns the TransactionBeginner bound to this request's
+// shared jsonArena and DataBuffer guard. Built only when a cache hook runs.
+func (l *Loader) cacheTransactions() TransactionBeginner {
+	return cacheTransactionBeginner{a: l.jsonArena, db: l.dataBuffer}
 }
 
 func (l *Loader) shouldSkipErroredDependencyLocked(item *FetchItem) bool {
@@ -633,6 +752,7 @@ func (l *Loader) mergeResult(fetchItem *FetchItem, res *result, items []*astjson
 		}
 		return l.renderErrorsFailedToFetch(fetchItem, res, invalidGraphQLResponse)
 	}
+	res.response = response
 
 	if l.allowCustomExtensionProperties {
 		extensions := response.Get("extensions")
@@ -648,6 +768,7 @@ func (l *Loader) mergeResult(fetchItem *FetchItem, res *result, items []*astjson
 	} else {
 		responseData = response
 	}
+	res.responseData = responseData
 
 	hasErrors := false
 
@@ -678,6 +799,7 @@ func (l *Loader) mergeResult(fetchItem *FetchItem, res *result, items []*astjson
 			}
 		}
 	}
+	res.responseHasErrors = hasErrors
 
 	// Check if data needs processing.
 	if res.postProcessing.SelectResponseDataPath != nil && astjson.ValueIsNull(responseData) {

--- a/v2/pkg/engine/resolve/node_object.go
+++ b/v2/pkg/engine/resolve/node_object.go
@@ -157,6 +157,39 @@ func (f *Field) Copy() *Field {
 	}
 }
 
+// ComputeHasAliases recursively checks whether any field below obj carries an
+// OriginalName or CacheArgs (i.e. the cached, schema-named form differs from
+// the query's shape) and sets HasAliases on EVERY object along the way, so the
+// runtime denormalization has a per-object fast path.
+func ComputeHasAliases(obj *Object) bool {
+	if obj == nil {
+		return false
+	}
+	hasAliases := false
+	for _, field := range obj.Fields {
+		if field.OriginalName != nil || len(field.CacheArgs) > 0 {
+			hasAliases = true
+		}
+		if computeNodeHasAliases(field.Value) {
+			hasAliases = true
+		}
+	}
+	obj.HasAliases = hasAliases
+	return hasAliases
+}
+
+func computeNodeHasAliases(node Node) bool {
+	switch n := node.(type) {
+	case *Object:
+		return ComputeHasAliases(n)
+	case *Array:
+		if n != nil && n.Item != nil {
+			return computeNodeHasAliases(n.Item)
+		}
+	}
+	return false
+}
+
 func (f *Field) Equals(n *Field) bool {
 	// NOTE: a lot of struct fields are not compared here
 	// because they are not relevant for the value comparison of response nodes

--- a/v2/pkg/engine/resolve/node_object.go
+++ b/v2/pkg/engine/resolve/node_object.go
@@ -145,15 +145,16 @@ func (f *Field) Copy() *Field {
 		deferField = &cp
 	}
 	return &Field{
-		Name:         f.Name,
-		Value:        f.Value.Copy(),
-		Position:     f.Position,
-		Defer:        deferField,
-		Stream:       f.Stream,
-		OnTypeNames:  f.OnTypeNames,
-		Info:         f.Info,
-		OriginalName: f.OriginalName,
-		CacheArgs:    slices.Clone(f.CacheArgs),
+		Name:              f.Name,
+		Value:             f.Value.Copy(),
+		Position:          f.Position,
+		Defer:             deferField,
+		Stream:            f.Stream,
+		OnTypeNames:       f.OnTypeNames,
+		ParentOnTypeNames: f.ParentOnTypeNames,
+		Info:              f.Info,
+		OriginalName:      f.OriginalName,
+		CacheArgs:         slices.Clone(f.CacheArgs),
 	}
 }
 

--- a/v2/pkg/engine/resolve/node_object.go
+++ b/v2/pkg/engine/resolve/node_object.go
@@ -13,6 +13,12 @@ type Object struct {
 	PossibleTypes map[string]struct{} `json:"-"`
 	SourceName    string              `json:"-"`
 	TypeName      string              `json:"-"`
+
+	// HasAliases marks that somewhere below this object a field carries an
+	// OriginalName or CacheArgs, i.e. the cached (schema-named) form differs
+	// from the query's shape and needs denormalization on read. Set by the
+	// caching planner walk.
+	HasAliases bool `json:"-"`
 }
 
 func (o *Object) Copy() Node {
@@ -21,9 +27,10 @@ func (o *Object) Copy() Node {
 		fields[i] = f.Copy()
 	}
 	return &Object{
-		Nullable: o.Nullable,
-		Path:     o.Path,
-		Fields:   fields,
+		Nullable:   o.Nullable,
+		Path:       o.Path,
+		Fields:     fields,
+		HasAliases: o.HasAliases,
 	}
 }
 
@@ -109,6 +116,21 @@ type Field struct {
 	OnTypeNames       [][]byte
 	ParentOnTypeNames []ParentOnTypeNames
 	Info              *FieldInfo
+
+	// OriginalName is the schema field name when Name is an alias; nil when the
+	// field is not aliased. The cache normalizes to OriginalName on write and
+	// denormalizes back to Name on read. Set by the caching planner walk.
+	OriginalName []byte `json:"-"`
+
+	// CacheArgs are the field's arguments relevant to cache identity, used to
+	// build argument-suffix cache keys. Set by the caching planner walk.
+	CacheArgs []CacheFieldArg `json:"-"`
+}
+
+// CacheFieldArg names one field argument and the operation variable it is
+// bound to, so the cache can render argument-suffix keys per request.
+type CacheFieldArg struct {
+	Name, VariableName string
 }
 
 type ParentOnTypeNames struct {
@@ -123,13 +145,15 @@ func (f *Field) Copy() *Field {
 		deferField = &cp
 	}
 	return &Field{
-		Name:        f.Name,
-		Value:       f.Value.Copy(),
-		Position:    f.Position,
-		Defer:       deferField,
-		Stream:      f.Stream,
-		OnTypeNames: f.OnTypeNames,
-		Info:        f.Info,
+		Name:         f.Name,
+		Value:        f.Value.Copy(),
+		Position:     f.Position,
+		Defer:        deferField,
+		Stream:       f.Stream,
+		OnTypeNames:  f.OnTypeNames,
+		Info:         f.Info,
+		OriginalName: f.OriginalName,
+		CacheArgs:    slices.Clone(f.CacheArgs),
 	}
 }
 

--- a/v2/pkg/engine/resolve/resolve.go
+++ b/v2/pkg/engine/resolve/resolve.go
@@ -395,6 +395,12 @@ func (r *Resolver) ResolveGraphQLResponse(ctx *Context, response *GraphQLRespons
 		resolvable.skipValueCompletion = loader.skipValueCompletion
 	}
 
+	if ctx.TracingOptions.Enable && ctx.TracingOptions.IncludeTraceOutputInResponseExtensions {
+		// The trace extension renders inside Resolve, before EndRequest can
+		// run — attach the cache traces now so it carries the cache sections.
+		ctx.flushCacheTraces()
+	}
+
 	responseResolveStart := time.Now()
 	err = resolvable.Resolve(ctx.ctx, response.Data, response.Fetches, writer)
 	resp.ResponseResolveStartTime = responseResolveStart
@@ -468,6 +474,13 @@ func (r *Resolver) ArenaResolveGraphQLResponse(ctx *Context, response *GraphQLRe
 		resolvable.errors = loader.errors
 		resolvable.subgraphExtensions = loader.subgraphExtensions
 		resolvable.skipValueCompletion = loader.skipValueCompletion
+	}
+
+	if ctx.TracingOptions.Enable && ctx.TracingOptions.IncludeTraceOutputInResponseExtensions {
+		// The trace extension renders inside Resolve, before EndRequest can
+		// run — attach the cache traces now so it carries the cache sections.
+		// FlushTraces shares EndRequest's no-arena contract.
+		ctx.flushCacheTraces()
 	}
 
 	// only when loading is done, acquire an arena for the response buffer

--- a/v2/pkg/engine/resolve/resolve.go
+++ b/v2/pkg/engine/resolve/resolve.go
@@ -409,6 +409,9 @@ func (r *Resolver) ResolveGraphQLResponse(ctx *Context, response *GraphQLRespons
 }
 
 func (r *Resolver) ArenaResolveGraphQLResponse(ctx *Context, response *GraphQLResponse, writer io.Writer) (*GraphQLResolveInfo, error) {
+	// Deferred BEFORE the arena acquire below, so EndRequest runs AFTER the
+	// arena is released — safe because EndRequest is arena-free by contract
+	// (see RequestCache.EndRequest).
 	defer ctx.endCacheRequest()
 
 	resp := &GraphQLResolveInfo{}
@@ -510,6 +513,8 @@ func (r *Resolver) ArenaResolveGraphQLResponse(ctx *Context, response *GraphQLRe
 }
 
 func (r *Resolver) ResolveGraphQLDeferResponse(ctx *Context, response *GraphQLDeferResponse, writer DeferResponseWriter) (*GraphQLResolveInfo, error) {
+	// EndRequest runs after the request arenas are released; it is arena-free
+	// by contract (see RequestCache.EndRequest).
 	defer ctx.endCacheRequest()
 
 	resolveInfo := &GraphQLResolveInfo{}
@@ -926,6 +931,8 @@ func (r *Resolver) executeSubscriptionUpdate(resolveCtx *Context, sub *subscript
 	defer cancel()
 
 	resolveCtx = resolveCtx.WithContext(ctx)
+	// EndRequest runs after resolveArena is released back to the pool below;
+	// it is arena-free by contract (see RequestCache.EndRequest).
 	defer resolveCtx.endCacheRequest()
 
 	// Copy the input.

--- a/v2/pkg/engine/resolve/resolve.go
+++ b/v2/pkg/engine/resolve/resolve.go
@@ -360,6 +360,8 @@ type GraphQLResolveInfo struct {
 }
 
 func (r *Resolver) ResolveGraphQLResponse(ctx *Context, response *GraphQLResponse, data []byte, writer io.Writer) (*GraphQLResolveInfo, error) {
+	defer ctx.endCacheRequest()
+
 	resp := &GraphQLResolveInfo{}
 
 	start := time.Now()
@@ -407,6 +409,8 @@ func (r *Resolver) ResolveGraphQLResponse(ctx *Context, response *GraphQLRespons
 }
 
 func (r *Resolver) ArenaResolveGraphQLResponse(ctx *Context, response *GraphQLResponse, writer io.Writer) (*GraphQLResolveInfo, error) {
+	defer ctx.endCacheRequest()
+
 	resp := &GraphQLResolveInfo{}
 
 	inflight, err := r.inboundRequestSingleFlight.GetOrCreate(ctx, response)
@@ -506,6 +510,8 @@ func (r *Resolver) ArenaResolveGraphQLResponse(ctx *Context, response *GraphQLRe
 }
 
 func (r *Resolver) ResolveGraphQLDeferResponse(ctx *Context, response *GraphQLDeferResponse, writer DeferResponseWriter) (*GraphQLResolveInfo, error) {
+	defer ctx.endCacheRequest()
+
 	resolveInfo := &GraphQLResolveInfo{}
 
 	start := time.Now()
@@ -920,6 +926,7 @@ func (r *Resolver) executeSubscriptionUpdate(resolveCtx *Context, sub *subscript
 	defer cancel()
 
 	resolveCtx = resolveCtx.WithContext(ctx)
+	defer resolveCtx.endCacheRequest()
 
 	// Copy the input.
 	input := make([]byte, len(sharedInput))

--- a/v2/pkg/engine/resolve/response.go
+++ b/v2/pkg/engine/resolve/response.go
@@ -41,6 +41,24 @@ type GraphQLResponse struct {
 
 	Info        *GraphQLResponseInfo
 	DataSources []DataSourceInfo
+
+	// cacheProvidesData is the ProvidesData side-table the caching planner walk
+	// produces: per fetch (keyed by its *FetchInfo identity), the field tree the
+	// fetch returns. Kept OFF the response tree so defer's response-tree Copy
+	// never touches it; consumed by the caching postprocess passes.
+	cacheProvidesData map[*FetchInfo]*Object
+}
+
+// SetCacheProvidesData attaches the caching planner walk's ProvidesData
+// side-table to the response.
+func (g *GraphQLResponse) SetCacheProvidesData(m map[*FetchInfo]*Object) {
+	g.cacheProvidesData = m
+}
+
+// CacheProvidesData returns the ProvidesData side-table; nil when caching is
+// not configured.
+func (g *GraphQLResponse) CacheProvidesData() map[*FetchInfo]*Object {
+	return g.cacheProvidesData
 }
 
 func (g *GraphQLResponse) SingleFlightAllowed() bool {

--- a/v2/pkg/engine/resolve/subgraph_request_singleflight_test.go
+++ b/v2/pkg/engine/resolve/subgraph_request_singleflight_test.go
@@ -31,6 +31,8 @@ func (s *stubFetch) IsEntityFetch() bool { return false }
 
 func (s *stubFetch) IsBatchEntityFetch() bool { return false }
 
+func (s *stubFetch) SetDataSource(DataSource) {}
+
 type nilInfoFetch struct{}
 
 func (n *nilInfoFetch) FetchKind() FetchKind {
@@ -52,6 +54,8 @@ func (n *nilInfoFetch) SetCacheConfig(*FetchCacheConfig) {}
 func (n *nilInfoFetch) IsEntityFetch() bool { return false }
 
 func (n *nilInfoFetch) IsBatchEntityFetch() bool { return false }
+
+func (n *nilInfoFetch) SetDataSource(DataSource) {}
 
 func newFetchItem(info *FetchInfo) *FetchItem {
 	return &FetchItem{

--- a/v2/pkg/engine/resolve/subgraph_request_singleflight_test.go
+++ b/v2/pkg/engine/resolve/subgraph_request_singleflight_test.go
@@ -23,6 +23,14 @@ func (s *stubFetch) FetchInfo() *FetchInfo {
 	return s.info
 }
 
+func (s *stubFetch) CacheConfig() *FetchCacheConfig { return nil }
+
+func (s *stubFetch) SetCacheConfig(*FetchCacheConfig) {}
+
+func (s *stubFetch) IsEntityFetch() bool { return false }
+
+func (s *stubFetch) IsBatchEntityFetch() bool { return false }
+
 type nilInfoFetch struct{}
 
 func (n *nilInfoFetch) FetchKind() FetchKind {
@@ -36,6 +44,14 @@ func (n *nilInfoFetch) Dependencies() *FetchDependencies {
 func (n *nilInfoFetch) FetchInfo() *FetchInfo {
 	return nil
 }
+
+func (n *nilInfoFetch) CacheConfig() *FetchCacheConfig { return nil }
+
+func (n *nilInfoFetch) SetCacheConfig(*FetchCacheConfig) {}
+
+func (n *nilInfoFetch) IsEntityFetch() bool { return false }
+
+func (n *nilInfoFetch) IsBatchEntityFetch() bool { return false }
 
 func newFetchItem(info *FetchInfo) *FetchItem {
 	return &FetchItem{

--- a/v2/pkg/engine/resolve/subgraph_request_singleflight_test.go
+++ b/v2/pkg/engine/resolve/subgraph_request_singleflight_test.go
@@ -33,6 +33,8 @@ func (s *stubFetch) IsBatchEntityFetch() bool { return false }
 
 func (s *stubFetch) SetDataSource(DataSource) {}
 
+func (s *stubFetch) LoadTrace() *DataSourceLoadTrace { return nil }
+
 type nilInfoFetch struct{}
 
 func (n *nilInfoFetch) FetchKind() FetchKind {
@@ -56,6 +58,8 @@ func (n *nilInfoFetch) IsEntityFetch() bool { return false }
 func (n *nilInfoFetch) IsBatchEntityFetch() bool { return false }
 
 func (n *nilInfoFetch) SetDataSource(DataSource) {}
+
+func (n *nilInfoFetch) LoadTrace() *DataSourceLoadTrace { return nil }
 
 func newFetchItem(info *FetchInfo) *FetchItem {
 	return &FetchItem{

--- a/v2/pkg/engine/resolve/tainted_objects_test.go
+++ b/v2/pkg/engine/resolve/tainted_objects_test.go
@@ -361,3 +361,5 @@ func (m *mockFetchWithInfo) SetCacheConfig(*FetchCacheConfig) {}
 func (m *mockFetchWithInfo) IsEntityFetch() bool { return false }
 
 func (m *mockFetchWithInfo) IsBatchEntityFetch() bool { return false }
+
+func (m *mockFetchWithInfo) SetDataSource(DataSource) {}

--- a/v2/pkg/engine/resolve/tainted_objects_test.go
+++ b/v2/pkg/engine/resolve/tainted_objects_test.go
@@ -354,6 +354,8 @@ func (m *mockFetchWithInfo) Dependencies() *FetchDependencies {
 	return nil
 }
 
+func (m *mockFetchWithInfo) LoadTrace() *DataSourceLoadTrace { return nil }
+
 func (m *mockFetchWithInfo) CacheConfig() *FetchCacheConfig { return nil }
 
 func (m *mockFetchWithInfo) SetCacheConfig(*FetchCacheConfig) {}

--- a/v2/pkg/engine/resolve/tainted_objects_test.go
+++ b/v2/pkg/engine/resolve/tainted_objects_test.go
@@ -353,3 +353,11 @@ func (m *mockFetchWithInfo) FetchKind() FetchKind {
 func (m *mockFetchWithInfo) Dependencies() *FetchDependencies {
 	return nil
 }
+
+func (m *mockFetchWithInfo) CacheConfig() *FetchCacheConfig { return nil }
+
+func (m *mockFetchWithInfo) SetCacheConfig(*FetchCacheConfig) {}
+
+func (m *mockFetchWithInfo) IsEntityFetch() bool { return false }
+
+func (m *mockFetchWithInfo) IsBatchEntityFetch() bool { return false }


### PR DESCRIPTION
## What this PR adds

A clean re-implementation of L1/L2 entity and root-field caching on top of the defer engine, executed as 20 reviewable task commits.
The old implementation (reference: `caching-base`) tangled caching into `loader.go` (~461 call sites); this port keeps the loader surface to a handful of explained seams and concentrates all caching semantics in a dedicated `v2/pkg/engine/cache` package.

## Architecture (one paragraph)

The planner side derives per-fetch `FetchCacheConfig` via additive passes (`cacheProvidesDataVisitor`, `cacheKeyBuilder`, `fetchCacheConfigurator`, `optimizeL1Cache`) wired through a single `postprocess.ConfigureCaching` facade; the runtime side is a `CacheController`/`RequestCache` pair the loader talks to through two hooks (`PrepareFetch` before the network, `OnFetchSkipped`/`OnFetchResult` after the merge) with an opaque `FetchCacheHandle` in between — a nil controller or nil config is a zero-cost no-op, and all arena work rides one `CacheTransaction` (one `DataBuffer.Lock` acquisition per hook).

## Feature checklist

- L2 entity caching: multi-`@key` best-effort candidates, freshest-first selection, union merge, write-back/backfill, coverage validation against `ProvidesData`
- Store-time normalization (schema names + argument-hash suffixes) with denormalize-at-splice — alias-independent reuse
- Batch entity caching (per-unique-representation buckets) and **partial fetching** (reduced representations + realign via `BatchIndex`)
- Negative caching (top-level null sentinel; cached and uncached responses stay byte-identical)
- Shadow mode (read-never-serve staleness probes; root-field asymmetry: force-refetch without compare)
- Root-field L2 with per-root-field **fetch isolation** (RFC-3, in core) and by-key root fields reusing entity entries (`EntityKeyMappings`)
- Request-lifetime **L1 store** (`*astjson.Value`, zero marshaling, keys shared with L2) with cross-defer-group serving
- ART observability: additive `cache` section on `DataSourceLoadTrace`, assembled by `cache.TraceObserver` with zero observer calls outside the controller

## Review aids

- `docs/caching/PROGRESS.md` — the task board with per-task commit hashes and the decision log
- `docs/caching/reviews/01-20-*.md` — one reviewer document per task commit: decisions, implementation summary, what to look into, verification evidence
- `docs/caching/PLAN.md`, `docs/caching/specs/` — the RFCs and the phased plan this executes

## Verification

- Unit + plan-driven e2e tests throughout (`v2/pkg/engine/cache`, `execution/cachingtesting` — real wgc-composed fixtures, real planner, in-process fakes; `testing/synctest` for all TTL rows, gate channels for ordering, no latency-based tests)
- Both modules test-clean and `-race`-clean; `golangci-lint` 0 issues in both modules at every task commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes https://github.com/wundergraph/graphql-go-tools/pull/1259
