### PR TITLE
fix: resolve concrete __typename for entity interfaces served by non-resolvable (event-driven) datasources

### DIFF
--- a/v2/pkg/astvisitor/visitor.go
+++ b/v2/pkg/astvisitor/visitor.go
@@ -1913,11 +1913,13 @@ func (w *Walker) walkField(ref int, skipFor SkipVisitors) {
 	w.setCurrent(ast.NodeKindField, ref)
 
 	for i := 0; i < len(w.visitors.enterField); {
-		ancestorAllowed := skipFor.Allow(w.visitors.enterField[i])
 		allowedToVisit := w.filter == nil || w.filter.AllowVisitor(EnterField, ref, w.visitors.enterField[i], skipFor)
 		skipFor = newSkipVisitors(skipFor, w.visitors.enterField[i], allowedToVisit)
 
-		if allowedToVisit && ancestorAllowed {
+		// gate on the filter decision alone: gating on the skip set from before this field's own
+		// allow/deny was applied could suppress EnterField for an explicitly allowed field while
+		// the LeaveField loop below, which sees the updated skip set, still fired
+		if allowedToVisit {
 			w.visitors.enterField[i].EnterField(ref)
 		}
 		if w.revisit {

--- a/v2/pkg/astvisitor/visitor_skipfor_test.go
+++ b/v2/pkg/astvisitor/visitor_skipfor_test.go
@@ -1,0 +1,254 @@
+package astvisitor_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/asttransform"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astvisitor"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/internal/unsafeparser"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/operationreport"
+)
+
+const skipForDefinition = `
+	schema { query: Query }
+	type Query {
+		root: Root
+		node: Node
+	}
+	type Root {
+		a: Leaf
+		b: Leaf
+	}
+	type Leaf {
+		x: String
+		y: String
+	}
+	interface Node {
+		id: ID
+	}
+	type NodeA implements Node {
+		id: ID
+		na: Leaf
+	}
+	type NodeB implements Node {
+		id: ID
+		nb: Leaf
+	}
+`
+
+// recordingPlanner mimics a datasource planner: a VisitorIdentifier keeping a node stack
+// pushed on enter and popped on leave - the invariant the walker has to keep balanced
+type recordingPlanner struct {
+	walker *astvisitor.Walker
+	op     *ast.Document
+
+	id int
+
+	trace           []string
+	fieldStack      []int
+	ancestryAtEnter []string
+	unbalanced      []string
+}
+
+func (r *recordingPlanner) ID() int      { return r.id }
+func (r *recordingPlanner) SetID(id int) { r.id = id }
+func (r *recordingPlanner) name(ref int) string {
+	return r.op.FieldAliasOrNameString(ref)
+}
+
+func (r *recordingPlanner) path(ref int) string {
+	return r.walker.Path.DotDelimitedString() + "." + r.op.FieldAliasOrNameString(ref)
+}
+
+func (r *recordingPlanner) EnterField(ref int) {
+	r.trace = append(r.trace, "enter:"+r.path(ref))
+	r.fieldStack = append(r.fieldStack, ref)
+	ancestors := make([]string, 0, len(r.walker.Ancestors))
+	for _, a := range r.walker.Ancestors {
+		ancestors = append(ancestors, a.Kind.String())
+	}
+	r.ancestryAtEnter = append(r.ancestryAtEnter, strings.Join(ancestors, ">"))
+}
+
+func (r *recordingPlanner) LeaveField(ref int) {
+	r.trace = append(r.trace, "leave:"+r.path(ref))
+	if len(r.fieldStack) == 0 {
+		r.unbalanced = append(r.unbalanced, fmt.Sprintf("LeaveField(%s) with empty stack", r.path(ref)))
+		return
+	}
+	top := r.fieldStack[len(r.fieldStack)-1]
+	if top != ref {
+		r.unbalanced = append(r.unbalanced, fmt.Sprintf("LeaveField(%s) but stack top is %s", r.path(ref), r.name(top)))
+	}
+	r.fieldStack = r.fieldStack[:len(r.fieldStack)-1]
+}
+
+func (r *recordingPlanner) EnterSelectionSet(ref int) {
+	r.trace = append(r.trace, "enterSS")
+}
+
+func (r *recordingPlanner) LeaveSelectionSet(ref int) {
+	r.trace = append(r.trace, "leaveSS")
+}
+
+func (r *recordingPlanner) EnterInlineFragment(ref int) {
+	r.trace = append(r.trace, "enterIF:"+r.op.InlineFragmentTypeConditionNameString(ref))
+}
+
+func (r *recordingPlanner) LeaveInlineFragment(ref int) {
+	r.trace = append(r.trace, "leaveIF:"+r.op.InlineFragmentTypeConditionNameString(ref))
+}
+
+// pathFilter mimics plan.Visitor.AllowVisitor: the field decision is a pure per-path lookup
+// which does not consult skipFor, every other node kind inherits the ancestor decision
+type pathFilter struct {
+	walker       *astvisitor.Walker
+	op           *ast.Document
+	allowedPaths map[string]bool
+}
+
+func (f *pathFilter) AllowVisitor(kind astvisitor.VisitorKind, ref int, visitor any, skipFor astvisitor.SkipVisitors) bool {
+	if visitor == f {
+		return true
+	}
+	switch kind {
+	case astvisitor.EnterField, astvisitor.LeaveField:
+		path := f.walker.Path.DotDelimitedString() + "." + f.op.FieldAliasOrNameString(ref)
+		return f.allowedPaths[path]
+	default:
+		return skipFor.Allow(visitor)
+	}
+}
+
+func runSkipForCase(t *testing.T, operation string, allowed map[string]bool) *recordingPlanner {
+	t.Helper()
+
+	def := unsafeparser.ParseGraphqlDocumentString(skipForDefinition)
+	require.NoError(t, asttransform.MergeDefinitionWithBaseSchema(&def))
+	op := unsafeparser.ParseGraphqlDocumentString(operation)
+	report := operationreport.Report{}
+
+	walker := astvisitor.NewWalker(48)
+	planner := &recordingPlanner{walker: &walker, op: &op}
+	filter := &pathFilter{walker: &walker, op: &op, allowedPaths: allowed}
+
+	walker.RegisterFieldVisitor(planner)
+	walker.RegisterSelectionSetVisitor(planner)
+	walker.RegisterInlineFragmentVisitor(planner)
+	walker.SetVisitorFilter(filter)
+
+	walker.Walk(&op, &def, &report)
+	require.False(t, report.HasErrors(), "%v", report)
+
+	return planner
+}
+
+func TestSkipForExplicitAllowUnderSkippedAncestor(t *testing.T) {
+	planner := runSkipForCase(t,
+		`query { root { a { x } b { y } } }`,
+		map[string]bool{
+			"query.root.a":   true,
+			"query.root.a.x": true,
+		})
+
+	assert.Empty(t, planner.unbalanced, "enter/leave must stay balanced")
+	assert.Empty(t, planner.fieldStack, "planner node stack must be empty at the end of the walk")
+
+	assert.Equal(t, []string{
+		"enter:query.root.a",
+		"enter:query.root.a.x",
+		"leave:query.root.a.x",
+		"leave:query.root.a",
+	}, fieldTrace(planner.trace))
+
+	assert.Equal(t,
+		"NodeKindOperationDefinition>NodeKindSelectionSet>NodeKindField>NodeKindSelectionSet",
+		planner.ancestryAtEnter[0])
+}
+
+func TestSkipForDenyThenAllowSiblings(t *testing.T) {
+	planner := runSkipForCase(t,
+		`query { root { a { x y } b { x y } } }`,
+		map[string]bool{
+			"query.root":     false,
+			"query.root.a":   true,
+			"query.root.a.y": true,
+			"query.root.b":   true,
+			"query.root.b.x": true,
+		})
+
+	assert.Empty(t, planner.unbalanced)
+	assert.Empty(t, planner.fieldStack)
+	assert.Equal(t, []string{
+		"enter:query.root.a",
+		"enter:query.root.a.y",
+		"leave:query.root.a.y",
+		"leave:query.root.a",
+		"enter:query.root.b",
+		"enter:query.root.b.x",
+		"leave:query.root.b.x",
+		"leave:query.root.b",
+	}, fieldTrace(planner.trace))
+}
+
+func TestSkipForNestedFragmentsMixedAllows(t *testing.T) {
+	planner := runSkipForCase(t,
+		`query {
+			node {
+				id
+				... on NodeA { id na { x } }
+				... on NodeB { nb { y } }
+			}
+		}`,
+		map[string]bool{
+			"query.node":              false,
+			"query.node.id":           true,
+			"query.node.$0NodeA.na":   true,
+			"query.node.$0NodeA.na.x": true,
+			"query.node.$1NodeB.nb":   true,
+		})
+
+	assert.Empty(t, planner.unbalanced)
+	assert.Empty(t, planner.fieldStack)
+	assert.Equal(t, []string{
+		"enter:query.node.id",
+		"leave:query.node.id",
+		"enter:query.node.$0NodeA.na",
+		"enter:query.node.$0NodeA.na.x",
+		"leave:query.node.$0NodeA.na.x",
+		"leave:query.node.$0NodeA.na",
+		"enter:query.node.$1NodeB.nb",
+		"leave:query.node.$1NodeB.nb",
+	}, fieldTrace(planner.trace))
+}
+
+func TestSkipForDeepestAllowUnderTwoDeniedAncestors(t *testing.T) {
+	planner := runSkipForCase(t,
+		`query { root { a { x y } } }`,
+		map[string]bool{
+			"query.root.a.y": true,
+		})
+
+	assert.Empty(t, planner.unbalanced)
+	assert.Empty(t, planner.fieldStack)
+	assert.Equal(t, []string{
+		"enter:query.root.a.y",
+		"leave:query.root.a.y",
+	}, fieldTrace(planner.trace))
+}
+
+func fieldTrace(trace []string) []string {
+	out := make([]string, 0, len(trace))
+	for _, t := range trace {
+		if strings.HasPrefix(t, "enter:") || strings.HasPrefix(t, "leave:") {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/v2/pkg/engine/datasource/graphql_datasource/entity_interfaces_engine_config.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/entity_interfaces_engine_config.go
@@ -55,12 +55,30 @@ const EntityInterfacesDefinition = `
 
 		union Accounts = Admin | Moderator | User
 
+		interface OrphanEvent {
+		  id: ID!
+		}
+
+		type OrphanA implements OrphanEvent {
+		  id: ID!
+		}
+
+		type OrphanB implements OrphanEvent {
+		  id: ID!
+		}
+
 		type Query {
 		  allAccountsInterface: [Account]
 		  allAccountsUnion: [Accounts]
 		  user(id: ID!): User
 		  admin(id: ID!): Admin
 		  accountLocations: [Account!]!
+		}
+
+		type Subscription {
+		  accountEvents: Account!
+		  userEvents: User!
+		  orphanEvents: OrphanEvent!
 		}`
 
 func EntityInterfacesPlanConfiguration(t *testing.T, factory plan.PlannerFactory[Configuration]) *plan.Configuration {
@@ -408,11 +426,209 @@ func EntityInterfacesPlanConfiguration(t *testing.T, factory plan.PlannerFactory
 	)
 	require.NoError(t, err)
 
+	// The fifth subgraph models an event-driven subgraph: it publishes entity interface events but
+	// cannot resolve entities itself, so all of its keys have the entity resolver disabled.
+	fifthSubgraphSDL := `
+		interface Account @key(fields: "id", resolvable: false) {
+			id: ID!
+		}
+
+		type Admin implements Account @key(fields: "id", resolvable: false) {
+			id: ID!
+		}
+
+		type Moderator implements Account @key(fields: "id", resolvable: false) {
+			id: ID!
+		}
+
+		type User implements Account @key(fields: "id", resolvable: false) {
+			id: ID!
+		}
+
+		type Subscription {
+			accountEvents: Account!
+			userEvents: User!
+		}`
+
+	fifthDatasourceSchemaConfiguration, err := NewSchemaConfiguration(
+		fifthSubgraphSDL,
+		&FederationConfiguration{
+			Enabled:    true,
+			ServiceSDL: fifthSubgraphSDL,
+		},
+	)
+	require.NoError(t, err)
+
+	fifthCustomConfiguration, err := NewConfiguration(ConfigurationInput{
+		Fetch: &FetchConfiguration{
+			URL: "http://localhost:4005/graphql",
+		},
+		Subscription: &SubscriptionConfiguration{
+			URL: "ws://localhost:4005/graphql",
+		},
+		SchemaConfiguration: fifthDatasourceSchemaConfiguration,
+	})
+	require.NoError(t, err)
+
+	fifthDatasourceConfiguration, err := plan.NewDataSourceConfiguration[Configuration](
+		"events",
+		factory,
+		&plan.DataSourceMetadata{
+			RootNodes: []plan.TypeField{
+				{
+					TypeName:   "Subscription",
+					FieldNames: []string{"accountEvents", "userEvents"},
+				},
+				{
+					TypeName:   "Account",
+					FieldNames: []string{"id"},
+				},
+				{
+					TypeName:   "Admin",
+					FieldNames: []string{"id"},
+				},
+				{
+					TypeName:   "Moderator",
+					FieldNames: []string{"id"},
+				},
+				{
+					TypeName:   "User",
+					FieldNames: []string{"id"},
+				},
+			},
+			FederationMetaData: plan.FederationMetaData{
+				EntityInterfaces: []plan.EntityInterfaceConfiguration{
+					{
+						InterfaceTypeName: "Account",
+						ConcreteTypeNames: []string{"Admin", "Moderator", "User"},
+					},
+				},
+				Keys: plan.FederationFieldConfigurations{
+					{
+						TypeName:              "Account",
+						SelectionSet:          "id",
+						DisableEntityResolver: true,
+					},
+					{
+						TypeName:              "Admin",
+						SelectionSet:          "id",
+						DisableEntityResolver: true,
+					},
+					{
+						TypeName:              "Moderator",
+						SelectionSet:          "id",
+						DisableEntityResolver: true,
+					},
+					{
+						TypeName:              "User",
+						SelectionSet:          "id",
+						DisableEntityResolver: true,
+					},
+				},
+			},
+		},
+		fifthCustomConfiguration,
+	)
+	require.NoError(t, err)
+
+	// The sixth subgraph publishes an entity interface which no other subgraph declares, so no
+	// datasource is able to resolve it. Its __typename has to stay on this datasource.
+	sixthSubgraphSDL := `
+		interface OrphanEvent @key(fields: "id", resolvable: false) {
+			id: ID!
+		}
+
+		type OrphanA implements OrphanEvent @key(fields: "id", resolvable: false) {
+			id: ID!
+		}
+
+		type OrphanB implements OrphanEvent @key(fields: "id", resolvable: false) {
+			id: ID!
+		}
+
+		type Subscription {
+			orphanEvents: OrphanEvent!
+		}`
+
+	sixthDatasourceSchemaConfiguration, err := NewSchemaConfiguration(
+		sixthSubgraphSDL,
+		&FederationConfiguration{
+			Enabled:    true,
+			ServiceSDL: sixthSubgraphSDL,
+		},
+	)
+	require.NoError(t, err)
+
+	sixthCustomConfiguration, err := NewConfiguration(ConfigurationInput{
+		Fetch: &FetchConfiguration{
+			URL: "http://localhost:4006/graphql",
+		},
+		Subscription: &SubscriptionConfiguration{
+			URL: "ws://localhost:4006/graphql",
+		},
+		SchemaConfiguration: sixthDatasourceSchemaConfiguration,
+	})
+	require.NoError(t, err)
+
+	sixthDatasourceConfiguration, err := plan.NewDataSourceConfiguration[Configuration](
+		"orphan-events",
+		factory,
+		&plan.DataSourceMetadata{
+			RootNodes: []plan.TypeField{
+				{
+					TypeName:   "Subscription",
+					FieldNames: []string{"orphanEvents"},
+				},
+				{
+					TypeName:   "OrphanEvent",
+					FieldNames: []string{"id"},
+				},
+				{
+					TypeName:   "OrphanA",
+					FieldNames: []string{"id"},
+				},
+				{
+					TypeName:   "OrphanB",
+					FieldNames: []string{"id"},
+				},
+			},
+			FederationMetaData: plan.FederationMetaData{
+				EntityInterfaces: []plan.EntityInterfaceConfiguration{
+					{
+						InterfaceTypeName: "OrphanEvent",
+						ConcreteTypeNames: []string{"OrphanA", "OrphanB"},
+					},
+				},
+				Keys: plan.FederationFieldConfigurations{
+					{
+						TypeName:              "OrphanEvent",
+						SelectionSet:          "id",
+						DisableEntityResolver: true,
+					},
+					{
+						TypeName:              "OrphanA",
+						SelectionSet:          "id",
+						DisableEntityResolver: true,
+					},
+					{
+						TypeName:              "OrphanB",
+						SelectionSet:          "id",
+						DisableEntityResolver: true,
+					},
+				},
+			},
+		},
+		sixthCustomConfiguration,
+	)
+	require.NoError(t, err)
+
 	dataSources := []plan.DataSource{
 		firstDatasourceConfiguration,
 		secondDatasourceConfiguration,
 		thirdDatasourceConfiguration,
 		fourthDatasourceConfiguration,
+		fifthDatasourceConfiguration,
+		sixthDatasourceConfiguration,
 	}
 
 	planConfiguration := plan.Configuration{

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
@@ -91,6 +91,8 @@ type Planner[T Configuration] struct {
 
 	addedInlineFragments map[onTypeInlineFragment]struct{}
 	hasFederationRoot    bool
+	// field ref whose on-type inline fragment is closed again in LeaveField
+	closeOnTypeInlineFragmentFieldRef int
 
 	minifier *astminify.Minifier
 
@@ -695,11 +697,13 @@ func (p *Planner[T]) EnterInlineFragment(ref int) {
 		return
 	}
 
-	if p.config.IsFederationEnabled() && !p.hasFederationRoot && p.isNestedRequest() {
+	if p.config.IsFederationEnabled() && (p.isInEntitiesSelectionSet() || (!p.hasFederationRoot && p.isNestedRequest())) {
 		// if we're inside the nested root of a federated abstract query,
 		// we're walking into the inline fragment as the root
 		// however, as we're already handling the inline fragment when we walk into the root field,
 		// we can skip this one
+		// isNestedRequest no longer holds once the _entities selection set exists,
+		// so we also key on being inside it
 		return
 	}
 
@@ -804,9 +808,29 @@ func (p *Planner[T]) EnterField(ref int) {
 		p.rootTypeName = p.lastFieldEnclosingTypeName
 	}
 
+	closeOnTypeInlineFragment := p.isTypenameOnAbstractEntitiesRoot(ref) && p.isOnTypeInlineFragmentAllowed()
+
 	p.handleOnTypeInlineFragment()
 
 	p.addFieldArguments(p.addField(ref), ref, fieldConfiguration)
+
+	if closeOnTypeInlineFragment {
+		p.closeOnTypeInlineFragmentFieldRef = ref
+	}
+}
+
+// isTypenameOnAbstractEntitiesRoot reports whether ref is a __typename selected directly on an
+// abstract type in the _entities selection set. Such a field needs a fragment on the abstract type
+// itself - a fragment on a concrete implementation cannot answer it - and that fragment has to be
+// closed again in LeaveField so the sibling on-type fragments don't end up nested inside it.
+func (p *Planner[T]) isTypenameOnAbstractEntitiesRoot(ref int) bool {
+	if !p.hasFederationRoot || !p.isInEntitiesSelectionSet() {
+		return false
+	}
+	if !bytes.Equal(p.visitor.Operation.FieldNameBytes(ref), literal.TYPENAME) {
+		return false
+	}
+	return p.visitor.Walker.EnclosingTypeDefinition.Kind.IsAbstractType()
 }
 
 func (p *Planner[T]) addFieldArguments(upstreamFieldRef int, fieldRef int, fieldConfiguration *plan.FieldConfiguration) {
@@ -848,6 +872,12 @@ func (p *Planner[T]) LeaveField(ref int) {
 	}
 
 	p.nodes = p.nodes[:len(p.nodes)-1]
+
+	if p.closeOnTypeInlineFragmentFieldRef == ref {
+		// leave the on-type inline fragment opened for this field in EnterField
+		p.closeOnTypeInlineFragmentFieldRef = ast.InvalidRef
+		p.nodes = p.nodes[:len(p.nodes)-1]
+	}
 }
 
 // allowField - allows processing a field if datasource has corresponding root or child node
@@ -902,6 +932,7 @@ func (p *Planner[T]) EnterDocument(_, _ *ast.Document) {
 
 	p.addDirectivesToVariableDefinitions = map[int][]int{}
 	p.addedInlineFragments = map[onTypeInlineFragment]struct{}{}
+	p.closeOnTypeInlineFragmentFieldRef = ast.InvalidRef
 }
 
 func (p *Planner[T]) LeaveDocument(_, _ *ast.Document) {

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource_federation_entity_interfaces_edfs_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource_federation_entity_interfaces_edfs_test.go
@@ -1,0 +1,586 @@
+package graphql_datasource
+
+import (
+	"testing"
+
+	. "github.com/wundergraph/graphql-go-tools/v2/pkg/engine/datasourcetesting"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+// TestGraphQLDataSourceFederationEntityInterfacesEventDriven covers entity interface subscription
+// roots on a datasource with every key having DisableEntityResolver, as composed for an event-driven
+// subgraph: the concrete __typename has to come from a datasource which can resolve the entity.
+func TestGraphQLDataSourceFederationEntityInterfacesEventDriven(t *testing.T) {
+	federationFactory := &Factory[Configuration]{}
+
+	definition := EntityInterfacesDefinition
+	planConfiguration := *EntityInterfacesPlanConfiguration(t, federationFactory)
+
+	t.Run("subscription 0 - entity interface __typename with a local and a key-only fragment", RunTest(
+		definition,
+		`
+			subscription _0_EntityInterfaceTypenameMixed {
+				accountEvents {
+					__typename
+					... on Moderator {
+						id
+						title
+					}
+					... on User {
+						id
+					}
+				}
+			}`,
+		"_0_EntityInterfaceTypenameMixed",
+		&plan.SubscriptionResponsePlan{
+			Response: &resolve.GraphQLSubscription{
+				Trigger: resolve.GraphQLSubscriptionTrigger{
+					Input:          []byte(`{"url":"ws://localhost:4005/graphql","body":{"query":"subscription{accountEvents {__typename ... on Moderator {id __typename} ... on User {id} id}}"}}`),
+					Source:         &SubscriptionSource{},
+					PostProcessing: DefaultPostProcessingConfiguration,
+					SourceName:     "events",
+					SourceID:       "events",
+				},
+				Response: &resolve.GraphQLResponse{
+					Fetches: resolve.Sequence(
+						resolve.SingleWithPath(&resolve.SingleFetch{
+							FetchDependencies: resolve.FetchDependencies{
+								FetchID:           1,
+								DependsOnFetchIDs: []int{0},
+							},
+							FetchConfiguration: resolve.FetchConfiguration{
+								Input: `{"method":"POST","url":"http://localhost:4001/graphql","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){... on Account {__typename} ... on Moderator {__typename title}}}","variables":{"representations":[$$0$$]}}}`,
+								Variables: []resolve.Variable{
+									&resolve.ResolvableObjectVariable{
+										Renderer: resolve.NewGraphQLVariableResolveRenderer(&resolve.Object{
+											Nullable: true,
+											Fields: []*resolve.Field{
+												{
+													Name: []byte("__typename"),
+													Value: &resolve.String{
+														Path: []string{"__typename"},
+													},
+													OnTypeNames: [][]byte{[]byte("Moderator"), []byte("Account")},
+												},
+												{
+													Name: []byte("id"),
+													Value: &resolve.Scalar{
+														Path: []string{"id"},
+													},
+													OnTypeNames: [][]byte{[]byte("Moderator"), []byte("Account")},
+												},
+												{
+													Name: []byte("__typename"),
+													Value: &resolve.String{
+														Path: []string{"__typename"},
+													},
+													OnTypeNames: [][]byte{[]byte("Account")},
+												},
+												{
+													Name: []byte("id"),
+													Value: &resolve.Scalar{
+														Path: []string{"id"},
+													},
+													OnTypeNames: [][]byte{[]byte("Account")},
+												},
+											},
+										}),
+									},
+								},
+								RequiresEntityFetch:                   true,
+								PostProcessing:                        SingleEntityPostProcessingConfiguration,
+								DataSource:                            &Source{},
+								SetTemplateOutputToNullOnVariableNull: true,
+							},
+							DataSourceIdentifier: []byte("graphql_datasource.Source"),
+						}, "accountEvents", resolve.ObjectPath("accountEvents")),
+					),
+					Data: &resolve.Object{
+						Fields: []*resolve.Field{
+							{
+								Name: []byte("accountEvents"),
+								Value: &resolve.Object{
+									Path: []string{"accountEvents"},
+									PossibleTypes: map[string]struct{}{
+										"Account":   {},
+										"Admin":     {},
+										"Moderator": {},
+										"User":      {},
+									},
+									TypeName: "Account",
+									Fields: []*resolve.Field{
+										{
+											Name: []byte("__typename"),
+											Value: &resolve.String{
+												Path:       []string{"__typename"},
+												IsTypeName: true,
+											},
+										},
+										{
+											Name: []byte("id"),
+											Value: &resolve.Scalar{
+												Path: []string{"id"},
+											},
+											OnTypeNames: [][]byte{[]byte("Moderator")},
+										},
+										{
+											Name: []byte("title"),
+											Value: &resolve.String{
+												Path: []string{"title"},
+											},
+											OnTypeNames: [][]byte{[]byte("Moderator")},
+										},
+										{
+											Name: []byte("id"),
+											Value: &resolve.Scalar{
+												Path: []string{"id"},
+											},
+											OnTypeNames: [][]byte{[]byte("User")},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		planConfiguration,
+		WithDefaultPostProcessor(),
+	))
+
+	t.Run("subscription 1 - entity interface __typename with a fragment resolved on a third subgraph", RunTest(
+		definition,
+		`
+			subscription _1_EntityInterfaceTypenameRemoteFragment {
+				accountEvents {
+					__typename
+					... on Admin {
+						id
+						title
+					}
+					... on User {
+						id
+					}
+				}
+			}`,
+		"_1_EntityInterfaceTypenameRemoteFragment",
+		&plan.SubscriptionResponsePlan{
+			Response: &resolve.GraphQLSubscription{
+				Trigger: resolve.GraphQLSubscriptionTrigger{
+					Input:          []byte(`{"url":"ws://localhost:4005/graphql","body":{"query":"subscription{accountEvents {__typename ... on Admin {id __typename} ... on User {id} id}}"}}`),
+					Source:         &SubscriptionSource{},
+					PostProcessing: DefaultPostProcessingConfiguration,
+					SourceName:     "events",
+					SourceID:       "events",
+				},
+				Response: &resolve.GraphQLResponse{
+					Fetches: resolve.Sequence(
+						// Admin.title is external on the first subgraph, so it is fetched from the
+						// third one, while the entity interface __typename comes from the first.
+						resolve.SingleWithPath(&resolve.SingleFetch{
+							FetchDependencies: resolve.FetchDependencies{
+								FetchID:           1,
+								DependsOnFetchIDs: []int{0},
+							},
+							FetchConfiguration: resolve.FetchConfiguration{
+								Input: `{"method":"POST","url":"http://localhost:4003/graphql","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){... on Admin {__typename title}}}","variables":{"representations":[$$0$$]}}}`,
+								Variables: []resolve.Variable{
+									&resolve.ResolvableObjectVariable{
+										Renderer: resolve.NewGraphQLVariableResolveRenderer(&resolve.Object{
+											Nullable: true,
+											Fields: []*resolve.Field{
+												{
+													Name: []byte("__typename"),
+													Value: &resolve.String{
+														Path: []string{"__typename"},
+													},
+													OnTypeNames: [][]byte{[]byte("Admin")},
+												},
+												{
+													Name: []byte("id"),
+													Value: &resolve.Scalar{
+														Path: []string{"id"},
+													},
+													OnTypeNames: [][]byte{[]byte("Admin")},
+												},
+											},
+										}),
+									},
+								},
+								RequiresEntityFetch:                   true,
+								PostProcessing:                        SingleEntityPostProcessingConfiguration,
+								DataSource:                            &Source{},
+								SetTemplateOutputToNullOnVariableNull: true,
+							},
+							DataSourceIdentifier: []byte("graphql_datasource.Source"),
+						}, "accountEvents", resolve.ObjectPath("accountEvents")),
+						resolve.SingleWithPath(&resolve.SingleFetch{
+							FetchDependencies: resolve.FetchDependencies{
+								FetchID:           2,
+								DependsOnFetchIDs: []int{0},
+							},
+							FetchConfiguration: resolve.FetchConfiguration{
+								Input: `{"method":"POST","url":"http://localhost:4001/graphql","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){... on Account {__typename}}}","variables":{"representations":[$$0$$]}}}`,
+								Variables: []resolve.Variable{
+									&resolve.ResolvableObjectVariable{
+										Renderer: resolve.NewGraphQLVariableResolveRenderer(&resolve.Object{
+											Nullable: true,
+											Fields: []*resolve.Field{
+												{
+													Name: []byte("__typename"),
+													Value: &resolve.String{
+														Path: []string{"__typename"},
+													},
+													OnTypeNames: [][]byte{[]byte("Account")},
+												},
+												{
+													Name: []byte("id"),
+													Value: &resolve.Scalar{
+														Path: []string{"id"},
+													},
+													OnTypeNames: [][]byte{[]byte("Account")},
+												},
+											},
+										}),
+									},
+								},
+								RequiresEntityFetch:                   true,
+								PostProcessing:                        SingleEntityPostProcessingConfiguration,
+								DataSource:                            &Source{},
+								SetTemplateOutputToNullOnVariableNull: true,
+							},
+							DataSourceIdentifier: []byte("graphql_datasource.Source"),
+						}, "accountEvents", resolve.ObjectPath("accountEvents")),
+					),
+					Data: &resolve.Object{
+						Fields: []*resolve.Field{
+							{
+								Name: []byte("accountEvents"),
+								Value: &resolve.Object{
+									Path: []string{"accountEvents"},
+									PossibleTypes: map[string]struct{}{
+										"Account":   {},
+										"Admin":     {},
+										"Moderator": {},
+										"User":      {},
+									},
+									TypeName: "Account",
+									Fields: []*resolve.Field{
+										{
+											Name: []byte("__typename"),
+											Value: &resolve.String{
+												Path:       []string{"__typename"},
+												IsTypeName: true,
+											},
+										},
+										{
+											Name: []byte("id"),
+											Value: &resolve.Scalar{
+												Path: []string{"id"},
+											},
+											OnTypeNames: [][]byte{[]byte("Admin")},
+										},
+										{
+											Name: []byte("title"),
+											Value: &resolve.String{
+												Path: []string{"title"},
+											},
+											OnTypeNames: [][]byte{[]byte("Admin")},
+										},
+										{
+											Name: []byte("id"),
+											Value: &resolve.Scalar{
+												Path: []string{"id"},
+											},
+											OnTypeNames: [][]byte{[]byte("User")},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		planConfiguration,
+		WithDefaultPostProcessor(),
+	))
+
+	t.Run("subscription 2 - entity interface __typename with key-only fragments", RunTest(
+		definition,
+		`
+			subscription _2_EntityInterfaceTypenameKeyOnly {
+				accountEvents {
+					__typename
+					... on User {
+						id
+					}
+				}
+			}`,
+		"_2_EntityInterfaceTypenameKeyOnly",
+		&plan.SubscriptionResponsePlan{
+			Response: &resolve.GraphQLSubscription{
+				Trigger: resolve.GraphQLSubscriptionTrigger{
+					Input:          []byte(`{"url":"ws://localhost:4005/graphql","body":{"query":"subscription{accountEvents {__typename ... on User {id} id}}"}}`),
+					Source:         &SubscriptionSource{},
+					PostProcessing: DefaultPostProcessingConfiguration,
+					SourceName:     "events",
+					SourceID:       "events",
+				},
+				Response: &resolve.GraphQLResponse{
+					Fetches: resolve.Sequence(
+						// Nothing but the key is selected from the concrete type, yet the entity
+						// still has to be fetched to learn its concrete __typename.
+						resolve.SingleWithPath(&resolve.SingleFetch{
+							FetchDependencies: resolve.FetchDependencies{
+								FetchID:           1,
+								DependsOnFetchIDs: []int{0},
+							},
+							FetchConfiguration: resolve.FetchConfiguration{
+								Input: `{"method":"POST","url":"http://localhost:4001/graphql","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){... on Account {__typename}}}","variables":{"representations":[$$0$$]}}}`,
+								Variables: []resolve.Variable{
+									&resolve.ResolvableObjectVariable{
+										Renderer: resolve.NewGraphQLVariableResolveRenderer(&resolve.Object{
+											Nullable: true,
+											Fields: []*resolve.Field{
+												{
+													Name: []byte("__typename"),
+													Value: &resolve.String{
+														Path: []string{"__typename"},
+													},
+													OnTypeNames: [][]byte{[]byte("Account")},
+												},
+												{
+													Name: []byte("id"),
+													Value: &resolve.Scalar{
+														Path: []string{"id"},
+													},
+													OnTypeNames: [][]byte{[]byte("Account")},
+												},
+											},
+										}),
+									},
+								},
+								RequiresEntityFetch:                   true,
+								PostProcessing:                        SingleEntityPostProcessingConfiguration,
+								DataSource:                            &Source{},
+								SetTemplateOutputToNullOnVariableNull: true,
+							},
+							DataSourceIdentifier: []byte("graphql_datasource.Source"),
+						}, "accountEvents", resolve.ObjectPath("accountEvents")),
+					),
+					Data: &resolve.Object{
+						Fields: []*resolve.Field{
+							{
+								Name: []byte("accountEvents"),
+								Value: &resolve.Object{
+									Path: []string{"accountEvents"},
+									PossibleTypes: map[string]struct{}{
+										"Account":   {},
+										"Admin":     {},
+										"Moderator": {},
+										"User":      {},
+									},
+									TypeName: "Account",
+									Fields: []*resolve.Field{
+										{
+											Name: []byte("__typename"),
+											Value: &resolve.String{
+												Path:       []string{"__typename"},
+												IsTypeName: true,
+											},
+										},
+										{
+											Name: []byte("id"),
+											Value: &resolve.Scalar{
+												Path: []string{"id"},
+											},
+											OnTypeNames: [][]byte{[]byte("User")},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		planConfiguration,
+		WithDefaultPostProcessor(),
+	))
+
+	t.Run("subscription 3 - entity interface which no datasource can resolve keeps __typename local", RunTest(
+		definition,
+		`
+			subscription _3_SoleSourceEntityInterfaceTypename {
+				orphanEvents {
+					__typename
+				}
+			}`,
+		"_3_SoleSourceEntityInterfaceTypename",
+		&plan.SubscriptionResponsePlan{
+			Response: &resolve.GraphQLSubscription{
+				Trigger: resolve.GraphQLSubscriptionTrigger{
+					Input:          []byte(`{"url":"ws://localhost:4006/graphql","body":{"query":"subscription{orphanEvents {__typename}}"}}`),
+					Source:         &SubscriptionSource{},
+					PostProcessing: DefaultPostProcessingConfiguration,
+					SourceName:     "orphan-events",
+					SourceID:       "orphan-events",
+				},
+				Response: &resolve.GraphQLResponse{
+					Fetches: resolve.Sequence(),
+					Data: &resolve.Object{
+						Fields: []*resolve.Field{
+							{
+								Name: []byte("orphanEvents"),
+								Value: &resolve.Object{
+									Path: []string{"orphanEvents"},
+									PossibleTypes: map[string]struct{}{
+										"OrphanA":     {},
+										"OrphanB":     {},
+										"OrphanEvent": {},
+									},
+									TypeName: "OrphanEvent",
+									Fields: []*resolve.Field{
+										{
+											Name: []byte("__typename"),
+											Value: &resolve.String{
+												Path:       []string{"__typename"},
+												IsTypeName: true,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		planConfiguration,
+		WithDefaultPostProcessor(),
+	))
+
+	t.Run("subscription 4 - __typename inside a concrete member fragment stays local", RunTest(
+		definition,
+		`
+			subscription _4_ConcreteMemberTypename {
+				accountEvents {
+					... on User {
+						__typename
+						id
+					}
+				}
+			}`,
+		"_4_ConcreteMemberTypename",
+		&plan.SubscriptionResponsePlan{
+			Response: &resolve.GraphQLSubscription{
+				Trigger: resolve.GraphQLSubscriptionTrigger{
+					Input:          []byte(`{"url":"ws://localhost:4005/graphql","body":{"query":"subscription{accountEvents {__typename ... on User {__typename id}}}"}}`),
+					Source:         &SubscriptionSource{},
+					PostProcessing: DefaultPostProcessingConfiguration,
+					SourceName:     "events",
+					SourceID:       "events",
+				},
+				Response: &resolve.GraphQLResponse{
+					Fetches: resolve.Sequence(),
+					Data: &resolve.Object{
+						Fields: []*resolve.Field{
+							{
+								Name: []byte("accountEvents"),
+								Value: &resolve.Object{
+									Path: []string{"accountEvents"},
+									PossibleTypes: map[string]struct{}{
+										"Account":   {},
+										"Admin":     {},
+										"Moderator": {},
+										"User":      {},
+									},
+									TypeName: "Account",
+									Fields: []*resolve.Field{
+										{
+											Name: []byte("__typename"),
+											Value: &resolve.String{
+												Path:       []string{"__typename"},
+												IsTypeName: true,
+											},
+											OnTypeNames: [][]byte{[]byte("User")},
+										},
+										{
+											Name: []byte("id"),
+											Value: &resolve.Scalar{
+												Path: []string{"id"},
+											},
+											OnTypeNames: [][]byte{[]byte("User")},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		planConfiguration,
+		WithDefaultPostProcessor(),
+	))
+
+	t.Run("subscription 5 - __typename on a concrete member root field stays local", RunTest(
+		definition,
+		`
+			subscription _5_ConcreteMemberRootTypename {
+				userEvents {
+					__typename
+					id
+				}
+			}`,
+		"_5_ConcreteMemberRootTypename",
+		&plan.SubscriptionResponsePlan{
+			Response: &resolve.GraphQLSubscription{
+				Trigger: resolve.GraphQLSubscriptionTrigger{
+					Input:          []byte(`{"url":"ws://localhost:4005/graphql","body":{"query":"subscription{userEvents {__typename id}}"}}`),
+					Source:         &SubscriptionSource{},
+					PostProcessing: DefaultPostProcessingConfiguration,
+					SourceName:     "events",
+					SourceID:       "events",
+				},
+				Response: &resolve.GraphQLResponse{
+					Fetches: resolve.Sequence(),
+					Data: &resolve.Object{
+						Fields: []*resolve.Field{
+							{
+								Name: []byte("userEvents"),
+								Value: &resolve.Object{
+									Path: []string{"userEvents"},
+									PossibleTypes: map[string]struct{}{
+										"User": {},
+									},
+									TypeName: "User",
+									Fields: []*resolve.Field{
+										{
+											Name: []byte("__typename"),
+											Value: &resolve.String{
+												Path:       []string{"__typename"},
+												IsTypeName: true,
+											},
+										},
+										{
+											Name: []byte("id"),
+											Value: &resolve.Scalar{
+												Path: []string{"id"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		planConfiguration,
+		WithDefaultPostProcessor(),
+	))
+}

--- a/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource_federation_entity_interfaces_test.go
+++ b/v2/pkg/engine/datasource/graphql_datasource/graphql_datasource_federation_entity_interfaces_test.go
@@ -664,7 +664,7 @@ func TestGraphQLDataSourceFederationEntityInterfaces(t *testing.T) {
 								DependsOnFetchIDs: []int{0},
 							},
 							FetchConfiguration: resolve.FetchConfiguration{
-								Input: `{"method":"POST","url":"http://localhost:4001/graphql","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){... on User {__typename title}}}","variables":{"representations":[$$0$$]}}}`,
+								Input: `{"method":"POST","url":"http://localhost:4001/graphql","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){... on Account {__typename} ... on User {__typename title}}}","variables":{"representations":[$$0$$]}}}`,
 								Variables: []resolve.Variable{
 									&resolve.ResolvableObjectVariable{
 										Renderer: resolve.NewGraphQLVariableResolveRenderer(&resolve.Object{
@@ -1340,7 +1340,7 @@ func TestGraphQLDataSourceFederationEntityInterfaces(t *testing.T) {
 								DependsOnFetchIDs: []int{0},
 							},
 							FetchConfiguration: resolve.FetchConfiguration{
-								Input: `{"method":"POST","url":"http://localhost:4001/graphql","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){... on Admin {__typename} ... on User {__typename title}}}","variables":{"representations":[$$0$$]}}}`,
+								Input: `{"method":"POST","url":"http://localhost:4001/graphql","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){... on Account {__typename} ... on Admin {__typename} ... on User {__typename title}}}","variables":{"representations":[$$0$$]}}}`,
 								Variables: []resolve.Variable{
 									&resolve.ResolvableObjectVariable{
 										Renderer: resolve.NewGraphQLVariableResolveRenderer(&resolve.Object{
@@ -3897,7 +3897,7 @@ func TestGraphQLDataSourceFederationEntityInterfaces(t *testing.T) {
 								DependsOnFetchIDs: []int{0},
 							},
 							FetchConfiguration: resolve.FetchConfiguration{
-								Input: `{"method":"POST","url":"http://localhost:4001/graphql","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){... on Account {__typename ... on User {title __typename}}}}","variables":{"representations":[$$0$$]}}}`,
+								Input: `{"method":"POST","url":"http://localhost:4001/graphql","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){... on Account {__typename} ... on User {__typename title}}}","variables":{"representations":[$$0$$]}}}`,
 								Variables: []resolve.Variable{
 									&resolve.ResolvableObjectVariable{
 										Renderer: resolve.NewGraphQLVariableResolveRenderer(&resolve.Object{
@@ -4960,7 +4960,7 @@ func TestGraphQLDataSourceFederationEntityInterfaces(t *testing.T) {
 								DependsOnFetchIDs: []int{0},
 							},
 							FetchConfiguration: resolve.FetchConfiguration{
-								Input: `{"method":"POST","url":"http://localhost:4001/graphql","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){... on User {__typename title}}}","variables":{"representations":[$$0$$]}}}`,
+								Input: `{"method":"POST","url":"http://localhost:4001/graphql","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){... on Account {__typename} ... on User {__typename title}}}","variables":{"representations":[$$0$$]}}}`,
 								Variables: []resolve.Variable{
 									&resolve.ResolvableObjectVariable{
 										Renderer: resolve.NewGraphQLVariableResolveRenderer(&resolve.Object{

--- a/v2/pkg/engine/plan/datasource_filter_collect_nodes_visitor.go
+++ b/v2/pkg/engine/plan/datasource_filter_collect_nodes_visitor.go
@@ -76,6 +76,22 @@ func (c *nodesCollector) initVisitors() {
 	c.dsVisitors = make([]*collectNodesDSVisitor, 0, len(c.dataSources))
 	c.dsVisitorsReports = make([]*operationreport.Report, 0, len(c.dataSources))
 
+	// entity interfaces declared with at least one key with an enabled entity resolver
+	entityInterfacesResolvable := make(map[string]struct{})
+	for _, dataSource := range c.dataSources {
+		fedCfg := dataSource.FederationConfiguration()
+		for _, entityInterface := range fedCfg.EntityInterfaces {
+			interfaceTypeName := entityInterface.InterfaceTypeName
+			keysForType := fedCfg.Keys.FilterByTypeAndResolvability(interfaceTypeName, false)
+			for _, key := range keysForType {
+				if !key.DisableEntityResolver {
+					entityInterfacesResolvable[interfaceTypeName] = struct{}{}
+					break
+				}
+			}
+		}
+	}
+
 	// prepare visitors for each data source
 	for _, dataSource := range c.dataSources {
 		visitor := &collectNodesDSVisitor{
@@ -92,6 +108,8 @@ func (c *nodesCollector) initVisitors() {
 			dataSource:              dataSource,
 			notExternalKeyPaths:     make(map[string]struct{}),
 			unfetchableFieldRefs:    c.unfetchableFieldRefs,
+
+			entityInterfacesResolvableElsewhere: entityInterfacesResolvable,
 		}
 		c.dsVisitors = append(c.dsVisitors, visitor)
 		c.dsVisitorsReports = append(c.dsVisitorsReports, operationreport.NewReport())
@@ -296,6 +314,10 @@ type collectNodesDSVisitor struct {
 	// reference to a global cache of field info shared between all collector instances
 	info map[int]fieldInfo
 
+	// entity interface type names some datasource can resolve entities for;
+	// shared by all collector instances, computed once in initVisitors
+	entityInterfacesResolvableElsewhere map[string]struct{}
+
 	// information about keys available for a given path collected during the current run
 	keys []DSKeyInfo
 
@@ -343,6 +365,17 @@ func (f *collectNodesDSVisitor) hasProvidesConfiguration(typeName, fieldName str
 func (f *collectNodesDSVisitor) isEntityInterface(typeName string) bool {
 	cfg := f.dataSource.FederationConfiguration()
 	return cfg.HasEntityInterface(typeName)
+}
+
+// isEntityInterfaceName matches only the entity interface's own type name, unlike
+// HasEntityInterface which also matches the concrete member type names
+func (f *collectNodesDSVisitor) isEntityInterfaceName(typeName string) bool {
+	for _, entityInterface := range f.dataSource.FederationConfiguration().EntityInterfaces {
+		if entityInterface.InterfaceTypeName == typeName {
+			return true
+		}
+	}
+	return false
 }
 
 func (f *collectNodesDSVisitor) isInterfaceObject(typeName string) bool {
@@ -544,6 +577,16 @@ func (f *collectNodesDSVisitor) EnterField(fieldRef int, itemIds []int, treeNode
 
 		// at the same time we should allow to select a typename on the entity interface
 		return nil
+	}
+
+	if info.isTypeName && f.isEntityInterfaceName(info.typeName) && f.allKeysHasDisabledEntityResolver(info.typeName) {
+		// a datasource which cannot resolve entities of the entity interface (e.g. an event-driven
+		// source) cannot be trusted to report the concrete __typename, so it should not claim the
+		// field when a datasource able to resolve the entity exists; when none exists, keep the
+		// local claim rather than making the field unplannable
+		if _, resolvableElsewhere := f.entityInterfacesResolvableElsewhere[info.typeName]; resolvableElsewhere {
+			return nil
+		}
 	}
 
 	hasRootNodeWithTypename := f.dataSource.HasRootNodeWithTypename(info.typeName)


### PR DESCRIPTION
A subscription root field returning a federated entity interface served by a datasource whose keys all have `DisableEntityResolver` (the shape composed for event-driven subgraphs) resolved `__typename` from that datasource's own data — for an EDFS source that is the event payload, which typically carries the abstract interface name. Clients received an abstract `__typename` with no type-conditioned fields, and with only key-local fields selected no entity fetch was planned at all.

This PR makes such a datasource stop claiming `__typename` for the entity interface when another datasource can resolve the entity (a sole-source interface keeps the local claim rather than becoming unplannable), emits the abstract `__typename` as `... on <AbstractType> { __typename }` in the `_entities` selection set, and fixes `walkField` firing `LeaveField` without `EnterField` for fields explicitly allowed under a skipped ancestor — which was dropping the field and unbalancing the datasource planner's node stack. The three changes form one mechanism and are not independently shippable.

Four existing entity-interface golden plans change: three gain an `... on Account { __typename }` fragment that the walker bug previously dropped (the shape already appears in the passing query 0 golden), one flattens a nested fragment into equivalent siblings. Representation variables and response mappings are unchanged in all four.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved federation planning for entity-interface subscriptions and abstract `__typename` fields.
  * Preserved required type information when resolving entities across multiple data sources.
  * Corrected traversal so explicitly allowed fields under skipped ancestors are handled consistently.
  * Improved handling of inline fragments within entity selections and prevented incorrect fragment nesting.

* **Tests**
  * Added coverage for nested visitor filters, event-driven entity interfaces, orphan events, and multi-source federation planning scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

Developed with AI assistance under human direction; every change was root-caused against a live router reproduction, adversarially reviewed, and is pinned by tests that fail on the specific unfixed hunk.
