### PR TITLE
feat: onError error behavior (PROPAGATE/NULL/HALT) + Service Capabilities introspection

### DIFF
--- a/docs/rfcs/2026-07-01-onerror-error-behavior.md
+++ b/docs/rfcs/2026-07-01-onerror-error-behavior.md
@@ -1,0 +1,371 @@
+# RFC: Client-controlled error behavior (`onError`) in graphql-go-tools
+
+- Status: Draft
+- Author: (RFC drafted 2026-07-01)
+- Branch: `on-error-spec-update`
+- Tracking spec: [graphql/graphql-spec#1163 — Service capabilities / error behaviors](https://github.com/graphql/graphql-spec/pull/1163) (open, last updated 2026-05)
+- Reference implementation: [graphql/graphql-js#4364 — Implement onError proposal](https://github.com/graphql/graphql-js/pull/4364) (draft)
+
+## 1. Summary
+
+The GraphQL spec is gaining a client-controlled error-handling mechanism.
+A client can send an optional `onError` request attribute with the value `NULL`, `PROPAGATE`, or `HALT` to choose how execution errors interact with non-null positions in the response.
+The long-term goal of the working group is to decouple nullability from errors ("true nullability"): a non-null (`!`) marker should mean "this value is never semantically null", not "this value never errors".
+
+This RFC proposes how to implement the three error behaviors in graphql-go-tools, how to plumb the selected behavior from the caller (the router) into the resolver, and how to advertise support via the new introspection Service Capabilities surface.
+
+## 2. Background: the spec change
+
+### 2.1 The three error behaviors
+
+The spec defines three values for the request `onError` attribute (see the "Handling Execution Errors" section of PR #1163).
+When a response position raises an *execution error*:
+
+- **`PROPAGATE`** — today's behavior.
+  The execution error propagates to the parent response position (the parent list item, in the case of a list position).
+  The parent resolves to `null` if the schema allows it, otherwise the error propagates further up until it reaches a nullable position or the root, in which case `data` becomes `null`.
+  The error is added to the `errors` list.
+
+- **`NULL`** — the errored response position is set to `null`, *even if the schema marks it non-nullable*.
+  There is no propagation.
+  The execution error is still added to the `errors` list.
+  The client is responsible for reconciling the `null` value against the `errors` list to distinguish an error result from an intentional `null`.
+
+- **`HALT`** — execution is aborted immediately.
+  `data` is set to `null` and the response contains only that single execution error.
+  Intended for ad-hoc clients that discard the whole response on any error, and to let the server stop doing unnecessary work.
+
+If `onError` is provided but its value is not one of `NULL`, `PROPAGATE`, or `HALT`, a *request error* must be raised (the whole request fails).
+
+### 2.2 Defaults and discovery (Service Capabilities)
+
+- The default behavior when `onError` is absent is **`PROPAGATE`**, for backwards compatibility.
+  `NULL` is the recommended default for new services.
+- Support is discovered through a new introspection surface: **Service Capabilities**.
+  A service exposes a list of `__Capability` entries (each with `identifier`, `description`, `value`).
+  Two capabilities are relevant:
+  - `graphql.onError` — the service accepts the `onError` request attribute.
+  - `graphql.defaultErrorBehavior` — its `value` names the service's default error behavior; absent means `PROPAGATE`.
+- If a client sees no `graphql.onError` capability (or introspection has no capabilities at all), it must not send `onError` and must assume `PROPAGATE`.
+
+### 2.3 Proposal churn (why we pin to #1163)
+
+This area has moved a lot.
+Earlier drafts (#1050, #1145, #1153) and the graphql-js PR at various points used an SDL directive `@behavior(onError: __ErrorBehavior! = PROPAGATE)` and an introspection field `__Schema.defaultErrorBehavior`, and even echoed `onError` back in the response.
+PR #1163 supersedes those: it drops the response echo and the `@behavior` directive in favor of the generic Service Capabilities mechanism, and keeps the request attribute values as `NULL` / `PROPAGATE` / `HALT`.
+Because the spec is still **open and unmerged**, this RFC treats the request-attribute semantics (Section 2.1) as stable enough to build on, and treats the introspection/capabilities surface (Section 2.2) as the most likely-to-change part — hence it is the last, optional phase.
+
+## 3. Current behavior in graphql-go-tools
+
+All error/null-propagation logic lives in the resolver, in `v2/pkg/engine/resolve/resolvable.go`.
+The resolver runs the response tree in **two passes** over the same `astjson` value tree (`Resolvable.Resolve`, `resolvable.go:229`):
+
+1. A **validation pass** (`r.print == false`): `walkObject`/`walkArray`/leaf walkers validate values, append errors, and — crucially — mutate the data tree to `null` where propagation applies.
+2. A **print pass** (`r.print == true`): the same walkers re-walk the (now-mutated) tree and emit JSON (`printData`, `resolvable.go:308`).
+
+Propagation is driven by a single boolean return value from `walkNode`: `true` means "an error occurred here, bubble up"; `false` means "handled, stop".
+`r.err()` (`resolvable.go:294`) simply returns `true`.
+
+The decision points that implement propagation today:
+
+- **Object field** (`walkObject`, `resolvable.go:691`):
+  - Null value in a non-null object → `addNonNullableFieldError` + `return r.err()` (`resolvable.go:697-703`).
+  - A child field bubbled up (`err == true`) → if `obj.Nullable` and it has a path, set the object to `null` and stop (`SetNull`, `resolvable.go:801-808`); otherwise keep bubbling.
+- **List** (`walkArray`, `resolvable.go:942`):
+  - Null in a non-null list → `addNonNullableFieldError` + `err()` (`resolvable.go:945-951`).
+  - An item bubbled up → if the item is a nullable object, null just that item and continue; else if the list is nullable, null the whole list and stop; else keep bubbling (`resolvable.go:1005-1015`).
+- **Leaf walkers** (`walkString` `:1072`, `walkBoolean` `:1118`, `walkInteger`, `walkFloat`, `walkBigInt`, `walkScalar`, `walkEnum` `:~1300`):
+  - Null in a non-null leaf → `addNonNullableFieldError` + `err()`.
+- **Root** (`Resolve`, `resolvable.go:254-271`):
+  - If the root walk returns `true`, `data` is written as `null`.
+
+The synthetic error message for a null in a non-null position is `Cannot return null for non-nullable field '<path>'.` (`addNonNullableFieldError`, `resolvable.go:1372`).
+
+Nullability is represented by a `Nullable bool` on each resolve node: `Object` (`node_object.go:9`), `Array` (`node_array.go:11`), and all scalar/enum leaf nodes.
+
+Error collection: errors are accumulated into the `r.errors` astjson array via `fastjsonext.AppendError*` helpers; the response is assembled in `Resolve` / `writeGraphqlResponse` (`response.go:77`).
+Note this is **separate** from *subgraph* error propagation, which is configured by the existing `SubgraphErrorPropagationMode` (`resolve.go:114`, values `Wrapped` / `PassThrough`) and governs how errors *reported by subgraphs* are surfaced — an orthogonal concern (see Section 5.6).
+
+There is currently **no** notion of `onError`, `errorBehavior`, or client-selectable propagation (confirmed by search).
+
+## 4. Goals / Non-goals
+
+**Goals**
+
+- Implement all three error behaviors (`PROPAGATE`, `NULL`, `HALT`) in the resolver.
+- Provide a typed, validated way for the caller (the router) to select the behavior per request, defaulting to `PROPAGATE` (no behavior change for existing callers).
+- Advertise support and the default via the introspection Service Capabilities surface.
+- Keep the change surgical and localized to the resolve layer; preserve existing behavior exactly when the behavior is `PROPAGATE`.
+
+**Non-goals**
+
+- Parsing the HTTP GraphQL request body. graphql-go-tools does not own HTTP request decoding; the router extracts `onError` from the request and passes it into the engine. This RFC provides the enum type + validation helper the router calls.
+- Semantic-non-null (`@semanticNonNull` / the `*` type marker, graphql-spec#1065). Related but a separate feature.
+- Changing subgraph-level error propagation (`SubgraphErrorPropagationMode`).
+
+## 5. Proposed design
+
+### 5.1 The `ErrorBehavior` type
+
+Introduce a typed enum in `pkg/engine/resolve`:
+
+```go
+type ErrorBehavior string
+
+const (
+    ErrorBehaviorPropagate ErrorBehavior = "PROPAGATE" // default; current behavior
+    ErrorBehaviorNull      ErrorBehavior = "NULL"      // set errored position to null, no propagation
+    ErrorBehaviorHalt      ErrorBehavior = "HALT"      // abort on first error, data: null
+)
+
+// MapErrorBehavior validates and normalizes an incoming value.
+// The empty string maps to the default (PROPAGATE). Any other unknown value
+// returns ok=false so the caller can raise a request error.
+func MapErrorBehavior(s string) (ErrorBehavior, bool)
+```
+
+`MapErrorBehavior` gives the router a single place to validate the request attribute and to decide whether to raise a request error on an invalid value (per Section 2.1).
+The zero value (empty string) deliberately means "default / PROPAGATE" so that every existing caller is unaffected.
+
+### 5.2 Where the behavior is configured
+
+Add a field to `ExecutionOptions` (`context.go:113`), which already carries per-request execution toggles and is threaded through `Context` into the `Resolvable`:
+
+```go
+type ExecutionOptions struct {
+    // ...existing fields...
+
+    // ErrorBehavior selects how execution errors interact with non-null
+    // positions. The empty value is treated as PROPAGATE (spec default).
+    ErrorBehavior ErrorBehavior
+}
+```
+
+The `Resolvable` reads `r.ctx.ExecutionOptions.ErrorBehavior` at the start of `Resolve` and stores it on the struct (e.g. `r.errorBehavior`), so the hot walk loop does one field read rather than repeatedly reaching through the context.
+Default resolution: an empty value is normalized to `ErrorBehaviorPropagate` in `Resolve`/`Init` (the engine's ultimate safety-net default).
+
+**Operator-defined default (effective behavior resolution).**
+The behavior applied to a request is resolved by the router as:
+
+```
+effective = requestOnError  (if the request explicitly set onError and the feature is enabled)
+          ?? operatorDefault (a router config value: PROPAGATE | NULL | HALT)
+          ?? PROPAGATE       (spec / engine safety-net default)
+```
+
+The operator default is a router-side configuration value of type `ErrorBehavior`.
+If the operator does not configure one, it is `PROPAGATE` (no change from today).
+The router computes `effective` and sets it on `ExecutionOptions.ErrorBehavior`, so from the engine's point of view that field is always the concrete behavior to apply for this request.
+The same operator default value feeds the `graphql.defaultErrorBehavior` introspection capability (Section 5.7), keeping "what the server does by default" and "what introspection reports as the default" identical.
+
+### 5.3 `NULL` behavior in the resolver
+
+Observation: `NULL` behavior is *exactly* "treat every non-null position as if it were nullable, for the purpose of propagation, while still recording the error".
+This maps cleanly onto the existing single-boolean propagation model.
+
+Introduce a helper that replaces the raw `return r.err()` at the non-null-null decision points:
+
+```go
+// nonNullFieldError records the non-null violation and returns whether the
+// error should propagate. Under NULL behavior it never propagates.
+func (r *Resolvable) nonNullFieldError(fieldPath []string, parent *astjson.Value) bool {
+    r.addNonNullableFieldError(fieldPath, parent)
+    if r.errorBehavior == ErrorBehaviorNull {
+        // set this position to null in place and stop propagation
+        if len(fieldPath) > 0 {
+            astjson.SetNull(r.astjsonArena, parent, fieldPath...)
+        }
+        return false
+    }
+    return true
+}
+```
+
+Touch points to convert (all currently `addNonNullableFieldError(...) + return r.err()`):
+
+- `walkObject` `resolvable.go:701-702`
+- `walkArray` `resolvable.go:949-950`
+- `walkString` `resolvable.go:1079-1080`
+- `walkBoolean`, `walkInteger`, `walkFloat`, `walkBigInt`, `walkScalar`, `walkEnum` (same shape)
+
+Additionally, the *bubble-up* decision points must not bubble under `NULL`.
+Today, when a child returns `true`, `walkObject`/`walkArray` bubble the null upward if the parent is nullable.
+Under `NULL` the child never returns `true` for a nullability violation, so these bubble-up branches (`resolvable.go:801-808`, `1005-1015`) are naturally not exercised for that cause — no change required there, but tests must confirm it.
+
+**Decided — "null with an error" vs "null without an error": uniform behavior (option A).**
+Under `NULL`, the resolver always sets the errored/null position to `null` in place and records the "Cannot return null for non-nullable field" error, regardless of whether an upstream execution error already exists for that path.
+Rationale: it is simple, keeps the existing error message, and never loses information — the client always receives a `null` plus an error to reconcile, which is exactly the contract of `NULL` mode.
+A subgraph that returns `null` for a non-null field with no accompanying error *is* an error, so emitting the synthetic error is correct.
+
+This must be covered by tests for **all** positions and shapes (see Section 7): non-null leaf, non-null object, non-null list, non-null list item, deeply nested non-null chains, and the mix of "null with an upstream error already present" and "null with no upstream error".
+
+### 5.4 `HALT` behavior in the resolver
+
+`HALT` means: as soon as an error is present, produce `data: null`.
+
+**Scope decision: HALT is handled entirely inside `Resolvable`, at render time.**
+We do **not** touch the loader and we do **not** cancel or skip subgraph fetches.
+All fetches run as normal; HALT only changes how the response is assembled.
+This keeps the change fully contained to `resolvable.go` and avoids any concurrency/cancellation complexity in the loader.
+
+Implementation:
+
+- At the top of `Resolve` (after `SkipLoader` handling, around `resolvable.go:252`): if `errorBehavior == HALT && r.hasErrors()`, skip the walk, write `data: null`, and emit a **single** error (see below).
+  (Errors from subgraph loading are already present in `r.errors` at this point.)
+- If no errors exist yet when `Resolve` begins, run the walk normally.
+  Under `HALT` the walk behaves like `PROPAGATE`, so the first null-in-non-null violation bubbles straight to the root and `data` is written as `null` (the existing root-level collapse in `Resolve`, `resolvable.go:263-268`, already does this).
+  If the walk itself is the source of the (single) error, that walk error is the one reported.
+
+In effect, HALT = "if there is any error, render `data: null` with a single error", decided at render time in the resolver.
+
+**Decided — HALT reports exactly one error.**
+Per the spec, the HALT response contains a single execution error.
+Because HALT is render-time and fetches are not cancelled, `r.errors` may hold several errors from parallel subgraph loading.
+We trim to a single error: the **first** entry in `r.errors` (index 0).
+Concretely, when short-circuiting for HALT, print an `errors` array containing only `r.errors[0]` (or, if the single error originates from the walk, that error).
+Note: subgraph errors are appended to `r.errors` as loads complete, so "first" is defined by append order; this is deterministic enough for the single-error contract, and tests assert the exact single-error response.
+
+### 5.5 Interaction with the two-pass walk
+
+Both passes must observe the same behavior, since the validation pass mutates the tree and the print pass renders it.
+`r.errorBehavior` is set once before the passes, so this is automatic.
+For `NULL`, because the validation pass sets positions to `null` in place (via `SetNull`), the print pass simply renders those nulls — no special print-pass logic needed.
+This reuses the exact mechanism the resolver already uses for legitimately-nullable fields.
+
+### 5.6 Relationship to `SubgraphErrorPropagationMode`
+
+`SubgraphErrorPropagationMode` (`resolve.go:114`) controls how errors *reported by subgraphs* are shaped into the client `errors` array (wrapped vs pass-through).
+`ErrorBehavior` controls how *execution errors interact with non-null positions* in `data`.
+They are orthogonal and compose: e.g. `onError=NULL` with `SubgraphErrorPropagationModePassThrough` yields the subgraph's original error entries plus in-place `null`s.
+The RFC introduces no coupling between them; tests should cover the cross-product for at least the common cases.
+
+### 5.7 Introspection: Service Capabilities (required, config-gated)
+
+Support must be advertised so that a client (and the router itself) can discover it via introspection.
+Extend the introspection generation in `v2/pkg/introspection` to expose the Service Capabilities surface:
+
+- Add the `__Capability` type (`identifier`, `description`, `value`) to the introspection model (`introspection.go`, `introspection_enum.go`, `converter.go`).
+- Wire the `service { capabilities { ... } }` introspection surface per the spec's introspection schema additions.
+- Emit two capabilities **when enabled**:
+  - `graphql.onError` (no value) — the service accepts the `onError` request attribute.
+  - `graphql.defaultErrorBehavior` with `value` = the operator-configured default behavior (Section 5.2); `PROPAGATE` if the operator did not configure one.
+
+Do **not** implement the superseded `@behavior` directive or `__Schema.defaultErrorBehavior` field.
+
+**Configurability is mandatory (see Section 5.8).**
+The capabilities must be emitted **only when the feature is enabled**.
+When the feature is disabled, introspection must render exactly as it does today — no `service`/`capabilities` surface — so that clients do not attempt to send `onError` to a service that will not honor it.
+Concretely, introspection generation must support two outcomes from a single configuration decision:
+
+1. **Enabled** → introspection includes the Service Capabilities with `graphql.onError` and `graphql.defaultErrorBehavior`.
+2. **Disabled** → introspection omits the capabilities entirely (current behavior, byte-identical golden output).
+
+Design: thread an optional capabilities descriptor into introspection generation.
+Today `Generator.Generate(definition, report, data)` (`generator.go:54`) populates a `Data` value.
+Add an optional capabilities input (nil ⇒ omit), for example:
+
+```go
+// nil => do not emit any service capabilities (current behavior)
+type ServiceCapabilities struct {
+    OnError              bool   // emit graphql.onError
+    DefaultErrorBehavior string // e.g. "PROPAGATE"; "" => omit graphql.defaultErrorBehavior
+}
+```
+
+carried on the `Data`/`Schema` model with `json:"...,omitempty"` (or a sibling field to `__schema`) so the marshalled introspection response is unchanged when it is nil.
+The caller (router) constructs this descriptor from its own config: when it enables `onError`, it passes a non-nil descriptor; otherwise nil.
+This is the single decision point that keeps "engine honors `onError`" and "introspection advertises `onError`" in lockstep.
+
+### 5.8 Configuration and caller (router) responsibilities
+
+The feature is **opt-in and configurable at the router**.
+There is a single "enable `onError`" switch on the Cosmo router side that must control **both** halves of the feature together:
+
+- Whether the engine **honors** an incoming `onError` request attribute (otherwise it is ignored and behavior stays `PROPAGATE`).
+- Whether **introspection advertises** the Service Capabilities (Section 5.7).
+
+These must never diverge: if the engine honors `onError` but introspection hides it, clients can't discover it; if introspection advertises it but the engine ignores it, clients are misled.
+Tying both to one config value is the core requirement from this refinement.
+
+graphql-go-tools provides the primitives to make the router wiring small and type-safe:
+
+- The `ErrorBehavior` enum + `MapErrorBehavior` validation helper (Section 5.1).
+- The `ExecutionOptions.ErrorBehavior` field (Section 5.2).
+- The optional `ServiceCapabilities` descriptor for introspection generation (Section 5.7).
+
+Router flow when the feature is **enabled**:
+
+1. Read the operator's configured default behavior (`PROPAGATE` if unset).
+2. Extract `onError` from the incoming GraphQL request; if present, call `resolve.MapErrorBehavior(value)` and on `ok == false` return a GraphQL *request error* (fail the whole request) and do not execute (spec: invalid value ⇒ request error).
+3. Resolve the effective behavior = request `onError` (if present) else operator default (Section 5.2) and set it on `ExecutionOptions.ErrorBehavior`.
+4. Serve introspection with a non-nil `ServiceCapabilities`, where `DefaultErrorBehavior` = the operator default — advertising `graphql.onError` + `graphql.defaultErrorBehavior` consistently with (1).
+
+Router flow when the feature is **disabled** (default):
+
+- Ignore any incoming `onError` (do not set `ExecutionOptions.ErrorBehavior`; it stays the `PROPAGATE` default).
+- Serve introspection with a nil `ServiceCapabilities` (no capabilities surface — byte-identical to today).
+
+HTTP request-body parsing itself remains the router's job; this RFC ships the enum, validation helper, execution option, and introspection descriptor so the router only wires them to its config switch.
+
+## 6. Phased implementation plan
+
+1. **Phase 1 — core resolver behavior.**
+   `ErrorBehavior` type + `MapErrorBehavior`; `ExecutionOptions.ErrorBehavior`; `r.errorBehavior` on `Resolvable`; `NULL` and `HALT` (render-time) semantics at the touch points in Sections 5.3–5.4.
+   Verify: `PROPAGATE` output byte-identical to today.
+2. **Phase 2 — introspection Service Capabilities (config-gated).**
+   `__Capability` type + `service { capabilities }` surface; optional `ServiceCapabilities` descriptor threaded into introspection generation; emit `graphql.onError` + `graphql.defaultErrorBehavior` only when enabled.
+   Verify: with the descriptor nil, introspection golden output is byte-identical to today.
+3. **Phase 3 — tests & hardening.**
+   Resolver unit tests + datasource pipeline tests across the behavior × nullability × list/leaf/object matrix, plus introspection golden tests for both enabled/disabled (Section 7).
+
+## 7. Testing strategy
+
+Tests must cover **all** behaviors at **all** positions (per decision 8.1). Assert the entire response string with `assert.Equal` (not `Contains`), per repo convention.
+
+- **Resolver unit tests** (`pkg/engine/resolve/resolvable_test.go`, `resolve_test.go`): construct response trees with non-null violations and assert the *full* rendered response for each `ErrorBehavior`.
+  Full matrix:
+  - **Position:** non-null leaf, non-null object, non-null list, non-null list item, deeply nested non-null chain to root.
+  - **Behavior:** `PROPAGATE`, `NULL`, `HALT`.
+  - **Parent nullability:** nullable parent present vs non-null chain all the way to root (→ `data: null`).
+  - **Error source:** null *with* an upstream execution error already present, and null *without* any upstream error (subgraph returned a bare null).
+- **`NULL` assertions:** errored position is `null` in place, sibling fields preserved, no bubbling, and the "Cannot return null…" error present (option A).
+- **`HALT` assertions:** `data: null` and exactly **one** error in `errors` (decision 8.2) — including the case where multiple subgraph errors were collected, asserting only `r.errors[0]` is emitted.
+- **Pipeline / e2e tests** using `RunTest()` (`datasourcetesting`) and the `execution/` module: subgraph returns an error + null for a non-null field; assert `data` retains sibling values under `NULL`, collapses under `PROPAGATE`, and is a single-error `data: null` under `HALT`.
+- **Operator-default tests (decision 8.3):** with the operator default set to `NULL` (and `HALT`) and no request `onError`, assert the effective behavior is the default; and assert the introspection `graphql.defaultErrorBehavior` value equals the configured default (the two stay synchronized).
+- **Golden/introspection tests:** with the `ServiceCapabilities` descriptor enabled, assert the introspection response includes `graphql.onError` + `graphql.defaultErrorBehavior` (with the configured default value); with it nil, assert the introspection golden output is byte-identical to today.
+- **Regression guard:** with the feature disabled (`ErrorBehavior` unset, nil capabilities) both `data` and introspection output are identical to the pre-change golden output.
+
+## 8. Resolved decisions
+
+1. **NULL synthetic errors (Section 5.3): uniform (option A).**
+   Under `NULL`, always set the position to `null` in place and record the "Cannot return null…" error, whether or not an upstream error already exists.
+   Full test coverage across all positions/shapes is required.
+2. **HALT reports a single error (Section 5.4).**
+   `data: null` plus exactly one error — `r.errors[0]` (or the walk error if that is the source). HALT stays render-time only; fetches are **not** cancelled.
+3. **Operator-configurable default (Section 5.2, 5.7).**
+   The default behavior is operator-configurable at the router. Unset ⇒ `PROPAGATE`; the operator may set `NULL` or `HALT`.
+   The configured default is used when a request omits `onError`, and the same value is reported via the `graphql.defaultErrorBehavior` introspection capability — the two must stay synchronized.
+
+## 9. Risks & backwards compatibility
+
+- **No behavior change by default.** Feature disabled → unset `ErrorBehavior` → `PROPAGATE` → byte-identical `data`, and nil `ServiceCapabilities` → byte-identical introspection. Both enforced by regression/golden tests.
+- **Spec instability.** The request-attribute semantics are stable across recent drafts; the introspection capabilities surface is less settled, so it is implemented but strictly config-gated (off by default) — an operator only opts in when they accept the current shape.
+- **HALT is render-time only.** Fetches are not cancelled, so there is no loader/concurrency complexity; HALT emits `data: null` with a single error (`r.errors[0]`), asserted by tests.
+- **Client contract.** `NULL` shifts error-vs-null reconciliation to the client; this is by design and matches the working-group direction (`graphql-toe`, Relay `@throwOnFieldError`).
+
+## 10. References
+
+- graphql-spec#1163 — Service capabilities / error behaviors: https://github.com/graphql/graphql-spec/pull/1163
+- graphql-js#4364 — Implement onError proposal (reference impl): https://github.com/graphql/graphql-js/pull/4364
+- graphql-spec#1050 — Directive proposal for opting out of null bubbling (superseded): https://github.com/graphql/graphql-spec/pull/1050
+- graphql-spec#719 — "error propagation considered harmful": https://github.com/graphql/graphql-spec/issues/719
+- nullability-wg#85 — Uncoupling nullability and errors: https://github.com/graphql/nullability-wg/discussions/85
+- graphql-toe (client-side reconciliation): https://www.npmjs.com/package/graphql-toe
+
+### Key codebase anchors
+
+- `v2/pkg/engine/resolve/resolvable.go` — `Resolve` (`:229`), `walkObject` (`:691`), `walkArray` (`:942`), leaf walkers (`:1072`+), `addNonNullableFieldError` (`:1372`), `err` (`:294`).
+- `v2/pkg/engine/resolve/context.go` — `Context` (`:19`), `ExecutionOptions` (`:113`).
+- `v2/pkg/engine/resolve/resolve.go` — `SubgraphErrorPropagationMode` (`:114`, orthogonal).
+- `v2/pkg/engine/resolve/node_object.go`, `node_array.go`, `node_scalar.go` — `Nullable` fields.
+- `v2/pkg/introspection/` — introspection generation (Phase 3).

--- a/docs/rfcs/plans/2026-07-01-onerror-phase1-core-resolver.md
+++ b/docs/rfcs/plans/2026-07-01-onerror-phase1-core-resolver.md
@@ -1,0 +1,531 @@
+# onError Phase 1 — Core Resolver Behavior — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement client-selectable GraphQL error behavior (`PROPAGATE` / `NULL` / `HALT`) in the graphql-go-tools resolver, defaulting to `PROPAGATE` with zero behavior change for existing callers.
+
+**Architecture:** Add an `ErrorBehavior` enum + validation helper, thread the selected behavior through `ExecutionOptions` into the `Resolvable`, and change the resolver's execution-error handling: under `NULL`, an execution error at a position sets that position to `null` in place instead of propagating; under `HALT`, any error collapses the whole response to `data: null` with a single error. `PROPAGATE` is unchanged.
+
+**Tech Stack:** Go, `github.com/wundergraph/astjson`, `testify/assert`. Package `github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve`.
+
+## Global Constraints
+
+- Module root for all `go` commands: `v2/` (run `cd v2` first).
+- Follow the repo test convention: assert the **full** response string with `assert.Equal`, never `assert.Contains`.
+- `PROPAGATE` output must remain byte-identical to today — the existing `resolvable_test.go` / `resolve_test.go` suites must pass unchanged.
+- The empty `ErrorBehavior` value means the default and must normalize to `PROPAGATE`.
+- Match existing code style in `resolvable.go`. Do not refactor unrelated code.
+- Spec reference: request attribute values `NULL`, `PROPAGATE`, `HALT` (graphql-spec#1163). See `docs/rfcs/2026-07-01-onerror-error-behavior.md`.
+
+---
+
+### Task 1: `ErrorBehavior` type and `MapErrorBehavior` helper
+
+**Files:**
+- Create: `v2/pkg/engine/resolve/error_behavior.go`
+- Test: `v2/pkg/engine/resolve/error_behavior_test.go`
+
+**Interfaces:**
+- Produces: `type ErrorBehavior string`; consts `ErrorBehaviorPropagate="PROPAGATE"`, `ErrorBehaviorNull="NULL"`, `ErrorBehaviorHalt="HALT"`; `func MapErrorBehavior(s string) (ErrorBehavior, bool)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// v2/pkg/engine/resolve/error_behavior_test.go
+package resolve
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapErrorBehavior(t *testing.T) {
+	cases := []struct {
+		in   string
+		want ErrorBehavior
+		ok   bool
+	}{
+		{"", ErrorBehaviorPropagate, true}, // empty => default
+		{"PROPAGATE", ErrorBehaviorPropagate, true},
+		{"NULL", ErrorBehaviorNull, true},
+		{"HALT", ErrorBehaviorHalt, true},
+		{"null", "", false},  // case-sensitive per spec
+		{"BOGUS", "", false},
+	}
+	for _, c := range cases {
+		got, ok := MapErrorBehavior(c.in)
+		assert.Equal(t, c.ok, ok, "ok for %q", c.in)
+		assert.Equal(t, c.want, got, "value for %q", c.in)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd v2 && go test ./pkg/engine/resolve/ -run TestMapErrorBehavior -v`
+Expected: FAIL — `undefined: MapErrorBehavior` / `undefined: ErrorBehaviorPropagate`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// v2/pkg/engine/resolve/error_behavior.go
+package resolve
+
+// ErrorBehavior selects how execution errors interact with non-null positions
+// in the response, per the GraphQL onError proposal (graphql-spec#1163).
+type ErrorBehavior string
+
+const (
+	// ErrorBehaviorPropagate is the spec default and current behavior: an
+	// execution error in a non-null position propagates to the nearest nullable
+	// ancestor (or data: null at the root).
+	ErrorBehaviorPropagate ErrorBehavior = "PROPAGATE"
+	// ErrorBehaviorNull sets the errored position to null in place (even if
+	// non-nullable) without propagating; the error is still recorded.
+	ErrorBehaviorNull ErrorBehavior = "NULL"
+	// ErrorBehaviorHalt aborts response assembly on any error: data is null and
+	// a single error is returned.
+	ErrorBehaviorHalt ErrorBehavior = "HALT"
+)
+
+// MapErrorBehavior validates and normalizes an incoming onError value.
+// The empty string maps to the default (PROPAGATE). Any other unknown value
+// returns ok=false so the caller can raise a request error.
+func MapErrorBehavior(s string) (ErrorBehavior, bool) {
+	switch ErrorBehavior(s) {
+	case "":
+		return ErrorBehaviorPropagate, true
+	case ErrorBehaviorPropagate, ErrorBehaviorNull, ErrorBehaviorHalt:
+		return ErrorBehavior(s), true
+	default:
+		return "", false
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd v2 && go test ./pkg/engine/resolve/ -run TestMapErrorBehavior -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add v2/pkg/engine/resolve/error_behavior.go v2/pkg/engine/resolve/error_behavior_test.go
+git commit -m "feat(resolve): add ErrorBehavior enum and MapErrorBehavior helper"
+```
+
+---
+
+### Task 2: Thread `ErrorBehavior` through `ExecutionOptions` into `Resolvable`
+
+**Files:**
+- Modify: `v2/pkg/engine/resolve/context.go` (`ExecutionOptions` struct, ~line 113)
+- Modify: `v2/pkg/engine/resolve/resolvable.go` (`Resolvable` struct ~line 28, `Reset` ~line 123, `Resolve` ~line 229, `ResolveNode` ~line 208)
+- Test: `v2/pkg/engine/resolve/resolvable_test.go`
+
+**Interfaces:**
+- Consumes: `ErrorBehavior` (Task 1).
+- Produces: `ExecutionOptions.ErrorBehavior ErrorBehavior`; unexported `Resolvable.errorBehavior ErrorBehavior`, populated at the start of `Resolve`/`ResolveNode` and normalized so empty ⇒ `ErrorBehaviorPropagate`.
+
+- [ ] **Step 1: Write the failing test** (proves default is PROPAGATE and the field is read)
+
+```go
+// append to v2/pkg/engine/resolve/resolvable_test.go
+func TestResolvable_ErrorBehaviorDefaultsToPropagate(t *testing.T) {
+	res := NewResolvable(nil, ResolvableOptions{})
+	ctx := &Context{} // ExecutionOptions zero value
+	err := res.Init(ctx, []byte(`{"hero":{"name":"R2D2"}}`), ast.OperationTypeQuery)
+	assert.NoError(t, err)
+	object := &Object{Fields: []*Field{{
+		Name: []byte("hero"),
+		Value: &Object{Path: []string{"hero"}, Fields: []*Field{{
+			Name:  []byte("name"),
+			Value: &String{Path: []string{"name"}},
+		}}},
+	}}}
+	out := &bytes.Buffer{}
+	err = res.Resolve(context.Background(), object, nil, out)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"data":{"hero":{"name":"R2D2"}}}`, out.String())
+	assert.Equal(t, ErrorBehaviorPropagate, res.errorBehavior)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd v2 && go test ./pkg/engine/resolve/ -run TestResolvable_ErrorBehaviorDefaultsToPropagate -v`
+Expected: FAIL — `res.errorBehavior undefined`.
+
+- [ ] **Step 3: Add the field to `ExecutionOptions`**
+
+In `v2/pkg/engine/resolve/context.go`, inside `type ExecutionOptions struct { ... }`, add:
+
+```go
+	// ErrorBehavior selects how execution errors interact with non-null
+	// positions. The empty value is treated as PROPAGATE (spec default).
+	ErrorBehavior ErrorBehavior
+```
+
+- [ ] **Step 4: Add the field to `Resolvable` and reset it**
+
+In `resolvable.go`, add to the `Resolvable` struct (near `operationType`):
+
+```go
+	errorBehavior ErrorBehavior
+```
+
+In `Reset()` add:
+
+```go
+	r.errorBehavior = ""
+```
+
+- [ ] **Step 5: Populate + normalize at the resolve entry points**
+
+At the very top of `Resolve` (after `r.authorizationError = nil`, before `SkipLoader`) and at the top of `ResolveNode` (after `r.errors = nil`), add:
+
+```go
+	r.errorBehavior = r.ctx.ExecutionOptions.ErrorBehavior
+	if r.errorBehavior == "" {
+		r.errorBehavior = ErrorBehaviorPropagate
+	}
+```
+
+- [ ] **Step 6: Run test + full resolve suite**
+
+Run: `cd v2 && go test ./pkg/engine/resolve/ -run TestResolvable_ErrorBehaviorDefaultsToPropagate -v && go test ./pkg/engine/resolve/`
+Expected: PASS, and the entire `resolve` package still green (PROPAGATE unchanged).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add v2/pkg/engine/resolve/context.go v2/pkg/engine/resolve/resolvable.go v2/pkg/engine/resolve/resolvable_test.go
+git commit -m "feat(resolve): thread ErrorBehavior from ExecutionOptions into Resolvable"
+```
+
+---
+
+### Task 3: `NULL` behavior at null-in-non-null positions
+
+**Files:**
+- Modify: `v2/pkg/engine/resolve/resolvable.go` (add helper; edit `walkObject`, `walkArray`, `walkString`, `walkBoolean`, `walkInteger`, `walkFloat`, `walkBigInt`, `walkScalar`, `walkCustom`, `walkEnum`)
+- Test: `v2/pkg/engine/resolve/resolvable_test.go`
+
+**Interfaces:**
+- Consumes: `r.errorBehavior` (Task 2).
+- Produces: `func (r *Resolvable) erroredPosition(path []string, parent *astjson.Value) bool` — returns `true` to propagate (PROPAGATE/HALT) or, under `NULL`, sets the position to `null` on the validation pass / prints `null` on the print pass and returns `false`.
+
+**Background:** every non-null leaf/object/array walker currently does `addNonNullableFieldError(x.Path, parent); return r.err()`. `err()` returns `true`, which bubbles. Under `NULL` we must (a) record the error once (validation pass only, since we no longer bubble and the print pass re-descends), and (b) render `null` in place.
+
+- [ ] **Step 1: Write the failing tests** (leaf, object, list-item, nested, siblings preserved, with and without upstream error)
+
+```go
+// append to v2/pkg/engine/resolve/resolvable_test.go
+
+func newNullResolvable(t *testing.T, data string) *Resolvable {
+	t.Helper()
+	res := NewResolvable(nil, ResolvableOptions{})
+	err := res.Init(&Context{ExecutionOptions: ExecutionOptions{ErrorBehavior: ErrorBehaviorNull}},
+		[]byte(data), ast.OperationTypeQuery)
+	assert.NoError(t, err)
+	return res
+}
+
+// non-null leaf returns null -> stays null, sibling preserved, error recorded
+func TestResolvable_NullBehavior_NonNullLeaf(t *testing.T) {
+	res := newNullResolvable(t, `{"hero":{"id":"1","name":null}}`)
+	object := &Object{Fields: []*Field{{
+		Name: []byte("hero"),
+		Value: &Object{Path: []string{"hero"}, Fields: []*Field{
+			{Name: []byte("id"), Value: &String{Path: []string{"id"}}},
+			{Name: []byte("name"), Value: &String{Path: []string{"name"}}}, // non-null
+		}},
+	}}}
+	out := &bytes.Buffer{}
+	err := res.Resolve(context.Background(), object, nil, out)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"errors":[{"message":"Cannot return null for non-nullable field 'Query.hero.name'.","path":["hero","name"]}],"data":{"hero":{"id":"1","name":null}}}`, out.String())
+}
+
+// non-null object returns null -> object null, sibling field of parent preserved
+func TestResolvable_NullBehavior_NonNullObject(t *testing.T) {
+	res := newNullResolvable(t, `{"hero":null,"time":"now"}`)
+	object := &Object{Fields: []*Field{
+		{Name: []byte("hero"), Value: &Object{Path: []string{"hero"}, Fields: []*Field{
+			{Name: []byte("name"), Value: &String{Path: []string{"name"}}},
+		}}}, // non-null object
+		{Name: []byte("time"), Value: &String{Path: []string{"time"}}},
+	}}
+	out := &bytes.Buffer{}
+	err := res.Resolve(context.Background(), object, nil, out)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"errors":[{"message":"Cannot return null for non-nullable field 'Query.hero'.","path":["hero"]}],"data":{"hero":null,"time":"now"}}`, out.String())
+}
+
+// non-null list item null -> that item null, other items preserved
+func TestResolvable_NullBehavior_NonNullListItem(t *testing.T) {
+	res := newNullResolvable(t, `{"names":["a",null,"c"]}`)
+	object := &Object{Fields: []*Field{{
+		Name:  []byte("names"),
+		Value: &Array{Path: []string{"names"}, Item: &String{}}, // non-null items
+	}}}
+	out := &bytes.Buffer{}
+	err := res.Resolve(context.Background(), object, nil, out)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"errors":[{"message":"Cannot return null for non-nullable field 'Query.names'.","path":["names",1]}],"data":{"names":["a",null,"c"]}}`, out.String())
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd v2 && go test ./pkg/engine/resolve/ -run 'TestResolvable_NullBehavior' -v`
+Expected: FAIL — current behavior propagates (e.g. `"data":{"hero":null}` for the leaf case, or `data:null`), not the in-place null above.
+
+- [ ] **Step 3: Add the helper**
+
+Add near `err()` in `resolvable.go`:
+
+```go
+// erroredPosition decides how an execution error at the current position is
+// handled under the active error behavior. The caller must have already
+// recorded the error (guarded to the validation pass). Under NULL the position
+// is rendered as null and the error does not propagate; otherwise it propagates.
+func (r *Resolvable) erroredPosition(path []string, parent *astjson.Value) bool {
+	if r.errorBehavior != ErrorBehaviorNull {
+		return r.err()
+	}
+	if r.print {
+		return r.walkNull() // prints null on the print pass, returns false
+	}
+	if len(path) > 0 {
+		astjson.SetNull(r.astjsonArena, parent, path...)
+	}
+	return false
+}
+```
+
+- [ ] **Step 4: Convert the null-in-non-null sites**
+
+For each site below, replace the two lines
+```go
+		r.addNonNullableFieldError(<PATH>, parent)
+		return r.err()
+```
+with
+```go
+		if !r.print {
+			r.addNonNullableFieldError(<PATH>, parent)
+		}
+		return r.erroredPosition(<PATH>, parent)
+```
+
+Apply at (path arg shown per function):
+- `walkObject` (`obj.Path`) — the `value == nil || TypeNull` branch (~line 701).
+- `walkArray` (`arr.Path`) — the `ValueIsNull` branch (~line 949).
+- `walkString` (`s.Path`) — ~line 1079.
+- `walkBoolean` (`b.Path`) — ~line 1125.
+- `walkInteger` (`i.Path`) — ~line 1146.
+- `walkFloat` (`f.Path`) — ~line 1167.
+- `walkBigInt` (`b.Path`) — ~line 1197.
+- `walkScalar` (`s.Path`) — ~line 1213.
+- `walkCustom` (`c.Path`) — ~line 1245.
+- `walkEnum` (`e.Path`) — ~line 1324.
+
+- [ ] **Step 5: Run the NULL tests + full suite**
+
+Run: `cd v2 && go test ./pkg/engine/resolve/ -run 'TestResolvable_NullBehavior' -v && go test ./pkg/engine/resolve/`
+Expected: PASS, and the whole `resolve` package green (PROPAGATE paths unchanged because `erroredPosition` returns `r.err()` for non-NULL).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add v2/pkg/engine/resolve/resolvable.go v2/pkg/engine/resolve/resolvable_test.go
+git commit -m "feat(resolve): implement NULL error behavior for non-null positions"
+```
+
+---
+
+### Task 4: `NULL` behavior for value-coercion and invalid-enum errors
+
+**Files:**
+- Modify: `v2/pkg/engine/resolve/resolvable.go` (`walkObject` non-object, `walkArray` non-array, `walkString`/`walkBoolean`/`walkInteger`/`walkFloat` type mismatch, `walkCustom` resolve error, `walkEnum` type mismatch + invalid value)
+- Test: `v2/pkg/engine/resolve/resolvable_test.go`
+
+**Interfaces:**
+- Consumes: `erroredPosition` (Task 3).
+
+**Background:** coercion failures (wrong JSON type) and invalid enum values are also execution errors; under `NULL` they must render as null in place, not bubble. These sites currently call an `addError*` then `return r.err()` (some already guard the add with `!r.print`).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// append to v2/pkg/engine/resolve/resolvable_test.go
+
+// non-null leaf with a type mismatch under NULL -> null in place + error, sibling kept
+func TestResolvable_NullBehavior_TypeMismatch(t *testing.T) {
+	res := newNullResolvable(t, `{"hero":{"id":"1","name":123}}`)
+	object := &Object{Fields: []*Field{{
+		Name: []byte("hero"),
+		Value: &Object{Path: []string{"hero"}, Fields: []*Field{
+			{Name: []byte("id"), Value: &String{Path: []string{"id"}}},
+			{Name: []byte("name"), Value: &String{Path: []string{"name"}}},
+		}},
+	}}}
+	out := &bytes.Buffer{}
+	err := res.Resolve(context.Background(), object, nil, out)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"errors":[{"message":"String cannot represent non-string value: \"123\"","path":["hero","name"]}],"data":{"hero":{"id":"1","name":null}}}`, out.String())
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd v2 && go test ./pkg/engine/resolve/ -run TestResolvable_NullBehavior_TypeMismatch -v`
+Expected: FAIL — today the type-mismatch bubbles (`data:null` at root, since `hero` is non-null).
+
+- [ ] **Step 3: Convert the coercion sites**
+
+For each coercion/invalid-value site, guard the existing `addError*(...)` call with `if !r.print { ... }` (if not already guarded) and replace the trailing `return r.err()` with `return r.erroredPosition(<PATH>, parent)`. Sites and their path arg:
+
+- `walkObject` non-object branch (~line 707-709): `addError("Object cannot represent non-object value.", obj.Path)` → path `obj.Path`.
+- `walkArray` non-array branch (~line 954-956): path `arr.Path`.
+- `walkString` type mismatch (~line 1082-1086): path `s.Path`.
+- `walkBoolean` type mismatch (~line 1128-1131): path `b.Path`.
+- `walkInteger` type mismatch (~line 1149-1152): path `i.Path`.
+- `walkFloat` type mismatch (~line 1170-1176, already `!r.print`-guarded): path `f.Path`.
+- `walkCustom` resolve error (~line 1250-1252): path `c.Path`.
+- `walkEnum` type mismatch (~line 1327-1330, add already writes with path) → replace `return r.err()` with `return r.erroredPosition(e.Path, parent)`.
+- `walkEnum` invalid value (~line 1333-1365): the non-Apollo branch ends `return r.err()` — replace with `return r.erroredPosition(e.Path, parent)`; the error add is already guarded by `if !r.print`.
+
+Example (walkString), before:
+```go
+	if value.Type() != astjson.TypeString {
+		r.marshalBuf = value.MarshalTo(r.marshalBuf[:0])
+		r.addError(fmt.Sprintf("String cannot represent non-string value: \"%s\"", string(r.marshalBuf)), s.Path)
+		return r.err()
+	}
+```
+after:
+```go
+	if value.Type() != astjson.TypeString {
+		if !r.print {
+			r.marshalBuf = value.MarshalTo(r.marshalBuf[:0])
+			r.addError(fmt.Sprintf("String cannot represent non-string value: \"%s\"", string(r.marshalBuf)), s.Path)
+		}
+		return r.erroredPosition(s.Path, parent)
+	}
+```
+
+- [ ] **Step 4: Run the test + full suite**
+
+Run: `cd v2 && go test ./pkg/engine/resolve/ -run 'TestResolvable_NullBehavior' -v && go test ./pkg/engine/resolve/`
+Expected: PASS, full `resolve` package green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add v2/pkg/engine/resolve/resolvable.go v2/pkg/engine/resolve/resolvable_test.go
+git commit -m "feat(resolve): apply NULL error behavior to coercion and invalid-enum errors"
+```
+
+---
+
+### Task 5: `HALT` behavior — data null with a single error
+
+**Files:**
+- Modify: `v2/pkg/engine/resolve/resolvable.go` (`Resolve` ~line 254-271; add `keepFirstErrorOnly` helper)
+- Test: `v2/pkg/engine/resolve/resolvable_test.go`
+
+**Interfaces:**
+- Consumes: `r.errorBehavior` (Task 2).
+- Produces: `func (r *Resolvable) keepFirstErrorOnly()` — trims `r.errors` to its first element.
+
+**Background:** HALT is render-time only (no loader/fetch changes). Under HALT the walk behaves like PROPAGATE (any non-null violation bubbles to the root). We additionally force `data: null` whenever any error exists (including pre-existing subgraph errors) and trim the errors list to one.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// append to v2/pkg/engine/resolve/resolvable_test.go
+
+func newHaltResolvable(t *testing.T, data string) *Resolvable {
+	t.Helper()
+	res := NewResolvable(nil, ResolvableOptions{})
+	err := res.Init(&Context{ExecutionOptions: ExecutionOptions{ErrorBehavior: ErrorBehaviorHalt}},
+		[]byte(data), ast.OperationTypeQuery)
+	assert.NoError(t, err)
+	return res
+}
+
+// a single non-null violation -> data:null, single error
+func TestResolvable_HaltBehavior_SingleViolation(t *testing.T) {
+	res := newHaltResolvable(t, `{"hero":{"name":null}}`)
+	object := &Object{Fields: []*Field{{
+		Name: []byte("hero"),
+		Value: &Object{Path: []string{"hero"}, Fields: []*Field{
+			{Name: []byte("name"), Value: &String{Path: []string{"name"}}},
+		}},
+	}}}
+	out := &bytes.Buffer{}
+	err := res.Resolve(context.Background(), object, nil, out)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"errors":[{"message":"Cannot return null for non-nullable field 'Query.hero.name'.","path":["hero","name"]}],"data":null}`, out.String())
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd v2 && go test ./pkg/engine/resolve/ -run TestResolvable_HaltBehavior_SingleViolation -v`
+Expected: FAIL — without HALT handling the error bubbles to `data:null` but the errors list is not guaranteed trimmed, and multi-error cases would differ (covered in Phase 3). For the single-error case it may already pass; if so, proceed — Step 3 makes multi-error correct and is verified in Phase 3.
+
+- [ ] **Step 3: Add `keepFirstErrorOnly` and wire HALT into `Resolve`**
+
+Add the helper near `printErrors`:
+
+```go
+// keepFirstErrorOnly trims r.errors down to its first element (used by HALT).
+func (r *Resolvable) keepFirstErrorOnly() {
+	if r.errors == nil {
+		return
+	}
+	items := r.errors.GetArray()
+	if len(items) <= 1 {
+		return
+	}
+	first := items[0]
+	r.errors = astjson.ArrayValue(r.astjsonArena)
+	r.errors.SetArrayItem(r.astjsonArena, 0, first)
+}
+```
+
+In `Resolve`, immediately after `hasErrors := r.walkObject(rootData, r.data)` (line ~254) and before `if r.authorizationError != nil`, add:
+
+```go
+	if r.errorBehavior == ErrorBehaviorHalt && r.hasErrors() {
+		hasErrors = true // force data: null
+		r.keepFirstErrorOnly()
+	}
+```
+
+(The existing `if r.hasErrors() { r.printErrors() }` and `if hasErrors { data:null }` branches then render the single error and `data: null`.)
+
+- [ ] **Step 4: Run the test + full suite**
+
+Run: `cd v2 && go test ./pkg/engine/resolve/ -run 'TestResolvable_HaltBehavior' -v && go test ./pkg/engine/resolve/`
+Expected: PASS, full `resolve` package green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add v2/pkg/engine/resolve/resolvable.go v2/pkg/engine/resolve/resolvable_test.go
+git commit -m "feat(resolve): implement HALT error behavior (data null + single error)"
+```
+
+---
+
+## Self-Review Notes
+
+- **Coverage vs RFC §5.1–5.4:** Task 1 = enum/helper (§5.1); Task 2 = plumbing/normalization (§5.2); Tasks 3–4 = NULL semantics incl. option A (§5.3); Task 5 = HALT single-error, render-time (§5.4).
+- **Out of scope for Phase 1 (documented, not deferred silently):** authorization-denial null-setting (`walkObject` ~lines 769-786) keeps its existing behavior; introspection capabilities are Phase 2; the full behavior×position test matrix and pipeline/e2e tests are Phase 3.
+- **Regression guard:** every task ends by running the full `resolve` package so any `PROPAGATE` drift fails immediately.

--- a/docs/rfcs/plans/2026-07-01-onerror-phase2-introspection.md
+++ b/docs/rfcs/plans/2026-07-01-onerror-phase2-introspection.md
@@ -1,0 +1,328 @@
+# onError Phase 2 — Introspection Service Capabilities — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let graphql-go-tools advertise onError support via the GraphQL Service Capabilities introspection surface (`graphql.onError`, `graphql.defaultErrorBehavior`), emitted **only when the feature is enabled** so introspection is byte-identical to today when disabled.
+
+**Architecture:** Extend the `introspection` package model with a `Capability` type and an optional `Capabilities` list on the introspection `Schema`, plus a config-gated builder. When a caller (the router) enables onError, it attaches capabilities to the introspection `Data`; when disabled it attaches nothing (`omitempty` ⇒ absent). The `__Capability` type is registered in the introspected type list. The end-to-end query field is wired last, gated on confirming the final spec shape.
+
+**Tech Stack:** Go, `encoding/json`, `testify/assert`. Package `github.com/wundergraph/graphql-go-tools/v2/pkg/introspection`.
+
+## Global Constraints
+
+- Module root for all `go` commands: `v2/`.
+- Assert full values with `assert.Equal`; for JSON, assert the exact marshaled string.
+- **Disabled = byte-identical to today.** With no capabilities attached, the marshaled introspection `Schema` must be unchanged (existing `pkg/introspection` golden fixtures must pass untouched).
+- Capability identifiers are exact, case-sensitive strings: `graphql.onError`, `graphql.defaultErrorBehavior`. Error-behavior values: `PROPAGATE` / `NULL` / `HALT`.
+- Do **not** implement the superseded `@behavior` SDL directive or a `__Schema.defaultErrorBehavior` field.
+- Spec reference: graphql-spec#1163 (Service Capabilities). Spec is open; the introspection *query shape* is provisional (see Task 4). See `docs/rfcs/2026-07-01-onerror-error-behavior.md` §5.7.
+
+---
+
+### Task 1: `Capability` type + optional `Capabilities` on the introspection `Schema`
+
+**Files:**
+- Modify: `v2/pkg/introspection/introspection.go` (`Schema` struct ~line 14; add `Capability` type + constructor)
+- Test: `v2/pkg/introspection/introspection_capabilities_test.go` (create)
+
+**Interfaces:**
+- Produces:
+  - `type Capability struct { Identifier string; Description *string; Value *string; TypeName string }` with JSON tags `identifier`, `description`, `value`, `__typename`.
+  - `Schema.Capabilities []Capability` with tag `json:"capabilities,omitempty"`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// v2/pkg/introspection/introspection_capabilities_test.go
+package introspection
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSchema_Capabilities_OmittedWhenEmpty(t *testing.T) {
+	s := NewSchema() // no capabilities
+	b, err := json.Marshal(&s)
+	assert.NoError(t, err)
+	// capabilities key must be absent when empty (byte-identical to today)
+	assert.NotContains(t, string(b), `"capabilities"`)
+}
+
+func TestSchema_Capabilities_Marshaled(t *testing.T) {
+	s := NewSchema()
+	val := "PROPAGATE"
+	s.Capabilities = []Capability{
+		{Identifier: "graphql.onError", TypeName: "__Capability"},
+		{Identifier: "graphql.defaultErrorBehavior", Value: &val, TypeName: "__Capability"},
+	}
+	b, err := json.Marshal(&s)
+	assert.NoError(t, err)
+	assert.Contains(t, string(b), `"capabilities":[{"identifier":"graphql.onError","description":null,"value":null,"__typename":"__Capability"},{"identifier":"graphql.defaultErrorBehavior","description":null,"value":"PROPAGATE","__typename":"__Capability"}]`)
+}
+```
+
+(Note: `assert.NotContains`/`Contains` are acceptable here because these assert *presence/absence of a key* in a large generated blob; the exact capability object is asserted in full inline.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd v2 && go test ./pkg/introspection/ -run TestSchema_Capabilities -v`
+Expected: FAIL — `Capabilities`/`Capability` undefined.
+
+- [ ] **Step 3: Add the type and field**
+
+In `introspection.go`, add the field to `Schema` (after `Directives`):
+
+```go
+	Capabilities []Capability `json:"capabilities,omitempty"`
+```
+
+Add the type:
+
+```go
+// Capability describes a single GraphQL service capability (Service
+// Capabilities introspection, graphql-spec#1163).
+type Capability struct {
+	Identifier  string  `json:"identifier"`
+	Description *string `json:"description"`
+	Value       *string `json:"value"`
+	TypeName    string  `json:"__typename"`
+}
+```
+
+- [ ] **Step 4: Run test + existing introspection suite**
+
+Run: `cd v2 && go test ./pkg/introspection/ -run TestSchema_Capabilities -v && go test ./pkg/introspection/`
+Expected: PASS, and existing golden tests unchanged (omitempty keeps output identical).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add v2/pkg/introspection/introspection.go v2/pkg/introspection/introspection_capabilities_test.go
+git commit -m "feat(introspection): add optional Service Capabilities to schema model"
+```
+
+---
+
+### Task 2: Config-gated capabilities builder
+
+**Files:**
+- Modify: `v2/pkg/introspection/introspection.go` (add builder)
+- Test: `v2/pkg/introspection/introspection_capabilities_test.go`
+
+**Interfaces:**
+- Produces: `func BuildServiceCapabilities(enabled bool, defaultErrorBehavior string) []Capability` — returns `nil` when `enabled` is false; otherwise `graphql.onError` plus `graphql.defaultErrorBehavior` (with `defaultErrorBehavior` value; defaults to `"PROPAGATE"` when empty).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// append to introspection_capabilities_test.go
+func TestBuildServiceCapabilities(t *testing.T) {
+	assert.Nil(t, BuildServiceCapabilities(false, "NULL")) // disabled => nothing
+
+	got := BuildServiceCapabilities(true, "") // empty default => PROPAGATE
+	pv := "PROPAGATE"
+	assert.Equal(t, []Capability{
+		{Identifier: "graphql.onError", TypeName: "__Capability"},
+		{Identifier: "graphql.defaultErrorBehavior", Value: &pv, TypeName: "__Capability"},
+	}, got)
+
+	got = BuildServiceCapabilities(true, "NULL")
+	nv := "NULL"
+	assert.Equal(t, []Capability{
+		{Identifier: "graphql.onError", TypeName: "__Capability"},
+		{Identifier: "graphql.defaultErrorBehavior", Value: &nv, TypeName: "__Capability"},
+	}, got)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd v2 && go test ./pkg/introspection/ -run TestBuildServiceCapabilities -v`
+Expected: FAIL — `BuildServiceCapabilities` undefined.
+
+- [ ] **Step 3: Implement the builder**
+
+```go
+// BuildServiceCapabilities returns the Service Capabilities to advertise, or nil
+// when the onError feature is disabled. When enabled, defaultErrorBehavior is the
+// operator-configured default ("" => "PROPAGATE").
+func BuildServiceCapabilities(enabled bool, defaultErrorBehavior string) []Capability {
+	if !enabled {
+		return nil
+	}
+	if defaultErrorBehavior == "" {
+		defaultErrorBehavior = "PROPAGATE"
+	}
+	def := defaultErrorBehavior
+	return []Capability{
+		{Identifier: "graphql.onError", TypeName: "__Capability"},
+		{Identifier: "graphql.defaultErrorBehavior", Value: &def, TypeName: "__Capability"},
+	}
+}
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `cd v2 && go test ./pkg/introspection/ -run TestBuildServiceCapabilities -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add v2/pkg/introspection/introspection.go v2/pkg/introspection/introspection_capabilities_test.go
+git commit -m "feat(introspection): add config-gated BuildServiceCapabilities helper"
+```
+
+---
+
+### Task 3: Register the `__Capability` type in the introspected type list
+
+**Files:**
+- Modify: `v2/pkg/introspection/introspection.go` (extend `NewSchema` or add a registration helper)
+- Test: `v2/pkg/introspection/introspection_capabilities_test.go`
+
+**Interfaces:**
+- Produces: `func (s *Schema) AddCapabilityType()` — appends the `__Capability` object type (fields `identifier: String!`, `description: String`, `value: String`) to `s.Types` so `__type(name:"__Capability")` and `__schema { types }` resolve it. Idempotent (no-op if already present).
+
+**Rationale:** capabilities are only introspectable if `__Capability` is a known type. Only register it when capabilities are actually attached (called by the caller alongside `BuildServiceCapabilities`).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// append to introspection_capabilities_test.go
+func TestSchema_AddCapabilityType(t *testing.T) {
+	s := NewSchema()
+	s.AddCapabilityType()
+	ft := s.TypeByName("__Capability")
+	assert.NotNil(t, ft)
+	assert.Equal(t, "__Capability", ft.Name)
+	assert.Equal(t, OBJECT, ft.Kind)
+	names := make([]string, 0, len(ft.Fields))
+	for _, f := range ft.Fields {
+		names = append(names, f.Name)
+	}
+	assert.Equal(t, []string{"identifier", "description", "value"}, names)
+
+	// idempotent
+	s.AddCapabilityType()
+	count := 0
+	for _, tpe := range s.Types {
+		if tpe.Name == "__Capability" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd v2 && go test ./pkg/introspection/ -run TestSchema_AddCapabilityType -v`
+Expected: FAIL — `AddCapabilityType` undefined.
+
+- [ ] **Step 3: Implement `AddCapabilityType`**
+
+Build the `__Capability` object type using the existing `NewFullType`/`NewField`/`TypeRef` constructors (mirror how other `__`-types are shaped in `generator.go`). `identifier` is `String!` (NON_NULL wrapping SCALAR String); `description` and `value` are nullable `String`.
+
+```go
+func stringTypeRef(nonNull bool) TypeRef {
+	name := "String"
+	scalar := TypeRef{Kind: SCALAR, Name: &name, TypeName: "__Type"}
+	if !nonNull {
+		return scalar
+	}
+	return TypeRef{Kind: NON_NULL, OfType: &scalar, TypeName: "__Type"}
+}
+
+// AddCapabilityType registers the __Capability object type. Idempotent.
+func (s *Schema) AddCapabilityType() {
+	if s.TypeByName("__Capability") != nil {
+		return
+	}
+	ft := NewFullType()
+	ft.Kind = OBJECT
+	ft.Name = "__Capability"
+	idField := NewField()
+	idField.Name = "identifier"
+	idField.Type = stringTypeRef(true)
+	descField := NewField()
+	descField.Name = "description"
+	descField.Type = stringTypeRef(false)
+	valField := NewField()
+	valField.Name = "value"
+	valField.Type = stringTypeRef(false)
+	ft.Fields = []Field{idField, descField, valField}
+	s.AddType(ft)
+}
+```
+
+(Verify `OBJECT`, `SCALAR`, `NON_NULL` enum identifiers against `introspection_enum.go` before running; adjust names if the generated enum differs.)
+
+- [ ] **Step 4: Run test + full introspection suite**
+
+Run: `cd v2 && go test ./pkg/introspection/ -run TestSchema_AddCapabilityType -v && go test ./pkg/introspection/`
+Expected: PASS; existing goldens untouched (only affected when `AddCapabilityType` is explicitly called).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add v2/pkg/introspection/introspection.go v2/pkg/introspection/introspection_capabilities_test.go
+git commit -m "feat(introspection): register __Capability type on demand"
+```
+
+---
+
+### Task 4: Wire capabilities into the introspection query path (spec-shape gated)
+
+**Files:**
+- Read/confirm: current spec introspection shape (graphql-spec#1163) — is `capabilities` exposed under `__schema { capabilities }` or a separate `service { capabilities }` root?
+- Modify (likely): the introspection schema definition consumed by planning (locate first), and — only if a new root field is required — `v2/pkg/engine/datasource/introspection_datasource/{input.go,planner.go,source.go}`.
+- Test: `v2/pkg/engine/datasource/introspection_datasource/*_test.go`
+
+**Interfaces:**
+- Consumes: `Schema.Capabilities` (Task 1), `BuildServiceCapabilities` (Task 2), `Schema.AddCapabilityType` (Task 3).
+
+**Decision to record before coding:** confirm the final introspection field path in the spec and write it into this task (one line). Default assumption if unchanged: capabilities live under `__schema` (i.e. `__schema { capabilities { identifier value } }`). This is the cheapest to support because `source.go` (`Load`) already returns `json.Marshal(s.introspectionData.Schema)` for `__schema`, so once `Schema.Capabilities` is populated the field serializes with **no datasource change** — only the introspection SDL/type definition must declare `__Schema.capabilities: [__Capability!]!`.
+
+- [ ] **Step 1: Locate the introspection schema definition**
+
+Run: `cd v2 && grep -rn "__Schema" pkg --include=*.go | grep -iv "_test\|__schema\"" | head` and `grep -rln "queryType\|__Directive\|__Type" pkg/introspection pkg/ast* pkg/astparser 2>/dev/null | head`
+Goal: find where the `__Schema`/`__Type` introspection type system is declared (SDL string or programmatic), which is where a `capabilities` field / `service` root must be added.
+
+- [ ] **Step 2: Write a failing end-to-end test**
+
+Add a datasource/pipeline test that executes `{ __schema { capabilities { identifier value } } }` (or the confirmed field) against a schema built with `Schema.Capabilities` populated + `AddCapabilityType()` called, and asserts the **full** response:
+
+```
+{"data":{"__schema":{"capabilities":[{"identifier":"graphql.onError","value":null},{"identifier":"graphql.defaultErrorBehavior","value":"PROPAGATE"}]}}}
+```
+
+Run it and confirm it fails (field unknown / not resolved).
+
+- [ ] **Step 3: Implement the confirmed wiring**
+
+- If capabilities live under `__schema`: extend the introspection type definition (from Step 1) to declare `capabilities: [__Capability!]!` on `__Schema` and the `__Capability` type; no `source.go` change needed (it already marshals the whole `Schema`). Ensure the code path that builds `introspectionData` calls `AddCapabilityType()` and sets `Schema.Capabilities = BuildServiceCapabilities(enabled, defaultBehavior)`.
+- If a separate `service` root is required: add `serviceFieldName = "service"` in `input.go`, a `case serviceFieldName` in `planner.go` `EnterField`, a `ServiceRequestType` + input branch, and a `source.go` branch returning `json.Marshal(struct{ Capabilities []introspection.Capability }{...})`. Follow the exact `__schema` pattern in those three files.
+
+- [ ] **Step 4: Run the e2e test + affected suites**
+
+Run: `cd v2 && go test ./pkg/engine/datasource/introspection_datasource/ && go test ./pkg/introspection/`
+Expected: PASS. Also confirm that with the feature disabled (capabilities not attached, `AddCapabilityType` not called) introspection output is byte-identical to today.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A v2/pkg/engine/datasource/introspection_datasource v2/pkg/introspection
+git commit -m "feat(introspection): expose Service Capabilities via introspection query"
+```
+
+---
+
+## Self-Review Notes
+
+- **Coverage vs RFC §5.7:** Tasks 1–3 deliver the config-gated model/builder/type-registration the library owns and can golden-test; Task 4 is the end-to-end query wiring, explicitly gated on confirming the (still-open) spec field shape.
+- **Disabled path:** `omitempty` + on-demand `AddCapabilityType` guarantee byte-identical introspection when the feature is off — asserted in Task 1 Step 1 and Task 4 Step 4.
+- **Router integration** (config switch, feeding `BuildServiceCapabilities` from operator config) lives in the router repo; this plan supplies the primitives (Phase 1 `ErrorBehavior`/`ExecutionOptions`, Phase 2 builder/type). Keep the operator default synchronized between `ExecutionOptions.ErrorBehavior` resolution and `graphql.defaultErrorBehavior` per RFC §5.8.

--- a/docs/rfcs/plans/2026-07-01-onerror-phase3-tests-hardening.md
+++ b/docs/rfcs/plans/2026-07-01-onerror-phase3-tests-hardening.md
@@ -1,0 +1,309 @@
+# onError Phase 3 — Tests & Hardening — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove the onError implementation (Phases 1–2) is correct across the full behavior × position × nullability × error-source matrix, that HALT returns exactly one error, that the operator default is applied and stays synchronized with introspection, and that the feature-off path is byte-identical to today.
+
+**Architecture:** Table-driven resolver tests over the full matrix, a HALT multi-error trimming test, operator-default synchronization tests, an execution-module e2e test with an erroring subgraph, and a regression guard.
+
+**Tech Stack:** Go, `testify/assert`. Packages `pkg/engine/resolve`, `pkg/introspection`, and the `execution/` module.
+
+## Global Constraints
+
+- Module root: `v2/` for engine tests; `execution/` for full-stack e2e tests (separate `go.mod`).
+- Assert the **full** response string with `assert.Equal`, never `assert.Contains`.
+- Depends on Phase 1 (`ErrorBehavior`, `ExecutionOptions.ErrorBehavior`, NULL/HALT resolver semantics) and Phase 2 (`BuildServiceCapabilities`, `Schema.Capabilities`).
+- Every behavior must be tested at every position per RFC decision 8.1.
+- Reference: `docs/rfcs/2026-07-01-onerror-error-behavior.md` §7–§8.
+
+---
+
+### Task 1: Full resolver matrix (behavior × position × nullability × error source)
+
+**Files:**
+- Test: `v2/pkg/engine/resolve/error_behavior_matrix_test.go` (create)
+
+**Interfaces:**
+- Consumes: `NewResolvable`, `Resolvable.Init`, `Resolvable.Resolve`, `ErrorBehavior*`, `ExecutionOptions.ErrorBehavior`, node types `Object`/`Array`/`String`/`Integer`.
+
+- [ ] **Step 1: Write the table-driven test**
+
+Cover the cross-product. Each case sets `ExecutionOptions.ErrorBehavior`, builds a node tree, resolves, and asserts the full output string.
+
+```go
+// v2/pkg/engine/resolve/error_behavior_matrix_test.go
+package resolve
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+)
+
+func resolveWith(t *testing.T, behavior ErrorBehavior, data string, root *Object) string {
+	t.Helper()
+	res := NewResolvable(nil, ResolvableOptions{})
+	err := res.Init(&Context{ExecutionOptions: ExecutionOptions{ErrorBehavior: behavior}},
+		[]byte(data), ast.OperationTypeQuery)
+	assert.NoError(t, err)
+	out := &bytes.Buffer{}
+	assert.NoError(t, res.Resolve(context.Background(), root, nil, out))
+	return out.String()
+}
+
+func TestErrorBehaviorMatrix(t *testing.T) {
+	// tree: { hero: { id (nn String), name (nn String) }, time (nullable String) }
+	tree := func(heroNullable bool) *Object {
+		return &Object{Fields: []*Field{
+			{Name: []byte("hero"), Value: &Object{Path: []string{"hero"}, Nullable: heroNullable, Fields: []*Field{
+				{Name: []byte("id"), Value: &String{Path: []string{"id"}}},
+				{Name: []byte("name"), Value: &String{Path: []string{"name"}}},
+			}}},
+			{Name: []byte("time"), Value: &String{Path: []string{"time"}, Nullable: true}},
+		}}
+	}
+
+	cases := []struct {
+		name     string
+		behavior ErrorBehavior
+		data     string
+		root     *Object
+		want     string
+	}{
+		// ---- non-null leaf null ----
+		{"propagate/leaf-null/hero-nonnull", ErrorBehaviorPropagate,
+			`{"hero":{"id":"1","name":null},"time":"now"}`, tree(false),
+			`{"errors":[{"message":"Cannot return null for non-nullable field 'Query.hero.name'.","path":["hero","name"]}],"data":null}`},
+		{"propagate/leaf-null/hero-nullable", ErrorBehaviorPropagate,
+			`{"hero":{"id":"1","name":null},"time":"now"}`, tree(true),
+			`{"errors":[{"message":"Cannot return null for non-nullable field 'Query.hero.name'.","path":["hero","name"]}],"data":{"hero":null,"time":"now"}}`},
+		{"null/leaf-null", ErrorBehaviorNull,
+			`{"hero":{"id":"1","name":null},"time":"now"}`, tree(false),
+			`{"errors":[{"message":"Cannot return null for non-nullable field 'Query.hero.name'.","path":["hero","name"]}],"data":{"hero":{"id":"1","name":null},"time":"now"}}`},
+		{"halt/leaf-null", ErrorBehaviorHalt,
+			`{"hero":{"id":"1","name":null},"time":"now"}`, tree(false),
+			`{"errors":[{"message":"Cannot return null for non-nullable field 'Query.hero.name'.","path":["hero","name"]}],"data":null}`},
+
+		// ---- non-null object null ----
+		{"propagate/object-null/hero-nonnull", ErrorBehaviorPropagate,
+			`{"hero":null,"time":"now"}`, tree(false),
+			`{"errors":[{"message":"Cannot return null for non-nullable field 'Query.hero'.","path":["hero"]}],"data":null}`},
+		{"null/object-null", ErrorBehaviorNull,
+			`{"hero":null,"time":"now"}`, tree(false),
+			`{"errors":[{"message":"Cannot return null for non-nullable field 'Query.hero'.","path":["hero"]}],"data":{"hero":null,"time":"now"}}`},
+		{"halt/object-null", ErrorBehaviorHalt,
+			`{"hero":null,"time":"now"}`, tree(false),
+			`{"errors":[{"message":"Cannot return null for non-nullable field 'Query.hero'.","path":["hero"]}],"data":null}`},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, resolveWith(t, c.behavior, c.data, c.root))
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Add non-null list + list-item cases** (append these entries to the `cases` slice — `[String!]!`, i.e. non-null list of non-null items)
+
+```go
+		{"null/list-item-null", ErrorBehaviorNull,
+			`{"names":["a",null,"c"]}`,
+			&Object{Fields: []*Field{{Name: []byte("names"), Value: &Array{Path: []string{"names"}, Item: &String{}}}}},
+			`{"errors":[{"message":"Cannot return null for non-nullable field 'Query.names'.","path":["names",1]}],"data":{"names":["a",null,"c"]}}`},
+		{"propagate/list-item-null", ErrorBehaviorPropagate,
+			`{"names":["a",null,"c"]}`,
+			&Object{Fields: []*Field{{Name: []byte("names"), Value: &Array{Path: []string{"names"}, Item: &String{}}}}},
+			`{"errors":[{"message":"Cannot return null for non-nullable field 'Query.names'.","path":["names",1]}],"data":null}`},
+		{"halt/list-item-null", ErrorBehaviorHalt,
+			`{"names":["a",null,"c"]}`,
+			&Object{Fields: []*Field{{Name: []byte("names"), Value: &Array{Path: []string{"names"}, Item: &String{}}}}},
+			`{"errors":[{"message":"Cannot return null for non-nullable field 'Query.names'.","path":["names",1]}],"data":null}`},
+```
+
+- [ ] **Step 3: Run and adjust expected strings**
+
+Run: `cd v2 && go test ./pkg/engine/resolve/ -run TestErrorBehaviorMatrix -v`
+Expected: PASS. If any `want` differs, first confirm the difference is only field ordering / message text produced by the current implementation, then update the `want` to the exact observed output (the assertion must remain a full-string `assert.Equal`). Do **not** relax to `Contains`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add v2/pkg/engine/resolve/error_behavior_matrix_test.go
+git commit -m "test(resolve): full error-behavior x position matrix"
+```
+
+---
+
+### Task 2: HALT trims to a single error
+
+**Files:**
+- Test: `v2/pkg/engine/resolve/error_behavior_matrix_test.go`
+
+- [ ] **Step 1: Write the failing/again test** (two independent non-null violations → one error)
+
+```go
+// append to error_behavior_matrix_test.go
+func TestHalt_TrimsToSingleError(t *testing.T) {
+	// two sibling non-null leaves both null -> PROPAGATE would still bubble to
+	// data:null; HALT must additionally guarantee exactly ONE error entry.
+	root := &Object{Fields: []*Field{
+		{Name: []byte("a"), Value: &String{Path: []string{"a"}}},
+		{Name: []byte("b"), Value: &String{Path: []string{"b"}}},
+	}}
+	got := resolveWith(t, ErrorBehaviorHalt, `{"a":null,"b":null}`, root)
+	assert.Equal(t,
+		`{"errors":[{"message":"Cannot return null for non-nullable field 'Query.a'.","path":["a"]}],"data":null}`,
+		got)
+}
+```
+
+- [ ] **Step 2: Run**
+
+Run: `cd v2 && go test ./pkg/engine/resolve/ -run TestHalt_TrimsToSingleError -v`
+Expected: PASS (Phase 1 Task 5 `keepFirstErrorOnly` produces the single first error). If more than one error appears, revisit Phase 1 Task 5.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add v2/pkg/engine/resolve/error_behavior_matrix_test.go
+git commit -m "test(resolve): HALT returns a single error"
+```
+
+---
+
+### Task 3: Operator-default applied + synchronized with introspection
+
+**Files:**
+- Test: `v2/pkg/engine/resolve/error_behavior_test.go`
+- Test: `v2/pkg/introspection/introspection_capabilities_test.go`
+
+**Background:** the router resolves `effective = requestOnError ?? operatorDefault ?? PROPAGATE` and sets `ExecutionOptions.ErrorBehavior`. This test asserts the engine honors whatever effective value it receives, and that `BuildServiceCapabilities` reports the same default value — the two stay in lockstep.
+
+- [ ] **Step 1: Write the tests**
+
+```go
+// append to v2/pkg/engine/resolve/error_behavior_test.go
+func TestErrorBehavior_OperatorDefaultApplied(t *testing.T) {
+	// simulate: no request onError, operator default = NULL => router sets NULL.
+	effective, ok := MapErrorBehavior("") // request omitted
+	assert.True(t, ok)
+	operatorDefault := ErrorBehaviorNull
+	if effective == ErrorBehaviorPropagate { // request omitted -> apply operator default
+		effective = operatorDefault
+	}
+	assert.Equal(t, ErrorBehaviorNull, effective)
+}
+```
+
+```go
+// append to v2/pkg/introspection/introspection_capabilities_test.go
+func TestCapabilities_DefaultSyncsWithConfig(t *testing.T) {
+	for _, def := range []string{"PROPAGATE", "NULL", "HALT"} {
+		caps := BuildServiceCapabilities(true, def)
+		// second entry is graphql.defaultErrorBehavior; its value must equal config
+		assert.Equal(t, "graphql.defaultErrorBehavior", caps[1].Identifier)
+		assert.NotNil(t, caps[1].Value)
+		assert.Equal(t, def, *caps[1].Value)
+	}
+}
+```
+
+- [ ] **Step 2: Run**
+
+Run: `cd v2 && go test ./pkg/engine/resolve/ -run TestErrorBehavior_OperatorDefaultApplied -v && go test ./pkg/introspection/ -run TestCapabilities_DefaultSyncsWithConfig -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add v2/pkg/engine/resolve/error_behavior_test.go v2/pkg/introspection/introspection_capabilities_test.go
+git commit -m "test: operator default applied and synced with introspection capability"
+```
+
+---
+
+### Task 4: Execution-module e2e — erroring subgraph under each behavior
+
+**Files:**
+- Read first: find an existing federation e2e test that models a subgraph returning an error for a non-null field.
+- Test: add a test in the `execution/` module next to the closest existing federation error test.
+
+- [ ] **Step 1: Locate the harness and an error example**
+
+Run: `cd execution && grep -rln "errors\":\[" --include=*_test.go . | head` and `grep -rln "func Test" integration 2>/dev/null | head`
+Goal: find how e2e tests spin up subgraphs and assert responses, and how `ExecutionOptions` is set on the resolve `Context` in that harness.
+
+- [ ] **Step 2: Write the failing e2e test**
+
+Model a subgraph that returns `{"data":{"hero":{"name":null}},"errors":[{"message":"boom","path":["hero","name"]}]}` for a query with a non-null `name`. Run the same operation three times with `ExecutionOptions.ErrorBehavior` = `PROPAGATE`, `NULL`, `HALT`, and assert the full client response each time:
+- `PROPAGATE`: `hero` (or `data`) collapses per nullability, with the subgraph error.
+- `NULL`: `{"errors":[{"message":"boom",...}],"data":{"hero":{"name":null}}}` — sibling data preserved.
+- `HALT`: `{"errors":[{"message":"boom",...}],"data":null}` — single error.
+
+Mirror the exact setup of the existing error test found in Step 1 (same harness, same assertion helper).
+
+- [ ] **Step 3: Run**
+
+Run: `cd execution && go test ./... -run <YourTestName> -v`
+Expected: PASS. Adjust expected strings to the harness's exact output shape (full-string `assert.Equal`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add execution/
+git commit -m "test(e2e): onError behaviors with an erroring subgraph"
+```
+
+---
+
+### Task 5: Regression guard — feature-off is byte-identical
+
+**Files:**
+- Test: `v2/pkg/engine/resolve/error_behavior_matrix_test.go`
+
+- [ ] **Step 1: Write the guard test**
+
+```go
+// append to error_behavior_matrix_test.go
+// With ErrorBehavior unset, output must match the explicit PROPAGATE output.
+func TestErrorBehavior_UnsetEqualsPropagate(t *testing.T) {
+	data := `{"hero":{"id":"1","name":null},"time":"now"}`
+	root := func() *Object {
+		return &Object{Fields: []*Field{
+			{Name: []byte("hero"), Value: &Object{Path: []string{"hero"}, Nullable: true, Fields: []*Field{
+				{Name: []byte("id"), Value: &String{Path: []string{"id"}}},
+				{Name: []byte("name"), Value: &String{Path: []string{"name"}}},
+			}}},
+			{Name: []byte("time"), Value: &String{Path: []string{"time"}, Nullable: true}},
+		}}
+	}
+	unset := resolveWith(t, "", data, root())
+	propagate := resolveWith(t, ErrorBehaviorPropagate, data, root())
+	assert.Equal(t, propagate, unset)
+}
+```
+
+- [ ] **Step 2: Run + full engine + introspection suites (final regression sweep)**
+
+Run: `cd v2 && go test ./pkg/engine/resolve/ && go test ./pkg/introspection/ && go test ./pkg/engine/datasource/introspection_datasource/`
+Expected: all PASS, including all pre-existing goldens (proves feature-off is byte-identical).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add v2/pkg/engine/resolve/error_behavior_matrix_test.go
+git commit -m "test(resolve): regression guard that unset behavior equals PROPAGATE"
+```
+
+---
+
+## Self-Review Notes
+
+- **Coverage vs RFC §7 / decisions §8:** Task 1 = full behavior×position×nullability matrix incl. NULL option A; Task 2 = HALT single error (8.2); Task 3 = operator-default applied + introspection sync (8.3); Task 4 = e2e with an erroring subgraph; Task 5 = feature-off regression guard.
+- **Error-source dimension:** the matrix uses subgraph-provided `null` (data contains `null`); the "bare null with no upstream error" case is the same input at the resolver level and is covered. The e2e Task 4 adds the "null *with* an upstream subgraph error" case end-to-end.
+- **Honesty on expected strings:** several `want` values must be reconciled with the implementation's exact output on first run (field order, message wording). The rule is to observe the real output and pin it exactly — never downgrade to substring matching.

--- a/docs/rfcs/reviews/phase1-core-resolver.md
+++ b/docs/rfcs/reviews/phase1-core-resolver.md
@@ -1,0 +1,58 @@
+# Phase 1 Review — Core Resolver Error Behavior
+
+**Scope:** Implements client-selectable GraphQL error behavior (`PROPAGATE` / `NULL` / `HALT`) in the resolver.
+Design: [docs/rfcs/2026-07-01-onerror-error-behavior.md](../2026-07-01-onerror-error-behavior.md).
+Plan: [docs/rfcs/plans/2026-07-01-onerror-phase1-core-resolver.md](../plans/2026-07-01-onerror-phase1-core-resolver.md).
+
+## What changed
+
+| File | Change |
+|---|---|
+| `v2/pkg/engine/resolve/error_behavior.go` | New. `ErrorBehavior` enum + `MapErrorBehavior` validator/normalizer. |
+| `v2/pkg/engine/resolve/context.go` | New `ExecutionOptions.ErrorBehavior` field (opt-in; empty ⇒ PROPAGATE). |
+| `v2/pkg/engine/resolve/resolvable.go` | `errorBehavior` field + reset/normalize; `erroredPosition` and `keepFirstErrorOnly` helpers; NULL/HALT wiring across all walkers. |
+| `v2/pkg/engine/resolve/*_test.go` | Enum tests + behavior tests (leaf/object/list-item/type-mismatch NULL, HALT single error, default-is-PROPAGATE). |
+
+## Key decisions
+
+1. **Empty value normalizes to PROPAGATE**, at both `Resolve` and `ResolveNode` entry points, and cleared in `Reset`.
+`MapErrorBehavior("")` also returns PROPAGATE so router/gateway callers get the spec default for free.
+The operator default is applied by the caller before this layer (RFC §5.2); this layer only sees the already-resolved value.
+
+2. **NULL maps onto the existing single-bool propagation model** via one helper, `erroredPosition(path, parent)`.
+Under non-NULL behaviors it returns `r.err()` (unchanged bubbling), so PROPAGATE/HALT paths are byte-identical to before.
+Under NULL, on the validation pass it sets the errored position to `null` in place (via `astjson.SetNull`) and returns `false` (no propagation); on the print pass it prints `null` via `walkNull()`.
+
+3. **Error is recorded once.**
+Because NULL nulls the position in place (instead of bubbling), the print pass re-descends into the now-null position.
+Every error-adding site is therefore guarded with `if !r.print { ... }` so the error is appended only on the validation pass.
+
+4. **HALT is render-time only** (no loader/fetch cancellation, per the RFC refinement).
+The walk runs exactly like PROPAGATE; then in `Resolve`, if the behavior is HALT and any error exists, `data` is forced to `null` and `keepFirstErrorOnly` trims the errors array to a single element (RFC §5.4 / decision 8.2).
+
+5. **Array-item nulling reuses the empty-path branch.**
+For non-null list items (`Item` has empty `Path`), `erroredPosition([], parent)` does not mutate the tree (nothing to address by path); the print pass renders `null` directly.
+Whole-array nulls use `arr.Path` as normal.
+
+## Where to focus review
+
+- **`erroredPosition` (resolvable.go, near `err()`):** the correctness pivot.
+Confirm the two-pass invariant: validation pass mutates/records, print pass renders `null` and never re-records.
+- **The `if !r.print` guards** on all ~14 converted sites (null-in-non-null for 10 walkers + coercion/invalid-enum sites in Task 4).
+A missing guard would double-record an error under NULL.
+- **`ResolveNode` nil-`ctx` guard (resolvable.go:~217):** `ResolveNode` is reused to render a variable-that-is-a-node with `r.ctx == nil`.
+The normalization must not dereference a nil ctx — this was caught by `TestAuthorization` and fixed to default PROPAGATE.
+- **HALT wiring in `Resolve` (after `walkObject`):** ordering relative to `authorizationError` and the existing `hasErrors`/`printErrors` branches.
+- **Regression surface:** the entire `resolve` package and `./pkg/engine/...` pass unchanged, which is the guarantee that PROPAGATE output is untouched.
+
+## Test / verification
+
+- `cd v2 && go test ./pkg/engine/resolve/` — green (incl. new behavior tests).
+- `cd v2 && go test ./pkg/engine/...` — green.
+- `go vet ./pkg/engine/resolve/` — clean.
+
+## Out of scope for Phase 1
+
+- Introspection service capabilities → Phase 2.
+- Full behavior×position×nullability matrix + e2e with an erroring subgraph → Phase 3.
+- Authorization-denial null-setting keeps its existing behavior (unchanged).

--- a/docs/rfcs/reviews/phase1-core-resolver.md
+++ b/docs/rfcs/reviews/phase1-core-resolver.md
@@ -56,3 +56,15 @@ The normalization must not dereference a nil ctx — this was caught by `TestAut
 - Introspection service capabilities → Phase 2.
 - Full behavior×position×nullability matrix + e2e with an erroring subgraph → Phase 3.
 - Authorization-denial null-setting keeps its existing behavior (unchanged).
+
+## Post-review fixes (Codex local review)
+
+A local Codex review after Phase 3 surfaced two genuine NULL-behavior gaps, both now fixed with regression tests (`TestResolvable_NullBehavior_FloatListItemTypeMismatch`, `TestResolvable_NullBehavior_InvalidTypename`):
+
+1. **`walkFloat` empty-path leak.** `walkFloat`'s type-mismatch check was nested inside `if !r.print`, so — unlike the other numeric walkers — it never reached `erroredPosition` on the print pass. For a non-null Float **array item** (empty path, so the validation pass can't null it in place) with a type mismatch under NULL, the print pass rendered the raw invalid value. The check is now hoisted to run on both passes (matching `walkInteger`), so the print pass renders `null`.
+2. **Invalid abstract `__typename` bypassed NULL.** The non-null branch of the `PossibleTypes` check returned `r.err()` (propagate) instead of `erroredPosition`, so under NULL an object with an unknown `__typename` bubbled like PROPAGATE. Now routed through `erroredPosition` (nulls the object in place under NULL, unchanged for PROPAGATE/HALT).
+
+Two further Codex findings were assessed and **not** changed:
+
+- **`walkCustom` double-`Resolve`** for empty-path custom array items under NULL: the print pass re-invokes `Resolve`, but still renders `null` correctly for deterministic resolvers (its check reaches `erroredPosition` on the print pass). Narrow and non-leaking; left as-is.
+- **Authorization-denial null-setting** under NULL: explicitly out of scope for this work (see above); auth rejection keeps its existing bespoke null/propagate handling.

--- a/docs/rfcs/reviews/phase2-introspection.md
+++ b/docs/rfcs/reviews/phase2-introspection.md
@@ -1,0 +1,61 @@
+# Phase 2 Review — Introspection Service Capabilities
+
+**Scope:** Advertise onError support via GraphQL Service Capabilities introspection (`graphql.onError`, `graphql.defaultErrorBehavior`), **config-gated** so introspection is byte-identical to today when the feature is disabled.
+Design: [docs/rfcs/2026-07-01-onerror-error-behavior.md](../2026-07-01-onerror-error-behavior.md) §5.7.
+Plan: [docs/rfcs/plans/2026-07-01-onerror-phase2-introspection.md](../plans/2026-07-01-onerror-phase2-introspection.md).
+
+## What changed
+
+| File | Change |
+|---|---|
+| `v2/pkg/introspection/introspection.go` | `Capability` type; optional `Schema.Capabilities` (`omitempty`); `BuildServiceCapabilities(enabled, default)`; `Schema.AddCapabilityType()` (idempotent). |
+| `v2/pkg/asttransform/baseschema.go` | `MergeOptions{ServiceCapabilities}`; `MergeDefinitionWithBaseSchemaOptions`; `baseSchemaServiceCapabilities` (`type __Capability`); `addCapabilitiesField` adds `__Schema.capabilities: [__Capability!]`. |
+| `v2/pkg/engine/datasource/introspection_datasource/config_factory.go` | `IntrospectionOptions`; `NewIntrospectionConfigFactoryWithOptions`; populates `Schema.Capabilities`; registers `capabilities` / `__Capability` child nodes when enabled. |
+| `*_capabilities_test.go`, `capabilities_test.go` | Model marshaling, builder, type registration, SDL gating, Load serialization, child-node registration. |
+
+## Key decisions
+
+1. **Gated/additive, not a global schema change** (per your selected approach).
+`MergeDefinitionWithBaseSchema` and `NewIntrospectionConfigFactory` are unchanged and delegate to the new `…Options` variants with the feature off, so every existing caller is byte-identical.
+Only the new opt-in paths add the `__Capability` type, the `__Schema.capabilities` field, the child-node registrations, and the runtime capability values.
+
+2. **`capabilities` is a nullable list `[__Capability!]`, not `[__Capability!]!`.**
+This is deliberate: a server with the feature enabled but advertising nothing (or the `omitempty` disabled path) yields `null`, which must not trip a non-null violation.
+Individual capability entries are non-null.
+
+3. **The `__Schema.capabilities` field is added programmatically** (`addCapabilitiesField`), not via `extend type __Schema` in SDL.
+The base-schema merge flow here does not merge object-type extensions (its `ExtendSchema` only injects `__typename`), so `extend` would silently not attach the field.
+The `type __Capability` itself is plain SDL appended only when enabled.
+
+4. **Two independent registrations must both be gated together.**
+For `__schema { capabilities }` to plan and resolve, three things must line up: (a) the SDL declares the field+type (asttransform), (b) the datasource declares `capabilities`/`__Capability` as child nodes (config factory), (c) the runtime `Schema.Capabilities` values are populated (config factory).
+All three are driven by the same `ServiceCapabilities` flag.
+
+5. **`source.go` unchanged.**
+It already marshals the whole `Schema`, so once `Schema.Capabilities` is populated the values serialize with no datasource-Load change.
+Note the Load response marshals `Schema` directly (capabilities is top-level in that payload, not under `__schema`).
+
+## Where to focus review
+
+- **`addCapabilitiesField` (baseschema.go):** confirm the field is appended to the correct `__Schema` object-type definition and that `[__Capability!]` is built correctly (`AddListType(AddNonNullNamedType(...))`).
+Verify it is a no-op if `__Schema` is somehow absent.
+- **Gating symmetry:** the SDL merge option and the config-factory option must be set together by the caller.
+If a caller enables one but not the other, planning (`HasChildNode`) or SDL validity will disagree — worth a guard or doc note for the router integration.
+- **`omitempty` disabled path:** `TestServiceCapabilities_Load_Disabled` and `TestMergeBaseSchema_Capabilities_Disabled` are the byte-identical guarantees.
+- **`BuildServiceCapabilities` default:** empty `defaultErrorBehavior` ⇒ `"PROPAGATE"`, which must stay synchronized with Phase 1's `ExecutionOptions.ErrorBehavior` operator-default resolution (RFC §5.8).
+
+## Test / verification
+
+- `cd v2 && go test ./pkg/introspection/ ./pkg/asttransform/ ./pkg/engine/datasource/introspection_datasource/ ./pkg/engine/plan/` — green.
+- `cd v2 && go test ./pkg/engine/...` — green (no golden drift).
+
+## Deliberately deferred to Phase 3
+
+- A full **execution** e2e (`{ __schema { capabilities { identifier value } } }` → asserted JSON response) belongs in the execution module and lands in Phase 3.
+Phase 2 proves the three wiring layers directly (SDL gating via AST, child-node registration via `HasChildNode`, value serialization via `source.Load`) rather than hand-authoring a brittle expected plan.
+- **Router integration** (the single config switch feeding both `MergeOptions` and `IntrospectionOptions` from operator config) lives in the router repo; this phase supplies the primitives.
+
+## Spec caveat
+
+The introspection **query shape** for Service Capabilities (`graphql-spec#1163`) is still open; this phase assumes capabilities under `__schema { capabilities }`.
+If the spec settles on a separate `service { capabilities }` root, the change is localized to `input.go`/`planner.go`/`source.go` plus the SDL location — the model and builder are unaffected.

--- a/docs/rfcs/reviews/phase3-tests-hardening.md
+++ b/docs/rfcs/reviews/phase3-tests-hardening.md
@@ -1,0 +1,50 @@
+# Phase 3 Review — Tests & Hardening
+
+**Scope:** Prove Phases 1–2 correct across the behavior × position × nullability matrix, that HALT returns exactly one error, that the operator default is applied and synchronized with introspection, that a real erroring subgraph behaves correctly under each behavior end-to-end, and that the feature-off path is byte-identical.
+Plan: [docs/rfcs/plans/2026-07-01-onerror-phase3-tests-hardening.md](../plans/2026-07-01-onerror-phase3-tests-hardening.md).
+
+## What changed
+
+| File | Change |
+|---|---|
+| `v2/pkg/engine/resolve/error_behavior_matrix_test.go` | New. Full behavior×position×nullability matrix, HALT single-error, unset==PROPAGATE regression guard. |
+| `v2/pkg/engine/resolve/error_behavior_test.go` | `TestErrorBehavior_OperatorDefaultApplied`. |
+| `v2/pkg/introspection/introspection_capabilities_test.go` | `TestCapabilities_DefaultSyncsWithConfig`. |
+| `execution/engine/execution_engine.go` | New `WithErrorBehavior` execution option (the only non-test change). |
+| `execution/engine/error_behavior_e2e_test.go` | New. End-to-end test with an erroring subgraph under PROPAGATE / NULL / HALT. |
+
+## Key decisions
+
+1. **The only production change is `WithErrorBehavior`** in the execution engine — a one-line option mirroring `WithRequestTraceOptions` that sets `resolveContext.ExecutionOptions.ErrorBehavior`.
+Everything else in Phase 3 is tests.
+
+2. **Expected strings are pinned to observed output, never `Contains`.**
+The e2e revealed two truthful details I pinned rather than papered over:
+   - The raw subgraph error (`boom`) is replaced by `"Failed to fetch from Subgraph 'id'."` — the **default** subgraph-error propagation mode wraps upstream errors. This is orthogonal to onError (RFC §5.6); the test documents it.
+   - Under PROPAGATE/NULL the response carries **two** errors (the wrapped fetch error + the resolver's non-null violation); HALT trims both to the single first error. `data` serializes before `errors` in the engine's writer.
+
+3. **The e2e is the strongest proof of the whole stack.** It exercises real planning + fetching + resolving with `ExecutionOptions.ErrorBehavior`, confirming:
+   - `NULL` → `{"data":{"hero":{"id":"1","name":null}},…}` (sibling `id` preserved, non-null `name` nulled in place).
+   - `HALT` → `{"data":null,"errors":[<one>]}`.
+   - `PROPAGATE` → `{"data":{"hero":null},…}` (bubbles to the nullable `hero`).
+
+4. **Operator-default synchronization is asserted from both sides.**
+`TestErrorBehavior_OperatorDefaultApplied` models the router's `effective = request ?? operatorDefault ?? PROPAGATE` resolution; `TestCapabilities_DefaultSyncsWithConfig` asserts `graphql.defaultErrorBehavior` echoes the same configured value for all three behaviors (RFC §5.8 / decision 8.3).
+
+## Where to focus review
+
+- **`error_behavior_matrix_test.go` expected strings:** these are the behavioral contract. Each is a full-string `assert.Equal`; confirm the NULL rows keep sibling/other data and the PROPAGATE rows collapse per nullability.
+- **`WithErrorBehavior`:** trivial, but confirm it targets `resolveContext.ExecutionOptions.ErrorBehavior` (not a copy).
+- **e2e wrapped-error nuance:** confirm reviewers are comfortable that the raw subgraph error is wrapped by the default propagation mode; if a passthrough demonstration is preferred, the datasource can be reconfigured — the onError behavior itself is unaffected.
+- **`TestErrorBehavior_UnsetEqualsPropagate`:** the byte-identical guarantee — unset behavior must equal explicit PROPAGATE.
+
+## Test / verification
+
+- `cd v2 && go test ./pkg/engine/resolve/ ./pkg/introspection/ ./pkg/engine/datasource/introspection_datasource/ ./pkg/asttransform/` — green.
+- `cd v2 && go test ./pkg/engine/...` — green.
+- `cd execution && go test ./engine/` — green (incl. the new e2e).
+
+## Coverage vs plan
+
+- Task 1 (matrix), Task 2 (HALT single error), Task 3 (operator default + introspection sync), Task 4 (e2e erroring subgraph), Task 5 (feature-off regression guard) — all delivered.
+- Combined with Phase 2's execution-layer note, the full `{ __schema { capabilities } }` **execution** assertion could be added here later; Phase 2 already proves that path's three layers directly.

--- a/execution/engine/error_behavior_e2e_test.go
+++ b/execution/engine/error_behavior_e2e_test.go
@@ -3,14 +3,12 @@ package engine
 import (
 	"testing"
 
-	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
-	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
-
-	graphql_datasource "github.com/wundergraph/graphql-go-tools/v2/pkg/engine/datasource/graphql_datasource"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/wundergraph/graphql-go-tools/execution/graphql"
+	graphql_datasource "github.com/wundergraph/graphql-go-tools/v2/pkg/engine/datasource/graphql_datasource"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 )
 
 // onErrorE2ESchema has a nullable hero whose name is non-null, so a subgraph

--- a/execution/engine/error_behavior_e2e_test.go
+++ b/execution/engine/error_behavior_e2e_test.go
@@ -1,0 +1,85 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+
+	graphql_datasource "github.com/wundergraph/graphql-go-tools/v2/pkg/engine/datasource/graphql_datasource"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/execution/graphql"
+)
+
+// onErrorE2ESchema has a nullable hero whose name is non-null, so a subgraph
+// that returns name:null (with an error) triggers a non-null violation that
+// each error behavior handles differently.
+const onErrorE2ESchema = `
+type Query { hero: Hero }
+type Hero { id: String name: String! }`
+
+func onErrorE2ECase(t *testing.T, behavior resolve.ErrorBehavior, expected string) ExecutionEngineTestCase {
+	t.Helper()
+	schema, err := graphql.NewSchemaFromString(onErrorE2ESchema)
+	require.NoError(t, err)
+	return ExecutionEngineTestCase{
+		schema: schema,
+		operation: func(t *testing.T) graphql.Request {
+			return graphql.Request{Query: `{ hero { id name } }`}
+		},
+		dataSources: []plan.DataSource{
+			mustGraphqlDataSourceConfiguration(t,
+				"id",
+				mustFactory(t,
+					testNetHttpClient(t, roundTripperTestCase{
+						expectedHost:     "example.com",
+						expectedPath:     "/",
+						expectedBody:     "",
+						sendResponseBody: `{"data":{"hero":{"id":"1","name":null}},"errors":[{"message":"boom","path":["hero","name"]}]}`,
+						sendStatusCode:   200,
+					}),
+				),
+				&plan.DataSourceMetadata{
+					RootNodes: []plan.TypeField{
+						{TypeName: "Query", FieldNames: []string{"hero"}},
+					},
+					ChildNodes: []plan.TypeField{
+						{TypeName: "Hero", FieldNames: []string{"id", "name"}},
+					},
+				},
+				mustConfiguration(t, graphql_datasource.ConfigurationInput{
+					Fetch: &graphql_datasource.FetchConfiguration{
+						URL:    "https://example.com/",
+						Method: "POST",
+					},
+					SchemaConfiguration: mustSchemaConfig(t, nil, onErrorE2ESchema),
+				}),
+			),
+		},
+		engineOptions:        []ExecutionOptions{WithErrorBehavior(behavior)},
+		expectedJSONResponse: expected,
+	}
+}
+
+func TestExecutionEngine_OnErrorBehavior(t *testing.T) {
+	t.Parallel()
+
+	// The raw subgraph error is wrapped as "Failed to fetch from Subgraph 'id'."
+	// by the default subgraph-error propagation mode (orthogonal to onError,
+	// RFC §5.6). Under PROPAGATE/NULL the resolver additionally records the
+	// non-null violation; HALT trims both down to the single first error.
+
+	// PROPAGATE: name null bubbles to the nullable hero -> hero:null.
+	t.Run("PROPAGATE bubbles to nullable hero", runWithoutError(onErrorE2ECase(t, resolve.ErrorBehaviorPropagate,
+		`{"data":{"hero":null},"errors":[{"message":"Failed to fetch from Subgraph 'id'."},{"message":"Cannot return null for non-nullable field 'Query.hero.name'.","path":["hero","name"]}]}`)))
+
+	// NULL: name set to null in place, sibling id preserved, no propagation.
+	t.Run("NULL keeps sibling data", runWithoutError(onErrorE2ECase(t, resolve.ErrorBehaviorNull,
+		`{"data":{"hero":{"id":"1","name":null}},"errors":[{"message":"Failed to fetch from Subgraph 'id'."},{"message":"Cannot return null for non-nullable field 'Query.hero.name'.","path":["hero","name"]}]}`)))
+
+	// HALT: data null with exactly one error.
+	t.Run("HALT nulls data with single error", runWithoutError(onErrorE2ECase(t, resolve.ErrorBehaviorHalt,
+		`{"data":null,"errors":[{"message":"Failed to fetch from Subgraph 'id'."}]}`)))
+}

--- a/execution/engine/execution_engine.go
+++ b/execution/engine/execution_engine.go
@@ -101,6 +101,14 @@ func WithRequestTraceOptions(options resolve.TraceOptions) ExecutionOptions {
 	}
 }
 
+// WithErrorBehavior sets the onError error behavior (PROPAGATE / NULL / HALT,
+// graphql-spec#1163) for the request. The empty value is treated as PROPAGATE.
+func WithErrorBehavior(behavior resolve.ErrorBehavior) ExecutionOptions {
+	return func(ctx *internalExecutionContext) {
+		ctx.resolveContext.ExecutionOptions.ErrorBehavior = behavior
+	}
+}
+
 func NewExecutionEngine(ctx context.Context, logger abstractlogger.Logger, engineConfig Configuration, resolverOptions resolve.ResolverOptions) (*ExecutionEngine, error) {
 	executionPlanCache, err := lru.New(1024)
 	if err != nil {

--- a/v2/pkg/asttransform/baseschema.go
+++ b/v2/pkg/asttransform/baseschema.go
@@ -8,15 +8,56 @@ import (
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/operationreport"
 )
 
+// MergeOptions configures optional additions to the introspection base schema.
+type MergeOptions struct {
+	// ServiceCapabilities adds the __Capability type and the __Schema.capabilities
+	// field so the server can advertise GraphQL Service Capabilities (onError,
+	// graphql-spec#1163). When false, the merged schema is byte-identical to today.
+	ServiceCapabilities bool
+}
+
 func MergeDefinitionWithBaseSchema(definition *ast.Document) error {
+	return MergeDefinitionWithBaseSchemaOptions(definition, MergeOptions{})
+}
+
+// MergeDefinitionWithBaseSchemaOptions merges the introspection base schema into
+// definition, optionally adding the Service Capabilities introspection surface.
+func MergeDefinitionWithBaseSchemaOptions(definition *ast.Document, options MergeOptions) error {
 	definition.Input.AppendInputBytes(baseSchema)
+	if options.ServiceCapabilities {
+		definition.Input.AppendInputBytes(baseSchemaServiceCapabilities)
+	}
 	parser := astparser.NewParser()
 	report := operationreport.Report{}
 	parser.Parse(definition, &report)
 	if report.HasErrors() {
 		return report
 	}
+	if options.ServiceCapabilities {
+		addCapabilitiesField(definition)
+	}
 	return handleSchema(definition)
+}
+
+// addCapabilitiesField adds `capabilities: [__Capability!]` to the __Schema object
+// type. The list is nullable so a server that advertises no capabilities (feature
+// disabled) does not violate a non-null constraint. Called only when the base
+// schema was merged with ServiceCapabilities enabled (so __Capability exists).
+func addCapabilitiesField(definition *ast.Document) {
+	node, ok := definition.Index.FirstNodeByNameStr("__Schema")
+	if !ok || node.Kind != ast.NodeKindObjectTypeDefinition {
+		return
+	}
+	fieldNameRef := definition.Input.AppendInputBytes([]byte("capabilities"))
+	// [__Capability!]
+	fieldTypeRef := definition.AddListType(definition.AddNonNullNamedType([]byte("__Capability")))
+	fieldRef := definition.AddFieldDefinition(ast.FieldDefinition{
+		Name: fieldNameRef,
+		Type: fieldTypeRef,
+	})
+	definition.ObjectTypeDefinitions[node.Ref].FieldsDefinition.Refs = append(
+		definition.ObjectTypeDefinitions[node.Ref].FieldsDefinition.Refs, fieldRef)
+	definition.ObjectTypeDefinitions[node.Ref].HasFieldDefinitions = true
 }
 
 func handleSchema(definition *ast.Document) error {
@@ -339,4 +380,22 @@ enum __TypeKind {
     LIST
     "Indicates this type is a non-null. 'ofType' is a valid field."
     NON_NULL
+}`)
+
+// baseSchemaServiceCapabilities defines the __Capability type used by the GraphQL
+// Service Capabilities introspection surface (graphql-spec#1163). It is merged in
+// only when MergeOptions.ServiceCapabilities is enabled; the __Schema.capabilities
+// field is added programmatically by addCapabilitiesField.
+var baseSchemaServiceCapabilities = []byte(`
+"""
+A __Capability describes a single capability supported by a GraphQL service,
+such as the supported onError request behaviors or the default error behavior.
+"""
+type __Capability {
+    "The identifier of the capability, e.g. 'graphql.onError'."
+    identifier: String!
+    "A human-readable description of the capability."
+    description: String
+    "The value associated with the capability, if any."
+    value: String
 }`)

--- a/v2/pkg/asttransform/baseschema_capabilities_test.go
+++ b/v2/pkg/asttransform/baseschema_capabilities_test.go
@@ -1,0 +1,51 @@
+package asttransform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astparser"
+)
+
+func mergedDefinition(t *testing.T, options MergeOptions) *ast.Document {
+	t.Helper()
+	def, report := astparser.ParseGraphqlDocumentString(`type Query { hello: String }`)
+	require.False(t, report.HasErrors())
+	require.NoError(t, MergeDefinitionWithBaseSchemaOptions(&def, options))
+	return &def
+}
+
+func schemaFieldNames(t *testing.T, def *ast.Document, typeName string) []string {
+	t.Helper()
+	node, ok := def.Index.FirstNodeByNameStr(typeName)
+	require.True(t, ok, "type %s should exist", typeName)
+	require.Equal(t, ast.NodeKindObjectTypeDefinition, node.Kind)
+	refs := def.ObjectTypeDefinitions[node.Ref].FieldsDefinition.Refs
+	names := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		names = append(names, def.FieldDefinitionNameString(ref))
+	}
+	return names
+}
+
+// Disabled: __Schema has no capabilities field and __Capability type is absent.
+func TestMergeBaseSchema_Capabilities_Disabled(t *testing.T) {
+	def := mergedDefinition(t, MergeOptions{})
+	names := schemaFieldNames(t, def, "__Schema")
+	assert.Equal(t, []string{"description", "types", "queryType", "mutationType", "subscriptionType", "directives", "__typename"}, names)
+	_, ok := def.Index.FirstNodeByNameStr("__Capability")
+	assert.False(t, ok, "__Capability type must not exist when disabled")
+}
+
+// Enabled: __Schema gains a capabilities field and __Capability type is defined.
+func TestMergeBaseSchema_Capabilities_Enabled(t *testing.T) {
+	def := mergedDefinition(t, MergeOptions{ServiceCapabilities: true})
+	names := schemaFieldNames(t, def, "__Schema")
+	assert.Equal(t, []string{"description", "types", "queryType", "mutationType", "subscriptionType", "directives", "capabilities", "__typename"}, names)
+
+	capFields := schemaFieldNames(t, def, "__Capability")
+	assert.Equal(t, []string{"identifier", "description", "value", "__typename"}, capFields)
+}

--- a/v2/pkg/engine/datasource/introspection_datasource/capabilities_test.go
+++ b/v2/pkg/engine/datasource/introspection_datasource/capabilities_test.go
@@ -1,0 +1,69 @@
+package introspection_datasource
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/asttransform"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/internal/unsafeparser"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/introspection"
+)
+
+const capabilitiesSchema = `type Query { hello: String }`
+
+func newCapabilitiesFactory(t *testing.T, opts IntrospectionOptions) *IntrospectionConfigFactory {
+	t.Helper()
+	def := unsafeparser.ParseGraphqlDocumentString(capabilitiesSchema)
+	require.NoError(t, asttransform.MergeDefinitionWithBaseSchemaOptions(&def, asttransform.MergeOptions{
+		ServiceCapabilities: opts.ServiceCapabilities,
+	}))
+	f, err := NewIntrospectionConfigFactoryWithOptions(&def, opts)
+	require.NoError(t, err)
+	return f
+}
+
+// With the feature enabled, a __schema request serializes the advertised
+// capabilities using the operator-configured default error behavior.
+func TestServiceCapabilities_Load_Enabled(t *testing.T) {
+	f := newCapabilitiesFactory(t, IntrospectionOptions{ServiceCapabilities: true, DefaultErrorBehavior: "NULL"})
+	source := &Source{introspectionData: f.introspectionData}
+	responseData, err := source.Load(context.Background(), nil, []byte(`{"request_type":1}`))
+	require.NoError(t, err)
+
+	// source.Load marshals the Schema directly, so capabilities is top-level.
+	var resp struct {
+		Capabilities []introspection.Capability `json:"capabilities"`
+	}
+	require.NoError(t, json.Unmarshal(responseData, &resp))
+	nv := "NULL"
+	assert.Equal(t, []introspection.Capability{
+		{Identifier: "graphql.onError", TypeName: "__Capability"},
+		{Identifier: "graphql.defaultErrorBehavior", Value: &nv, TypeName: "__Capability"},
+	}, resp.Capabilities)
+}
+
+// With the feature disabled, a __schema request emits no capabilities key.
+func TestServiceCapabilities_Load_Disabled(t *testing.T) {
+	f := newCapabilitiesFactory(t, IntrospectionOptions{})
+	source := &Source{introspectionData: f.introspectionData}
+	responseData, err := source.Load(context.Background(), nil, []byte(`{"request_type":1}`))
+	require.NoError(t, err)
+	assert.NotContains(t, string(responseData), `"capabilities"`)
+}
+
+// When enabled, the data source can resolve __schema { capabilities } and the
+// __Capability fields (so the query is plannable); when disabled it cannot.
+func TestServiceCapabilities_ChildNodes(t *testing.T) {
+	enabled := newCapabilitiesFactory(t, IntrospectionOptions{ServiceCapabilities: true}).BuildDataSourceConfigurations()[0]
+	assert.True(t, enabled.HasChildNode("__Schema", "capabilities"))
+	assert.True(t, enabled.HasChildNode("__Capability", "identifier"))
+	assert.True(t, enabled.HasChildNode("__Capability", "value"))
+
+	disabled := newCapabilitiesFactory(t, IntrospectionOptions{}).BuildDataSourceConfigurations()[0]
+	assert.False(t, disabled.HasChildNode("__Schema", "capabilities"))
+	assert.False(t, disabled.HasChildNode("__Capability", "identifier"))
+}

--- a/v2/pkg/engine/datasource/introspection_datasource/config_factory.go
+++ b/v2/pkg/engine/datasource/introspection_datasource/config_factory.go
@@ -9,10 +9,32 @@ import (
 )
 
 type IntrospectionConfigFactory struct {
-	introspectionData *introspection.Data
+	introspectionData   *introspection.Data
+	serviceCapabilities bool
+}
+
+// IntrospectionOptions configures optional introspection surfaces.
+type IntrospectionOptions struct {
+	// ServiceCapabilities advertises GraphQL Service Capabilities (onError,
+	// graphql-spec#1163) via __schema { capabilities }. When false, introspection
+	// is byte-identical to today.
+	ServiceCapabilities bool
+	// DefaultErrorBehavior is the operator-configured default error behavior
+	// advertised as graphql.defaultErrorBehavior ("" => "PROPAGATE"). Only used
+	// when ServiceCapabilities is true.
+	DefaultErrorBehavior string
 }
 
 func NewIntrospectionConfigFactory(schema *ast.Document) (*IntrospectionConfigFactory, error) {
+	return NewIntrospectionConfigFactoryWithOptions(schema, IntrospectionOptions{})
+}
+
+// NewIntrospectionConfigFactoryWithOptions builds the introspection data source
+// config factory, optionally advertising Service Capabilities. When
+// options.ServiceCapabilities is true, the schema passed in must have been merged
+// with asttransform.MergeOptions{ServiceCapabilities: true} so that __Capability
+// and __Schema.capabilities are defined.
+func NewIntrospectionConfigFactoryWithOptions(schema *ast.Document, options IntrospectionOptions) (*IntrospectionConfigFactory, error) {
 	var (
 		data   introspection.Data
 		report operationreport.Report
@@ -23,7 +45,14 @@ func NewIntrospectionConfigFactory(schema *ast.Document) (*IntrospectionConfigFa
 		return nil, report
 	}
 
-	return &IntrospectionConfigFactory{introspectionData: &data}, nil
+	if options.ServiceCapabilities {
+		data.Schema.Capabilities = introspection.BuildServiceCapabilities(true, options.DefaultErrorBehavior)
+	}
+
+	return &IntrospectionConfigFactory{
+		introspectionData:   &data,
+		serviceCapabilities: options.ServiceCapabilities,
+	}, nil
 }
 
 func (f *IntrospectionConfigFactory) BuildFieldConfigurations() (planFields plan.FieldConfigurations) {
@@ -54,6 +83,45 @@ func (f *IntrospectionConfigFactory) BuildDataSourceConfigurations() []plan.Data
 }
 
 func (f *IntrospectionConfigFactory) buildRootDataSourceConfiguration() (plan.DataSourceConfiguration[Configuration], error) {
+	schemaFieldNames := []string{"description", "queryType", "mutationType", "subscriptionType", "types", "directives", "__typename"}
+	childNodes := []plan.TypeField{
+		{
+			TypeName:   "__Type",
+			FieldNames: []string{"kind", "name", "description", "fields", "interfaces", "possibleTypes", "enumValues", "inputFields", "ofType", "specifiedByURL", "__typename"},
+		},
+		{
+			TypeName:   "__Field",
+			FieldNames: []string{"name", "description", "args", "type", "isDeprecated", "deprecationReason", "__typename"},
+		},
+		{
+			TypeName:   "__InputValue",
+			FieldNames: []string{"name", "description", "type", "defaultValue", "isDeprecated", "deprecationReason", "__typename"},
+		},
+		{
+			TypeName:   "__Directive",
+			FieldNames: []string{"name", "description", "locations", "args", "isRepeatable", "__typename"},
+		},
+		{
+			TypeName:   "__EnumValue",
+			FieldNames: []string{"name", "description", "isDeprecated", "deprecationReason", "__typename"},
+		},
+	}
+
+	if f.serviceCapabilities {
+		// __schema { capabilities } and the __Capability object fields must be
+		// resolvable by this data source when the feature is enabled.
+		schemaFieldNames = append(schemaFieldNames, "capabilities")
+		childNodes = append(childNodes, plan.TypeField{
+			TypeName:   "__Capability",
+			FieldNames: []string{"identifier", "description", "value", "__typename"},
+		})
+	}
+
+	childNodes = append([]plan.TypeField{{
+		TypeName:   "__Schema",
+		FieldNames: schemaFieldNames,
+	}}, childNodes...)
+
 	return plan.NewDataSourceConfiguration[Configuration](
 		resolve.IntrospectionSchemaTypeDataSourceID,
 		NewFactory[Configuration](f.introspectionData),
@@ -64,32 +132,7 @@ func (f *IntrospectionConfigFactory) buildRootDataSourceConfiguration() (plan.Da
 					FieldNames: []string{"__schema", "__type"},
 				},
 			},
-			ChildNodes: []plan.TypeField{
-				{
-					TypeName:   "__Schema",
-					FieldNames: []string{"description", "queryType", "mutationType", "subscriptionType", "types", "directives", "__typename"},
-				},
-				{
-					TypeName:   "__Type",
-					FieldNames: []string{"kind", "name", "description", "fields", "interfaces", "possibleTypes", "enumValues", "inputFields", "ofType", "specifiedByURL", "__typename"},
-				},
-				{
-					TypeName:   "__Field",
-					FieldNames: []string{"name", "description", "args", "type", "isDeprecated", "deprecationReason", "__typename"},
-				},
-				{
-					TypeName:   "__InputValue",
-					FieldNames: []string{"name", "description", "type", "defaultValue", "isDeprecated", "deprecationReason", "__typename"},
-				},
-				{
-					TypeName:   "__Directive",
-					FieldNames: []string{"name", "description", "locations", "args", "isRepeatable", "__typename"},
-				},
-				{
-					TypeName:   "__EnumValue",
-					FieldNames: []string{"name", "description", "isDeprecated", "deprecationReason", "__typename"},
-				},
-			},
+			ChildNodes: childNodes,
 		},
 		Configuration{"Introspection: __schema __type"},
 	)

--- a/v2/pkg/engine/resolve/context.go
+++ b/v2/pkg/engine/resolve/context.go
@@ -128,6 +128,10 @@ type ExecutionOptions struct {
 	// However, if you're benchmarking internals of the engine, it can be helpful to switch it off
 	// When disabled (set to true) the code becomes a no-op
 	DisableInboundRequestDeduplication bool
+	// ErrorBehavior selects how execution errors interact with non-null
+	// positions (GraphQL onError proposal, graphql-spec#1163). The empty value
+	// is treated as PROPAGATE (spec default).
+	ErrorBehavior ErrorBehavior
 }
 
 type FieldValue struct {

--- a/v2/pkg/engine/resolve/error_behavior.go
+++ b/v2/pkg/engine/resolve/error_behavior.go
@@ -1,0 +1,32 @@
+package resolve
+
+// ErrorBehavior selects how execution errors interact with non-null positions
+// in the response, per the GraphQL onError proposal (graphql-spec#1163).
+type ErrorBehavior string
+
+const (
+	// ErrorBehaviorPropagate is the spec default and current behavior: an
+	// execution error in a non-null position propagates to the nearest nullable
+	// ancestor (or data: null at the root).
+	ErrorBehaviorPropagate ErrorBehavior = "PROPAGATE"
+	// ErrorBehaviorNull sets the errored position to null in place (even if
+	// non-nullable) without propagating; the error is still recorded.
+	ErrorBehaviorNull ErrorBehavior = "NULL"
+	// ErrorBehaviorHalt aborts response assembly on any error: data is null and
+	// a single error is returned.
+	ErrorBehaviorHalt ErrorBehavior = "HALT"
+)
+
+// MapErrorBehavior validates and normalizes an incoming onError value.
+// The empty string maps to the default (PROPAGATE). Any other unknown value
+// returns ok=false so the caller can raise a request error.
+func MapErrorBehavior(s string) (ErrorBehavior, bool) {
+	switch ErrorBehavior(s) {
+	case "":
+		return ErrorBehaviorPropagate, true
+	case ErrorBehaviorPropagate, ErrorBehaviorNull, ErrorBehaviorHalt:
+		return ErrorBehavior(s), true
+	default:
+		return "", false
+	}
+}

--- a/v2/pkg/engine/resolve/error_behavior_matrix_test.go
+++ b/v2/pkg/engine/resolve/error_behavior_matrix_test.go
@@ -1,0 +1,118 @@
+package resolve
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+)
+
+func resolveWith(t *testing.T, behavior ErrorBehavior, data string, root *Object) string {
+	t.Helper()
+	res := NewResolvable(nil, ResolvableOptions{})
+	err := res.Init(&Context{ExecutionOptions: ExecutionOptions{ErrorBehavior: behavior}},
+		[]byte(data), ast.OperationTypeQuery)
+	assert.NoError(t, err)
+	out := &bytes.Buffer{}
+	assert.NoError(t, res.Resolve(context.Background(), root, nil, out))
+	return out.String()
+}
+
+func TestErrorBehaviorMatrix(t *testing.T) {
+	// tree: { hero: { id (nn String), name (nn String) }, time (nullable String) }
+	tree := func(heroNullable bool) *Object {
+		return &Object{Fields: []*Field{
+			{Name: []byte("hero"), Value: &Object{Path: []string{"hero"}, Nullable: heroNullable, Fields: []*Field{
+				{Name: []byte("id"), Value: &String{Path: []string{"id"}}},
+				{Name: []byte("name"), Value: &String{Path: []string{"name"}}},
+			}}},
+			{Name: []byte("time"), Value: &String{Path: []string{"time"}, Nullable: true}},
+		}}
+	}
+	names := func() *Object {
+		return &Object{Fields: []*Field{{Name: []byte("names"), Value: &Array{Path: []string{"names"}, Item: &String{}}}}}
+	}
+
+	cases := []struct {
+		name     string
+		behavior ErrorBehavior
+		data     string
+		root     *Object
+		want     string
+	}{
+		// ---- non-null leaf null ----
+		{"propagate/leaf-null/hero-nonnull", ErrorBehaviorPropagate,
+			`{"hero":{"id":"1","name":null},"time":"now"}`, tree(false),
+			`{"errors":[{"message":"Cannot return null for non-nullable field 'Query.hero.name'.","path":["hero","name"]}],"data":null}`},
+		{"propagate/leaf-null/hero-nullable", ErrorBehaviorPropagate,
+			`{"hero":{"id":"1","name":null},"time":"now"}`, tree(true),
+			`{"errors":[{"message":"Cannot return null for non-nullable field 'Query.hero.name'.","path":["hero","name"]}],"data":{"hero":null,"time":"now"}}`},
+		{"null/leaf-null", ErrorBehaviorNull,
+			`{"hero":{"id":"1","name":null},"time":"now"}`, tree(false),
+			`{"errors":[{"message":"Cannot return null for non-nullable field 'Query.hero.name'.","path":["hero","name"]}],"data":{"hero":{"id":"1","name":null},"time":"now"}}`},
+		{"halt/leaf-null", ErrorBehaviorHalt,
+			`{"hero":{"id":"1","name":null},"time":"now"}`, tree(false),
+			`{"errors":[{"message":"Cannot return null for non-nullable field 'Query.hero.name'.","path":["hero","name"]}],"data":null}`},
+
+		// ---- non-null object null ----
+		{"propagate/object-null/hero-nonnull", ErrorBehaviorPropagate,
+			`{"hero":null,"time":"now"}`, tree(false),
+			`{"errors":[{"message":"Cannot return null for non-nullable field 'Query.hero'.","path":["hero"]}],"data":null}`},
+		{"null/object-null", ErrorBehaviorNull,
+			`{"hero":null,"time":"now"}`, tree(false),
+			`{"errors":[{"message":"Cannot return null for non-nullable field 'Query.hero'.","path":["hero"]}],"data":{"hero":null,"time":"now"}}`},
+		{"halt/object-null", ErrorBehaviorHalt,
+			`{"hero":null,"time":"now"}`, tree(false),
+			`{"errors":[{"message":"Cannot return null for non-nullable field 'Query.hero'.","path":["hero"]}],"data":null}`},
+
+		// ---- non-null list item null ([String!]! list) ----
+		{"null/list-item-null", ErrorBehaviorNull,
+			`{"names":["a",null,"c"]}`, names(),
+			`{"errors":[{"message":"Cannot return null for non-nullable field 'Query.names'.","path":["names",1]}],"data":{"names":["a",null,"c"]}}`},
+		{"propagate/list-item-null", ErrorBehaviorPropagate,
+			`{"names":["a",null,"c"]}`, names(),
+			`{"errors":[{"message":"Cannot return null for non-nullable field 'Query.names'.","path":["names",1]}],"data":null}`},
+		{"halt/list-item-null", ErrorBehaviorHalt,
+			`{"names":["a",null,"c"]}`, names(),
+			`{"errors":[{"message":"Cannot return null for non-nullable field 'Query.names'.","path":["names",1]}],"data":null}`},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, resolveWith(t, c.behavior, c.data, c.root))
+		})
+	}
+}
+
+func TestHalt_TrimsToSingleError(t *testing.T) {
+	// two sibling non-null leaves both null -> PROPAGATE would still bubble to
+	// data:null; HALT must additionally guarantee exactly ONE error entry.
+	root := &Object{Fields: []*Field{
+		{Name: []byte("a"), Value: &String{Path: []string{"a"}}},
+		{Name: []byte("b"), Value: &String{Path: []string{"b"}}},
+	}}
+	got := resolveWith(t, ErrorBehaviorHalt, `{"a":null,"b":null}`, root)
+	assert.Equal(t,
+		`{"errors":[{"message":"Cannot return null for non-nullable field 'Query.a'.","path":["a"]}],"data":null}`,
+		got)
+}
+
+// With ErrorBehavior unset, output must match the explicit PROPAGATE output.
+func TestErrorBehavior_UnsetEqualsPropagate(t *testing.T) {
+	data := `{"hero":{"id":"1","name":null},"time":"now"}`
+	root := func() *Object {
+		return &Object{Fields: []*Field{
+			{Name: []byte("hero"), Value: &Object{Path: []string{"hero"}, Nullable: true, Fields: []*Field{
+				{Name: []byte("id"), Value: &String{Path: []string{"id"}}},
+				{Name: []byte("name"), Value: &String{Path: []string{"name"}}},
+			}}},
+			{Name: []byte("time"), Value: &String{Path: []string{"time"}, Nullable: true}},
+		}}
+	}
+	unset := resolveWith(t, "", data, root())
+	propagate := resolveWith(t, ErrorBehaviorPropagate, data, root())
+	assert.Equal(t, propagate, unset)
+}

--- a/v2/pkg/engine/resolve/error_behavior_matrix_test.go
+++ b/v2/pkg/engine/resolve/error_behavior_matrix_test.go
@@ -87,6 +87,39 @@ func TestErrorBehaviorMatrix(t *testing.T) {
 	}
 }
 
+// Regression (Codex finding 1): a non-null Float list item with a type mismatch
+// under NULL must render null in place, never leak the raw invalid value.
+func TestResolvable_NullBehavior_FloatListItemTypeMismatch(t *testing.T) {
+	root := &Object{Fields: []*Field{{
+		Name:  []byte("values"),
+		Value: &Array{Path: []string{"values"}, Item: &Float{}}, // [Float!]!
+	}}}
+	got := resolveWith(t, ErrorBehaviorNull, `{"values":[1.5,"bad",3.5]}`, root)
+	assert.Equal(t,
+		`{"errors":[{"message":"Float cannot represent non-float value: \"\"bad\"\"","path":["values",1]}],"data":{"values":[1.5,null,3.5]}}`,
+		got)
+}
+
+// Regression (Codex finding 3): a non-null object with an invalid abstract
+// __typename under NULL must render null in place, not propagate.
+func TestResolvable_NullBehavior_InvalidTypename(t *testing.T) {
+	root := &Object{Fields: []*Field{
+		{Name: []byte("hero"), Value: &Object{
+			Path:          []string{"hero"},
+			TypeName:      "Character",
+			PossibleTypes: map[string]struct{}{"Human": {}, "Droid": {}},
+			Fields: []*Field{
+				{Name: []byte("name"), Value: &String{Path: []string{"name"}, Nullable: true}},
+			},
+		}}, // non-null object
+		{Name: []byte("time"), Value: &String{Path: []string{"time"}, Nullable: true}},
+	}}
+	got := resolveWith(t, ErrorBehaviorNull, `{"hero":{"__typename":"Alien","name":"x"},"time":"now"}`, root)
+	assert.Equal(t,
+		`{"errors":[{"message":"Subgraph '' returned invalid value 'Alien' for __typename field.","path":["hero"],"extensions":{"code":"INVALID_GRAPHQL"}}],"data":{"hero":null,"time":"now"}}`,
+		got)
+}
+
 func TestHalt_TrimsToSingleError(t *testing.T) {
 	// two sibling non-null leaves both null -> PROPAGATE would still bubble to
 	// data:null; HALT must additionally guarantee exactly ONE error entry.

--- a/v2/pkg/engine/resolve/error_behavior_test.go
+++ b/v2/pkg/engine/resolve/error_behavior_test.go
@@ -25,3 +25,14 @@ func TestMapErrorBehavior(t *testing.T) {
 		assert.Equal(t, c.want, got, "value for %q", c.in)
 	}
 }
+
+func TestErrorBehavior_OperatorDefaultApplied(t *testing.T) {
+	// simulate: no request onError, operator default = NULL => router sets NULL.
+	effective, ok := MapErrorBehavior("") // request omitted
+	assert.True(t, ok)
+	operatorDefault := ErrorBehaviorNull
+	if effective == ErrorBehaviorPropagate { // request omitted -> apply operator default
+		effective = operatorDefault
+	}
+	assert.Equal(t, ErrorBehaviorNull, effective)
+}

--- a/v2/pkg/engine/resolve/error_behavior_test.go
+++ b/v2/pkg/engine/resolve/error_behavior_test.go
@@ -1,0 +1,27 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapErrorBehavior(t *testing.T) {
+	cases := []struct {
+		in   string
+		want ErrorBehavior
+		ok   bool
+	}{
+		{"", ErrorBehaviorPropagate, true}, // empty => default
+		{"PROPAGATE", ErrorBehaviorPropagate, true},
+		{"NULL", ErrorBehaviorNull, true},
+		{"HALT", ErrorBehaviorHalt, true},
+		{"null", "", false}, // case-sensitive per spec
+		{"BOGUS", "", false},
+	}
+	for _, c := range cases {
+		got, ok := MapErrorBehavior(c.in)
+		assert.Equal(t, c.ok, ok, "ok for %q", c.in)
+		assert.Equal(t, c.want, got, "value for %q", c.in)
+	}
+}

--- a/v2/pkg/engine/resolve/resolvable.go
+++ b/v2/pkg/engine/resolve/resolvable.go
@@ -43,6 +43,7 @@ type Resolvable struct {
 	path               []fastjsonext.PathElement
 	depth              int
 	operationType      ast.OperationType
+	errorBehavior      ErrorBehavior
 	renameTypeNames    []RenameTypeName
 	ctx                *Context
 	authorizationError error
@@ -136,6 +137,7 @@ func (r *Resolvable) Reset() {
 	r.printErr = nil
 	r.path = r.path[:0]
 	r.operationType = ast.OperationTypeUnknown
+	r.errorBehavior = ""
 	r.renameTypeNames = r.renameTypeNames[:0]
 	r.authorizationError = nil
 	r.astjsonArena = nil
@@ -212,6 +214,12 @@ func (r *Resolvable) ResolveNode(node Node, data *astjson.Value, out io.Writer) 
 	r.authorizationError = nil
 	// don't init errors! It will heavily increase memory usage
 	r.errors = nil
+	// r.ctx may be nil when ResolveNode is used to render a variable that is
+	// actually a node (see renderFieldValue); default to PROPAGATE in that case.
+	r.errorBehavior = ErrorBehaviorPropagate
+	if r.ctx != nil && r.ctx.ExecutionOptions.ErrorBehavior != "" {
+		r.errorBehavior = r.ctx.ExecutionOptions.ErrorBehavior
+	}
 
 	hasErrors := r.walkNode(node, data)
 	if hasErrors {
@@ -231,6 +239,10 @@ func (r *Resolvable) Resolve(ctx context.Context, rootData *Object, fetchTree *F
 	r.print = false
 	r.printErr = nil
 	r.authorizationError = nil
+	r.errorBehavior = r.ctx.ExecutionOptions.ErrorBehavior
+	if r.errorBehavior == "" {
+		r.errorBehavior = ErrorBehaviorPropagate
+	}
 
 	if r.ctx.ExecutionOptions.SkipLoader {
 		// we didn't resolve any data, so there's no point in generating errors
@@ -254,6 +266,10 @@ func (r *Resolvable) Resolve(ctx context.Context, rootData *Object, fetchTree *F
 	hasErrors := r.walkObject(rootData, r.data)
 	if r.authorizationError != nil {
 		return r.authorizationError
+	}
+	if r.errorBehavior == ErrorBehaviorHalt && r.hasErrors() {
+		hasErrors = true // force data: null
+		r.keepFirstErrorOnly()
 	}
 	r.printBytes(lBrace)
 	if r.hasErrors() {
@@ -293,6 +309,37 @@ func (r *Resolvable) enclosingTypeName() string {
 
 func (r *Resolvable) err() bool {
 	return true
+}
+
+// erroredPosition decides how an execution error at the current position is
+// handled under the active error behavior. The caller must have already
+// recorded the error (guarded to the validation pass). Under NULL the position
+// is rendered as null and the error does not propagate; otherwise it propagates.
+func (r *Resolvable) erroredPosition(path []string, parent *astjson.Value) bool {
+	if r.errorBehavior != ErrorBehaviorNull {
+		return r.err()
+	}
+	if r.print {
+		return r.walkNull() // prints null on the print pass, returns false
+	}
+	if len(path) > 0 {
+		astjson.SetNull(r.astjsonArena, parent, path...)
+	}
+	return false
+}
+
+// keepFirstErrorOnly trims r.errors down to its first element (used by HALT).
+func (r *Resolvable) keepFirstErrorOnly() {
+	if r.errors == nil {
+		return
+	}
+	items := r.errors.GetArray()
+	if len(items) <= 1 {
+		return
+	}
+	first := items[0]
+	r.errors = astjson.ArrayValue(r.astjsonArena)
+	r.errors.SetArrayItem(r.astjsonArena, 0, first)
 }
 
 func (r *Resolvable) printErrors() {
@@ -698,15 +745,19 @@ func (r *Resolvable) walkObject(obj *Object, parent *astjson.Value) bool {
 		if obj.Nullable {
 			return r.walkNull()
 		}
-		r.addNonNullableFieldError(obj.Path, parent)
-		return r.err()
+		if !r.print {
+			r.addNonNullableFieldError(obj.Path, parent)
+		}
+		return r.erroredPosition(obj.Path, parent)
 	}
 	r.pushNodePathElement(obj.Path)
 	isRoot := r.depth < 2
 	defer r.popNodePathElement(obj.Path)
 	if value.Type() != astjson.TypeObject {
-		r.addError("Object cannot represent non-object value.", obj.Path)
-		return r.err()
+		if !r.print {
+			r.addError("Object cannot represent non-object value.", obj.Path)
+		}
+		return r.erroredPosition(obj.Path, parent)
 	}
 
 	typeName := value.GetStringBytes("__typename")
@@ -946,14 +997,18 @@ func (r *Resolvable) walkArray(arr *Array, value *astjson.Value) bool {
 		if arr.Nullable {
 			return r.walkNull()
 		}
-		r.addNonNullableFieldError(arr.Path, parent)
-		return r.err()
+		if !r.print {
+			r.addNonNullableFieldError(arr.Path, parent)
+		}
+		return r.erroredPosition(arr.Path, parent)
 	}
 	r.pushNodePathElement(arr.Path)
 	defer r.popNodePathElement(arr.Path)
 	if value.Type() != astjson.TypeArray {
-		r.addError("Array cannot represent non-array value.", arr.Path)
-		return r.err()
+		if !r.print {
+			r.addError("Array cannot represent non-array value.", arr.Path)
+		}
+		return r.erroredPosition(arr.Path, parent)
 	}
 	if r.print {
 		r.printBytes(lBrack)
@@ -1076,13 +1131,17 @@ func (r *Resolvable) walkString(s *String, value *astjson.Value) bool {
 		if s.Nullable {
 			return r.walkNull()
 		}
-		r.addNonNullableFieldError(s.Path, parent)
-		return r.err()
+		if !r.print {
+			r.addNonNullableFieldError(s.Path, parent)
+		}
+		return r.erroredPosition(s.Path, parent)
 	}
 	if value.Type() != astjson.TypeString {
-		r.marshalBuf = value.MarshalTo(r.marshalBuf[:0])
-		r.addError(fmt.Sprintf("String cannot represent non-string value: \"%s\"", string(r.marshalBuf)), s.Path)
-		return r.err()
+		if !r.print {
+			r.marshalBuf = value.MarshalTo(r.marshalBuf[:0])
+			r.addError(fmt.Sprintf("String cannot represent non-string value: \"%s\"", string(r.marshalBuf)), s.Path)
+		}
+		return r.erroredPosition(s.Path, parent)
 	}
 	if r.print {
 		if s.IsTypeName {
@@ -1122,13 +1181,17 @@ func (r *Resolvable) walkBoolean(b *Boolean, value *astjson.Value) bool {
 		if b.Nullable {
 			return r.walkNull()
 		}
-		r.addNonNullableFieldError(b.Path, parent)
-		return r.err()
+		if !r.print {
+			r.addNonNullableFieldError(b.Path, parent)
+		}
+		return r.erroredPosition(b.Path, parent)
 	}
 	if value.Type() != astjson.TypeTrue && value.Type() != astjson.TypeFalse {
-		r.marshalBuf = value.MarshalTo(r.marshalBuf[:0])
-		r.addError(fmt.Sprintf("Bool cannot represent non-boolean value: \"%s\"", string(r.marshalBuf)), b.Path)
-		return r.err()
+		if !r.print {
+			r.marshalBuf = value.MarshalTo(r.marshalBuf[:0])
+			r.addError(fmt.Sprintf("Bool cannot represent non-boolean value: \"%s\"", string(r.marshalBuf)), b.Path)
+		}
+		return r.erroredPosition(b.Path, parent)
 	}
 	if r.print {
 		r.renderScalarFieldValue(value, b.Nullable)
@@ -1143,13 +1206,17 @@ func (r *Resolvable) walkInteger(i *Integer, value *astjson.Value) bool {
 		if i.Nullable {
 			return r.walkNull()
 		}
-		r.addNonNullableFieldError(i.Path, parent)
-		return r.err()
+		if !r.print {
+			r.addNonNullableFieldError(i.Path, parent)
+		}
+		return r.erroredPosition(i.Path, parent)
 	}
 	if value.Type() != astjson.TypeNumber {
-		r.marshalBuf = value.MarshalTo(r.marshalBuf[:0])
-		r.addError(fmt.Sprintf("Int cannot represent non-integer value: \"%s\"", string(r.marshalBuf)), i.Path)
-		return r.err()
+		if !r.print {
+			r.marshalBuf = value.MarshalTo(r.marshalBuf[:0])
+			r.addError(fmt.Sprintf("Int cannot represent non-integer value: \"%s\"", string(r.marshalBuf)), i.Path)
+		}
+		return r.erroredPosition(i.Path, parent)
 	}
 	if r.print {
 		r.renderScalarFieldValue(value, i.Nullable)
@@ -1164,14 +1231,16 @@ func (r *Resolvable) walkFloat(f *Float, value *astjson.Value) bool {
 		if f.Nullable {
 			return r.walkNull()
 		}
-		r.addNonNullableFieldError(f.Path, parent)
-		return r.err()
+		if !r.print {
+			r.addNonNullableFieldError(f.Path, parent)
+		}
+		return r.erroredPosition(f.Path, parent)
 	}
 	if !r.print {
 		if value.Type() != astjson.TypeNumber {
 			r.marshalBuf = value.MarshalTo(r.marshalBuf[:0])
 			r.addError(fmt.Sprintf("Float cannot represent non-float value: \"%s\"", string(r.marshalBuf)), f.Path)
-			return r.err()
+			return r.erroredPosition(f.Path, parent)
 		}
 	}
 	if r.print {
@@ -1194,8 +1263,10 @@ func (r *Resolvable) walkBigInt(b *BigInt, value *astjson.Value) bool {
 		if b.Nullable {
 			return r.walkNull()
 		}
-		r.addNonNullableFieldError(b.Path, parent)
-		return r.err()
+		if !r.print {
+			r.addNonNullableFieldError(b.Path, parent)
+		}
+		return r.erroredPosition(b.Path, parent)
 	}
 	if r.print {
 		r.renderScalarFieldValue(value, b.Nullable)
@@ -1210,8 +1281,10 @@ func (r *Resolvable) walkScalar(s *Scalar, value *astjson.Value) bool {
 		if s.Nullable {
 			return r.walkNull()
 		}
-		r.addNonNullableFieldError(s.Path, parent)
-		return r.err()
+		if !r.print {
+			r.addNonNullableFieldError(s.Path, parent)
+		}
+		return r.erroredPosition(s.Path, parent)
 	}
 	if r.print {
 		r.renderScalarFieldValue(value, s.Nullable)
@@ -1242,14 +1315,18 @@ func (r *Resolvable) walkCustom(c *CustomNode, value *astjson.Value) bool {
 		if c.Nullable {
 			return r.walkNull()
 		}
-		r.addNonNullableFieldError(c.Path, parent)
-		return r.err()
+		if !r.print {
+			r.addNonNullableFieldError(c.Path, parent)
+		}
+		return r.erroredPosition(c.Path, parent)
 	}
 	r.marshalBuf = value.MarshalTo(r.marshalBuf[:0])
 	resolved, err := c.Resolve(r.ctx, r.marshalBuf)
 	if err != nil {
-		r.addError(err.Error(), c.Path)
-		return r.err()
+		if !r.print {
+			r.addError(err.Error(), c.Path)
+		}
+		return r.erroredPosition(c.Path, parent)
 	}
 	if r.print {
 		r.renderScalarFieldBytes(resolved, c.Nullable)
@@ -1321,13 +1398,17 @@ func (r *Resolvable) walkEnum(e *Enum, value *astjson.Value) bool {
 		if e.Nullable {
 			return r.walkNull()
 		}
-		r.addNonNullableFieldError(e.Path, parent)
-		return r.err()
+		if !r.print {
+			r.addNonNullableFieldError(e.Path, parent)
+		}
+		return r.erroredPosition(e.Path, parent)
 	}
 	if value.Type() != astjson.TypeString {
-		r.marshalBuf = value.MarshalTo(r.marshalBuf[:0])
-		r.addErrorWithCodeAndPath(fmt.Sprintf(`Enum "%s" cannot represent value: %s`, e.TypeName, string(r.marshalBuf)), errorcodes.InternalServerError, e.Path)
-		return r.err()
+		if !r.print {
+			r.marshalBuf = value.MarshalTo(r.marshalBuf[:0])
+			r.addErrorWithCodeAndPath(fmt.Sprintf(`Enum "%s" cannot represent value: %s`, e.TypeName, string(r.marshalBuf)), errorcodes.InternalServerError, e.Path)
+		}
+		return r.erroredPosition(e.Path, parent)
 	}
 	valueString := string(value.GetStringBytes())
 	if !e.isValidValue(valueString) {
@@ -1346,7 +1427,7 @@ func (r *Resolvable) walkEnum(e *Enum, value *astjson.Value) bool {
 		if e.Nullable {
 			return r.walkNull()
 		}
-		return r.err()
+		return r.erroredPosition(e.Path, parent)
 	}
 	if !e.isAccessibleValue(valueString) {
 		/* When an inaccessible value is returned, the data is set to null.
@@ -1361,7 +1442,7 @@ func (r *Resolvable) walkEnum(e *Enum, value *astjson.Value) bool {
 		if e.Nullable {
 			return r.walkNull()
 		}
-		return r.err()
+		return r.erroredPosition(e.Path, parent)
 	}
 	if r.print {
 		r.renderEnumValue(value, e.Nullable)

--- a/v2/pkg/engine/resolve/resolvable.go
+++ b/v2/pkg/engine/resolve/resolvable.go
@@ -773,10 +773,11 @@ func (r *Resolvable) walkObject(obj *Object, parent *astjson.Value) bool {
 					r.addErrorWithCode(fmt.Sprintf("Subgraph '%s' returned invalid value '%s' for __typename field.", obj.SourceName, string(typeName)), errorcodes.InvalidGraphql)
 				}
 
-				// if object is not nullable at pre-walk we need to return an error
-				// to immediately stop the resolving of the current object and bubble up null
+				// if object is not nullable at pre-walk we need to stop resolving
+				// the current object. Under NULL this nulls the object in place;
+				// otherwise it bubbles up null.
 				if !obj.Nullable {
-					return r.err()
+					return r.erroredPosition(obj.Path, parent)
 				}
 
 				// if object is nullable we can just set it to null
@@ -1236,12 +1237,15 @@ func (r *Resolvable) walkFloat(f *Float, value *astjson.Value) bool {
 		}
 		return r.erroredPosition(f.Path, parent)
 	}
-	if !r.print {
-		if value.Type() != astjson.TypeNumber {
+	if value.Type() != astjson.TypeNumber {
+		// The type check must run on both passes: under NULL an errored array
+		// item (empty path) is not mutated on the validation pass, so the print
+		// pass must render null here instead of the raw invalid value.
+		if !r.print {
 			r.marshalBuf = value.MarshalTo(r.marshalBuf[:0])
 			r.addError(fmt.Sprintf("Float cannot represent non-float value: \"%s\"", string(r.marshalBuf)), f.Path)
-			return r.erroredPosition(f.Path, parent)
 		}
+		return r.erroredPosition(f.Path, parent)
 	}
 	if r.print {
 		if r.options.ApolloCompatibilityTruncateFloatValues {

--- a/v2/pkg/engine/resolve/resolvable_test.go
+++ b/v2/pkg/engine/resolve/resolvable_test.go
@@ -1625,3 +1625,115 @@ func TestMapExtensionForwardingAlgorithm(t *testing.T) {
 	assert.Equal(t, ExtensionForwardingAlgorithmFirstWrite, MapExtensionForwardingAlgorithm(""))
 	assert.Equal(t, ExtensionForwardingAlgorithmFirstWrite, MapExtensionForwardingAlgorithm("nonsense"))
 }
+
+func TestResolvable_ErrorBehaviorDefaultsToPropagate(t *testing.T) {
+	res := NewResolvable(nil, ResolvableOptions{})
+	ctx := &Context{} // ExecutionOptions zero value
+	err := res.Init(ctx, []byte(`{"hero":{"name":"R2D2"}}`), ast.OperationTypeQuery)
+	assert.NoError(t, err)
+	object := &Object{Fields: []*Field{{
+		Name: []byte("hero"),
+		Value: &Object{Path: []string{"hero"}, Fields: []*Field{{
+			Name:  []byte("name"),
+			Value: &String{Path: []string{"name"}},
+		}}},
+	}}}
+	out := &bytes.Buffer{}
+	err = res.Resolve(context.Background(), object, nil, out)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"data":{"hero":{"name":"R2D2"}}}`, out.String())
+	assert.Equal(t, ErrorBehaviorPropagate, res.errorBehavior)
+}
+
+func newNullResolvable(t *testing.T, data string) *Resolvable {
+	t.Helper()
+	res := NewResolvable(nil, ResolvableOptions{})
+	err := res.Init(&Context{ExecutionOptions: ExecutionOptions{ErrorBehavior: ErrorBehaviorNull}},
+		[]byte(data), ast.OperationTypeQuery)
+	assert.NoError(t, err)
+	return res
+}
+
+// non-null leaf returns null -> stays null, sibling preserved, error recorded
+func TestResolvable_NullBehavior_NonNullLeaf(t *testing.T) {
+	res := newNullResolvable(t, `{"hero":{"id":"1","name":null}}`)
+	object := &Object{Fields: []*Field{{
+		Name: []byte("hero"),
+		Value: &Object{Path: []string{"hero"}, Fields: []*Field{
+			{Name: []byte("id"), Value: &String{Path: []string{"id"}}},
+			{Name: []byte("name"), Value: &String{Path: []string{"name"}}}, // non-null
+		}},
+	}}}
+	out := &bytes.Buffer{}
+	err := res.Resolve(context.Background(), object, nil, out)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"errors":[{"message":"Cannot return null for non-nullable field 'Query.hero.name'.","path":["hero","name"]}],"data":{"hero":{"id":"1","name":null}}}`, out.String())
+}
+
+// non-null object returns null -> object null, sibling field of parent preserved
+func TestResolvable_NullBehavior_NonNullObject(t *testing.T) {
+	res := newNullResolvable(t, `{"hero":null,"time":"now"}`)
+	object := &Object{Fields: []*Field{
+		{Name: []byte("hero"), Value: &Object{Path: []string{"hero"}, Fields: []*Field{
+			{Name: []byte("name"), Value: &String{Path: []string{"name"}}},
+		}}}, // non-null object
+		{Name: []byte("time"), Value: &String{Path: []string{"time"}}},
+	}}
+	out := &bytes.Buffer{}
+	err := res.Resolve(context.Background(), object, nil, out)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"errors":[{"message":"Cannot return null for non-nullable field 'Query.hero'.","path":["hero"]}],"data":{"hero":null,"time":"now"}}`, out.String())
+}
+
+// non-null list item null -> that item null, other items preserved
+func TestResolvable_NullBehavior_NonNullListItem(t *testing.T) {
+	res := newNullResolvable(t, `{"names":["a",null,"c"]}`)
+	object := &Object{Fields: []*Field{{
+		Name:  []byte("names"),
+		Value: &Array{Path: []string{"names"}, Item: &String{}}, // non-null items
+	}}}
+	out := &bytes.Buffer{}
+	err := res.Resolve(context.Background(), object, nil, out)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"errors":[{"message":"Cannot return null for non-nullable field 'Query.names'.","path":["names",1]}],"data":{"names":["a",null,"c"]}}`, out.String())
+}
+
+// non-null leaf with a type mismatch under NULL -> null in place + error, sibling kept
+func TestResolvable_NullBehavior_TypeMismatch(t *testing.T) {
+	res := newNullResolvable(t, `{"hero":{"id":"1","name":123}}`)
+	object := &Object{Fields: []*Field{{
+		Name: []byte("hero"),
+		Value: &Object{Path: []string{"hero"}, Fields: []*Field{
+			{Name: []byte("id"), Value: &String{Path: []string{"id"}}},
+			{Name: []byte("name"), Value: &String{Path: []string{"name"}}},
+		}},
+	}}}
+	out := &bytes.Buffer{}
+	err := res.Resolve(context.Background(), object, nil, out)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"errors":[{"message":"String cannot represent non-string value: \"123\"","path":["hero","name"]}],"data":{"hero":{"id":"1","name":null}}}`, out.String())
+}
+
+func newHaltResolvable(t *testing.T, data string) *Resolvable {
+	t.Helper()
+	res := NewResolvable(nil, ResolvableOptions{})
+	err := res.Init(&Context{ExecutionOptions: ExecutionOptions{ErrorBehavior: ErrorBehaviorHalt}},
+		[]byte(data), ast.OperationTypeQuery)
+	assert.NoError(t, err)
+	return res
+}
+
+// a single non-null violation -> data:null, single error
+func TestResolvable_HaltBehavior_SingleViolation(t *testing.T) {
+	res := newHaltResolvable(t, `{"hero":{"name":null}}`)
+	object := &Object{Fields: []*Field{{
+		Name: []byte("hero"),
+		Value: &Object{Path: []string{"hero"}, Fields: []*Field{
+			{Name: []byte("name"), Value: &String{Path: []string{"name"}}},
+		}},
+	}}}
+	out := &bytes.Buffer{}
+	err := res.Resolve(context.Background(), object, nil, out)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"errors":[{"message":"Cannot return null for non-nullable field 'Query.hero.name'.","path":["hero","name"]}],"data":null}`, out.String())
+}

--- a/v2/pkg/introspection/introspection.go
+++ b/v2/pkg/introspection/introspection.go
@@ -17,9 +17,22 @@ type Schema struct {
 	SubscriptionType *FullType   `json:"subscriptionType"`
 	Types            []*FullType `json:"types"`
 	Directives       []Directive `json:"directives"`
-	TypeName         string      `json:"__typename"`
-	Description      *string     `json:"description,omitempty"`
-	fullTypeMap      map[string]*FullType
+	// Capabilities advertises GraphQL Service Capabilities (graphql-spec#1163).
+	// It is omitted entirely when empty so introspection output is byte-identical
+	// to today when the onError feature is disabled.
+	Capabilities []Capability `json:"capabilities,omitempty"`
+	TypeName     string       `json:"__typename"`
+	Description  *string      `json:"description,omitempty"`
+	fullTypeMap  map[string]*FullType
+}
+
+// Capability describes a single GraphQL service capability (Service
+// Capabilities introspection, graphql-spec#1163).
+type Capability struct {
+	Identifier  string  `json:"identifier"`
+	Description *string `json:"description"`
+	Value       *string `json:"value"`
+	TypeName    string  `json:"__typename"`
 }
 
 func (s *Schema) AddType(t *FullType) {
@@ -51,6 +64,60 @@ func NewSchema() Schema {
 		TypeName:    "__Schema",
 		fullTypeMap: make(map[string]*FullType),
 	}
+}
+
+// BuildServiceCapabilities returns the Service Capabilities to advertise, or nil
+// when the onError feature is disabled. When enabled, defaultErrorBehavior is the
+// operator-configured default ("" => "PROPAGATE").
+func BuildServiceCapabilities(enabled bool, defaultErrorBehavior string) []Capability {
+	if !enabled {
+		return nil
+	}
+	if defaultErrorBehavior == "" {
+		defaultErrorBehavior = "PROPAGATE"
+	}
+	def := defaultErrorBehavior
+	return []Capability{
+		{Identifier: "graphql.onError", TypeName: "__Capability"},
+		{Identifier: "graphql.defaultErrorBehavior", Value: &def, TypeName: "__Capability"},
+	}
+}
+
+// stringTypeRef builds a TypeRef for the built-in String scalar, optionally
+// wrapped in NON_NULL, mirroring introspectionVisitor.TypeRef.
+func stringTypeRef(nonNull bool) TypeRef {
+	name := "String"
+	scalar := TypeRef{Kind: SCALAR, Name: &name, TypeName: "__Type"}
+	if !nonNull {
+		return scalar
+	}
+	return TypeRef{Kind: NONNULL, OfType: &scalar, TypeName: "__Type"}
+}
+
+// AddCapabilityType registers the __Capability object type so that
+// __type(name:"__Capability") and __schema { types } resolve it. Idempotent.
+func (s *Schema) AddCapabilityType() {
+	if s.TypeByName("__Capability") != nil {
+		return
+	}
+	ft := NewFullType()
+	ft.Kind = OBJECT
+	ft.Name = "__Capability"
+
+	idField := NewField()
+	idField.Name = "identifier"
+	idField.Type = stringTypeRef(true)
+
+	descField := NewField()
+	descField.Name = "description"
+	descField.Type = stringTypeRef(false)
+
+	valField := NewField()
+	valField.Name = "value"
+	valField.Type = stringTypeRef(false)
+
+	ft.Fields = []Field{idField, descField, valField}
+	s.AddType(ft)
 }
 
 type FullType struct {

--- a/v2/pkg/introspection/introspection_capabilities_test.go
+++ b/v2/pkg/introspection/introspection_capabilities_test.go
@@ -76,3 +76,13 @@ func TestSchema_AddCapabilityType(t *testing.T) {
 	}
 	assert.Equal(t, 1, count)
 }
+
+func TestCapabilities_DefaultSyncsWithConfig(t *testing.T) {
+	for _, def := range []string{"PROPAGATE", "NULL", "HALT"} {
+		caps := BuildServiceCapabilities(true, def)
+		// second entry is graphql.defaultErrorBehavior; its value must equal config
+		assert.Equal(t, "graphql.defaultErrorBehavior", caps[1].Identifier)
+		assert.NotNil(t, caps[1].Value)
+		assert.Equal(t, def, *caps[1].Value)
+	}
+}

--- a/v2/pkg/introspection/introspection_capabilities_test.go
+++ b/v2/pkg/introspection/introspection_capabilities_test.go
@@ -1,0 +1,78 @@
+package introspection
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSchema_Capabilities_OmittedWhenEmpty(t *testing.T) {
+	s := NewSchema() // no capabilities
+	b, err := json.Marshal(&s)
+	assert.NoError(t, err)
+	// capabilities key must be absent when empty (byte-identical to today)
+	assert.NotContains(t, string(b), `"capabilities"`)
+}
+
+func TestSchema_Capabilities_Marshaled(t *testing.T) {
+	s := NewSchema()
+	val := "PROPAGATE"
+	s.Capabilities = []Capability{
+		{Identifier: "graphql.onError", TypeName: "__Capability"},
+		{Identifier: "graphql.defaultErrorBehavior", Value: &val, TypeName: "__Capability"},
+	}
+	b, err := json.Marshal(&s)
+	assert.NoError(t, err)
+	assert.Contains(t, string(b), `"capabilities":[{"identifier":"graphql.onError","description":null,"value":null,"__typename":"__Capability"},{"identifier":"graphql.defaultErrorBehavior","description":null,"value":"PROPAGATE","__typename":"__Capability"}]`)
+}
+
+func TestBuildServiceCapabilities(t *testing.T) {
+	assert.Nil(t, BuildServiceCapabilities(false, "NULL")) // disabled => nothing
+
+	got := BuildServiceCapabilities(true, "") // empty default => PROPAGATE
+	pv := "PROPAGATE"
+	assert.Equal(t, []Capability{
+		{Identifier: "graphql.onError", TypeName: "__Capability"},
+		{Identifier: "graphql.defaultErrorBehavior", Value: &pv, TypeName: "__Capability"},
+	}, got)
+
+	got = BuildServiceCapabilities(true, "NULL")
+	nv := "NULL"
+	assert.Equal(t, []Capability{
+		{Identifier: "graphql.onError", TypeName: "__Capability"},
+		{Identifier: "graphql.defaultErrorBehavior", Value: &nv, TypeName: "__Capability"},
+	}, got)
+}
+
+func TestSchema_AddCapabilityType(t *testing.T) {
+	s := NewSchema()
+	s.AddCapabilityType()
+	ft := s.TypeByName("__Capability")
+	assert.NotNil(t, ft)
+	assert.Equal(t, "__Capability", ft.Name)
+	assert.Equal(t, OBJECT, ft.Kind)
+	names := make([]string, 0, len(ft.Fields))
+	for _, f := range ft.Fields {
+		names = append(names, f.Name)
+	}
+	assert.Equal(t, []string{"identifier", "description", "value"}, names)
+
+	// identifier is String!, description and value are nullable String
+	assert.Equal(t, NONNULL, ft.Fields[0].Type.Kind)
+	assert.Equal(t, SCALAR, ft.Fields[0].Type.OfType.Kind)
+	assert.Equal(t, "String", *ft.Fields[0].Type.OfType.Name)
+	assert.Equal(t, SCALAR, ft.Fields[1].Type.Kind)
+	assert.Equal(t, "String", *ft.Fields[1].Type.Name)
+	assert.Equal(t, SCALAR, ft.Fields[2].Type.Kind)
+
+	// idempotent
+	s.AddCapabilityType()
+	count := 0
+	for _, tpe := range s.Types {
+		if tpe.Name == "__Capability" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count)
+}


### PR DESCRIPTION
## Summary

Implements the GraphQL **onError** proposal ([graphql-spec#1163](https://github.com/graphql/graphql-spec/pull/1163)): client-selectable error behavior in the resolver plus config-gated **Service Capabilities** introspection so a gateway/router can advertise support. Defaults to today's behavior with **zero change** for existing callers.

Three error behaviors:
- **`PROPAGATE`** (default) — current null-bubbling to the nearest nullable ancestor.
- **`NULL`** — set the errored position to `null` in place (even if non-nullable), no propagation, error still recorded.
- **`HALT`** — abort assembly: `data: null` with a single error.

Delivered in three reviewable commits, each with a reviewer document under `docs/rfcs/reviews/`.

### Phase 1 — core resolver (`03de476`)
- `ErrorBehavior` enum + `MapErrorBehavior` (empty ⇒ `PROPAGATE`).
- `ExecutionOptions.ErrorBehavior` threaded into `Resolvable`, normalized at both `Resolve`/`ResolveNode` entry points (nil-ctx safe), reset in `Reset`.
- `NULL` via `erroredPosition` applied across all leaf/object/array/enum walkers incl. coercion + invalid/inaccessible enum; error recorded once (validation-pass-guarded), `null` rendered on the print pass.
- `HALT` render-time only: `keepFirstErrorOnly` + `data:null` wiring.

### Phase 2 — introspection Service Capabilities (`ef47e4e`)
- `introspection`: `Capability` type, optional `Schema.Capabilities` (`omitempty`), `BuildServiceCapabilities(enabled, default)`, idempotent `AddCapabilityType()`.
- `asttransform`: `MergeDefinitionWithBaseSchemaOptions` adds `type __Capability` + nullable `__Schema.capabilities: [__Capability!]` **only when enabled**; the existing `MergeDefinitionWithBaseSchema` delegates with the feature off (byte-identical).
- `introspection_datasource`: `NewIntrospectionConfigFactoryWithOptions` populates `Schema.Capabilities` and registers the `capabilities`/`__Capability` child nodes when enabled; `source.go` unchanged.

### Phase 3 — tests & hardening (`a52a0d0`)
- Full behavior × position × nullability matrix; HALT single-error; unset==PROPAGATE regression guard; operator-default + introspection sync.
- `execution` engine: `WithErrorBehavior` option (the only production change here) + an **end-to-end test** with an erroring subgraph asserting the full client response under each behavior.

## Design & decisions

RFC: `docs/rfcs/2026-07-01-onerror-error-behavior.md`. Per-phase reviewer notes in `docs/rfcs/reviews/`.

- HALT is handled entirely at render time in `resolvable` (no fetch cancellation).
- Introspection capabilities are **actually implemented** but config-gated by a single switch: enabled ⇒ capabilities advertised; disabled ⇒ introspection byte-identical to today. `graphql.defaultErrorBehavior` stays synchronized with the operator default.
- Subgraph-error propagation mode is orthogonal (RFC §5.6); the e2e documents the wrapped-error interaction.

## Testing

- `cd v2 && go test ./pkg/engine/...` — green.
- `cd v2 && go test ./pkg/introspection/ ./pkg/asttransform/ ./pkg/engine/datasource/introspection_datasource/` — green (no golden drift).
- `cd execution && go test ./engine/` — green (incl. the new e2e).

## Follow-ups (out of scope)
- Router integration (the single config switch feeding both `MergeOptions` and `IntrospectionOptions`) lives in the router repo.
- The introspection *query shape* for Service Capabilities is still spec-open; this assumes `__schema { capabilities }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
