### PR TITLE
feat(execution): expose SubgraphHeadersBuilder and ExecutionOptions as execution options

### DIFF
--- a/execution/engine/execution_engine.go
+++ b/execution/engine/execution_engine.go
@@ -119,6 +119,34 @@ func WithPreFetchFieldAuthorizer(authorizer resolve.BatchAuthorizer) ExecutionOp
 	}
 }
 
+// WithSubgraphHeadersBuilder sets the builder that produces the headers for subgraph
+// requests of this execution.
+//
+// Callers that forward per-client headers to subgraphs should use this instead of
+// setting the headers outside the engine, for example from an http.RoundTripper
+// installed on the datasource client. The resolver folds the builder's hash into its
+// request deduplication keys, and a request whose headers reach the subgraph by any
+// other route contributes nothing to those keys. Concurrent operations whose subgraph
+// request bodies are byte-identical then collapse into a single fetch, and every caller
+// receives the response resolved for one arbitrary set of headers.
+//
+// A builder must return a copy of its header map from HeadersForSubgraph: the value is
+// assigned directly to the outgoing http.Request.Header and written to afterwards, so a
+// shared map races across concurrent fetches.
+func WithSubgraphHeadersBuilder(builder resolve.SubgraphHeadersBuilder) ExecutionOptions {
+	return func(ctx *internalExecutionContext) {
+		ctx.resolveContext.SubgraphHeadersBuilder = builder
+	}
+}
+
+// WithExecutionOptions sets resolve.ExecutionOptions for this execution, which control
+// request deduplication and loading behaviour.
+func WithExecutionOptions(options resolve.ExecutionOptions) ExecutionOptions {
+	return func(ctx *internalExecutionContext) {
+		ctx.resolveContext.ExecutionOptions = options
+	}
+}
+
 func NewExecutionEngine(ctx context.Context, logger abstractlogger.Logger, engineConfig Configuration, resolverOptions resolve.ResolverOptions) (*ExecutionEngine, error) {
 	executionPlanCache, err := lru.New(1024)
 	if err != nil {

--- a/execution/engine/execution_engine_deduplication_test.go
+++ b/execution/engine/execution_engine_deduplication_test.go
@@ -1,0 +1,271 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cespare/xxhash/v2"
+	"github.com/jensneuse/abstractlogger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/execution/graphql"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/datasource/graphql_datasource"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+const deduplicationTestSchema = `type Query { hello: String }`
+
+// deduplicationTestSubgraph echoes the Authorization header it received back as the
+// value of "hello", so a response reveals which caller's headers the fetch was made
+// with. The delay keeps the single flight window open long enough for concurrent
+// executions to meet inside it.
+type deduplicationTestSubgraph struct {
+	server *httptest.Server
+	calls  atomic.Int64
+}
+
+func newDeduplicationTestSubgraph(t *testing.T, delay time.Duration) *deduplicationTestSubgraph {
+	t.Helper()
+
+	subgraph := &deduplicationTestSubgraph{}
+	subgraph.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		subgraph.calls.Add(1)
+		authorization := r.Header.Get("Authorization")
+
+		time.Sleep(delay)
+
+		w.Header().Set("Content-Type", "application/json")
+		response, err := json.Marshal(map[string]any{
+			"data": map[string]any{"hello": authorization},
+		})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write(response)
+	}))
+	t.Cleanup(subgraph.server.Close)
+
+	return subgraph
+}
+
+func newDeduplicationTestEngine(t *testing.T, subgraphURL string) *ExecutionEngine {
+	t.Helper()
+
+	schema, err := graphql.NewSchemaFromString(deduplicationTestSchema)
+	require.NoError(t, err)
+
+	engineConf := NewConfiguration(schema)
+	engineConf.SetDataSources([]plan.DataSource{
+		mustGraphqlDataSourceConfiguration(t,
+			"id",
+			mustFactory(t, http.DefaultClient),
+			&plan.DataSourceMetadata{
+				RootNodes: []plan.TypeField{
+					{TypeName: "Query", FieldNames: []string{"hello"}},
+				},
+			},
+			mustConfiguration(t, graphql_datasource.ConfigurationInput{
+				Fetch: &graphql_datasource.FetchConfiguration{
+					URL:    subgraphURL,
+					Method: http.MethodPost,
+				},
+				SchemaConfiguration: mustSchemaConfig(t, nil, deduplicationTestSchema),
+			}),
+		),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	engine, err := NewExecutionEngine(ctx, abstractlogger.Noop{}, engineConf, resolve.ResolverOptions{
+		MaxConcurrency: 1024,
+	})
+	require.NoError(t, err)
+
+	return engine
+}
+
+// testSubgraphHeaders is a minimal resolve.SubgraphHeadersBuilder that forwards a
+// single Authorization header.
+type testSubgraphHeaders struct {
+	header http.Header
+	hash   uint64
+}
+
+func newTestSubgraphHeaders(authorization string) *testSubgraphHeaders {
+	header := http.Header{}
+	header.Set("Authorization", authorization)
+
+	keys := make([]string, 0, len(header))
+	for key := range header {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	digest := xxhash.New()
+	for _, key := range keys {
+		_, _ = digest.WriteString(key)
+		_, _ = digest.WriteString(":")
+		_, _ = digest.WriteString(strings.Join(header[key], ","))
+		_, _ = digest.WriteString(";")
+	}
+
+	return &testSubgraphHeaders{header: header, hash: digest.Sum64()}
+}
+
+func (h *testSubgraphHeaders) HeadersForSubgraph(_ string) (http.Header, uint64) {
+	return h.header.Clone(), h.hash
+}
+
+func (h *testSubgraphHeaders) HashAll() uint64 {
+	return h.hash
+}
+
+// executeConcurrently runs one execution per session, all released at the same moment,
+// and returns the value of "hello" each of them saw.
+func executeConcurrently(t *testing.T, engine *ExecutionEngine, sessions []string, options func(session string) []ExecutionOptions) []string {
+	t.Helper()
+
+	results := make([]string, len(sessions))
+	start := make(chan struct{})
+
+	var wg sync.WaitGroup
+	for i, session := range sessions {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			operation := graphql.Request{Query: `query Op { hello }`, OperationName: "Op"}
+			resultWriter := graphql.NewEngineResultWriter()
+
+			<-start
+			err := engine.Execute(context.Background(), &operation, &resultWriter, options(session)...)
+			assert.NoError(t, err)
+
+			var parsed struct {
+				Data struct {
+					Hello string `json:"hello"`
+				} `json:"data"`
+			}
+			assert.NoError(t, json.Unmarshal([]byte(resultWriter.String()), &parsed))
+			results[i] = parsed.Data.Hello
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	return results
+}
+
+func TestWithSubgraphHeadersBuilder(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sets the builder on the resolve context", func(t *testing.T) {
+		t.Parallel()
+
+		builder := newTestSubgraphHeaders("session-1")
+		executionCtx := &internalExecutionContext{
+			resolveContext: resolve.NewContext(context.Background()),
+		}
+
+		WithSubgraphHeadersBuilder(builder)(executionCtx)
+
+		assert.Same(t, builder, executionCtx.resolveContext.SubgraphHeadersBuilder)
+	})
+
+	t.Run("concurrent identical operations resolve against their own headers", func(t *testing.T) {
+		t.Parallel()
+
+		subgraph := newDeduplicationTestSubgraph(t, 50*time.Millisecond)
+		engine := newDeduplicationTestEngine(t, subgraph.server.URL)
+
+		sessions := make([]string, 8)
+		for i := range sessions {
+			sessions[i] = fmt.Sprintf("session-%d", i)
+		}
+
+		results := executeConcurrently(t, engine, sessions, func(session string) []ExecutionOptions {
+			return []ExecutionOptions{WithSubgraphHeadersBuilder(newTestSubgraphHeaders(session))}
+		})
+
+		assert.Equal(t, sessions, results)
+		assert.Equal(t, int64(len(sessions)), subgraph.calls.Load(),
+			"each distinct header set must produce its own fetch")
+	})
+
+	t.Run("identical headers are still deduplicated", func(t *testing.T) {
+		t.Parallel()
+
+		subgraph := newDeduplicationTestSubgraph(t, 50*time.Millisecond)
+		engine := newDeduplicationTestEngine(t, subgraph.server.URL)
+
+		sessions := make([]string, 8)
+		for i := range sessions {
+			sessions[i] = "session-shared"
+		}
+
+		results := executeConcurrently(t, engine, sessions, func(session string) []ExecutionOptions {
+			return []ExecutionOptions{WithSubgraphHeadersBuilder(newTestSubgraphHeaders(session))}
+		})
+
+		assert.Equal(t, sessions, results)
+		assert.Less(t, subgraph.calls.Load(), int64(len(sessions)),
+			"a shared header set must still collapse into fewer fetches")
+	})
+}
+
+func TestWithExecutionOptions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sets the execution options on the resolve context", func(t *testing.T) {
+		t.Parallel()
+
+		executionCtx := &internalExecutionContext{
+			resolveContext: resolve.NewContext(context.Background()),
+		}
+
+		WithExecutionOptions(resolve.ExecutionOptions{
+			DisableSubgraphRequestDeduplication: true,
+			DisableInboundRequestDeduplication:  true,
+		})(executionCtx)
+
+		assert.True(t, executionCtx.resolveContext.ExecutionOptions.DisableSubgraphRequestDeduplication)
+		assert.True(t, executionCtx.resolveContext.ExecutionOptions.DisableInboundRequestDeduplication)
+	})
+
+	t.Run("disabling subgraph deduplication gives every execution its own fetch", func(t *testing.T) {
+		t.Parallel()
+
+		subgraph := newDeduplicationTestSubgraph(t, 50*time.Millisecond)
+		engine := newDeduplicationTestEngine(t, subgraph.server.URL)
+
+		sessions := make([]string, 8)
+		for i := range sessions {
+			sessions[i] = "session-shared"
+		}
+
+		results := executeConcurrently(t, engine, sessions, func(session string) []ExecutionOptions {
+			return []ExecutionOptions{
+				WithSubgraphHeadersBuilder(newTestSubgraphHeaders(session)),
+				WithExecutionOptions(resolve.ExecutionOptions{DisableSubgraphRequestDeduplication: true}),
+			}
+		})
+
+		assert.Equal(t, sessions, results)
+		assert.Equal(t, int64(len(sessions)), subgraph.calls.Load(),
+			"deduplication is disabled, so no fetch may be shared")
+	})
+}

--- a/execution/engine/execution_engine_deduplication_test.go
+++ b/execution/engine/execution_engine_deduplication_test.go
@@ -144,10 +144,7 @@ func executeConcurrently(t *testing.T, engine *ExecutionEngine, sessions []strin
 
 	var wg sync.WaitGroup
 	for i, session := range sessions {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
+		wg.Go(func() {
 			operation := graphql.Request{Query: `query Op { hello }`, OperationName: "Op"}
 			resultWriter := graphql.NewEngineResultWriter()
 
@@ -163,7 +160,7 @@ func executeConcurrently(t *testing.T, engine *ExecutionEngine, sessions []strin
 			}
 			assert.NoError(t, json.Unmarshal([]byte(resultWriter.String()), &parsed))
 			results[i] = parsed.Data.Hello
-		}()
+		})
 	}
 
 	// Wait until every worker has done its setup and is about to park on start.

--- a/execution/engine/execution_engine_deduplication_test.go
+++ b/execution/engine/execution_engine_deduplication_test.go
@@ -139,6 +139,7 @@ func executeConcurrently(t *testing.T, engine *ExecutionEngine, sessions []strin
 	t.Helper()
 
 	results := make([]string, len(sessions))
+	ready := make(chan struct{}, len(sessions))
 	start := make(chan struct{})
 
 	var wg sync.WaitGroup
@@ -150,6 +151,7 @@ func executeConcurrently(t *testing.T, engine *ExecutionEngine, sessions []strin
 			operation := graphql.Request{Query: `query Op { hello }`, OperationName: "Op"}
 			resultWriter := graphql.NewEngineResultWriter()
 
+			ready <- struct{}{}
 			<-start
 			err := engine.Execute(context.Background(), &operation, &resultWriter, options(session)...)
 			assert.NoError(t, err)
@@ -162,6 +164,13 @@ func executeConcurrently(t *testing.T, engine *ExecutionEngine, sessions []strin
 			assert.NoError(t, json.Unmarshal([]byte(resultWriter.String()), &parsed))
 			results[i] = parsed.Data.Hello
 		}()
+	}
+
+	// Wait until every worker has done its setup and is about to park on start.
+	// Releasing the burst earlier lets a straggler begin after the leader's fetch
+	// has already finished, which would measure scheduling rather than deduplication.
+	for range sessions {
+		<-ready
 	}
 
 	close(start)

--- a/v2/pkg/engine/resolve/context.go
+++ b/v2/pkg/engine/resolve/context.go
@@ -128,7 +128,13 @@ type ExecutionOptions struct {
 	IncludeQueryPlanInResponse bool
 	// SendHeartbeat sends regular HeartBeats for Subscriptions
 	SendHeartbeat bool
-	// DisableSubgraphRequestDeduplication disables deduplication of requests to the same subgraph with the same input within a single operation execution.
+	// DisableSubgraphRequestDeduplication disables deduplication of requests to the same subgraph with the same input.
+	// Deduplication is not limited to a single operation execution: a Resolver keeps one
+	// SubgraphRequestSingleFlight for its whole lifetime, so concurrent operations from different
+	// clients share an in-flight fetch whenever their keys match. The key covers the data source ID,
+	// the rendered input, and the hash returned by SubgraphHeadersBuilder, which is why per-client
+	// headers must reach subgraphs through that builder rather than through a transport wrapped
+	// around the data source HTTP client.
 	DisableSubgraphRequestDeduplication bool
 	// DisableInboundRequestDeduplication disables deduplication of inbound client requests
 	// The engine is hashing the normalized operation, variables, and forwarded headers to achieve robust deduplication


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration options for customizing subgraph request headers and execution behavior.
  * Added support for distinct per-request headers while safely deduplicating equivalent concurrent subgraph requests.
  * Added an option to disable subgraph request deduplication when each execution must be fetched independently.

* **Documentation**
  * Clarified deduplication behavior, including how requests are matched and how per-request headers should be provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #1616.

### What

Adds two execution options to `execution/engine`:

```go
// Sets the builder that produces the headers for subgraph requests, and whose
// hash the resolver folds into its request deduplication keys.
func WithSubgraphHeadersBuilder(builder resolve.SubgraphHeadersBuilder) ExecutionOptions

// Sets resolve.ExecutionOptions, e.g. to turn request deduplication off.
func WithExecutionOptions(options resolve.ExecutionOptions) ExecutionOptions
```

and corrects the documented scope of
`resolve.ExecutionOptions.DisableSubgraphRequestDeduplication`.

### Why

`resolve.Context` already carries `SubgraphHeadersBuilder` and `ExecutionOptions`,
but `ExecutionEngine` builds its `resolve.Context` internally and
`type ExecutionOptions func(ctx *internalExecutionContext)` takes an unexported
struct, so no function of that type can be declared outside the package. Both
fields are therefore unreachable for embedders.

That is a correctness gap rather than a missing convenience. The subgraph
deduplication key is
`hash(DataSourceID + renderedInput + SubgraphHeadersBuilder hash)`. With no
builder the hash is `0`, so per-client headers forwarded by any other route — an
`http.RoundTripper` on the data source client is the only option
`execution/engine` leaves — are not part of the key. Concurrent operations with
byte-identical subgraph request bodies collapse into one fetch, and the followers
copy the leader's response without ever issuing a request of their own. Every
argument-free operation has an identical body across clients, so concurrent
clients receive each other's data.

The issue has a self-contained reproducer. On an idle machine, eight concurrent
clients produce one upstream fetch and seven responses carrying another client's
data.

With `WithSubgraphHeadersBuilder` the headers travel through the engine, become
part of the key, and deduplication keeps working for callers that genuinely do
share headers — which is why this is preferable to just switching the feature
off. `WithExecutionOptions` is there for embedders who would rather disable
deduplication outright.

### Tests

New file `execution/engine/execution_engine_deduplication_test.go`:

- `TestWithSubgraphHeadersBuilder/sets the builder on the resolve context`
- `TestWithSubgraphHeadersBuilder/concurrent identical operations resolve against their own headers` —
  8 concurrent executions, 8 distinct header sets, each response matches its own
  headers and the subgraph is hit exactly 8 times
- `TestWithSubgraphHeadersBuilder/identical headers are still deduplicated` —
  8 concurrent executions sharing one header set collapse into fewer fetches, so
  the option does not disable single flight
- `TestWithExecutionOptions/sets the execution options on the resolve context`
- `TestWithExecutionOptions/disabling subgraph deduplication gives every execution its own fetch`

The subgraph in these tests echoes the `Authorization` header it received, so a
response identifies which caller's headers the fetch was made with, and a fixed
delay keeps the single flight window open for the whole burst.

`SubgraphHeadersBuilder` had no test coverage before this change.

Verified locally: `go test ./engine/` passes, and
`go test -race ./engine/ -run 'TestWithSubgraphHeadersBuilder|TestWithExecutionOptions' -count=3`
passes with no races.

### Compatibility

Additive. Nothing changes for callers that do not pass the new options; both
default to today's behaviour.

### Note for implementers

A `SubgraphHeadersBuilder` must return a copy of its header map from
`HeadersForSubgraph`. `httpclient.makeHTTPRequest` assigns the returned value
straight into `http.Request.Header` and then adds `Accept` and `Content-Type` to
it, so a shared map races across concurrent fetches. This is documented on the
new option.

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.

The first box is intentionally unchecked: I opened #1616 at the same time as this
PR rather than waiting for approval first, because the change is small and easier
to judge with the code in front of you. Happy to close this and continue in the
issue if you would prefer to settle the approach there.

## Open Source AI Manifesto

I have read and verified every line of this change, and the reproducer and tests
back it up.
