### PR TITLE
feat: subscription bulk update

### DIFF
--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
@@ -8489,6 +8489,10 @@ func (t *testSubscriptionUpdater) Subscriptions() map[context.Context]resolve.Su
 func (t *testSubscriptionUpdater) UpdateSubscription(id resolve.SubscriptionIdentifier, data []byte) {
 }
 
+// empty method to satisfy the interface, not used in this tests
+func (t *testSubscriptionUpdater) UpdateBulk(_ map[resolve.SubscriptionIdentifier][]byte) {
+}
+
 func TestSubscriptionSource_Start(t *testing.T) {
 	chatServer := httptest.NewServer(subscriptiontesting.ChatGraphQLEndpointHandler())
 	defer chatServer.Close()

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client_test.go
@@ -25,6 +25,8 @@ func (t *testBridgeUpdater) Update(data []byte) {
 
 func (t *testBridgeUpdater) UpdateSubscription(id resolve.SubscriptionIdentifier, data []byte) {}
 
+func (t *testBridgeUpdater) UpdateBulk(_ map[resolve.SubscriptionIdentifier][]byte) {}
+
 func (t *testBridgeUpdater) Complete() {
 	t.completed = true
 }

--- a/v2/pkg/engine/resolve/resolve.go
+++ b/v2/pkg/engine/resolve/resolve.go
@@ -1481,7 +1481,6 @@ type pendingFilterError struct {
 }
 
 // handleTriggerUpdate sends data to all subscriptions of a trigger.
-// all-at-once
 func (r *Resolver) handleTriggerUpdate(id uint64, data []byte) {
 	trig, ok := r.getTrigger(id)
 	if !ok {
@@ -1509,8 +1508,7 @@ func (r *Resolver) handleTriggerUpdate(id uint64, data []byte) {
 	wg.Wait()
 }
 
-// new: block update
-func (r *Resolver) handleTriggerBlockUpdate(triggerID uint64, subData map[SubscriptionIdentifier][]byte) {
+func (r *Resolver) handleTriggerBulkUpdate(triggerID uint64, subData map[SubscriptionIdentifier][]byte) {
 	trigger, ok := r.getTrigger(triggerID)
 	if !ok {
 		return
@@ -1543,7 +1541,6 @@ func (r *Resolver) handleTriggerBlockUpdate(triggerID uint64, subData map[Subscr
 }
 
 // handleUpdateSubscription sends data to a single subscription.
-// single-update
 func (r *Resolver) handleUpdateSubscription(id uint64, data []byte, subIdentifier SubscriptionIdentifier) {
 	trig, ok := r.getTrigger(id)
 	if !ok {
@@ -1956,7 +1953,6 @@ type subscriptionUpdater struct {
 	subsFn    func() map[context.Context]SubscriptionIdentifier
 }
 
-// all-at-once
 func (s *subscriptionUpdater) Update(data []byte) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1969,9 +1965,7 @@ func (s *subscriptionUpdater) Update(data []byte) {
 	s.resolver.handleTriggerUpdate(s.triggerID, data)
 }
 
-// new: update collectively
-// subIDs => map key = sub id, value = data
-func (s *subscriptionUpdater) BlockUpdate(subData map[SubscriptionIdentifier][]byte) {
+func (s *subscriptionUpdater) UpdateBulk(subData map[SubscriptionIdentifier][]byte) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.done || s.ctx.Err() != nil {
@@ -1980,7 +1974,7 @@ func (s *subscriptionUpdater) BlockUpdate(subData map[SubscriptionIdentifier][]b
 	if s.debug {
 		fmt.Printf("resolver:subscription_updater:block_update:%d\n", s.triggerID)
 	}
-	s.resolver.handleTriggerBlockUpdate(s.triggerID, subData)
+	s.resolver.handleTriggerBulkUpdate(s.triggerID, subData)
 }
 
 func (s *subscriptionUpdater) Heartbeat() {
@@ -2080,11 +2074,15 @@ type addSubscription struct {
 }
 
 type SubscriptionUpdater interface {
-	// Update sends an update to the client. It is not guaranteed that the update is sent immediately.
+	// Update sends an update all clients of updaters trigger.
+	// It is not guaranteed that the update is sent immediately.
 	Update(data []byte)
-	// TODO: godoc
-	BlockUpdate(subData map[SubscriptionIdentifier][]byte)
-	// UpdateSubscription sends an update to a single subscription. It is not guaranteed that the update is sent immediately.
+	// UpdateBulk sends an update to all clients in subData using subData's value as event data.
+	// It is not guaranteed that the update is sent immediately.
+	UpdateBulk(subData map[SubscriptionIdentifier][]byte)
+	// UpdateSubscription sends an update to a single subscription.
+	// It is not guaranteed that the update is sent immediately.
+	// Warning: Using this highly concurrent slows updates down tremendously.
 	UpdateSubscription(id SubscriptionIdentifier, data []byte)
 	// Complete delivers a "subscription done" signal to all subscriptions on the trigger.
 	// Does not perform cleanup — call Done() after Complete().

--- a/v2/pkg/engine/resolve/resolve.go
+++ b/v2/pkg/engine/resolve/resolve.go
@@ -1481,6 +1481,7 @@ type pendingFilterError struct {
 }
 
 // handleTriggerUpdate sends data to all subscriptions of a trigger.
+// all-at-once
 func (r *Resolver) handleTriggerUpdate(id uint64, data []byte) {
 	trig, ok := r.getTrigger(id)
 	if !ok {
@@ -1508,7 +1509,41 @@ func (r *Resolver) handleTriggerUpdate(id uint64, data []byte) {
 	wg.Wait()
 }
 
+// new: block update
+func (r *Resolver) handleTriggerBlockUpdate(triggerID uint64, subData map[SubscriptionIdentifier][]byte) {
+	trigger, ok := r.getTrigger(triggerID)
+	if !ok {
+		return
+	}
+
+	// convert SubscriptionIdentifier to subscriptionState
+	subs := make(map[*subscriptionState][]byte, len(subData))
+	for id, data := range subData {
+		subState, err := trigger.filterSubscription(id, data)
+		if err != nil {
+			err.sub.writeError(r.errorFormatter, err.ctx, err.err, err.response)
+			// TODO: don't we need to ignore this sub now? existing paths don't do it
+		}
+
+		subs[subState] = data
+	}
+
+	// now update it the same way as single-update
+	var wg sync.WaitGroup
+	for sub, data := range subs {
+		if sub.removed.Load() {
+			continue
+		}
+		wg.Go(func() {
+			r.executeSubscriptionUpdate(sub.ctx, sub, data)
+		})
+	}
+
+	wg.Wait()
+}
+
 // handleUpdateSubscription sends data to a single subscription.
+// single-update
 func (r *Resolver) handleUpdateSubscription(id uint64, data []byte, subIdentifier SubscriptionIdentifier) {
 	trig, ok := r.getTrigger(id)
 	if !ok {
@@ -1921,6 +1956,7 @@ type subscriptionUpdater struct {
 	subsFn    func() map[context.Context]SubscriptionIdentifier
 }
 
+// all-at-once
 func (s *subscriptionUpdater) Update(data []byte) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1933,6 +1969,20 @@ func (s *subscriptionUpdater) Update(data []byte) {
 	s.resolver.handleTriggerUpdate(s.triggerID, data)
 }
 
+// new: update collectively
+// subIDs => map key = sub id, value = data
+func (s *subscriptionUpdater) BlockUpdate(subData map[SubscriptionIdentifier][]byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.done || s.ctx.Err() != nil {
+		return
+	}
+	if s.debug {
+		fmt.Printf("resolver:subscription_updater:block_update:%d\n", s.triggerID)
+	}
+	s.resolver.handleTriggerBlockUpdate(s.triggerID, subData)
+}
+
 func (s *subscriptionUpdater) Heartbeat() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1942,6 +1992,7 @@ func (s *subscriptionUpdater) Heartbeat() {
 	s.resolver.heartbeatTriggerSubscriptions(s.triggerID)
 }
 
+// single-update
 func (s *subscriptionUpdater) UpdateSubscription(id SubscriptionIdentifier, data []byte) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -2031,6 +2082,8 @@ type addSubscription struct {
 type SubscriptionUpdater interface {
 	// Update sends an update to the client. It is not guaranteed that the update is sent immediately.
 	Update(data []byte)
+	// TODO: godoc
+	BlockUpdate(subData map[SubscriptionIdentifier][]byte)
 	// UpdateSubscription sends an update to a single subscription. It is not guaranteed that the update is sent immediately.
 	UpdateSubscription(id SubscriptionIdentifier, data []byte)
 	// Complete delivers a "subscription done" signal to all subscriptions on the trigger.

--- a/v2/pkg/engine/resolve/resolve.go
+++ b/v2/pkg/engine/resolve/resolve.go
@@ -1529,7 +1529,7 @@ func (r *Resolver) handleTriggerBulkUpdate(triggerID uint64, subData map[Subscri
 	// now update it the same way as single-update
 	var wg sync.WaitGroup
 	for sub, data := range subs {
-		if sub.removed.Load() {
+		if sub == nil || sub.removed.Load() {
 			continue
 		}
 		wg.Go(func() {


### PR DESCRIPTION
Currently the engine provides two ways of updating subscribers:
- One `data` payload to resolve all subscriptions on a trigger
- Individual `data` payloads for a specific subscription

The former is used by Cosmo Streams when the hook `OnReceiveHandler` is **not used**.  
The latter is used when the OnReceiveHandler` **is used**.  

The reason is once the hook is involved the `data` payload can be different for subscribers. We need a way to provide individual `data` payloads to the engine for subscribers and the latter entry path allowed it.

Because this entry point is designed to handle highly concurrent calls it is heavy on mutex use. This in turn led to performance problems when there are lots of calls. The router does that when there are lots of subscribers. It slows down the updates massively.

This PR adds a new entry point, `UpdateBulk`, which works nearly similar to the first entry point.  
But instead of resolving all subscribers of a trigger with the same `data` payload it uses a map given by the router to update specific subscribers with individual payloads.

The advantage is that the engine can serially update subscribers and avoid heavy mutex work - just like first entry point - while still being atomic about it's operations.


@coderabbitai summary

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->