### PR TITLE
feat: entitycache cache interface

### DIFF
--- a/v2/pkg/entitycaching/cache.go
+++ b/v2/pkg/entitycaching/cache.go
@@ -21,14 +21,20 @@ type Result struct {
 	Found bool
 }
 
+// Cache is a batch oriented key/value cache.
 type Cache interface {
 	// GetMany looks up every key and returns one Result per key, in the same
 	// order as keys, so results[i] belongs to keys[i]. Duplicate keys are
 	// looked up independently.
+	// A miss is reported as a Result with Found false, never as an error. An
+	// error means the lookup itself failed, and the returned slice is then nil:
+	// there is no partial read to salvage, so callers treat the whole batch as
+	// a miss and recompute. Only a nil error guarantees a slice of len(keys).
 	GetMany(ctx context.Context, keys []string) ([]Result, error)
 
 	// SetMany stores every item. When items contains the same key twice, the
 	// last one wins. A nil error is not a guarantee that a subsequent GetMany
-	// will hit.
+	// will hit. An error means an unspecified subset of the items may already
+	// have been stored.
 	SetMany(ctx context.Context, items []Item) error
 }

--- a/v2/pkg/entitycaching/cache.go
+++ b/v2/pkg/entitycaching/cache.go
@@ -2,38 +2,57 @@ package entitycaching
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 )
 
+// Item is a single cache entry, both on the way in through SetMany and on the
+// way back out of GetMany.
 type Item struct {
-	Key   string
+	// Key is the key the entry is stored under, exactly as GetMany was asked
+	// for it, so an Item carries enough to be acted on once it has been taken
+	// out of the map it came in.
+	Key string
+	// Value is the cached bytes. An entry with an empty Value is still an
+	// entry: GetMany omitting the key is the only thing that means a miss.
 	Value []byte
-	TTL   time.Duration
-}
-
-// Result is a single lookup outcome returned by Cache.GetMany.
-type Result struct {
-	// Value is only meaningful when Found is true.
-	Value []byte
-	// Found reports whether the key was cached, so that a cached empty value
-	// stays distinguishable from a miss. The zero Result is a miss.
-	Found bool
+	// TTL is how long the entry should live when passed to SetMany, and how
+	// much of that life it has left when returned by GetMany, so the same key
+	// comes back with less of it on every lookup. It is always positive in
+	// both directions: SetMany refuses an item without a positive TTL, and
+	// GetMany treats an entry with nothing left to live, or one it finds with
+	// no expiry attached at all, as a miss rather than a hit.
+	TTL time.Duration
 }
 
 // Cache is a batch oriented key/value cache.
 type Cache interface {
-	// GetMany looks up every key and returns one Result per key, in the same
-	// order as keys, so results[i] belongs to keys[i]. Duplicate keys are
-	// looked up independently.
-	// A miss is reported as a Result with Found false, never as an error. An
-	// error means the lookup itself failed, and the returned slice is then nil:
-	// there is no partial read to salvage, so callers treat the whole batch as
-	// a miss and recompute. Only a nil error guarantees a slice of len(keys).
-	GetMany(ctx context.Context, keys []string) ([]Result, error)
+	// GetMany looks up every key and returns the ones it found, keyed by the
+	// key they were asked for. A miss is simply absent, never an error and
+	// never a zero Item
+	GetMany(ctx context.Context, keys []string) (map[string]Item, error)
 
-	// SetMany stores every item. When items contains the same key twice, the
-	// last one wins. A nil error is not a guarantee that a subsequent GetMany
-	// will hit. An error means an unspecified subset of the items may already
-	// have been stored.
+	// SetMany stores every item, all of which must carry a positive TTL. When
+	// items contains the same key twice, the last one wins. An error means an
+	// unspecified subset of the items may already have been stored.
 	SetMany(ctx context.Context, items []Item) error
+}
+
+var ErrMissingTTL = errors.New("cache item requires a positive TTL")
+
+type SetManyError struct {
+	// This depicts the known stored keys in a case of a partial write
+	// this means that some more keys could have been written but there is no way to know
+	// because the client did not receive a response
+	KnownStoredKeys []string
+	Err             error
+}
+
+func (e *SetManyError) Error() string {
+	return fmt.Sprintf("%v (%d keys were known to be written)", e.Err, len(e.KnownStoredKeys))
+}
+
+func (e *SetManyError) Unwrap() error {
+	return e.Err
 }

--- a/v2/pkg/entitycaching/cache.go
+++ b/v2/pkg/entitycaching/cache.go
@@ -14,9 +14,11 @@ type Item struct {
 
 // Result is a single lookup outcome returned by Cache.GetMany.
 type Result struct {
-	// Value is nil when the key was not cached. A cached but empty value comes
-	// back as an empty, non-nil slice, so the two stay distinguishable.
+	// Value is only meaningful when Found is true.
 	Value []byte
+	// Found reports whether the key was cached, so that a cached empty value
+	// stays distinguishable from a miss. The zero Result is a miss.
+	Found bool
 }
 
 type Cache interface {

--- a/v2/pkg/entitycaching/cache.go
+++ b/v2/pkg/entitycaching/cache.go
@@ -36,6 +36,8 @@ type Cache interface {
 	// SetMany stores every item, all of which must carry a positive TTL. When
 	// items contains the same key twice, the last one wins. An error means an
 	// unspecified subset of the items may already have been stored.
+	// In case any of the passed ttls are invalid, SetMany should return
+	// without saving any items that may have valid ttl values
 	SetMany(ctx context.Context, items []Item) error
 }
 

--- a/v2/pkg/entitycaching/cache.go
+++ b/v2/pkg/entitycaching/cache.go
@@ -1,0 +1,32 @@
+package entitycaching
+
+import (
+	"context"
+	"time"
+)
+
+type Item struct {
+	Key       string
+	Value     []byte
+	CacheTags []string
+	TTL       time.Duration
+}
+
+// Result is a single lookup outcome returned by Cache.GetMany.
+type Result struct {
+	// Value is nil when the key was not cached. A cached but empty value comes
+	// back as an empty, non-nil slice, so the two stay distinguishable.
+	Value []byte
+}
+
+type Cache interface {
+	// GetMany looks up every key and returns one Result per key, in the same
+	// order as keys, so results[i] belongs to keys[i]. Duplicate keys are
+	// looked up independently.
+	GetMany(ctx context.Context, keys []string) ([]Result, error)
+
+	// SetMany stores every item. When items contains the same key twice, the
+	// last one wins. A nil error is not a guarantee that a subsequent GetMany
+	// will hit.
+	SetMany(ctx context.Context, items []Item) error
+}

--- a/v2/pkg/entitycaching/cache.go
+++ b/v2/pkg/entitycaching/cache.go
@@ -6,10 +6,9 @@ import (
 )
 
 type Item struct {
-	Key       string
-	Value     []byte
-	CacheTags []string
-	TTL       time.Duration
+	Key   string
+	Value []byte
+	TTL   time.Duration
 }
 
 // Result is a single lookup outcome returned by Cache.GetMany.


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

This PR creates the interface of the cache for the adapters used by entity caching. The router will create implementations based on this interface.

Used here: https://github.com/wundergraph/cosmo/pull/3137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standardized interface for batch retrieving and storing cached values.
  * Added support for per-item expiration times, including validation for missing or invalid lifetimes.
  * Cache reads now return found entries by key, omitting missing values while preserving empty stored values.
  * Defined consistent handling for duplicate keys, last-write-wins updates, partial storage failures, and reporting successfully stored entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->