### PR TITLE
chore: enable gocritic linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters:
     - errorlint
     - fatcontext
     - gocheckcompilerdirectives
+    - gocritic
     - govet
     - ineffassign
     - loggercheck

--- a/execution/engine/config_factory_federation.go
+++ b/execution/engine/config_factory_federation.go
@@ -250,11 +250,9 @@ func (f *FederationEngineConfigFactory) subgraphDataSourceConfiguration(engineCo
 			subscriptionUseSSE = true
 			subscriptionSSEMethodPost = true
 		}
-	} else {
+	} else if in.CustomGraphql.Subscription.UseSSE != nil {
 		// Old style config
-		if in.CustomGraphql.Subscription.UseSSE != nil {
-			subscriptionUseSSE = *in.CustomGraphql.Subscription.UseSSE
-		}
+		subscriptionUseSSE = *in.CustomGraphql.Subscription.UseSSE
 	}
 	// dataSourceRules := FetchURLRules(&routerEngineConfig.Headers, routerConfig.Subgraphs, subscriptionUrl)
 	// forwardedClientHeaders, forwardedClientRegexps, err := PropagatedHeaders(dataSourceRules)

--- a/execution/engine/execution_engine_test.go
+++ b/execution/engine/execution_engine_test.go
@@ -165,10 +165,8 @@ func runExecutionTest(testCase ExecutionEngineTestCase, withError bool, expected
 			if len(testCase.expectedResponses) > 0 {
 				assert.Contains(t, testCase.expectedResponses, streamingResponse)
 			}
-		} else {
-			if testCase.expectedResponse != "" {
-				assert.Equal(t, testCase.expectedResponse, actualResponse)
-			}
+		} else if testCase.expectedResponse != "" {
+			assert.Equal(t, testCase.expectedResponse, actualResponse)
 		}
 
 		if testCase.expectedEstimatedCost != nil {

--- a/execution/engine/federation_integration_test.go
+++ b/execution/engine/federation_integration_test.go
@@ -53,8 +53,7 @@ func TestFederationIntegrationTestWithArt(t *testing.T) {
 	gqlClient := NewGraphqlClient(http.DefaultClient)
 
 	normalizeResponse := func(resp string) string {
-		rex, err := regexp.Compile(`http://127.0.0.1:\d+`)
-		require.NoError(t, err)
+		rex := regexp.MustCompile(`http://127.0.0.1:\d+`)
 		resp = rex.ReplaceAllString(resp, "http://localhost/graphql")
 		return resp
 	}

--- a/execution/graphql/request.go
+++ b/execution/graphql/request.go
@@ -121,11 +121,12 @@ func (r *Request) IsIntrospectionQuery() (result bool, err error) {
 		}
 	}
 
-	if len(possibleOperationDefinitionRefs) == 0 {
+	switch len(possibleOperationDefinitionRefs) {
+	case 0:
 		return
-	} else if len(possibleOperationDefinitionRefs) == 1 {
+	case 1:
 		operationDefinitionRef = possibleOperationDefinitionRefs[0]
-	} else {
+	default:
 		for i := 0; i < len(possibleOperationDefinitionRefs); i++ {
 			ref := possibleOperationDefinitionRefs[i]
 			name := r.document.OperationDefinitionNameString(ref)

--- a/execution/subscription/executor_v2.go
+++ b/execution/subscription/executor_v2.go
@@ -60,8 +60,7 @@ type ExecutorV2 struct {
 
 func (e *ExecutorV2) Execute(writer resolve.SubscriptionResponseWriter) error {
 	options := make([]engine.ExecutionOptions, 0)
-	switch ctx := e.reqCtx.(type) {
-	case *InitialHttpRequestContext:
+	if ctx, ok := e.reqCtx.(*InitialHttpRequestContext); ok {
 		options = append(options, engine.WithAdditionalHttpHeaders(ctx.Request.Header))
 	}
 

--- a/execution/subscription/handler.go
+++ b/execution/subscription/handler.go
@@ -147,10 +147,11 @@ func (u *UniversalProtocolHandler) Handle(ctx context.Context) {
 		}
 
 		message, err := u.client.ReadBytesFromClient()
-		if errors.Is(err, ErrTransportClientClosedConnection) {
+		switch {
+		case errors.Is(err, ErrTransportClientClosedConnection):
 			u.logger.Debug("subscription.UniversalProtocolHandler.Handle: reading from a closed connection")
 			return
-		} else if err != nil {
+		case err != nil:
 			u.logger.Error("subscription.UniversalProtocolHandler.Handle: on reading bytes from client",
 				abstractlogger.Error(err),
 				abstractlogger.ByteString("message", message),
@@ -173,7 +174,7 @@ func (u *UniversalProtocolHandler) Handle(ctx context.Context) {
 			}
 
 			u.protocol.EventHandler().Emit(EventTypeOnConnectionError, "", nil, ErrCouldNotReadMessageFromClient)
-		} else {
+		default:
 			if u.isReadTimeOutTimerRunning && u.readTimeOutCancel != nil {
 				u.readTimeOutCancel()
 				u.isReadTimeOutTimerRunning = false

--- a/execution/subscription/init.go
+++ b/execution/subscription/init.go
@@ -7,10 +7,12 @@ import (
 
 // WebsocketInitFunc is called when the server receives connection init message from the client.
 // This can be used to check initial payload to see whether to accept the websocket connection.
+//
 // Deprecated: Use websocket.InitFunc instead.
 type WebsocketInitFunc func(ctx context.Context, initPayload InitPayload) (context.Context, error)
 
 // InitPayload is a structure that is parsed from the websocket init message payload.
+//
 // Deprecated: Use websocket.InitPayload instead.
 type InitPayload json.RawMessage
 

--- a/execution/subscription/legacy_handler.go
+++ b/execution/subscription/legacy_handler.go
@@ -225,8 +225,7 @@ func (h *Handler) handleStart(ctx context.Context, id string, payload []byte) {
 }
 
 func (h *Handler) handleOnBeforeStart(executor Executor) error {
-	switch e := executor.(type) {
-	case *ExecutorV2:
+	if e, ok := executor.(*ExecutorV2); ok {
 		if hook := e.engine.GetWebsocketBeforeStartHook(); hook != nil {
 			return hook.OnBeforeStart(e.reqCtx, e.operation)
 		}

--- a/v2/pkg/ast/ast_field_definition.go
+++ b/v2/pkg/ast/ast_field_definition.go
@@ -77,8 +77,7 @@ func (d *Document) FieldDefinitionHasNamedDirective(fieldDefinition int, directi
 }
 
 func (d *Document) FieldDefinitionResolverTypeName(enclosingType Node) ByteSlice {
-	switch enclosingType.Kind {
-	case NodeKindObjectTypeDefinition:
+	if enclosingType.Kind == NodeKindObjectTypeDefinition {
 		name := d.ObjectTypeDefinitionNameBytes(enclosingType.Ref)
 		switch {
 		case bytes.Equal(name, d.Index.QueryTypeName):
@@ -89,6 +88,7 @@ func (d *Document) FieldDefinitionResolverTypeName(enclosingType Node) ByteSlice
 			return literal.SUBSCRIPTION
 		}
 	}
+
 	return d.NodeNameBytes(enclosingType)
 }
 

--- a/v2/pkg/ast/ast_node.go
+++ b/v2/pkg/ast/ast_node.go
@@ -301,8 +301,7 @@ func (d *Document) NodeInputFieldDefinitions(node Node) []int {
 }
 
 func (d *Document) NodeInputFieldDefinitionByName(node Node, name ByteSlice) (int, bool) {
-	switch node.Kind {
-	case NodeKindInputObjectTypeDefinition:
+	if node.Kind == NodeKindInputObjectTypeDefinition {
 		refs := d.InputObjectTypeDefinitions[node.Ref].InputFieldsDefinition.Refs
 		for _, ref := range refs {
 			if bytes.Equal(d.Input.ByteSlice(d.InputValueDefinitions[ref].Name), name) {
@@ -310,6 +309,7 @@ func (d *Document) NodeInputFieldDefinitionByName(node Node, name ByteSlice) (in
 			}
 		}
 	}
+
 	return 0, false
 }
 

--- a/v2/pkg/astnormalization/inject_input_default_values.go
+++ b/v2/pkg/astnormalization/inject_input_default_values.go
@@ -91,15 +91,16 @@ func (v *inputFieldDefaultInjectionVisitor) recursiveInjectInputFields(inputObje
 
 		if !isTypeScalarOrEnum {
 			var valToUse []byte
-			if existsInVal {
+			switch {
+			case existsInVal:
 				valToUse = varVal
-			} else if hasDefault {
+			case hasDefault:
 				defVal, err := v.definition.ValueToJSON(valDef.DefaultValue.Value)
 				if err != nil {
 					return nil, false, err
 				}
 				valToUse = defVal
-			} else {
+			default:
 				continue
 			}
 			fieldValue, replaced, err := v.processObjectOrListInput(valDef.Type, valToUse, v.definition)
@@ -202,7 +203,8 @@ func (v *inputFieldDefaultInjectionVisitor) jsonWalker(fieldType int, defaultVal
 		if err != nil {
 			return
 		}
-		if listOfList && dataType == jsonparser.Array {
+		switch {
+		case listOfList && dataType == jsonparser.Array:
 			newVal, replaced, err := v.processObjectOrListInput(typeDoc.Types[fieldType].OfType, value, typeDoc)
 			if err != nil {
 				return
@@ -215,7 +217,7 @@ func (v *inputFieldDefaultInjectionVisitor) jsonWalker(fieldType int, defaultVal
 				}
 				*finalValueReplaced = true
 			}
-		} else if !listOfList && dataType == jsonparser.Object {
+		case !listOfList && dataType == jsonparser.Object:
 			newVal, replaced, err := v.recursiveInjectInputFields(node.Ref, value)
 			if err != nil {
 				return
@@ -228,7 +230,7 @@ func (v *inputFieldDefaultInjectionVisitor) jsonWalker(fieldType int, defaultVal
 				}
 				*finalValueReplaced = true
 			}
-		} else {
+		default:
 			return
 		}
 		i++

--- a/v2/pkg/astparser/errors.go
+++ b/v2/pkg/astparser/errors.go
@@ -2,6 +2,7 @@ package astparser
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/lexer/identkeyword"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/lexer/keyword"
@@ -25,12 +26,12 @@ type ErrUnexpectedToken struct {
 
 func (e ErrUnexpectedToken) Error() string {
 
-	origins := ""
+	var origins strings.Builder
 	for _, origin := range e.origins {
-		origins = origins + fmt.Sprintf("\n\t\t%s:%d\n\t\t%s", origin.file, origin.line, origin.funcName)
+		fmt.Fprintf(&origins, "\n\t\t%s:%d\n\t\t%s", origin.file, origin.line, origin.funcName)
 	}
 
-	return fmt.Sprintf("unexpected token - keyword: '%s' literal: '%s' - expected: '%s' position: '%s'%s", e.keyword, e.literal, e.expected, e.position, origins)
+	return fmt.Sprintf("unexpected token - keyword: '%s' literal: '%s' - expected: '%s' position: '%s'%s", e.keyword, e.literal, e.expected, e.position, origins.String())
 }
 
 // ErrUnexpectedIdentKey is a custom error object to properly render an unexpected ident key error
@@ -44,12 +45,12 @@ type ErrUnexpectedIdentKey struct {
 
 func (e ErrUnexpectedIdentKey) Error() string {
 
-	origins := ""
+	var origins strings.Builder
 	for _, origin := range e.origins {
-		origins = origins + fmt.Sprintf("\n\t\t%s:%d\n\t\t%s", origin.file, origin.line, origin.funcName)
+		fmt.Fprintf(&origins, "\n\t\t%s:%d\n\t\t%s", origin.file, origin.line, origin.funcName)
 	}
 
-	return fmt.Sprintf("unexpected ident - keyword: '%s' literal: '%s' - expected: '%s' position: '%s'%s", e.keyword, e.literal, e.expected, e.position, origins)
+	return fmt.Sprintf("unexpected ident - keyword: '%s' literal: '%s' - expected: '%s' position: '%s'%s", e.keyword, e.literal, e.expected, e.position, origins.String())
 }
 
 // ErrDepthLimitExceeded is returned when the parser encounters nesting depth

--- a/v2/pkg/astprinter/astprinter.go
+++ b/v2/pkg/astprinter/astprinter.go
@@ -660,21 +660,19 @@ func (p *printVisitor) LeaveInputValueDefinition(ref int) {
 			}
 		}
 		p.writeIndentedWithDepth(p.inputValueDefinitionCloser, closerDepth)
-	} else {
-		if len(p.Ancestors) > 0 {
-			// check enclosing type kind
-			if parent.Kind == ast.NodeKindFieldDefinition {
-				if multilineField {
-					// Args are separated by line terminators emitted on
-					// Enter of the next arg, not by ", ".
-					return
-				}
-				p.write(literal.COMMA)
-				p.write(literal.SPACE)
-			} else if len(p.indent) == 0 {
-				// add space between arguments when printing without indents
-				p.write(literal.SPACE)
+	} else if len(p.Ancestors) > 0 {
+		// check enclosing type kind
+		if parent.Kind == ast.NodeKindFieldDefinition {
+			if multilineField {
+				// Args are separated by line terminators emitted on
+				// Enter of the next arg, not by ", ".
+				return
 			}
+			p.write(literal.COMMA)
+			p.write(literal.SPACE)
+		} else if len(p.indent) == 0 {
+			// add space between arguments when printing without indents
+			p.write(literal.SPACE)
 		}
 	}
 }

--- a/v2/pkg/astvalidation/reference/main.go
+++ b/v2/pkg/astvalidation/reference/main.go
@@ -315,24 +315,6 @@ func (c *Converter) transformLine(line string) (out string, skip bool) {
 			out = line
 		}
 
-		// replacing a rule js function name with a simple string rule name
-	case strings.Contains(line, "Rule,"):
-		// if we are inside importing of rule function just skip a line
-		if c.insideImport {
-			return "", true
-		}
-		var ruleName string
-		for s := range strings.SplitSeq(line, ",") {
-			if strings.Contains(s, "Rule") {
-				ruleName = strings.TrimSpace(s)
-				break
-			}
-		}
-		if strings.Contains(ruleName, "(") {
-			ruleName = strings.Split(ruleName, "(")[1]
-		}
-		out = strings.ReplaceAll(line, ruleName, ruleName)
-
 		// do not transform a line when no conditions met
 		// in case we are inside an import just skip a line
 	default:

--- a/v2/pkg/astvalidation/reference/main.go
+++ b/v2/pkg/astvalidation/reference/main.go
@@ -315,8 +315,10 @@ func (c *Converter) transformLine(line string) (out string, skip bool) {
 			out = line
 		}
 
-		// do not transform a line when no conditions met
-		// in case we are inside an import just skip a line
+		// Preserve lines that don't require translation. This intentionally includes rule
+		// identifiers: testsgo/harness_test.go declares matching Go string constants, so
+		// generated helper calls must keep bare identifiers instead of quoted literals.
+		// In case we are inside an import, skip the line instead.
 	default:
 		if c.insideImport {
 			return "", true

--- a/v2/pkg/astvalidation/reference/main_test.go
+++ b/v2/pkg/astvalidation/reference/main_test.go
@@ -1,0 +1,35 @@
+package main
+
+import "testing"
+
+func TestConverterPreservesRuleIdentifiers(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want string
+	}{
+		{
+			name: "helper call argument",
+			line: "  return expectValidationErrors(FieldsOnCorrectTypeRule, queryStr)",
+			want: "  return ExpectValidationErrors(t,FieldsOnCorrectTypeRule, queryStr)",
+		},
+		{
+			name: "multiline helper call argument",
+			line: "    FieldsOnCorrectTypeRule,",
+			want: "    FieldsOnCorrectTypeRule,",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			converter := &Converter{}
+			got, skip := converter.transformLine(tt.line)
+			if skip {
+				t.Fatal("transformLine unexpectedly skipped the rule argument")
+			}
+			if got != tt.want {
+				t.Fatalf("transformLine() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/v2/pkg/astvalidation/reference/replacements.yml
+++ b/v2/pkg/astvalidation/reference/replacements.yml
@@ -130,9 +130,7 @@
           return expect(errors[0].message);
         }
   replacement: >-
-    ExpectErrorMessage := func(t *testing.T, schema string, queryStr string) MessageCompare {
-      return ExpectValidationErrorMessage(t, schema, queryStr)
-    }
+    ExpectErrorMessage := ExpectValidationErrorMessage
 -
   rule: FieldsOnCorrectTypeRule
   reason: related to expectErrorMessage - msg.to.equal replaced by a function call

--- a/v2/pkg/astvalidation/reference/testsgo/FieldsOnCorrectTypeRule_test.go
+++ b/v2/pkg/astvalidation/reference/testsgo/FieldsOnCorrectTypeRule_test.go
@@ -246,9 +246,7 @@ func TestFieldsOnCorrectTypeRule(t *testing.T) {
 		})
 
 		t.Run("Fields on correct type error message", func(t *testing.T) {
-			ExpectErrorMessage := func(t *testing.T, schema string, queryStr string) MessageCompare {
-				return ExpectValidationErrorMessage(t, schema, queryStr)
-			}
+			ExpectErrorMessage := ExpectValidationErrorMessage
 			t.Run("Works with no suggestions", func(t *testing.T) {
 				schema := BuildSchema(`
         type T {

--- a/v2/pkg/astvisitor/visitor.go
+++ b/v2/pkg/astvisitor/visitor.go
@@ -3983,7 +3983,8 @@ func (w *Walker) ArgumentInputValueDefinition(argument int) (definition int, exi
 	return
 }
 
-// FieldDefinitionWithExists
+// FieldDefinitionWithExists returns the field definition and whether it exists.
+//
 // Deprecated: use FieldDefinition
 func (w *Walker) FieldDefinitionWithExists(field int) (definition int, exists bool) {
 	return w.FieldDefinition(field)

--- a/v2/pkg/engine/cache/lex.go
+++ b/v2/pkg/engine/cache/lex.go
@@ -166,8 +166,7 @@ func (l *lexer) nextToken() (token, error) {
 		return tok, nil
 	}
 
-	switch next {
-	case runes.QUOTE:
+	if next == runes.QUOTE {
 		// We expect a string token here.
 		err := l.readString(&tok)
 		return tok, err
@@ -242,8 +241,7 @@ func (l *lexer) readString(tok *token) error {
 			return fmt.Errorf("control character %#x found in input at position %d", next, l.pos)
 		}
 
-		switch next {
-		case runes.QUOTE:
+		if next == runes.QUOTE {
 			tok.setEnd(l.pos, l.input)
 			l.advance(1) // consume the quote
 			return nil

--- a/v2/pkg/engine/plan/cost_visitor.go
+++ b/v2/pkg/engine/plan/cost_visitor.go
@@ -202,8 +202,7 @@ func (v *CostVisitor) extractFieldArguments(fieldRef int) map[string]ArgumentInf
 		argValue := v.Operation.ArgumentValue(argRef)
 		argInfo := ArgumentInfo{}
 
-		switch argValue.Kind {
-		case ast.ValueKindVariable:
+		if argValue.Kind == ast.ValueKindVariable {
 			variableValue := v.Operation.VariableValueNameString(argValue.Ref)
 			if !v.Operation.OperationDefinitionHasVariableDefinition(*v.operationDefinition, variableValue) {
 				continue // omit optional argument when the variable is not defined
@@ -239,7 +238,6 @@ func (v *CostVisitor) extractFieldArguments(fieldRef int) map[string]ArgumentInf
 			}
 
 		}
-
 		arguments[argName] = argInfo
 	}
 

--- a/v2/pkg/engine/plan/datasource_configuration.go
+++ b/v2/pkg/engine/plan/datasource_configuration.go
@@ -443,6 +443,7 @@ type DataSourcePlanningBehavior struct {
 	//  }
 	// When true expected response will be { "rootField": ..., "alias": ... }
 	// When false expected response will be { "rootField": ..., "original": ... }
+	//
 	// Deprecated: has no effect anymore
 	OverrideFieldPathFromAlias bool
 

--- a/v2/pkg/engine/plan/key_fields_visitor.go
+++ b/v2/pkg/engine/plan/key_fields_visitor.go
@@ -240,10 +240,11 @@ func (v *keyInfoVisitor) EnterField(ref int) {
 	isExternal := hasExternalRootNode || hasExternalChildNode
 
 	if isExternal {
-		if isProvided {
+		switch {
+		case isProvided:
 			// if the field is provided, it should not be marked as external
 			isExternal = false
-		} else if hasRootNode || hasChildNode {
+		case hasRootNode || hasChildNode:
 			// fallback for how we used to handle keys marked as external in the current composition version
 			// if the key field present in both external fields and regular fields it should not be marked as external
 			// this logic is parallel to what we have in collect fields visitor
@@ -253,7 +254,7 @@ func (v *keyInfoVisitor) EnterField(ref int) {
 			if !v.input.keyIsConditional {
 				isExternal = false
 			}
-		} else if !v.input.keyIsConditional && len(v.currentKeyPath) > 0 && !v.isRootKeyPathExternal() {
+		case !v.input.keyIsConditional && len(v.currentKeyPath) > 0 && !v.isRootKeyPathExternal():
 
 			// handles edge case when we mark direct child node as not external
 			// but nested fields was external for implicit key
@@ -271,7 +272,6 @@ func (v *keyInfoVisitor) EnterField(ref int) {
 
 			isExternal = false
 		}
-
 	}
 
 	fieldKeyPath := KeyInfoFieldPath{
@@ -285,7 +285,7 @@ func (v *keyInfoVisitor) EnterField(ref int) {
 		v.hasExternalFields = true
 	}
 
-	v.currentKeyPath = append(v.keyPaths, fieldKeyPath)
+	v.currentKeyPath = append(v.currentKeyPath, fieldKeyPath)
 }
 
 func (v *keyInfoVisitor) LeaveField(ref int) {

--- a/v2/pkg/engine/plan/source_connection_graph.go
+++ b/v2/pkg/engine/plan/source_connection_graph.go
@@ -96,7 +96,7 @@ func (g *DataSourceJumpsGraph) getPaths(source DSHash, target DSHash, includeFal
 			}
 
 			if !visited[jump.To] {
-				newPath := append(path, jump)
+				newPath := slices.Concat(path, []KeyJump{jump})
 				if conns, exists := dfs(jump.To, newPath, depth+1); exists {
 					connections = append(connections, conns...)
 					found = true

--- a/v2/pkg/engine/plan/visitor.go
+++ b/v2/pkg/engine/plan/visitor.go
@@ -1168,8 +1168,7 @@ func (v *Visitor) resolveInputTemplates(config *objectFetchConfiguration, input 
 			if len(path) != 2 {
 				break
 			}
-			switch path[0] {
-			case "headers":
+			if path[0] == "headers" {
 				key := path[1]
 				variableName, _ = variables.AddVariable(&resolve.HeaderVariable{
 					Path: []string{key},

--- a/v2/pkg/engine/postprocess/create_concrete_single_fetch_types.go
+++ b/v2/pkg/engine/postprocess/create_concrete_single_fetch_types.go
@@ -38,10 +38,10 @@ func (d *createConcreteSingleFetchTypes) traverseFetch(fetch resolve.Fetch) reso
 	if fetch == nil {
 		return nil
 	}
-	switch f := fetch.(type) {
-	case *resolve.SingleFetch:
+	if f, ok := fetch.(*resolve.SingleFetch); ok {
 		return d.traverseSingleFetch(f)
 	}
+
 	return fetch
 }
 

--- a/v2/pkg/engine/postprocess/deduplicate_single_fetches.go
+++ b/v2/pkg/engine/postprocess/deduplicate_single_fetches.go
@@ -95,7 +95,7 @@ func (d *deduplicateSingleFetches) mergeTypeNames(left []string, right []string)
 		return nil // if either side is empty, fetch is unscoped
 	}
 
-	out := append(left, right...)
+	out := slices.Concat(left, right)
 
 	slices.Sort(out)
 	return slices.Compact(out) // removes consecutive duplicates from the sorted slice

--- a/v2/pkg/engine/resolve/subgraph_request_singleflight.go
+++ b/v2/pkg/engine/resolve/subgraph_request_singleflight.go
@@ -125,7 +125,7 @@ func (s *SubgraphRequestSingleFlight) Finish(item *SingleFlightItem) {
 	}
 	if size.count == 50 {
 		size.count = 1
-		size.totalBytes = size.totalBytes / 50
+		size.totalBytes /= 50
 	}
 	size.count++
 	size.totalBytes += len(item.response)

--- a/v2/pkg/graphqljsonschema/jsonschema.go
+++ b/v2/pkg/graphqljsonschema/jsonschema.go
@@ -51,8 +51,7 @@ func FromTypeRef(operation, definition *ast.Document, typeRef int, opts ...Optio
 }
 
 func resolveJsonSchemaPath(jsonSchema JsonSchema, path []string) JsonSchema {
-	switch typedJsonSchema := jsonSchema.(type) {
-	case Object:
+	if typedJsonSchema, ok := jsonSchema.(Object); ok {
 		for i := range path {
 			propertyJsonSchema, exists := typedJsonSchema.Properties[path[i]]
 			if !exists {

--- a/v2/pkg/grpctest/cmd/main.go
+++ b/v2/pkg/grpctest/cmd/main.go
@@ -44,7 +44,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}
-	defer l.Close()
 
 	s := grpc.NewServer(
 		grpc.UnaryInterceptor(loggingInterceptor),

--- a/v2/pkg/grpctest/mockservice_resolve.go
+++ b/v2/pkg/grpctest/mockservice_resolve.go
@@ -709,11 +709,12 @@ func (s *MockService) ResolveProductRecommendedCategory(_ context.Context, req *
 		} else {
 			// Create a recommended category based on product context
 			var categoryKind productv1.CategoryKind
-			if ctx.GetPrice() < 50 {
+			switch {
+			case ctx.GetPrice() < 50:
 				categoryKind = productv1.CategoryKind_CATEGORY_KIND_BOOK
-			} else if ctx.GetPrice() < 200 {
+			case ctx.GetPrice() < 200:
 				categoryKind = productv1.CategoryKind_CATEGORY_KIND_ELECTRONICS
-			} else {
+			default:
 				categoryKind = productv1.CategoryKind_CATEGORY_KIND_FURNITURE
 			}
 

--- a/v2/pkg/imports/imports.go
+++ b/v2/pkg/imports/imports.go
@@ -10,8 +10,8 @@ import (
 )
 
 var (
-	importStatementRegex, _ = regexp.Compile(`(#import "[^";]+")`)
-	pathStatementRegex, _   = regexp.Compile(`"(.*?)"`)
+	importStatementRegex = regexp.MustCompile(`(#import "[^";]+")`)
+	pathStatementRegex   = regexp.MustCompile(`"(.*?)"`)
 )
 
 type Scanner struct {

--- a/v2/pkg/middleware/operation_complexity/operation_complexity.go
+++ b/v2/pkg/middleware/operation_complexity/operation_complexity.go
@@ -153,7 +153,7 @@ type multiplier struct {
 
 func (c *complexityVisitor) calculateMultiplied(i int) int {
 	for _, j := range c.multipliers {
-		i = i * j.multi
+		i *= j.multi
 	}
 	return i
 }
@@ -217,12 +217,12 @@ func (c *complexityVisitor) EnterField(ref int) {
 		return
 	}
 
-	c.complexity = c.complexity + c.calculateMultiplied(1)
+	c.complexity += c.calculateMultiplied(1)
 	if c.Depth > c.maxFieldDepth {
 		c.maxFieldDepth = c.Depth
 	}
 
-	c.currentRootFieldStats.Stats.Complexity = c.currentRootFieldStats.Stats.Complexity + c.calculateMultiplied(1)
+	c.currentRootFieldStats.Stats.Complexity += c.calculateMultiplied(1)
 	if c.Depth > c.currentRootFieldMaxDepth {
 		c.currentRootFieldMaxDepth = c.Depth
 	}
@@ -248,13 +248,13 @@ func (c *complexityVisitor) EnterSelectionSet(ref int) {
 		return
 	}
 
-	c.count = c.count + c.calculateMultiplied(1)
+	c.count += c.calculateMultiplied(1)
 	if c.Depth > c.maxSelectionSetFieldDepth {
 		c.maxSelectionSetFieldDepth = c.Depth
 		c.selectionSetDepth++
 	}
 
-	c.currentRootFieldStats.Stats.NodeCount = c.currentRootFieldStats.Stats.NodeCount + c.calculateMultiplied(1)
+	c.currentRootFieldStats.Stats.NodeCount += c.calculateMultiplied(1)
 	if c.Depth > c.currentRootFieldMaxSelectionSetDepth {
 		c.currentRootFieldMaxSelectionSetDepth = c.Depth
 		c.currentRootFieldSelectionSetDepth++


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected nested key-path tracking for federated query planning.
  * Improved formatting for multiline field arguments.

* **Documentation**
  * Added deprecation guidance for legacy WebSocket APIs.
  * Clarified deprecated visitor API documentation.

* **Refactor**
  * Simplified internal control flow, string construction, arithmetic, and path handling without changing expected behavior.
  * Strengthened regular-expression initialization and enabled an additional code-quality check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Refs ROUTER-615.

Enables gocritic and resolves the existing findings across the v2 and execution modules. The cleanup is primarily mechanical and also preserves independent DFS path slices and correct nested key-path tracking where appendAssign identified suspicious slice usage. The reference-test converter now documents and tests that JavaScript rule identifiers remain bare Go constants, matching the intent of the 2022 rule-map refactor.

Validation:

- go test ./... in v2
- go test ./... in execution
- golangci-lint v2.10.1 in both modules
- golangci-lint v2.12.2 in both modules

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev).