### PR TITLE
fix: accept empty lists for non-null list items

### DIFF
--- a/v2/pkg/astvalidation/operation_rule_values.go
+++ b/v2/pkg/astvalidation/operation_rule_values.go
@@ -140,8 +140,8 @@ func (v *valuesVisitor) valueSatisfiesOperationListType(value ast.Value, operati
 
 	if v.operation.Types[listItemType].TypeKind == ast.TypeKindNonNull {
 		if len(v.operation.ListValues[value.Ref].Refs) == 0 {
-			v.handleOperationTypeError(value, operationTypeRef)
-			return false
+			// [] empty list is a valid input for [item!] lists
+			return true
 		}
 		listItemType = v.operation.Types[listItemType].OfType
 	}

--- a/v2/pkg/astvalidation/reference/testsgo/ValuesOfCorrectTypeRule_test.go
+++ b/v2/pkg/astvalidation/reference/testsgo/ValuesOfCorrectTypeRule_test.go
@@ -1010,9 +1010,13 @@ func TestValuesOfCorrectTypeRule(t *testing.T) {
           $a: Int = 1,
           $b: String = "ok",
           $c: ComplexInput = { requiredField: true, intField: 3 }
-          $d: Int! = 123
+          $d: Int! = 123,
+          $values: [String!] = []
         ) {
           dog { name }
+          complicatedArgs {
+            stringListNonNullArgField(stringListNonNullArg: $values)
+          }
         }
       `)
 			})
@@ -1059,7 +1063,8 @@ func TestValuesOfCorrectTypeRule(t *testing.T) {
         query InvalidDefaultValues(
           $a: Int = "one",
           $b: String = 4,
-          $c: ComplexInput = "NotVeryComplex"
+          $c: ComplexInput = "NotVeryComplex",
+          $commands: [DogCommand!] = [INVALID]
         ) {
           dog { name }
         }
@@ -1075,6 +1080,10 @@ func TestValuesOfCorrectTypeRule(t *testing.T) {
 					{
 						message:   `Expected value of type "ComplexInput", found "NotVeryComplex".`,
 						locations: []Loc{{line: 5, column: 30}},
+					},
+					{
+						message:   `Value "INVALID" does not exist in "DogCommand" enum.`,
+						locations: []Loc{{line: 6, column: 39}},
 					},
 				})
 			})


### PR DESCRIPTION
## Summary

- Accept empty list defaults for GraphQL list types with non-null items in operation-level validation.
- Preserve validation of invalid non-empty list elements.
- Add regression coverage for `[]` defaults and invalid enum-list defaults.

## Links

- **Linear**: https://linear.app/wundergraph/issue/ENG-9882/string-cannot-represent-value
- **Cosmo issue**: https://github.com/wundergraph/cosmo/issues/3095

## Verification

- `go test ./pkg/astvalidation/reference/testsgo -run "^TestValuesOfCorrectTypeRule$" -count=1`
- `go test ./...` from `v2`
- Cosmo staged regression and race test passed against this fixed local module revision.
