### PR TITLE
fix(resolve): don't duplicate non-nullable field error when one already covers the path

### DIFF
--- a/v2/pkg/engine/resolve/resolvable.go
+++ b/v2/pkg/engine/resolve/resolvable.go
@@ -1381,6 +1381,15 @@ func (r *Resolvable) addNonNullableFieldError(fieldPath []string, parent *astjso
 		}
 	}
 	r.pushNodePathElement(fieldPath)
+	// A non-nullable field that is null because an existing error already covers
+	// its path (or a descendant it bubbled up from) is already explained by that
+	// error. Synthesizing a second "Cannot return null" error there duplicates it,
+	// which notably happens for federated partial-data responses where
+	// skipAddingNullErrors (whole-response-null only) does not apply.
+	if r.hasErrorAtOrBelowPath(r.path) {
+		r.popNodePathElement(fieldPath)
+		return
+	}
 	if r.options.ApolloCompatibilityValueCompletionInExtensions {
 		r.addValueCompletion(r.renderApolloCompatibleNonNullableErrorMessage(), errorcodes.InvalidGraphql)
 	} else {
@@ -1389,6 +1398,49 @@ func (r *Resolvable) addNonNullableFieldError(fieldPath []string, parent *astjso
 		fastjsonext.AppendErrorToArray(r.astjsonArena, r.errors, errorMessage, r.path)
 	}
 	r.popNodePathElement(fieldPath)
+}
+
+// hasErrorAtOrBelowPath reports whether an already-collected error has a path
+// equal to prefix or descending from it. Such an error already accounts for the
+// null at prefix, so no synthetic non-nullable-field error should be added.
+func (r *Resolvable) hasErrorAtOrBelowPath(prefix []fastjsonext.PathElement) bool {
+	if r.errors == nil || len(prefix) == 0 {
+		return false
+	}
+	items, err := r.errors.Array()
+	if err != nil {
+		return false
+	}
+	for _, item := range items {
+		path := item.Get("path")
+		if path == nil || path.Type() != astjson.TypeArray {
+			continue
+		}
+		elems, err := path.Array()
+		if err != nil || len(elems) < len(prefix) {
+			continue
+		}
+		if pathHasPrefix(elems, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathHasPrefix(path []*astjson.Value, prefix []fastjsonext.PathElement) bool {
+	for i, want := range prefix {
+		got := path[i]
+		if want.Name != "" {
+			if got.Type() != astjson.TypeString || string(got.GetStringBytes()) != want.Name {
+				return false
+			}
+			continue
+		}
+		if got.Type() != astjson.TypeNumber || got.GetInt() != want.Idx {
+			return false
+		}
+	}
+	return true
 }
 
 func (r *Resolvable) renderFieldPath() string {

--- a/v2/pkg/engine/resolve/resolvable_nullbubble_test.go
+++ b/v2/pkg/engine/resolve/resolvable_nullbubble_test.go
@@ -1,0 +1,91 @@
+package resolve
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/fastjsonext"
+)
+
+func TestResolvable_NonNullableNullBubble_DedupsExistingError(t *testing.T) {
+	// A nullable parent (order) with a non-nullable child (order.items).
+	// When items resolves to null because of an error, only one error should
+	// be present — the synthetic "Cannot return null for non-nullable field"
+	// error must not be added on top of an error that already covers the path.
+	plan := func() *Object {
+		return &Object{
+			Fields: []*Field{
+				{
+					Name: []byte("order"),
+					Value: &Object{
+						Nullable: true,
+						Path:     []string{"order"},
+						Fields: []*Field{
+							{
+								Name: []byte("items"),
+								Value: &Object{
+									Path: []string{"items"},
+									Fields: []*Field{
+										{
+											Name:  []byte("totalCount"),
+											Value: &Integer{Path: []string{"totalCount"}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	seed := func(res *Resolvable, msg string, path ...fastjsonext.PathElement) {
+		res.ensureErrorsInitialized()
+		fastjsonext.AppendErrorToArray(res.astjsonArena, res.errors, msg, path)
+	}
+
+	t.Run("existing error covering the null field is not duplicated", func(t *testing.T) {
+		res := NewResolvable(nil, ResolvableOptions{})
+		err := res.Init(&Context{}, []byte(`{"order":{"items":null}}`), ast.OperationTypeQuery)
+		assert.NoError(t, err)
+		seed(res, "items are unavailable",
+			fastjsonext.PathElement{Name: "order"}, fastjsonext.PathElement{Name: "items"})
+
+		out := &bytes.Buffer{}
+		err = res.Resolve(context.Background(), plan(), nil, out)
+		assert.NoError(t, err)
+		assert.Equal(t, `{"errors":[{"message":"items are unavailable","path":["order","items"]}],"data":{"order":null}}`, out.String())
+	})
+
+	t.Run("existing error descending from the null field is not duplicated", func(t *testing.T) {
+		res := NewResolvable(nil, ResolvableOptions{})
+		err := res.Init(&Context{}, []byte(`{"order":{"items":null}}`), ast.OperationTypeQuery)
+		assert.NoError(t, err)
+		seed(res, "boom",
+			fastjsonext.PathElement{Name: "order"}, fastjsonext.PathElement{Name: "items"},
+			fastjsonext.PathElement{Name: "nodes"}, fastjsonext.PathElement{Idx: 0})
+
+		out := &bytes.Buffer{}
+		err = res.Resolve(context.Background(), plan(), nil, out)
+		assert.NoError(t, err)
+		assert.Equal(t, `{"errors":[{"message":"boom","path":["order","items","nodes",0]}],"data":{"order":null}}`, out.String())
+	})
+
+	t.Run("unrelated sibling error still yields the synthetic error", func(t *testing.T) {
+		res := NewResolvable(nil, ResolvableOptions{})
+		err := res.Init(&Context{}, []byte(`{"order":{"items":null}}`), ast.OperationTypeQuery)
+		assert.NoError(t, err)
+		seed(res, "boom",
+			fastjsonext.PathElement{Name: "order"}, fastjsonext.PathElement{Name: "shipments"})
+
+		out := &bytes.Buffer{}
+		err = res.Resolve(context.Background(), plan(), nil, out)
+		assert.NoError(t, err)
+		assert.Equal(t, `{"errors":[{"message":"boom","path":["order","shipments"]},{"message":"Cannot return null for non-nullable field 'Query.order.items'.","path":["order","items"]}],"data":{"order":null}}`, out.String())
+	})
+}


### PR DESCRIPTION
[`skipAddingNullErrors`](https://github.com/wundergraph/graphql-go-tools/blob/c9af890f1e51726c1b46f426e6392cededf5d232/v2/pkg/engine/resolve/resolvable.go#L34) only works for the top-level `"data":null`. 

This PR extends that behavior to other non-nullable fields: it skips synthesizing the error when an already-collected error has a `path` equal to, or descending from, the null field's path.

This change will make the behavior compatible with [the graphql spec](https://spec.graphql.org/September2025/#sel-FANXNNCAACKjB_yX):
> If a [response position](https://spec.graphql.org/September2025/#response-position) resolves to null because of an execution error which has already been added to the "errors" list in the [execution result](https://spec.graphql.org/September2025/#execution-result), the "errors" list must not be further affected.



### How `skipAddingNullErrors` works today

The resolver walks the already-fetched response against the plan; every non-nullable field holding `null` gets a synthesized `Cannot return null for non-nullable field 'X'.` error (`addNonNullableFieldError`). `skipAddingNullErrors` is the single global switch that turns all of that synthesis off. It is computed once, up front:

```go
r.skipAddingNullErrors = r.hasErrors() && !r.hasData()
```

- `hasErrors()` — the merged response already carries at least one error.
- `hasData()` — the **root** `data` object has at least one key.

| root `data` | already-collected error | `skipAddingNullErrors` | synthetic error — **before** | synthetic error — **after (this PR)** |
|---|---|---|---|---|
| `null` / empty | any error present | **`true`** | suppressed (single error) | suppressed — unchanged |
| `null` / empty | none | `false` | added (null with no error) | added — unchanged |
| present (partial) | **covers the null field's path** | `false` | **added → duplicate** | **suppressed** ✅ the fix |
| present (partial) | only an unrelated sibling error | `false` | added | added — unchanged |
| present (partial) | none | `false` | added (genuine null-without-error) | added — unchanged |

Only the third row changes: a partial-data response (so the whole-response `skipAddingNullErrors` guard is off) where an existing error already covers the null field's path. Before, the resolver added a second `Cannot return null for non-nullable field 'X'.` on top of that error; after, it recognises the covering error and skips the duplicate. Every other row — including the unrelated-sibling and no-error cases — is untouched.

---

<details>
<summary>🤖 AI-generated description</summary>

## Problem

When a **non-nullable** field resolves to `null` because of an error, the resolver adds a synthesized `Cannot return null for non-nullable field 'X'.` error **on top of** the error that already caused the null. The result is two errors describing the same failure at the same path.

The only broad suppression today is:

```go
r.skipAddingNullErrors = r.hasErrors() && !r.hasData()
```

This fires only when the **entire** response `data` is null. In a **partial-data** response — where a sibling part of the tree resolved successfully (very common in federation, where different parts of the object graph come from different sources) — `hasData()` is true, so the guard does not apply and the duplicate error is emitted.

### Example

Query: `{ order { items { totalCount } } }`, where `order` is nullable and `order.items` is non-null. The `items` fetch fails and returns an error at `["order","items"]`, so `items` is `null` and the null bubbles up to `order`.

**Expected** (single error):

```json
{"data":{"order":null},"errors":[{"message":"items are unavailable","path":["order","items"]}]}
```

**Actual** (duplicate synthesized error):

```json
{"data":{"order":null},
 "errors":[
   {"message":"items are unavailable","path":["order","items"]},
   {"message":"Cannot return null for non-nullable field 'Query.order.items'.","path":["order","items"]}
 ]}
```

## Fix

In `addNonNullableFieldError`, skip synthesizing the error when an already-collected error has a `path` **equal to**, or **descending from**, the null field's path — i.e. the null legitimately bubbled up from that deeper error, which already explains it.

This matches [GraphQL spec §6.4.4](https://spec.graphql.org/October2021/#sec-Errors-and-Non-Nullability): the non-nullable field error exists specifically for a `null` returned *without* an accompanying error. When an accompanying error already covers the path, the second error is redundant.

Two small helpers are added:

- `hasErrorAtOrBelowPath(prefix)` — scans `r.errors` for an error whose `path` array starts with `prefix`.
- `pathHasPrefix(path, prefix)` — element-wise compare of an `astjson` path against `[]fastjsonext.PathElement`, handling both string field names and integer list indices.

The change is conservative and fail-safe:

- A genuine `null`-without-error still produces the synthetic error.
- An **unrelated sibling** error (same depth, different field) does **not** suppress it.
- Only an error **at or below** the null field's path suppresses the duplicate.
- The existing whole-response-null path (`skipAddingNullErrors`) is unchanged.

## Tests

Added `TestResolvable_NonNullableNullBubble_DedupsExistingError` covering:

1. existing error **at** the null field's path → no duplicate;
2. existing error **descending** from it (incl. a list index) → no duplicate;
3. **unrelated sibling** error → synthetic error still emitted.

Confirmed load-bearing: reverting the guard reproduces the duplicate error in case 1. The full `pkg/engine/resolve` suite passes and `gofmt` is clean.

</details>

<!--
copilot-session-ids: c6d17cf8-d88a-4cb1-b6ab-8d73d5cf746a
Copilot sessions that authored this PR body — hidden metadata for future reference.
-->




