### PR TITLE
fix: compute operation depth from field nesting only

### DIFF
--- a/v2/pkg/middleware/operation_complexity/operation_complexity.go
+++ b/v2/pkg/middleware/operation_complexity/operation_complexity.go
@@ -91,6 +91,11 @@ func (n *OperationComplexityEstimator) Do(operation, definition *ast.Document, r
 	n.visitor.maxFieldDepth = 0
 	n.visitor.multipliers = n.visitor.multipliers[:0]
 
+	// An aborted walk skips the root field cleanup in LeaveField.
+	// Reset the root field state so the next call does not read stale values.
+	n.visitor.currentRootFieldMaxDepth = 0
+	n.visitor.currentRootFieldStats = RootFieldStats{}
+
 	if n.visitor.calculatedRootFieldStats == nil {
 		n.visitor.calculatedRootFieldStats = make([]RootFieldStats, 0, len(definition.RootOperationTypeDefinitions))
 	}

--- a/v2/pkg/middleware/operation_complexity/operation_complexity.go
+++ b/v2/pkg/middleware/operation_complexity/operation_complexity.go
@@ -36,7 +36,10 @@ import (
 type OperationStats struct {
 	NodeCount  int
 	Complexity int
-	Depth      int
+	// Depth is the largest number of nested field levels in the operation.
+	// The operation root is level 0. Each nested field adds one level. Leaf fields also count.
+	// Inline fragments do not count. An operation that selects only root scalars has depth 0.
+	Depth int
 }
 
 type RootFieldStats struct {
@@ -88,9 +91,6 @@ func (n *OperationComplexityEstimator) Do(operation, definition *ast.Document, r
 	n.visitor.maxFieldDepth = 0
 	n.visitor.multipliers = n.visitor.multipliers[:0]
 
-	n.visitor.maxSelectionSetFieldDepth = 0
-	n.visitor.selectionSetDepth = 0
-
 	if n.visitor.calculatedRootFieldStats == nil {
 		n.visitor.calculatedRootFieldStats = make([]RootFieldStats, 0, len(definition.RootOperationTypeDefinitions))
 	}
@@ -105,11 +105,10 @@ func (n *OperationComplexityEstimator) Do(operation, definition *ast.Document, r
 
 	n.walker.Walk(operation, definition, report)
 
-	depth := n.visitor.maxFieldDepth - n.visitor.selectionSetDepth
 	globalResult := OperationStats{
 		NodeCount:  n.visitor.count,
 		Complexity: n.visitor.complexity,
-		Depth:      depth,
+		Depth:      n.visitor.maxFieldDepth,
 	}
 
 	return globalResult, n.visitor.calculatedRootFieldStats
@@ -130,15 +129,10 @@ type complexityVisitor struct {
 	maxFieldDepth         int
 	multipliers           []multiplier
 
-	maxSelectionSetFieldDepth int
-	selectionSetDepth         int
-
 	rootOperationTypeNames map[string]struct{}
 
-	currentRootFieldStats                RootFieldStats
-	currentRootFieldMaxDepth             int
-	currentRootFieldMaxSelectionSetDepth int
-	currentRootFieldSelectionSetDepth    int
+	currentRootFieldStats    RootFieldStats
+	currentRootFieldMaxDepth int
 
 	calculatedRootFieldStats []RootFieldStats
 
@@ -218,14 +212,30 @@ func (c *complexityVisitor) EnterField(ref int) {
 	}
 
 	c.complexity = c.complexity + c.calculateMultiplied(1)
-	if c.Depth > c.maxFieldDepth {
-		c.maxFieldDepth = c.Depth
+
+	// This field has selections. The selections add one more level.
+	depth := c.fieldNestingLevel() + 1
+	if depth > c.maxFieldDepth {
+		c.maxFieldDepth = depth
 	}
 
 	c.currentRootFieldStats.Stats.Complexity = c.currentRootFieldStats.Stats.Complexity + c.calculateMultiplied(1)
-	if c.Depth > c.currentRootFieldMaxDepth {
-		c.currentRootFieldMaxDepth = c.Depth
+	if depth > c.currentRootFieldMaxDepth {
+		c.currentRootFieldMaxDepth = depth
 	}
+}
+
+// fieldNestingLevel returns the number of fields on the path from the operation root
+// to the current field. The count includes the current field.
+// Selection sets and fragments do not count.
+func (c *complexityVisitor) fieldNestingLevel() int {
+	level := 1
+	for i := range c.Ancestors {
+		if c.Ancestors[i].Kind == ast.NodeKindField {
+			level++
+		}
+	}
+	return level
 }
 
 func (c *complexityVisitor) LeaveField(ref int) {
@@ -249,16 +259,7 @@ func (c *complexityVisitor) EnterSelectionSet(ref int) {
 	}
 
 	c.count = c.count + c.calculateMultiplied(1)
-	if c.Depth > c.maxSelectionSetFieldDepth {
-		c.maxSelectionSetFieldDepth = c.Depth
-		c.selectionSetDepth++
-	}
-
 	c.currentRootFieldStats.Stats.NodeCount = c.currentRootFieldStats.Stats.NodeCount + c.calculateMultiplied(1)
-	if c.Depth > c.currentRootFieldMaxSelectionSetDepth {
-		c.currentRootFieldMaxSelectionSetDepth = c.Depth
-		c.currentRootFieldSelectionSetDepth++
-	}
 }
 
 func (c *complexityVisitor) EnterFragmentDefinition(ref int) {
@@ -279,7 +280,8 @@ func (c *complexityVisitor) resetCurrentRootFieldComplexity(typeName, fieldName,
 }
 
 func (c *complexityVisitor) endRootFieldComplexityCalculation() {
-	currentDepth := c.currentRootFieldMaxDepth - c.currentRootFieldSelectionSetDepth
+	// The root field depth does not include the level of the root field itself.
+	currentDepth := c.currentRootFieldMaxDepth
 	if currentDepth > 0 {
 		currentDepth--
 	}
@@ -287,8 +289,6 @@ func (c *complexityVisitor) endRootFieldComplexityCalculation() {
 	c.calculatedRootFieldStats = append(c.calculatedRootFieldStats, c.currentRootFieldStats)
 
 	c.currentRootFieldMaxDepth = 0
-	c.currentRootFieldMaxSelectionSetDepth = 0
-	c.currentRootFieldSelectionSetDepth = 0
 }
 
 func (c *complexityVisitor) extractFieldRelatedNames(ref, definitionRef int) (typeName, fieldName, alias string) {

--- a/v2/pkg/middleware/operation_complexity/operation_complexity.go
+++ b/v2/pkg/middleware/operation_complexity/operation_complexity.go
@@ -92,7 +92,7 @@ func (n *OperationComplexityEstimator) Do(operation, definition *ast.Document, r
 	n.visitor.multipliers = n.visitor.multipliers[:0]
 
 	// An aborted walk skips the root field cleanup in LeaveField.
-	// Reset the root field state so the next call does not read stale values.
+	// Reset the root field state here. Then this call does not read stale values.
 	n.visitor.currentRootFieldMaxDepth = 0
 	n.visitor.currentRootFieldStats = RootFieldStats{}
 

--- a/v2/pkg/middleware/operation_complexity/operation_complexity_test.go
+++ b/v2/pkg/middleware/operation_complexity/operation_complexity_test.go
@@ -626,6 +626,50 @@ func TestCalculateOperationComplexityDepthWithInlineFragments(t *testing.T) {
 	})
 }
 
+// TestEstimatorReuseAfterAbortedWalk reuses one estimator for two operations.
+// The walk of the first operation stops on an error before it leaves the root field.
+// The stale root field state must not change the result of the second operation.
+func TestEstimatorReuseAfterAbortedWalk(t *testing.T) {
+	def := unsafeparser.ParseGraphqlDocumentString(unionTestDefinition)
+	estimator := NewOperationComplexityEstimator(false)
+
+	// The unknown type condition stops the walk below three nested fields.
+	badOperation := unsafeparser.ParseGraphqlDocumentString(`
+			{
+			  plain {
+				child {
+				  child {
+					child {
+					  ... on Unknown { leaf }
+					}
+				  }
+				}
+			  }
+			}`)
+	badReport := operationreport.Report{}
+	estimator.Do(&badOperation, &def, &badReport)
+	require.True(t, badReport.HasErrors())
+
+	goodOperation := unsafeparser.ParseGraphqlDocumentString(`
+			{
+			  node {
+				... on Success {
+				  child {
+					leaf
+				  }
+				}
+			  }
+			}`)
+	goodReport := operationreport.Report{}
+	astnormalization.NormalizeOperation(&goodOperation, &def, &goodReport)
+	globalStats, rootFieldStats := estimator.Do(&goodOperation, &def, &goodReport)
+	require.False(t, goodReport.HasErrors(), goodReport.Error())
+
+	assert.Equal(t, 3, globalStats.Depth, "unexpected global depth")
+	require.Len(t, rootFieldStats, 1)
+	assert.Equal(t, 2, rootFieldStats[0].Stats.Depth, "unexpected root field depth")
+}
+
 func runConfig(t *testing.T, definition, operation string, expectedGlobalComplexityResult OperationStats, expectedFieldsComplexityResult []RootFieldStats, skipIntrospection bool) {
 	def := unsafeparser.ParseGraphqlDocumentString(definition)
 	op := unsafeparser.ParseGraphqlDocumentString(operation)

--- a/v2/pkg/middleware/operation_complexity/operation_complexity_test.go
+++ b/v2/pkg/middleware/operation_complexity/operation_complexity_test.go
@@ -497,6 +497,135 @@ func TestCalculateOperationComplexity(t *testing.T) {
 	})
 }
 
+// TestCalculateOperationComplexityDepthWithInlineFragments tests the depth of operations
+// that select through inline fragments. Normalization keeps inline fragments that have
+// type conditions. The estimator must not add depth for these fragments.
+// The order of sibling branches must not change the depth.
+func TestCalculateOperationComplexityDepthWithInlineFragments(t *testing.T) {
+	t.Run("an inline fragment does not add depth", func(t *testing.T) {
+		run(t, unionTestDefinition, `
+				{
+				  node {
+					... on Success {
+					  child {
+						leaf
+					  }
+					}
+				  }
+				}`,
+			OperationStats{
+				NodeCount:  2,
+				Complexity: 2,
+				Depth:      3,
+			},
+			[]RootFieldStats{
+				{
+					TypeName:  "Query",
+					FieldName: "node",
+					Stats: OperationStats{
+						NodeCount:  2,
+						Complexity: 2,
+						Depth:      2,
+					},
+				},
+			},
+		)
+	})
+	// The next two cases select the same fields in a different order.
+	// The fragment-free branch is one level deeper than the fragment branch,
+	// so the depth must be 4 in both cases.
+	t.Run("fragment branch before a deeper plain branch", func(t *testing.T) {
+		run(t, unionTestDefinition, `
+				{
+				  node {
+					... on Success {
+					  child {
+						leaf
+					  }
+					}
+				  }
+				  plain {
+					child {
+					  child {
+						leaf
+					  }
+					}
+				  }
+				}`,
+			OperationStats{
+				NodeCount:  5,
+				Complexity: 5,
+				Depth:      4,
+			},
+			[]RootFieldStats{
+				{
+					TypeName:  "Query",
+					FieldName: "node",
+					Stats: OperationStats{
+						NodeCount:  2,
+						Complexity: 2,
+						Depth:      2,
+					},
+				},
+				{
+					TypeName:  "Query",
+					FieldName: "plain",
+					Stats: OperationStats{
+						NodeCount:  3,
+						Complexity: 3,
+						Depth:      3,
+					},
+				},
+			},
+		)
+	})
+	t.Run("deeper plain branch before a fragment branch", func(t *testing.T) {
+		run(t, unionTestDefinition, `
+				{
+				  plain {
+					child {
+					  child {
+						leaf
+					  }
+					}
+				  }
+				  node {
+					... on Success {
+					  child {
+						leaf
+					  }
+					}
+				  }
+				}`,
+			OperationStats{
+				NodeCount:  5,
+				Complexity: 5,
+				Depth:      4,
+			},
+			[]RootFieldStats{
+				{
+					TypeName:  "Query",
+					FieldName: "plain",
+					Stats: OperationStats{
+						NodeCount:  3,
+						Complexity: 3,
+						Depth:      3,
+					},
+				},
+				{
+					TypeName:  "Query",
+					FieldName: "node",
+					Stats: OperationStats{
+						NodeCount:  2,
+						Complexity: 2,
+						Depth:      2,
+					},
+				},
+			},
+		)
+	})
+}
+
 func runConfig(t *testing.T, definition, operation string, expectedGlobalComplexityResult OperationStats, expectedFieldsComplexityResult []RootFieldStats, skipIntrospection bool) {
 	def := unsafeparser.ParseGraphqlDocumentString(definition)
 	op := unsafeparser.ParseGraphqlDocumentString(operation)
@@ -506,7 +635,7 @@ func runConfig(t *testing.T, definition, operation string, expectedGlobalComplex
 
 	estimator := NewOperationComplexityEstimator(skipIntrospection)
 	actualGlobalComplexityResult, actualFieldsComplexityResult := estimator.Do(&op, &def, &report)
-	require.False(t, report.HasErrors())
+	require.False(t, report.HasErrors(), report.Error())
 
 	assert.Equal(t, expectedGlobalComplexityResult.NodeCount, actualGlobalComplexityResult.NodeCount, "unexpected global node count")
 	assert.Equal(t, expectedGlobalComplexityResult.Complexity, actualGlobalComplexityResult.Complexity, "unexpected global complexity")
@@ -581,6 +710,22 @@ const complexQuery = `
 	}
   }
 }`
+
+const unionTestDefinition = `
+scalar String
+
+schema { query: Query }
+
+type Query {
+    node: Result
+    plain: Wrapper
+}
+
+union Result = Success | Failure
+type Failure { message: String }
+type Success { child: Wrapper }
+type Wrapper { child: Wrapper leaf: String }
+`
 
 const testDefinition = `
 


### PR DESCRIPTION
## Problem

The complexity metric reported wrong `Depth` values for operations with inline fragments.

The estimator derived `Depth` from the depth counter of the AST walker. That counter
increases for fields, selection sets, and inline fragments. A correction term subtracted
the selection sets. It did not subtract inline fragments. It also depended on traversal
order. This caused two defects:

1. Each inline fragment on the deepest path added 2 to the depth.
2. Sibling selections changed the depth. This occurred even when they did not extend
   the deepest path.

Smallest reproduction (true depth 3, reported depth 5):

```graphql
{
  node {
    ... on Success {
      child {
        leaf
      }
    }
  }
}
```

The existing tests did not show this defect. Their only inline fragment had no type
condition. Normalization removed that fragment before the estimator ran. Fragments
with type conditions on unions and interfaces stay in the operation.

## Fix

Count field nesting directly. `EnterField` records the number of field ancestors, plus
itself, plus one leaf level. Fragments do not add depth. The result does not depend on
traversal order.

The depth convention does not change for fragment-free operations. The operation root
is level 0. Each nested field adds one level. Leaf fields also count. An operation that
selects only root scalars has depth 0.

## Behavior change

Operations with inline fragments reported too much depth before this change. After this
change, they can pass depth limits that they failed before. If you calibrated depth
limits against the old values, review those limits.

With help from Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved operation complexity depth calculations for nested fields.
  * Ensured selection sets and fragments do not incorrectly increase depth.
  * Corrected global and root-field depth reporting.
  * Prevented stale depth values when processing is interrupted and reused.

* **Tests**
  * Added coverage for inline fragments on union types.
  * Verified depth remains consistent regardless of sibling branch order.
  * Improved normalization error assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->