### PR TITLE
chore: strengthen and pin golangci-lint

### DIFF
--- a/.github/workflows/execution.yml
+++ b/.github/workflows/execution.yml
@@ -6,6 +6,8 @@ on:
       - 'execution/**'
       - '.github/workflows/execution.yml'
       - '.golangci.yml'
+      - 'Makefile'
+      - 'scripts/golangci-lint.sh'
       - '.coderabbit.yaml'
   push:
     branches:
@@ -15,6 +17,8 @@ on:
       - 'execution/**'
       - '.github/workflows/execution.yml'
       - '.golangci.yml'
+      - 'Makefile'
+      - 'scripts/golangci-lint.sh'
       - '.coderabbit.yaml'
 jobs:
   test:
@@ -57,11 +61,14 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ^${{ matrix.go }}
+      - name: Read golangci-lint version
+        id: golangci-lint-version
+        run: echo "version=$(./scripts/golangci-lint.sh --print-version)" >> "$GITHUB_OUTPUT"
       - name: Run linters
         uses: golangci/golangci-lint-action@v8.0.0
         with:
           working-directory: execution
-          version: v2.10.1
+          version: ${{ steps.golangci-lint-version.outputs.version }}
           args: --timeout=3m
   ci:
     name: CI Success

--- a/.github/workflows/v2.yml
+++ b/.github/workflows/v2.yml
@@ -8,6 +8,8 @@ on:
       - '.github/workflows/release.yml'
       - 'commitlint.config.js'
       - '.golangci.yml'
+      - 'Makefile'
+      - 'scripts/golangci-lint.sh'
       - '.coderabbit.yaml'
   push:
     branches:
@@ -19,6 +21,8 @@ on:
       - '.github/workflows/release.yml'
       - 'commitlint.config.js'
       - '.golangci.yml'
+      - 'Makefile'
+      - 'scripts/golangci-lint.sh'
       - '.coderabbit.yaml'
 jobs:
   test:
@@ -61,11 +65,14 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ^${{ matrix.go }}
+      - name: Read golangci-lint version
+        id: golangci-lint-version
+        run: echo "version=$(./scripts/golangci-lint.sh --print-version)" >> "$GITHUB_OUTPUT"
       - name: Run linters
         uses: golangci/golangci-lint-action@v8.0.0
         with:
           working-directory: v2
-          version: v2.10.1
+          version: ${{ steps.golangci-lint-version.outputs.version }}
           args: --timeout=3m
   ci:
     name: CI Success

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,24 +2,43 @@ version: "2"
 linters:
   default: none
   enable:
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - durationcheck
     - errcheck
+    - errchkjson
+    - errorlint
+    - fatcontext
+    - gocheckcompilerdirectives
     - govet
     - ineffassign
-    - staticcheck
-    - bodyclose
+    - loggercheck
+    - makezero
+    - nilerr
+    - nilnesserr
+    - nolintlint
+    - reassign
+    - rowserrcheck
+    - spancheck
+    - sqlclosecheck
     - embeddedstructfieldcheck
     - modernize
+    - staticcheck
     - tparallel
-    # - unused
+    - unconvert
+    - wastedassign
 
   exclusions:
     generated: lax
     presets:
       - comments
       - common-false-positives
-      - legacy
       - std-error-handling
     rules:
+      - path: _test\.go
+        linters:
+          - errchkjson
       - linters:
           - staticcheck
         text: "QF1008:"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: lint format lint-fix
+
+lint:
+	$(MAKE) -C v2 lint
+
+format:
+	$(MAKE) -C v2 format
+	$(MAKE) -C execution format
+
+lint-fix:
+	$(MAKE) -C v2 lint-fix

--- a/execution/Makefile
+++ b/execution/Makefile
@@ -22,14 +22,14 @@ update-fixtures:
 # golangci-lint will find the config file in the root dir of the repo.
 .PHONY: format
 format:
-	golangci-lint fmt
+	../scripts/golangci-lint.sh fmt
 
 lint:
-	golangci-lint run
+	../scripts/golangci-lint.sh run
 
 .PHONY: lint-fix
 lint-fix:
-	golangci-lint run --fix
+	../scripts/golangci-lint.sh run --fix
 
 .PHONY: prepare-merge
 prepare-merge: format test

--- a/execution/engine/execution_engine_test.go
+++ b/execution/engine/execution_engine_test.go
@@ -6605,7 +6605,7 @@ func newFederationEngineStaticConfig(ctx context.Context, setup *federationtesti
 	return
 }
 
-// nolint
+//nolint
 func federationSchema() (*graphql.Schema, error) {
 	rawSchema := `
 type Query {

--- a/execution/federationtesting/gateway/httphandler/ws.go
+++ b/execution/federationtesting/gateway/httphandler/ws.go
@@ -3,6 +3,7 @@ package httphandler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net"
 
 	"github.com/gobwas/ws"
@@ -114,7 +115,8 @@ func (w *WebsocketSubscriptionClient) Disconnect() error {
 
 // isClosedConnectionError will indicate if the given error is a connection closed error.
 func (w *WebsocketSubscriptionClient) isClosedConnectionError(err error) bool {
-	if _, ok := err.(wsutil.ClosedError); ok {
+	var closedError wsutil.ClosedError
+	if errors.As(err, &closedError) {
 		w.isClosedConnection = true
 	}
 

--- a/execution/graphql/schema.go
+++ b/execution/graphql/schema.go
@@ -84,6 +84,7 @@ func NewSchemaFromBytes(schema []byte) (*Schema, error) {
 func ValidateSchemaString(schema string) (result ValidationResult, err error) {
 	parsedSchema, err := NewSchemaFromString(schema)
 	if err != nil {
+		//nolint:nilerr // Validation failures are returned in ValidationResult.
 		return ValidationResult{
 			Valid: false,
 			Errors: SchemaValidationErrors{
@@ -280,7 +281,7 @@ func (s *Schema) addTypeFieldArgsForFieldRef(ref int, typeName string, fieldName
 
 	for _, argRef := range s.document.FieldDefinitions[ref].ArgumentsDefinition.Refs {
 		argName := s.document.InputValueDefinitionNameString(argRef)
-		currentTypeFieldArgs.ArgumentNames = append(currentTypeFieldArgs.ArgumentNames, string(argName))
+		currentTypeFieldArgs.ArgumentNames = append(currentTypeFieldArgs.ArgumentNames, argName)
 	}
 
 	*fieldArguments = append(*fieldArguments, currentTypeFieldArgs)

--- a/execution/subscription/context_test.go
+++ b/execution/subscription/context_test.go
@@ -33,7 +33,7 @@ func TestSubscriptionCancellations(t *testing.T) {
 	t.Run("should add a cancellation func to map", func(t *testing.T) {
 		require.Equal(t, 0, cancellations.Len())
 
-		ctx, err = cancellations.AddWithParent("1", context.Background())
+		ctx, err = cancellations.AddWithParent("1", context.Background()) //nolint:fatcontext // Sequential subtests share this context.
 		assert.Nil(t, err)
 		assert.Equal(t, 1, cancellations.Len())
 		assert.NotNil(t, ctx)

--- a/execution/subscription/legacy_handler.go
+++ b/execution/subscription/legacy_handler.go
@@ -353,7 +353,7 @@ func (h *Handler) sendData(id string, responseData []byte) {
 	}
 }
 
-// nolint
+//nolint
 // sendComplete will send a complete message to the client.
 func (h *Handler) sendComplete(id string) {
 	completeMessage := Message{

--- a/execution/subscription/websocket/protocol_graphql_ws.go
+++ b/execution/subscription/websocket/protocol_graphql_ws.go
@@ -167,7 +167,7 @@ type GraphQLWSWriteEventHandler struct {
 
 // Emit is an implementation of subscription.EventHandler. It forwards events to the HandleWriteEvent.
 func (g *GraphQLWSWriteEventHandler) Emit(eventType subscription.EventType, id string, data []byte, err error) {
-	messageType := GraphQLWSMessageType("")
+	var messageType GraphQLWSMessageType
 	switch eventType {
 	case subscription.EventTypeOnSubscriptionCompleted:
 		messageType = GraphQLWSMessageTypeComplete

--- a/scripts/golangci-lint.sh
+++ b/scripts/golangci-lint.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+set -eu
+
+GOLANGCI_LINT_VERSION=${GOLANGCI_LINT_VERSION:-v2.12.2}
+
+validate_version() {
+	if ! printf '%s\n' "$GOLANGCI_LINT_VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$'; then
+		echo "invalid GOLANGCI_LINT_VERSION: $GOLANGCI_LINT_VERSION" >&2
+		exit 1
+	fi
+}
+
+validate_version
+
+if [ "${1:-}" = "--print-version" ]; then
+	printf '%s\n' "$GOLANGCI_LINT_VERSION"
+	exit 0
+fi
+
+install_golangci_lint() {
+	mkdir -p "$install_dir"
+	installer="$install_dir/install.sh.$$"
+	trap 'rm -f "$installer"' EXIT HUP INT TERM
+
+	if command -v curl >/dev/null 2>&1; then
+		curl -sSfL https://golangci-lint.run/install.sh -o "$installer"
+	elif command -v wget >/dev/null 2>&1; then
+		wget -qO "$installer" https://golangci-lint.run/install.sh
+	else
+		echo "installing golangci-lint requires curl or wget" >&2
+		exit 1
+	fi
+
+	sh "$installer" -b "$install_dir" "$GOLANGCI_LINT_VERSION"
+	rm -f "$installer"
+	trap - EXIT HUP INT TERM
+}
+
+install_dir="${TMPDIR:-/tmp}/golangci-lint/$GOLANGCI_LINT_VERSION"
+binary="$install_dir/golangci-lint"
+
+if [ ! -x "$binary" ]; then
+	echo "installing golangci-lint $GOLANGCI_LINT_VERSION in $install_dir" >&2
+	install_golangci_lint
+fi
+
+exec "$binary" "$@"

--- a/v2/Makefile
+++ b/v2/Makefile
@@ -22,16 +22,16 @@ update-fixtures:
 # golangci-lint will find the config file in the root dir of the repo.
 .PHONY: format
 format:
-	golangci-lint fmt
+	../scripts/golangci-lint.sh fmt
 
 .PHONY: lint
 lint:
-	golangci-lint run
+	../scripts/golangci-lint.sh run
 	cd ../execution && make lint
 
 .PHONY: lint-fix
 lint-fix:
-	golangci-lint run --fix
+	../scripts/golangci-lint.sh run --fix
 	cd ../execution && make lint-fix
 
 .PHONY: prepare-merge

--- a/v2/pkg/ast/ast_description.go
+++ b/v2/pkg/ast/ast_description.go
@@ -16,7 +16,7 @@ type Description struct {
 	Position      position.Position
 }
 
-// nolint
+//nolint
 func (d *Document) PrintDescription(description Description, indent []byte, depth int, writer io.Writer) (err error) {
 	for i := 0; i < depth; i++ {
 		_, err = writer.Write(indent)

--- a/v2/pkg/ast/ast_value.go
+++ b/v2/pkg/ast/ast_value.go
@@ -204,7 +204,7 @@ func (d *Document) writeJSONValue(buf *bytes.Buffer, value Value) error {
 		variableValue, dataType, _, err := jsonparser.Get(d.Input.Variables, variableName)
 		if err != nil {
 			buf.Write(literal.NULL)
-			return nil
+			return nil //nolint:nilerr // A missing variable is rendered as GraphQL null.
 		}
 		if dataType == jsonparser.String {
 			buf.WriteByte('"')
@@ -227,7 +227,7 @@ func (d *Document) ValueToJSON(value Value) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// nolint
+//nolint
 func (d *Document) PrintValue(value Value, w io.Writer) (err error) {
 	switch value.Kind {
 	case ValueKindBoolean:

--- a/v2/pkg/astnormalization/inject_input_default_values.go
+++ b/v2/pkg/astnormalization/inject_input_default_values.go
@@ -1,6 +1,7 @@
 package astnormalization
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/buger/jsonparser"
@@ -37,7 +38,7 @@ func (v *inputFieldDefaultInjectionVisitor) EnterVariableDefinition(ref int) {
 	v.variableName = v.operation.VariableDefinitionNameString(ref)
 
 	variableVal, _, _, err := jsonparser.Get(v.operation.Input.Variables, v.variableName)
-	if err == jsonparser.KeyPathNotFoundError {
+	if errors.Is(err, jsonparser.KeyPathNotFoundError) {
 		return
 	}
 	if err != nil {
@@ -82,11 +83,11 @@ func (v *inputFieldDefaultInjectionVisitor) recursiveInjectInputFields(inputObje
 		hasDefault := valDef.DefaultValue.IsDefined
 
 		varVal, _, _, err := jsonparser.Get(varValue, fieldName)
-		if err != nil && err != jsonparser.KeyPathNotFoundError {
+		if err != nil && !errors.Is(err, jsonparser.KeyPathNotFoundError) {
 			v.StopWithInternalErr(err)
 			return nil, false, err
 		}
-		existsInVal := err != jsonparser.KeyPathNotFoundError
+		existsInVal := !errors.Is(err, jsonparser.KeyPathNotFoundError)
 
 		if !isTypeScalarOrEnum {
 			var valToUse []byte

--- a/v2/pkg/astnormalization/input_coercion_for_list.go
+++ b/v2/pkg/astnormalization/input_coercion_for_list.go
@@ -1,6 +1,7 @@
 package astnormalization
 
 import (
+	"errors"
 	"strconv"
 	"strings"
 
@@ -103,7 +104,7 @@ func (i *inputCoercionForListVisitor) EnterVariableDefinition(ref int) {
 	variableTypeRef = i.operation.ResolveListOrNameType(variableTypeRef)
 
 	value, dataType, _, err := i.getVariableValue(variableNameString)
-	if err == jsonparser.KeyPathNotFoundError {
+	if errors.Is(err, jsonparser.KeyPathNotFoundError) {
 		// If the user doesn't provide any variable with that name,
 		// there is no need for coercion. Stop the operation
 		return

--- a/v2/pkg/astprinter/astprinter_test.go
+++ b/v2/pkg/astprinter/astprinter_test.go
@@ -2,6 +2,7 @@ package astprinter
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"testing"
 
@@ -17,7 +18,8 @@ import (
 
 func must(t *testing.T, err error) {
 	t.Helper()
-	if report, ok := err.(operationreport.Report); ok {
+	var report operationreport.Report
+	if errors.As(err, &report) {
 		if report.HasErrors() {
 			t.Fatalf("report has errors %s", report.Error())
 		}

--- a/v2/pkg/astvalidation/operation_validation_test.go
+++ b/v2/pkg/astvalidation/operation_validation_test.go
@@ -1,6 +1,7 @@
 package astvalidation
 
 import (
+	"errors"
 	"net/http"
 	"testing"
 
@@ -27,7 +28,7 @@ type options struct {
 
 type option func(options *options)
 
-// nolint
+//nolint
 func withDisableNormalization() option {
 	return func(options *options) {
 		options.disableNormalization = true
@@ -49,7 +50,8 @@ func withValidationErrors(errMsgs ...string) option {
 
 func TestExecutionValidation(t *testing.T) {
 	must := func(err error) {
-		if report, ok := err.(operationreport.Report); ok {
+		var report operationreport.Report
+		if errors.As(err, &report) {
 			if report.HasErrors() {
 				t.Fatal(report.Error())
 			}

--- a/v2/pkg/astvalidation/reference/testsgo/harness_test.go
+++ b/v2/pkg/astvalidation/reference/testsgo/harness_test.go
@@ -237,7 +237,7 @@ func ExpectValidationErrorMessage(t *testing.T, schema string, queryStr string) 
 
 // ExtendSchema - helper to extend schema with provided sdl
 //
-//nolint:unused
+
 func ExtendSchema(schema string, sdlStr string) string {
 	if sdlStr != "" {
 		schema = schema + "\n" + sdlStr

--- a/v2/pkg/engine/datasource/graphql_datasource/configuration.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/configuration.go
@@ -176,12 +176,12 @@ func NewSchemaConfiguration(upstreamSchema string, federationCfg *FederationConf
 
 		federationSchema, err := federation.BuildFederationSchema(cfg.upstreamSchema, cfg.federation.ServiceSDL)
 		if err != nil {
-			return nil, fmt.Errorf("unable to build federation schema: %v", err)
+			return nil, fmt.Errorf("unable to build federation schema: %w", err)
 		}
 		definition.Input.ResetInputString(federationSchema)
 		definitionParser.Parse(definition, report)
 		if report.HasErrors() {
-			return nil, fmt.Errorf("unable to parse federation schema: %v", report)
+			return nil, fmt.Errorf("unable to parse federation schema: %w", report)
 		}
 
 		// As BuildFederationSchema is already merged with base definitions, we actually don't want to do it again,
@@ -189,17 +189,17 @@ func NewSchemaConfiguration(upstreamSchema string, federationCfg *FederationConf
 		// TODO: find a better way to do this
 		typeNamesVisitor := asttransform.NewTypeNameVisitor()
 		if err := typeNamesVisitor.ExtendSchema(definition); err != nil {
-			return nil, fmt.Errorf("unable to extend federation schema with type names: %v", err)
+			return nil, fmt.Errorf("unable to extend federation schema with type names: %w", err)
 		}
 	} else {
 		definition.Input.ResetInputString(cfg.upstreamSchema)
 		definitionParser.Parse(definition, report)
 		if report.HasErrors() {
-			return nil, fmt.Errorf("unable to parse upstream schema: %v", report)
+			return nil, fmt.Errorf("unable to parse upstream schema: %w", report)
 		}
 
 		if err := asttransform.MergeDefinitionWithBaseSchema(definition); err != nil {
-			return nil, fmt.Errorf("unable to merge upstream schema with base schema: %v", err)
+			return nil, fmt.Errorf("unable to merge upstream schema with base schema: %w", err)
 		}
 	}
 

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_subscription_client.go
@@ -309,7 +309,7 @@ func formatUpstreamServiceError(err error, code string) []byte {
 	}{
 		Errors: []graphqlError{gqlErr},
 	}
-	data, _ := json.Marshal(resp)
+	data, _ := json.Marshal(resp) //nolint:errchkjson // The response contains only JSON-safe fields.
 	return data
 }
 
@@ -326,7 +326,7 @@ func formatSubscriptionError(err error) []byte {
 			{Message: err.Error()},
 		},
 	}
-	data, _ := json.Marshal(errResponse)
+	data, _ := json.Marshal(errResponse) //nolint:errchkjson // The response contains only JSON-safe fields.
 	return data
 }
 

--- a/v2/pkg/engine/datasource/graphql_datasource/subscriptionclient/transport/ws_transport.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/subscriptionclient/transport/ws_transport.go
@@ -321,7 +321,7 @@ func (t *WSTransport) negotiateSubprotocol(requested common.WSSubprotocol, accep
 	// that strip the Sec-WebSocket-Protocol header). That fallback was
 	// intentionally removed. Re-add it here if such compatibility is needed
 	// again.
-	switch common.WSSubprotocol(accepted) {
+	switch accepted {
 	case common.SubprotocolGraphQLTransportWS:
 		return protocol.NewGraphQLTransportWS(), nil
 	case common.SubprotocolGraphQLWS:

--- a/v2/pkg/engine/datasource/grpc_datasource/compiler.go
+++ b/v2/pkg/engine/datasource/grpc_datasource/compiler.go
@@ -303,7 +303,7 @@ func NewProtoCompiler(schema string, mapping *GRPCMapping) (*RPCCompiler, error)
 	// before we can parse the schema.
 	for i := 0; i < schemaFile.Imports().Len(); i++ {
 		protoImport := schemaFile.Imports().Get(i)
-		pc.doc.Imports = append(pc.doc.Imports, string(protoImport.Path()))
+		pc.doc.Imports = append(pc.doc.Imports, protoImport.Path())
 		pc.processFile(protoImport, mapping)
 	}
 

--- a/v2/pkg/engine/datasource/httpclient/nethttpclient.go
+++ b/v2/pkg/engine/datasource/httpclient/nethttpclient.go
@@ -411,7 +411,7 @@ func multipartBytes(values map[string]io.Reader, files []*FileUpload) (*io.PipeR
 
 			for {
 				n, err := f.Read(buf)
-				if err != nil && err == io.EOF {
+				if err != nil && errors.Is(err, io.EOF) {
 					break
 				} else if err != nil {
 					return

--- a/v2/pkg/engine/plan/datasource_filter_collect_nodes_visitor.go
+++ b/v2/pkg/engine/plan/datasource_filter_collect_nodes_visitor.go
@@ -166,7 +166,7 @@ func (c *nodesCollector) collectNodes() {
 
 			for _, node := range nodesToVisit {
 				if err := visitor.EnterField(node.fieldRef, node.treeNodeData, node.treeNodeId); err != nil {
-					report.AddInternalError(fmt.Errorf("data source %s: %v", visitor.dataSource.Name(), err))
+					report.AddInternalError(fmt.Errorf("data source %s: %w", visitor.dataSource.Name(), err))
 					// stop processing on error
 					return
 				}
@@ -402,7 +402,7 @@ func (f *collectNodesDSVisitor) handleProvidesSuggestions(fieldRef int, typeName
 	}
 	selection, report := providesSuggestions(input)
 	if report.HasErrors() {
-		return fmt.Errorf("failed to get provides suggestions for %s.%s at path %s: %v", typeName, fieldName, currentPath, report)
+		return fmt.Errorf("failed to get provides suggestions for %s.%s at path %s: %w", typeName, fieldName, currentPath, report)
 	}
 
 	if len(selection) > 0 {

--- a/v2/pkg/engine/plan/datasource_filter_node_suggestions.go
+++ b/v2/pkg/engine/plan/datasource_filter_node_suggestions.go
@@ -104,12 +104,12 @@ func (n *NodeSuggestion) orphan() {
 }
 
 func (n *NodeSuggestion) String() string {
-	j, _ := json.Marshal(n)
+	j, _ := json.Marshal(n) //nolint:errchkjson // NodeSuggestions contains only JSON-safe fields.
 	return string(j)
 }
 
 func (n *NodeSuggestion) StringShort() string {
-	j, _ := json.Marshal(struct {
+	j, _ := json.Marshal(struct { //nolint:errchkjson // The debug structure contains only JSON-safe fields.
 		DsName           string   `json:"dsName"`
 		TypeName         string   `json:"typeName"`
 		Path             string   `json:"path"`

--- a/v2/pkg/engine/plan/federation_metadata.go
+++ b/v2/pkg/engine/plan/federation_metadata.go
@@ -127,7 +127,7 @@ func (f *FederationFieldConfiguration) parseSelectionSet() error {
 // String - implements fmt.Stringer
 // NOTE: do not change to pointer receiver, it won't work for not pointer values
 func (f FederationFieldConfiguration) String() string {
-	b, _ := json.Marshal(f)
+	b, _ := json.Marshal(f) //nolint:errchkjson // Federation metadata contains only JSON-safe fields.
 	return string(b)
 }
 

--- a/v2/pkg/engine/plan/node_selection_builder.go
+++ b/v2/pkg/engine/plan/node_selection_builder.go
@@ -235,12 +235,12 @@ func (p *NodeSelectionBuilder) SelectNodes(operation, definition *ast.Document, 
 				// and this iteration made no progress (per-walk state is reset in
 				// EnterDocument) - further iterations cannot change anything,
 				// so report the unresolved fields right away
-				report.AddInternalError(fmt.Errorf("could not resolve a field: %v", resolvableReport))
+				report.AddInternalError(fmt.Errorf("could not resolve a field: %w", resolvableReport))
 				return
 			}
 
 			if i > 100 {
-				report.AddInternalError(fmt.Errorf("could not resolve a field: %v", resolvableReport))
+				report.AddInternalError(fmt.Errorf("could not resolve a field: %w", resolvableReport))
 				return
 			}
 			continue

--- a/v2/pkg/engine/resolve/loader.go
+++ b/v2/pkg/engine/resolve/loader.go
@@ -1510,7 +1510,7 @@ func (l *Loader) prepareSingleFetch(fetchItem *FetchItem, fetch *SingleFetch, it
 	if err != nil {
 		res.out = l.renderErrorsInvalidInput(fetchItem)
 		prepared.skipLoad = true
-		return nil
+		return nil //nolint:nilerr // The render error is represented in the GraphQL response.
 	}
 	fetchInput := buf.Bytes()
 	allowed, err := l.validatePreFetch(fetchInput, fetch.Info, res)
@@ -1676,10 +1676,8 @@ func (l *Loader) prepareBatchEntityFetch(fetchItem *FetchItem, fetch *BatchEntit
 		// we need to clear the batchStats slice to avoid memory corruption
 		// once the outer func returns, we must not keep pointers to items on the arena
 		for i := range batchStats {
-			// nolint:ineffassign
 			batchStats[i] = nil
 		}
-		// nolint:ineffassign
 		batchStats = nil
 	}()
 
@@ -1700,7 +1698,6 @@ WithNextItem:
 			err = fetch.Input.Items[j].Render(l.ctx, item, itemInput)
 			if err != nil {
 				if fetch.Input.SkipErrItems {
-					err = nil // nolint:ineffassign
 					continue
 				}
 				if l.ctx.TracingOptions.Enable {

--- a/v2/pkg/engine/resolve/resolve_test.go
+++ b/v2/pkg/engine/resolve/resolve_test.go
@@ -6810,7 +6810,7 @@ func TestResolver_ResolveGraphQLSubscription(t *testing.T) {
 				messagesHeartbeat++
 			}
 		}
-		assert.Equal(t, int32(messagesToSendFromHook+messagesToSendFromOtherSources+messagesHeartbeat), int32(len(recorder.Messages())))
+		assert.Equal(t, messagesToSendFromHook+messagesToSendFromOtherSources+messagesHeartbeat, int32(len(recorder.Messages())))
 		assert.Equal(t, `{"data":{"counter":20000}}`, recorder.Messages()[0])
 	})
 

--- a/v2/pkg/graphqlerrors/errors.go
+++ b/v2/pkg/graphqlerrors/errors.go
@@ -2,6 +2,7 @@ package graphqlerrors
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -20,10 +21,12 @@ type Errors interface {
 type RequestErrors []RequestError
 
 func RequestErrorsFromError(err error) RequestErrors {
-	if errors, ok := err.(RequestErrors); ok {
-		return errors
+	var requestErrors RequestErrors
+	if errors.As(err, &requestErrors) {
+		return requestErrors
 	}
-	if report, ok := err.(operationreport.Report); ok {
+	var report operationreport.Report
+	if errors.As(err, &report) {
 		if len(report.ExternalErrors) == 0 {
 			return RequestErrors{
 				{
@@ -31,9 +34,9 @@ func RequestErrorsFromError(err error) RequestErrors {
 				},
 			}
 		}
-		var errors RequestErrors
+		var requestErrors RequestErrors
 		for _, externalError := range report.ExternalErrors {
-			errors = append(errors, RequestError{
+			requestErrors = append(requestErrors, RequestError{
 				Message:   externalError.Message,
 				Locations: externalError.Locations,
 				Path: ErrorPath{
@@ -41,7 +44,7 @@ func RequestErrorsFromError(err error) RequestErrors {
 				},
 			})
 		}
-		return errors
+		return requestErrors
 	}
 	return RequestErrors{
 		{

--- a/v2/pkg/introspection/converter.go
+++ b/v2/pkg/introspection/converter.go
@@ -21,7 +21,7 @@ type JsonConverter struct {
 func (j *JsonConverter) GraphQLDocument(introspectionJSON io.Reader) (*ast.Document, error) {
 	var data Data
 	if err := json.NewDecoder(introspectionJSON).Decode(&data); err != nil {
-		return nil, fmt.Errorf("failed to parse inrospection json: %v", err)
+		return nil, fmt.Errorf("failed to parse inrospection json: %w", err)
 	}
 
 	j.schema = &data.Schema
@@ -29,7 +29,7 @@ func (j *JsonConverter) GraphQLDocument(introspectionJSON io.Reader) (*ast.Docum
 	j.parser = astparser.NewParser()
 
 	if err := j.importSchema(); err != nil {
-		return nil, fmt.Errorf("failed to convert graphql schema: %v", err)
+		return nil, fmt.Errorf("failed to convert graphql schema: %w", err)
 	}
 
 	return j.doc, nil

--- a/v2/pkg/netpoll/fd_test.go
+++ b/v2/pkg/netpoll/fd_test.go
@@ -25,7 +25,7 @@ func rawSocketFD(conn net.Conn) uint64 {
 			return 0
 		}
 		sfd := uint64(0)
-		raw.Control(func(fd uintptr) { // nolint: errcheck
+		raw.Control(func(fd uintptr) { //nolint: errcheck
 			sfd = uint64(fd)
 		})
 		return sfd

--- a/v2/pkg/netpoll/netpoll.go
+++ b/v2/pkg/netpoll/netpoll.go
@@ -33,7 +33,7 @@ func SocketFD(conn net.Conn) int {
 			return 0
 		}
 		sfd := 0
-		raw.Control(func(fd uintptr) { // nolint: errcheck
+		raw.Control(func(fd uintptr) { //nolint: errcheck
 			sfd = int(fd)
 		})
 		return sfd
@@ -86,7 +86,7 @@ func Supported() error {
 			return fmt.Errorf("failed to remove connection from poller: %w", err)
 		}
 
-		return nil //nolint intentionally return nil
+		return nil
 
 	})
 

--- a/v2/pkg/netpoll/netpoll_bsd.go
+++ b/v2/pkg/netpoll/netpoll_bsd.go
@@ -78,7 +78,7 @@ func (e *KQueue) Close(closeConns bool) error {
 func (e *KQueue) Add(conn net.Conn) error {
 	conn = newConnImpl(conn)
 	fd := SocketFD(conn)
-	if e := syscall.SetNonblock(int(fd), true); e != nil {
+	if e := syscall.SetNonblock(fd, true); e != nil {
 		return errors.New("udev: unix.SetNonblock failed")
 	}
 

--- a/v2/pkg/netpoll/netpoll_linux.go
+++ b/v2/pkg/netpoll/netpoll_linux.go
@@ -69,7 +69,7 @@ func (e *Epoll) Close(closeConns bool) error {
 func (e *Epoll) Add(conn net.Conn) error {
 	conn = newConnImpl(conn)
 	fd := SocketFD(conn)
-	if e := syscall.SetNonblock(int(fd), true); e != nil {
+	if e := syscall.SetNonblock(fd, true); e != nil {
 		return errors.New("udev: unix.SetNonblock failed")
 	}
 

--- a/v2/pkg/netpoll/netpoll_test.go
+++ b/v2/pkg/netpoll/netpoll_test.go
@@ -60,7 +60,7 @@ func TestPoller(t *testing.T) {
 					t.Errorf("expect to write %d bytes but got %d bytes", len("hello world"), n)
 				}
 			}
-			conn.Close() // nolint: errcheck
+			conn.Close()
 		}()
 	}
 
@@ -87,9 +87,9 @@ func TestPoller(t *testing.T) {
 			for _, conn := range conns {
 				n, err := conn.Read(buf)
 				if err != nil {
-					if err == io.EOF || errors.Is(err, net.ErrClosed) {
-						poller.Remove(conn) // nolint: errcheck
-						conn.Close()        // nolint: errcheck
+					if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) {
+						poller.Remove(conn) //nolint:errcheck
+						conn.Close()
 					} else {
 						t.Error(err)
 					}
@@ -173,9 +173,9 @@ func TestPoller_growstack(t *testing.T) {
 	}
 	time.Sleep(200 * time.Millisecond)
 	for range 100 {
-		conn.Write([]byte("hello world")) // nolint: errcheck
+		conn.Write([]byte("hello world")) //nolint:errcheck
 	}
-	conn.Close() // nolint: errcheck
+	conn.Close()
 }
 
 func TestNetPollSupported(t *testing.T) {

--- a/v2/pkg/testing/subscriptiontesting/resolvers.go
+++ b/v2/pkg/testing/subscriptiontesting/resolvers.go
@@ -16,7 +16,7 @@ type ckey string
 
 type resolver struct {
 	Rooms map[string]*Chatroom
-	mu    sync.Mutex // nolint: structcheck
+	mu    sync.Mutex //nolint: structcheck
 }
 
 func (r *resolver) Mutation() MutationResolver {


### PR DESCRIPTION
## Summary

- expand the high-signal golangci-lint policy and clean up resulting findings
- define `GOLANGCI_LINT_VERSION` once in `scripts/golangci-lint.sh`
- add `make lint`, `make format`, and `make lint-fix` entry points using the pinned release
- make CI read the version through `--print-version` and pass it to the official golangci-lint action
- download the official prebuilt binary into a shared temporary cache for local runs

## Validation

- `make lint`
- `make test-quick` in `v2`
- `make test-quick` in `execution`
- golangci-lint configuration verification
- `git diff --check`

Both gated modules report zero lint issues.