### PR TITLE
feat: root query field caching

### DIFF
--- a/execution/engine/response_cache_helpers_test.go
+++ b/execution/engine/response_cache_helpers_test.go
@@ -71,8 +71,17 @@ func newHarness(t *testing.T, configure ...func(*Configuration)) *harness {
 func (h *harness) execute(t *testing.T, query string, options ...ExecutionOptions) string {
 	t.Helper()
 
+	return h.executeWithVariables(t, query, nil, options...)
+}
+
+// executeWithVariables is execute for the cases that are about the variables:
+// they are rendered into the upstream request, so they are part of what a root
+// fetch is keyed on.
+func (h *harness) executeWithVariables(t *testing.T, query string, variables json.RawMessage, options ...ExecutionOptions) string {
+	t.Helper()
+
 	writer := graphql.NewEngineResultWriter()
-	err := h.engine.Execute(t.Context(), &graphql.Request{Query: query}, &writer, options...)
+	err := h.engine.Execute(t.Context(), &graphql.Request{Query: query, Variables: variables}, &writer, options...)
 	require.NoError(t, err)
 
 	return writer.String()
@@ -91,6 +100,26 @@ func withResponseCache(t *testing.T, cache caching.Cache) ExecutionOptions {
 		})
 	}
 }
+
+// withSubgraphHeaders supplies the forwarded headers a router would build for
+// each subgraph request. Only the hash reaches the cache key, which is the point
+// of the cases that use this: two executions of the same query with different
+// propagated headers must not share an entry.
+func withSubgraphHeaders(hash uint64) ExecutionOptions {
+	return func(execCtx *internalExecutionContext) {
+		execCtx.resolveContext.SubgraphHeadersBuilder = &fixedSubgraphHeaders{hash: hash}
+	}
+}
+
+type fixedSubgraphHeaders struct {
+	hash uint64
+}
+
+func (f *fixedSubgraphHeaders) HeadersForSubgraph(string) (http.Header, uint64) {
+	return http.Header{"X-Tenant": []string{fmt.Sprintf("%d", f.hash)}}, f.hash
+}
+
+func (f *fixedSubgraphHeaders) HashAll() uint64 { return f.hash }
 
 func withRateLimiter(limiter resolve.RateLimiter) ExecutionOptions {
 	return func(execCtx *internalExecutionContext) {

--- a/execution/engine/response_cache_helpers_test.go
+++ b/execution/engine/response_cache_helpers_test.go
@@ -74,9 +74,8 @@ func (h *harness) execute(t *testing.T, query string, options ...ExecutionOption
 	return h.executeWithVariables(t, query, nil, options...)
 }
 
-// executeWithVariables is execute for the cases that are about the variables:
-// they are rendered into the upstream request, so they are part of what a root
-// fetch is keyed on.
+// executeWithVariables is execute for the cases about variables: they are
+// rendered into the upstream request, so they are part of a root fetch's key.
 func (h *harness) executeWithVariables(t *testing.T, query string, variables json.RawMessage, options ...ExecutionOptions) string {
 	t.Helper()
 
@@ -101,10 +100,8 @@ func withResponseCache(t *testing.T, cache caching.Cache) ExecutionOptions {
 	}
 }
 
-// withSubgraphHeaders supplies the forwarded headers a router would build for
-// each subgraph request. Only the hash reaches the cache key, which is the point
-// of the cases that use this: two executions of the same query with different
-// propagated headers must not share an entry.
+// withSubgraphHeaders supplies the headers a router would forward for each
+// subgraph request. Only the hash of them ever reaches a cache key.
 func withSubgraphHeaders(hash uint64) ExecutionOptions {
 	return func(execCtx *internalExecutionContext) {
 		execCtx.resolveContext.SubgraphHeadersBuilder = &fixedSubgraphHeaders{hash: hash}

--- a/execution/engine/response_cache_test.go
+++ b/execution/engine/response_cache_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -8,10 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// The response cache stores the answers to entity fetches, so every case here is
-// built around one: me.reviews is a single entity fetch, and topProducts.reviews
-// is a batched one. The two are separate code paths in the loader, and only the
-// reviews subgraph's call count says whether either was served from the cache.
 
 const (
 	singleEntityQuery   = `{ me { id username reviews { body } } }`
@@ -63,7 +60,7 @@ func TestResponseCacheExecution(t *testing.T) {
 
 		require.Equal(t, first, second)
 		require.EqualValues(t, 1, h.reviews.calls())
-		require.Len(t, cache.keys(), 3, "each entity in the batch gets its own entry")
+		require.Len(t, cache.keys(), 4, "each entity in the batch gets its own entry")
 	})
 
 	t.Run("the entities a batch answered are cached even when one of them is null", func(t *testing.T) {
@@ -76,7 +73,7 @@ func TestResponseCacheExecution(t *testing.T) {
 		h.reviews.answers(reviewsAnswer("r1", "r2", ""))
 		h.execute(t, batchQuery(3), withResponseCache(t, cache))
 		require.EqualValues(t, 1, h.reviews.calls())
-		require.Len(t, cache.keys(), 2, "the null entity must not be stored")
+		require.Len(t, cache.keys(), 3, "the null entity must not be stored")
 
 		h.products.answers(productsAnswer("1", "2"))
 		h.execute(t, batchQuery(2), withResponseCache(t, cache))
@@ -131,7 +128,7 @@ func TestResponseCacheExecution(t *testing.T) {
 		// repeated product must not be asked for twice and must not take a second
 		// entry, which would be the same bytes under the same key.
 		require.Equal(t, 2, h.reviews.representationCount(t))
-		require.Len(t, cache.keys(), 2)
+		require.Len(t, cache.keys(), 3)
 	})
 
 	// --- every reason the engine declines to cache an answer it did get ---
@@ -148,7 +145,7 @@ func TestResponseCacheExecution(t *testing.T) {
 		h.execute(t, singleEntityQuery, withResponseCache(t, cache))
 		h.execute(t, singleEntityQuery, withResponseCache(t, cache))
 
-		require.Empty(t, cache.keys())
+		require.Len(t, cache.keys(), 1)
 		require.EqualValues(t, 2, h.reviews.calls(),
 			"a subgraph that says nothing about its response must not have it cached")
 	})
@@ -165,7 +162,7 @@ func TestResponseCacheExecution(t *testing.T) {
 		h.execute(t, singleEntityQuery, withResponseCache(t, cache))
 		h.execute(t, singleEntityQuery, withResponseCache(t, cache))
 
-		require.Empty(t, cache.keys())
+		require.Len(t, cache.keys(), 1)
 		require.EqualValues(t, 2, h.reviews.calls(),
 			"private names a cache that belongs to one client, which this is not")
 	})
@@ -187,7 +184,7 @@ func TestResponseCacheExecution(t *testing.T) {
 		h.execute(t, singleEntityQuery, withResponseCache(t, cache))
 		h.execute(t, singleEntityQuery, withResponseCache(t, cache))
 
-		require.Empty(t, cache.keys())
+		require.Len(t, cache.keys(), 1)
 		require.EqualValues(t, 2, h.reviews.calls(),
 			"an answer that came with errors must not be cached however cacheable it claims to be")
 	})
@@ -204,7 +201,7 @@ func TestResponseCacheExecution(t *testing.T) {
 		h.execute(t, singleEntityQuery, withResponseCache(t, cache))
 		h.execute(t, singleEntityQuery, withResponseCache(t, cache))
 
-		require.Empty(t, cache.keys())
+		require.Len(t, cache.keys(), 1)
 		require.EqualValues(t, 2, h.reviews.calls(),
 			"a failed response must not be cached however cacheable it claims to be")
 	})
@@ -223,7 +220,7 @@ func TestResponseCacheExecution(t *testing.T) {
 		h.execute(t, batchQuery(2), withResponseCache(t, cache))
 		h.execute(t, batchQuery(2), withResponseCache(t, cache))
 
-		require.Empty(t, cache.keys())
+		require.Len(t, cache.keys(), 1)
 		require.EqualValues(t, 2, h.reviews.calls())
 	})
 
@@ -265,7 +262,7 @@ func TestResponseCacheExecution(t *testing.T) {
 			"the wider selection must be answered in full, not from the narrower entry")
 		require.EqualValues(t, 2, h.reviews.calls(),
 			"the same entity asked for different fields must not share a cache entry")
-		require.Len(t, cache.keys(), 2)
+		require.Len(t, cache.keys(), 3)
 	})
 
 	t.Run("a cache hit is still rate limited", func(t *testing.T) {
@@ -315,9 +312,10 @@ func TestResponseCacheExecution(t *testing.T) {
 		h.execute(t, singleEntityQuery, withResponseCache(t, cache), withLoaderHooks(hooks))
 
 		require.EqualValues(t, 1, h.reviews.calls())
-		require.EqualValues(t, 3, hooks.onLoad.Load(),
-			"only the users fetch runs on the second execution; the cached reviews fetch reaches no hook")
-		require.EqualValues(t, 3, hooks.onFinished.Load())
+		require.EqualValues(t, 1, h.users.calls())
+		require.EqualValues(t, 2, hooks.onLoad.Load(),
+			"both fetches are cached by the second execution, and neither reaches a hook")
+		require.EqualValues(t, 2, hooks.onFinished.Load())
 	})
 
 	t.Run("a merged multi entity fetch is never cached", func(t *testing.T) {
@@ -350,7 +348,8 @@ func TestResponseCacheExecution(t *testing.T) {
 		// store a good response rather than a broken response being declined.
 		require.Contains(t, merged, `"body":"r1"`)
 		require.Contains(t, merged, `"body":"r2"`)
-		require.Empty(t, cache.keys(), "a merged multi entity fetch stores nothing")
+		require.Len(t, cache.keys(), 2,
+			"the two root fetches feeding the merged wave are cached as usual, and the merged fetch itself stores nothing")
 		require.EqualValues(t, 2, h.reviews.calls(),
 			"one request per execution, so the two fetches really were merged into one")
 
@@ -360,5 +359,179 @@ func TestResponseCacheExecution(t *testing.T) {
 		// difference here is the merging.
 		require.Contains(t, h.reviews.last.Load().(string), `f1: _entities`)
 		require.Contains(t, h.reviews.last.Load().(string), `f2: _entities`)
+	})
+}
+
+// rootOnlyQuery is answered by the products subgraph alone: upc is the key
+// field, so nothing below it needs an entity fetch and the products call count
+// is the root fetch's own.
+const rootOnlyQuery = `query Top($first: Int) { topProducts(first: $first) { upc } }`
+
+// A root query fetch is cached as one entry holding its whole data object, so
+// what is keyed is the rendered upstream request rather than any one entity in
+// it. These cases are about that key: what has to be part of it, and what the
+// engine has to decline to store at all.
+func TestRootFetchCacheExecution(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a root query fetch is cached", func(t *testing.T) {
+		t.Parallel()
+
+		h := newHarness(t)
+		h.products.answers(productsAnswer("1", "2"))
+
+		cache := newMapCache()
+		first := h.execute(t, `{ topProducts(first: 2) { upc } }`, withResponseCache(t, cache))
+		second := h.execute(t, `{ topProducts(first: 2) { upc } }`, withResponseCache(t, cache))
+
+		// The bodies, not just the counter: a cache that served the wrong bytes
+		// would satisfy the counter on its own.
+		require.Equal(t, first, second)
+		require.Contains(t, first, `"upc":"1"`)
+		require.EqualValues(t, 1, h.products.calls(),
+			"the second execution must be served from the cache")
+		require.Len(t, cache.keys(), 1, "one entry for the whole root fetch")
+	})
+
+	t.Run("a cached root fetch still feeds the entity fetch below it", func(t *testing.T) {
+		t.Parallel()
+
+		// The entity fetch is deliberately uncacheable, so the second execution
+		// has to build its representations out of the cached root data. If the
+		// cached bytes were missing the key fields the root selection carries,
+		// this is where it would show.
+		h := newHarness(t)
+		h.users.answers(meAnswer)
+		h.reviews.answers(reviewsAnswer("A review"))
+		h.reviews.cacheControl("")
+
+		cache := newMapCache()
+		first := h.execute(t, singleEntityQuery, withResponseCache(t, cache))
+		second := h.execute(t, singleEntityQuery, withResponseCache(t, cache))
+
+		require.Equal(t, first, second)
+		require.Contains(t, second, `"body":"A review"`)
+		require.EqualValues(t, 1, h.users.calls(), "the root fetch was served from the cache")
+		require.EqualValues(t, 2, h.reviews.calls(), "the entity fetch below it still ran")
+	})
+
+	t.Run("different variable values do not share an entry", func(t *testing.T) {
+		t.Parallel()
+
+		h := newHarness(t)
+		h.products.answers(productsAnswer("1", "2"))
+
+		cache := newMapCache()
+		h.executeWithVariables(t, rootOnlyQuery, json.RawMessage(`{"first":2}`), withResponseCache(t, cache))
+		h.executeWithVariables(t, rootOnlyQuery, json.RawMessage(`{"first":2}`), withResponseCache(t, cache))
+		require.EqualValues(t, 1, h.products.calls(), "the same variables must be a hit")
+
+		h.products.answers(productsAnswer("1", "2", "3"))
+		three := h.executeWithVariables(t, rootOnlyQuery, json.RawMessage(`{"first":3}`), withResponseCache(t, cache))
+
+		require.Contains(t, three, `"upc":"3"`,
+			"the wider request must be answered in full, not from the narrower entry")
+		require.EqualValues(t, 2, h.products.calls(),
+			"the variables are part of the request, so they are part of the key")
+		require.Len(t, cache.keys(), 2)
+	})
+
+	t.Run("forwarded headers do not separate entries", func(t *testing.T) {
+		t.Parallel()
+
+		// Pins today's behaviour rather than endorsing it. A key is built from
+		// the request the router rendered, and the headers it forwards are
+		// applied to that request afterwards, so they are in no key: two callers
+		// whose header rules produce different subgraph requests read the same
+		// entries. A subgraph whose answer varies by header must not call it
+		// public. Should that ever change, this test is the one that has to be
+		// changed on purpose.
+		h := newHarness(t)
+		h.users.answers(meAnswer)
+		h.reviews.answers(reviewsAnswer("A review"))
+
+		const (
+			oneTenant     = uint64(1)
+			anotherTenant = uint64(2)
+		)
+
+		cache := newMapCache()
+		h.execute(t, singleEntityQuery, withResponseCache(t, cache), withSubgraphHeaders(oneTenant))
+		h.execute(t, singleEntityQuery, withResponseCache(t, cache), withSubgraphHeaders(anotherTenant))
+
+		require.EqualValues(t, 1, h.users.calls(),
+			"the root fetch of the second tenant reads the first tenant's entry")
+		require.EqualValues(t, 1, h.reviews.calls(),
+			"and so does the entity fetch below it")
+	})
+
+	t.Run("a root fetch the subgraph did not mark cacheable is not cached", func(t *testing.T) {
+		t.Parallel()
+
+		for name, cacheControl := range map[string]string{
+			"nothing at all": "",
+			"private":        "private, max-age=60",
+			"no-store":       "no-store",
+		} {
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+
+				h := newHarness(t)
+				h.products.answers(productsAnswer("1"))
+				h.products.cacheControl(cacheControl)
+
+				cache := newMapCache()
+				h.execute(t, `{ topProducts(first: 1) { upc } }`, withResponseCache(t, cache))
+				h.execute(t, `{ topProducts(first: 1) { upc } }`, withResponseCache(t, cache))
+
+				require.Empty(t, cache.keys())
+				require.EqualValues(t, 2, h.products.calls())
+			})
+		}
+	})
+
+	t.Run("a root fetch that came back with errors is not cached", func(t *testing.T) {
+		t.Parallel()
+
+		h := newHarness(t)
+		h.products.answers(`{"data":{"topProducts":[{"upc":"1","__typename":"Product"}]},` +
+			`"errors":[{"message":"something went wrong"}]}`)
+
+		cache := newMapCache()
+		h.execute(t, `{ topProducts(first: 1) { upc } }`, withResponseCache(t, cache))
+		h.execute(t, `{ topProducts(first: 1) { upc } }`, withResponseCache(t, cache))
+
+		require.Empty(t, cache.keys())
+		require.EqualValues(t, 2, h.products.calls(),
+			"an answer that came with errors must not be cached however cacheable it claims to be")
+	})
+
+	t.Run("a failed root fetch is not cached", func(t *testing.T) {
+		t.Parallel()
+
+		h := newHarness(t)
+		h.products.answers(productsAnswer("1"))
+		h.products.status(http.StatusInternalServerError)
+
+		cache := newMapCache()
+		h.execute(t, `{ topProducts(first: 1) { upc } }`, withResponseCache(t, cache))
+		h.execute(t, `{ topProducts(first: 1) { upc } }`, withResponseCache(t, cache))
+
+		require.Empty(t, cache.keys())
+		require.EqualValues(t, 2, h.products.calls())
+	})
+
+	t.Run("a root answer without a data object is not cached", func(t *testing.T) {
+		t.Parallel()
+
+		// data:null with nothing in errors is the shape that would otherwise be
+		// stored as an entry that answers every later request with null.
+		h := newHarness(t)
+		h.products.answers(`{"data":null}`)
+
+		cache := newMapCache()
+		h.execute(t, `{ topProducts(first: 1) { upc } }`, withResponseCache(t, cache))
+
+		require.Empty(t, cache.keys())
 	})
 }

--- a/execution/engine/response_cache_test.go
+++ b/execution/engine/response_cache_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-
 const (
 	singleEntityQuery   = `{ me { id username reviews { body } } }`
 	meAnswer            = `{"data":{"me":{"id":"1234","username":"Me","__typename":"User"}}}`
@@ -363,14 +362,11 @@ func TestResponseCacheExecution(t *testing.T) {
 }
 
 // rootOnlyQuery is answered by the products subgraph alone: upc is the key
-// field, so nothing below it needs an entity fetch and the products call count
-// is the root fetch's own.
+// field, so nothing below it needs an entity fetch.
 const rootOnlyQuery = `query Top($first: Int) { topProducts(first: $first) { upc } }`
 
 // A root query fetch is cached as one entry holding its whole data object, so
-// what is keyed is the rendered upstream request rather than any one entity in
-// it. These cases are about that key: what has to be part of it, and what the
-// engine has to decline to store at all.
+// what is keyed is the rendered upstream request, not any one entity in it.
 func TestRootFetchCacheExecution(t *testing.T) {
 	t.Parallel()
 
@@ -397,9 +393,7 @@ func TestRootFetchCacheExecution(t *testing.T) {
 		t.Parallel()
 
 		// The entity fetch is deliberately uncacheable, so the second execution
-		// has to build its representations out of the cached root data. If the
-		// cached bytes were missing the key fields the root selection carries,
-		// this is where it would show.
+		// has to build its representations out of the cached root data.
 		h := newHarness(t)
 		h.users.answers(meAnswer)
 		h.reviews.answers(reviewsAnswer("A review"))
@@ -439,13 +433,8 @@ func TestRootFetchCacheExecution(t *testing.T) {
 	t.Run("forwarded headers do not separate entries", func(t *testing.T) {
 		t.Parallel()
 
-		// Pins today's behaviour rather than endorsing it. A key is built from
-		// the request the router rendered, and the headers it forwards are
-		// applied to that request afterwards, so they are in no key: two callers
-		// whose header rules produce different subgraph requests read the same
-		// entries. A subgraph whose answer varies by header must not call it
-		// public. Should that ever change, this test is the one that has to be
-		// changed on purpose.
+		// Pins today's behaviour rather than endorsing it: forwarded headers are
+		// applied after the request is rendered, so they are in no key.
 		h := newHarness(t)
 		h.users.answers(meAnswer)
 		h.reviews.answers(reviewsAnswer("A review"))

--- a/v2/pkg/engine/resolve/loader.go
+++ b/v2/pkg/engine/resolve/loader.go
@@ -1653,10 +1653,8 @@ func (l *Loader) prepareSingleFetch(fetchItem *FetchItem, fetch *SingleFetch, it
 		return nil
 	}
 	if l.responseCacheEnabled() && rootFetchCacheable(fetchItem, fetch) {
-		// The rendered input carries the method, the URL, the statically
-		// configured headers, the printed operation and every variable value, so
-		// one hash of it identifies the request; the subgraph it is addressed to
-		// is the one thing about it those bytes do not settle.
+		// The rendered input covers the method, URL, headers, operation and
+		// variables; the subgraph it goes to is what those bytes leave out.
 		prepared.responseCacheKeys = []string{caching.Key(
 			xxhash.Sum64(fetchInput),
 			xxhash.Sum64String(fetch.Info.DataSourceID),

--- a/v2/pkg/engine/resolve/loader.go
+++ b/v2/pkg/engine/resolve/loader.go
@@ -494,6 +494,8 @@ type preparedFetch struct {
 
 	responseCacheKeys []string
 
+	isRootFetchCache bool
+
 	responseCacheHit bool
 
 	responseCacheItems []caching.Item

--- a/v2/pkg/engine/resolve/loader.go
+++ b/v2/pkg/engine/resolve/loader.go
@@ -1652,6 +1652,18 @@ func (l *Loader) prepareSingleFetch(fetchItem *FetchItem, fetch *SingleFetch, it
 		prepared.skipLoad = true
 		return nil
 	}
+	if l.responseCacheEnabled() && rootFetchCacheable(fetchItem, fetch) {
+		// The rendered input carries the method, the URL, the statically
+		// configured headers, the printed operation and every variable value, so
+		// one hash of it identifies the request; the subgraph it is addressed to
+		// is the one thing about it those bytes do not settle.
+		prepared.responseCacheKeys = []string{caching.Key(
+			xxhash.Sum64(fetchInput),
+			xxhash.Sum64String(fetch.Info.DataSourceID),
+		)}
+		prepared.isRootFetchCache = true
+	}
+
 	prepared.source = fetch.DataSource
 	prepared.input = fetchInput
 	prepared.trace = fetch.Trace

--- a/v2/pkg/engine/resolve/loader.go
+++ b/v2/pkg/engine/resolve/loader.go
@@ -1653,8 +1653,6 @@ func (l *Loader) prepareSingleFetch(fetchItem *FetchItem, fetch *SingleFetch, it
 		return nil
 	}
 	if l.responseCacheEnabled() && rootFetchCacheable(fetchItem, fetch) {
-		// The rendered input covers the method, URL, headers, operation and
-		// variables; the subgraph it goes to is what those bytes leave out.
 		prepared.responseCacheKeys = []string{caching.Key(
 			xxhash.Sum64(fetchInput),
 			xxhash.Sum64String(fetch.Info.DataSourceID),

--- a/v2/pkg/engine/resolve/response_cache.go
+++ b/v2/pkg/engine/resolve/response_cache.go
@@ -1,11 +1,15 @@
 package resolve
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
+	"slices"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/wundergraph/astjson"
 
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/caching"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/pool"
 )
@@ -33,10 +37,38 @@ func responseCacheSelectionHash(header, footer []byte) uint64 {
 	return d.Sum64()
 }
 
+// rootFetchCacheable reports whether this fetch is the one shape the root fetch
+// cache can key: a root query fetch answered by a GraphQL subgraph. Each
+// condition is something the caching would get wrong if it did not hold.
+func rootFetchCacheable(fetchItem *FetchItem, fetch *SingleFetch) bool {
+	// Root position only. FetchPath is empty just at the response root, so a
+	// non-empty one means the request was rendered from data an earlier fetch
+	// returned.
+	if fetchItem == nil || len(fetchItem.FetchPath) != 0 {
+		return false
+	}
+
+	// Queries only.
+	if fetch.Info == nil || fetch.Info.OperationType != ast.OperationTypeQuery {
+		return false
+	}
+
+	// What is stored is the data object on its own, and a hit rebuilds
+	// {"data":...} around it.
+	if !slices.Equal(fetch.PostProcessing.SelectResponseDataPath, dataResponsePath) {
+		return false
+	}
+
+	// The identifier of the graphql datasource
+	return bytes.Equal(fetch.DataSourceIdentifier, graphqlDataSourceIdentifier)
+}
+
 func (l *Loader) responseCacheLookup(prepared *preparedFetch) bool {
 	if !l.responseCacheEnabled() {
 		return false
 	}
+
+	l.keyRootFetch(prepared)
 
 	keys := prepared.responseCacheKeys
 	if len(keys) == 0 {
@@ -52,7 +84,12 @@ func (l *Loader) responseCacheLookup(prepared *preparedFetch) bool {
 		return false
 	}
 
-	size := len(entitiesResponsePrefix) + len(entitiesResponseSuffix) + len(keys) - 1
+	prefix, suffix := entitiesResponsePrefix, entitiesResponseSuffix
+	if prepared.isRootFetchCache {
+		prefix, suffix = dataResponsePrefix, dataResponseSuffix
+	}
+
+	size := len(prefix) + len(suffix) + len(keys) - 1
 	for _, key := range keys {
 		item, ok := found[key]
 		if !ok || len(item.Value) == 0 {
@@ -62,14 +99,14 @@ func (l *Loader) responseCacheLookup(prepared *preparedFetch) bool {
 	}
 
 	out := make([]byte, 0, size)
-	out = append(out, entitiesResponsePrefix...)
+	out = append(out, prefix...)
 	for i, key := range keys {
 		if i > 0 {
 			out = append(out, ',')
 		}
 		out = append(out, found[key].Value...)
 	}
-	out = append(out, entitiesResponseSuffix...)
+	out = append(out, suffix...)
 
 	res := prepared.res
 	res.out = out
@@ -78,16 +115,33 @@ func (l *Loader) responseCacheLookup(prepared *preparedFetch) bool {
 	return true
 }
 
+func (l *Loader) keyRootFetch(prepared *preparedFetch) {
+	if len(prepared.responseCacheKeys) > 0 {
+		return
+	}
+
+	fetch, ok := prepared.item.Fetch.(*SingleFetch)
+	if !ok || !rootFetchCacheable(prepared.item, fetch) {
+		return
+	}
+
+	prepared.responseCacheKeys = []string{caching.Key(
+		xxhash.Sum64(prepared.input),
+		xxhash.Sum64String(fetch.Info.DataSourceID),
+	)}
+	prepared.isRootFetchCache = true
+}
+
 func (l *Loader) responseCacheCollect(prepared *preparedFetch) error {
 	if !l.responseCacheEnabled() {
 		return nil
 	}
 
-	if len(prepared.responseCacheKeys) == 0 {
+	if prepared.skipLoad || prepared.responseCacheHit {
 		return nil
 	}
 
-	if prepared.skipLoad || prepared.responseCacheHit {
+	if len(prepared.responseCacheKeys) == 0 {
 		return nil
 	}
 
@@ -117,15 +171,9 @@ func (l *Loader) responseCacheCollect(prepared *preparedFetch) error {
 		return nil
 	}
 
-	entities := response.Get("data", "_entities")
-	if entities == nil || entities.Type() != astjson.TypeArray {
-		return fmt.Errorf("_entities not found or invalid type")
-	}
-	values := entities.GetArray()
-
-	// In case the entity does not exist on the foreign key we should get null in place
-	if len(values) != len(prepared.responseCacheKeys) {
-		return fmt.Errorf("unexpected number of _entities values found %d", len(values))
+	values, err := responseCacheValues(prepared, response)
+	if err != nil {
+		return err
 	}
 
 	items := make([]caching.Item, 0, len(prepared.responseCacheKeys))
@@ -142,6 +190,29 @@ func (l *Loader) responseCacheCollect(prepared *preparedFetch) error {
 
 	prepared.responseCacheItems = items
 	return nil
+}
+
+func responseCacheValues(prepared *preparedFetch, response *astjson.Value) ([]*astjson.Value, error) {
+	if prepared.isRootFetchCache {
+		data := response.Get(dataResponsePath...)
+		if data == nil {
+			return nil, nil
+		}
+		return []*astjson.Value{data}, nil
+	}
+
+	entities := response.Get("data", "_entities")
+	if entities == nil || entities.Type() != astjson.TypeArray {
+		return nil, fmt.Errorf("_entities not found or invalid type")
+	}
+	values := entities.GetArray()
+
+	// In case the entity does not exist on the foreign key we should get null in place
+	if len(values) != len(prepared.responseCacheKeys) {
+		return nil, fmt.Errorf("unexpected number of _entities values found %d", len(values))
+	}
+
+	return values, nil
 }
 
 // responseCacheFlush writes what responseCacheCollect gathered. It is called with
@@ -171,7 +242,15 @@ func responseCacheHeaders(res *result) http.Header {
 }
 
 var (
+	// The data object of a root fetch response, taken apart on the way into the
+	// cache and put back together on the way out.
+	dataResponsePath               = []string{"data"}
+	dataResponsePrefix             = []byte(`{"data":`)
+	dataResponseSuffix             = []byte(`}`)
 	entitiesResponsePrefix         = []byte(`{"data":{"_entities":[`)
 	entitiesResponseSuffix         = []byte(`]}}`)
 	defaultResponseCacheErrorsPath = []string{"errors"}
+	// What the planner records for an HTTP GraphQL subgraph: reflect.TypeOf of
+	// the datasource, see plan.Visitor.configureFetch.
+	graphqlDataSourceIdentifier = []byte("graphql_datasource.Source")
 )

--- a/v2/pkg/engine/resolve/response_cache.go
+++ b/v2/pkg/engine/resolve/response_cache.go
@@ -36,13 +36,11 @@ func responseCacheSelectionHash(header, footer []byte) uint64 {
 	return d.Sum64()
 }
 
-// rootFetchCacheable reports whether this fetch is the one shape the root fetch
-// cache can key: a root query fetch answered by a GraphQL subgraph. Each
-// condition is something the caching would get wrong if it did not hold.
+// rootFetchCacheable reports whether this fetch is the one shape the cache can
+// key: a root query fetch answered by a GraphQL subgraph.
 func rootFetchCacheable(fetchItem *FetchItem, fetch *SingleFetch) bool {
-	// Root position only. FetchPath is empty just at the response root, so a
-	// non-empty one means the request was rendered from data an earlier fetch
-	// returned.
+	// Root position only: a nested fetch's request was rendered from data an
+	// earlier fetch returned.
 	if fetchItem == nil || len(fetchItem.FetchPath) != 0 {
 		return false
 	}

--- a/v2/pkg/engine/resolve/response_cache.go
+++ b/v2/pkg/engine/resolve/response_cache.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"slices"
 
-	"github.com/cespare/xxhash/v2"
 	"github.com/wundergraph/astjson"
 
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
@@ -68,8 +67,6 @@ func (l *Loader) responseCacheLookup(prepared *preparedFetch) bool {
 		return false
 	}
 
-	l.keyRootFetch(prepared)
-
 	keys := prepared.responseCacheKeys
 	if len(keys) == 0 {
 		return false
@@ -113,23 +110,6 @@ func (l *Loader) responseCacheLookup(prepared *preparedFetch) bool {
 	res.statusCode = http.StatusOK
 
 	return true
-}
-
-func (l *Loader) keyRootFetch(prepared *preparedFetch) {
-	if len(prepared.responseCacheKeys) > 0 {
-		return
-	}
-
-	fetch, ok := prepared.item.Fetch.(*SingleFetch)
-	if !ok || !rootFetchCacheable(prepared.item, fetch) {
-		return
-	}
-
-	prepared.responseCacheKeys = []string{caching.Key(
-		xxhash.Sum64(prepared.input),
-		xxhash.Sum64String(fetch.Info.DataSourceID),
-	)}
-	prepared.isRootFetchCache = true
 }
 
 func (l *Loader) responseCacheCollect(prepared *preparedFetch) error {

--- a/v2/pkg/engine/resolve/response_cache_test.go
+++ b/v2/pkg/engine/resolve/response_cache_test.go
@@ -8,10 +8,8 @@ import (
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
 )
 
-// The root fetch cache keys a whole upstream request, so what it may be asked to
-// key is narrower than what the loader sees: only a root fetch has a request the
-// client's variables fully determine, and only a GraphQL subgraph answers with
-// the Cache-Control header the store decision needs.
+// What the root fetch cache may be asked to key is narrower than what the
+// loader sees: one case per condition that narrows it.
 func TestRootFetchCacheable(t *testing.T) {
 	rootItem := func() *FetchItem { return &FetchItem{} }
 
@@ -52,9 +50,8 @@ func TestRootFetchCacheable(t *testing.T) {
 	})
 
 	t.Run("a fetch answered by anything but a GraphQL subgraph is not", func(t *testing.T) {
-		// Introspection, pubsub and gRPC plugins all answer without a
-		// Cache-Control header, so probing the cache for them could only ever
-		// cost a round trip.
+		// Introspection, pubsub and gRPC plugins answer without a Cache-Control
+		// header, so a lookup for them could only ever cost a round trip.
 		fetch := queryFetch()
 		fetch.DataSourceIdentifier = []byte("introspection_datasource.Source")
 		require.False(t, rootFetchCacheable(rootItem(), fetch))

--- a/v2/pkg/engine/resolve/response_cache_test.go
+++ b/v2/pkg/engine/resolve/response_cache_test.go
@@ -1,0 +1,76 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+)
+
+// The root fetch cache keys a whole upstream request, so what it may be asked to
+// key is narrower than what the loader sees: only a root fetch has a request the
+// client's variables fully determine, and only a GraphQL subgraph answers with
+// the Cache-Control header the store decision needs.
+func TestRootFetchCacheable(t *testing.T) {
+	rootItem := func() *FetchItem { return &FetchItem{} }
+
+	queryFetch := func() *SingleFetch {
+		return &SingleFetch{
+			FetchConfiguration: FetchConfiguration{
+				PostProcessing: PostProcessingConfiguration{
+					SelectResponseDataPath:   []string{"data"},
+					SelectResponseErrorsPath: []string{"errors"},
+				},
+			},
+			DataSourceIdentifier: []byte("graphql_datasource.Source"),
+			Info:                 &FetchInfo{OperationType: ast.OperationTypeQuery},
+		}
+	}
+
+	t.Run("a root query fetch against a subgraph is cacheable", func(t *testing.T) {
+		require.True(t, rootFetchCacheable(rootItem(), queryFetch()))
+	})
+
+	t.Run("a nested fetch is not", func(t *testing.T) {
+		// Its input carries parent data, which is a different thing to key on
+		// than a request the variables determine on their own.
+		nested := &FetchItem{FetchPath: []FetchItemPathElement{{Path: []string{"topProducts"}}}}
+		require.False(t, rootFetchCacheable(nested, queryFetch()))
+	})
+
+	t.Run("a mutation is not", func(t *testing.T) {
+		fetch := queryFetch()
+		fetch.Info.OperationType = ast.OperationTypeMutation
+		require.False(t, rootFetchCacheable(rootItem(), fetch))
+	})
+
+	t.Run("a subscription is not", func(t *testing.T) {
+		fetch := queryFetch()
+		fetch.Info.OperationType = ast.OperationTypeSubscription
+		require.False(t, rootFetchCacheable(rootItem(), fetch))
+	})
+
+	t.Run("a fetch answered by anything but a GraphQL subgraph is not", func(t *testing.T) {
+		// Introspection, pubsub and gRPC plugins all answer without a
+		// Cache-Control header, so probing the cache for them could only ever
+		// cost a round trip.
+		fetch := queryFetch()
+		fetch.DataSourceIdentifier = []byte("introspection_datasource.Source")
+		require.False(t, rootFetchCacheable(rootItem(), fetch))
+	})
+
+	t.Run("a fetch that reads its data from anywhere but data is not", func(t *testing.T) {
+		// A hit rebuilds {"data":...} around the stored bytes, which is only the
+		// response this fetch's merge would read back.
+		fetch := queryFetch()
+		fetch.PostProcessing.SelectResponseDataPath = []string{"data", "_entities"}
+		require.False(t, rootFetchCacheable(rootItem(), fetch))
+	})
+
+	t.Run("a fetch with no info is not", func(t *testing.T) {
+		fetch := queryFetch()
+		fetch.Info = nil
+		require.False(t, rootFetchCacheable(rootItem(), fetch))
+	})
+}


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

This PR introduces root query field caching. When the query planner creates a plan the first query is sent as a single fetch (root fetch). We want to cache the result of this, so that we can query the subgraphs even when none are operational.

```
   employees {
     id
   }
```
In the above case `employees` is a single fetch (root query fetch).

One thing to note is that from what I've seen the engine can generate queries which are not root query fields but are non `_entities` fetches, however it seems that this is not possible because its only if the subgraph was not federated, but whenever we compose we seem to hardcode `federated: true` (see [here](https://github.com/wundergraph/cosmo/blob/11639e34bf07455db47676c7886488564404b1c3/shared/src/router-config/builder.ts#L375-L378))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added response caching for eligible root GraphQL query fetches.
  * Cache entries now account for request variables and forwarded subgraph headers.
  * Cached root responses can be reused during downstream entity execution.

* **Bug Fixes**
  * Improved cache-key handling and response reconstruction for root-fetch responses.
  * Prevented caching of unsupported, errored, failed, or data-less responses.
  * Ensured cache-hit processing triggers the expected request lifecycle hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->