### PR TITLE
fix: query planning time regression

### DIFF
--- a/v2/pkg/engine/plan/datasource_filter_visitor.go
+++ b/v2/pkg/engine/plan/datasource_filter_visitor.go
@@ -318,7 +318,13 @@ func (f *DataSourceFilter) selectUniqNodeParentsUpToRootNode(i int) {
 // requires extra gather fetches for the missing key members, so it is always the last resort.
 // Fallback paths are present in possiblePaths only when includeFallback is true.
 func hasPathBetweenDs(jumps *DataSourceJumpsGraph, from, to DSHash, includeFallback bool) (bestPath *SourceConnection, exists bool) {
-	possiblePaths, exists := jumps.getPaths(from, to, includeFallback)
+	// An exact key path always wins over a fallback one, so ask for the exact paths first:
+	// enumerating the fallback-inclusive paths - which is much more expensive because
+	// fallback edges densify the jump graph - is only needed when no exact path exists.
+	possiblePaths, exists := jumps.getPaths(from, to, false)
+	if !exists && includeFallback {
+		possiblePaths, exists = jumps.getPaths(from, to, true)
+	}
 	if !exists {
 		return nil, false
 	}

--- a/v2/pkg/engine/plan/source_connection_graph.go
+++ b/v2/pkg/engine/plan/source_connection_graph.go
@@ -1,5 +1,7 @@
 package plan
 
+import "slices"
+
 // KeyJump represents possible jump from one data source to another
 type KeyJump struct {
 	From DSHash
@@ -199,13 +201,13 @@ func sourceKeyIsSubsetOfTargetKey(sourceKey, targetKey KeyInfo) bool {
 		return false
 	}
 
-	targetPaths := make(map[string]struct{}, len(targetKey.FieldPaths))
-	for _, path := range targetKey.FieldPaths {
-		targetPaths[path.Path] = struct{}{}
-	}
-
+	// keys have only a few field paths, so a nested scan is cheaper
+	// than building a lookup map: this runs for every (source key, target key)
+	// pair of every datasource pair sharing a type
 	for _, path := range sourceKey.FieldPaths {
-		if _, ok := targetPaths[path.Path]; !ok {
+		if !slices.ContainsFunc(targetKey.FieldPaths, func(targetPath KeyInfoFieldPath) bool {
+			return targetPath.Path == path.Path
+		}) {
 			return false
 		}
 	}


### PR DESCRIPTION
## Problem

The planner-fixes merge (#1581) made planning of large federated operations up to ~1.9x slower
(reference operation from a 46-subgraph federated graph: ~600 ms → ~1090 ms single-threaded plan time).
In the CI benchmark the regression is amplified by concurrent planning of all operations,
showing up as >20 s plan times against the 4s error threshold.

## Root cause

Multi-hop compound `@key` synthesis added fallback `KeyJump` edges (source key ⊂ target compound key) to the datasource jump graphs.
`DataSourceJumpsGraph.getPaths` enumerates all simple paths up to depth 10,
so even ~4% more edges multiply the enumerated paths by an order of magnitude
(DFS invocations per plan: 429k → 2,259k; a single (source, target) pair: 7,178 paths / ~60 ms).

Nearly all of that work is discarded:
`hasPathBetweenDs` always prefers an exact path over every fallback path,
and on the reference operation the 202 (of 1146) fallback-mode queries which do have an exact path
carried 513.4 ms of the 513.7 ms of fallback DFS time.
The 944 queries which genuinely need fallback paths cost 0.30 ms in total.

## Fix

- `hasPathBetweenDs` now asks for exact-only paths first,
  and enumerates the fallback-inclusive path set only when no exact path exists.
  This is result-identical:
  the fallback-inclusive set is exactly the exact-only set plus paths containing a fallback jump,  and the preference order ignores those extra paths whenever any exact path exists.
- `sourceKeyIsSubsetOfTargetKey` no longer allocates a lookup map per (source key, target key) comparison inside the O(datasources² × keys²) jump-graph construction loop.

## Results

- Reference operation: ~1090 ms → ~710 ms plan time (pre-regression baseline ~630 ms); worst regressed operation: 1161 ms → 770 ms.
- Generated plans are byte-identical to both master and the pre-regression baseline.
- Full v2 suite green, lint clean.

<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data source path selection to prioritize exact matches.
  * Fallback paths are now considered only when no exact path is available and fallback behavior is enabled.
  * Improved path matching consistency when evaluating connections between data sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->