### PR TITLE
fix: correct operation depth for typed fragments

### DIFF
--- a/v2/pkg/middleware/operation_complexity/operation_complexity.go
+++ b/v2/pkg/middleware/operation_complexity/operation_complexity.go
@@ -33,12 +33,19 @@ import (
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/operationreport"
 )
 
+// OperationStats contains estimates for an operation or root field.
 type OperationStats struct {
-	NodeCount  int
+	// NodeCount is the maximum number of returned nodes.
+	NodeCount int
+	// Complexity is the maximum number of field requests.
 	Complexity int
-	Depth      int
+	// Depth is the maximum number of response field levels on a path.
+	// Root-field depth is relative to the root.
+	Depth int
 }
 
+// RootFieldStats contains the stats for one top-level field. Alias is empty
+// when the response name is the same as FieldName.
 type RootFieldStats struct {
 	TypeName  string
 	FieldName string
@@ -56,11 +63,15 @@ const (
 	__typeLiteral   = "__type"
 )
 
+// OperationComplexityEstimator estimates stats for normalized operations.
+// It may be reused sequentially, but is not safe for concurrent use.
 type OperationComplexityEstimator struct {
 	walker  *astvisitor.Walker
 	visitor *complexityVisitor
 }
 
+// NewOperationComplexityEstimator creates an estimator. If skipIntrospection
+// is true, __schema and __type root fields are excluded.
 func NewOperationComplexityEstimator(skipIntrospection bool) *OperationComplexityEstimator {
 	walker := astvisitor.NewWalker(48)
 	visitor := &complexityVisitor{
@@ -82,13 +93,14 @@ func NewOperationComplexityEstimator(skipIntrospection bool) *OperationComplexit
 	}
 }
 
+// Do returns global and per-root-field estimates for the operation.
 func (n *OperationComplexityEstimator) Do(operation, definition *ast.Document, report *operationreport.Report) (OperationStats, []RootFieldStats) {
 	n.visitor.count = 0
 	n.visitor.complexity = 0
-	n.visitor.maxFieldDepth = 0
+	n.visitor.maxOperationDepth = 0
 	n.visitor.multipliers = n.visitor.multipliers[:0]
 
-	n.visitor.selectionSetDepth = 0
+	n.visitor.fieldDepth = 0
 
 	if n.visitor.calculatedRootFieldStats == nil {
 		n.visitor.calculatedRootFieldStats = make([]RootFieldStats, 0, len(definition.RootOperationTypeDefinitions))
@@ -107,7 +119,7 @@ func (n *OperationComplexityEstimator) Do(operation, definition *ast.Document, r
 	globalResult := OperationStats{
 		NodeCount:  n.visitor.count,
 		Complexity: n.visitor.complexity,
-		Depth:      n.visitor.maxFieldDepth,
+		Depth:      n.visitor.maxOperationDepth,
 	}
 
 	return globalResult, n.visitor.calculatedRootFieldStats
@@ -125,15 +137,24 @@ type complexityVisitor struct {
 	operation, definition *ast.Document
 	count                 int
 	complexity            int
-	maxFieldDepth         int
-	multipliers           []multiplier
 
-	selectionSetDepth int
+	// maxOperationDepth includes the root field.
+	maxOperationDepth int
+
+	// multipliers contains @nodeCountMultiply argument values for the active
+	// field path.
+	multipliers []multiplier
+
+	// fieldDepth counts active fields with selections. Fragments add no depth.
+	fieldDepth int
 
 	rootOperationTypeNames map[string]struct{}
 
-	currentRootFieldStats    RootFieldStats
-	currentRootFieldMaxDepth int
+	// currentRootFieldStats is reused because root fields are visited depth-first.
+	currentRootFieldStats RootFieldStats
+
+	// maxRootFieldDepth is relative to the current root field.
+	maxRootFieldDepth int
 
 	calculatedRootFieldStats []RootFieldStats
 
@@ -212,22 +233,20 @@ func (c *complexityVisitor) EnterField(ref int) {
 		return
 	}
 
+	// A field's multiplier applies to its result, not its own request.
 	c.complexity = c.complexity + c.calculateMultiplied(1)
-	// Count the current field and its selected child level.
-	depth := c.selectionSetDepth + 1 + 1
-	if depth > c.maxFieldDepth {
-		c.maxFieldDepth = depth
-	}
+	c.fieldDepth++
+
+	// Operation depth includes the selected child. Root depth is root-relative.
+	c.maxOperationDepth = max(c.maxOperationDepth, c.fieldDepth+1)
 
 	c.currentRootFieldStats.Stats.Complexity = c.currentRootFieldStats.Stats.Complexity + c.calculateMultiplied(1)
-	if depth > c.currentRootFieldMaxDepth {
-		c.currentRootFieldMaxDepth = depth
-	}
+	c.maxRootFieldDepth = max(c.maxRootFieldDepth, c.fieldDepth)
 }
 
 func (c *complexityVisitor) LeaveField(ref int) {
 	if c.operation.FieldHasSelections(ref) {
-		c.selectionSetDepth--
+		c.fieldDepth--
 	}
 
 	if c.isRootTypeField() {
@@ -245,13 +264,12 @@ func (c *complexityVisitor) LeaveField(ref int) {
 
 func (c *complexityVisitor) EnterSelectionSet(ref int) {
 
+	// Operation and fragment selection sets do not represent returned nodes.
 	if c.Ancestors[len(c.Ancestors)-1].Kind != ast.NodeKindField {
 		return
 	}
 
 	c.count = c.count + c.calculateMultiplied(1)
-	c.selectionSetDepth++
-
 	c.currentRootFieldStats.Stats.NodeCount = c.currentRootFieldStats.Stats.NodeCount + c.calculateMultiplied(1)
 }
 
@@ -273,14 +291,10 @@ func (c *complexityVisitor) resetCurrentRootFieldComplexity(typeName, fieldName,
 }
 
 func (c *complexityVisitor) endRootFieldComplexityCalculation() {
-	currentDepth := c.currentRootFieldMaxDepth
-	if currentDepth > 0 {
-		currentDepth--
-	}
-	c.currentRootFieldStats.Stats.Depth = currentDepth
+	c.currentRootFieldStats.Stats.Depth = c.maxRootFieldDepth
 	c.calculatedRootFieldStats = append(c.calculatedRootFieldStats, c.currentRootFieldStats)
 
-	c.currentRootFieldMaxDepth = 0
+	c.maxRootFieldDepth = 0
 }
 
 func (c *complexityVisitor) extractFieldRelatedNames(ref, definitionRef int) (typeName, fieldName, alias string) {

--- a/v2/pkg/middleware/operation_complexity/operation_complexity.go
+++ b/v2/pkg/middleware/operation_complexity/operation_complexity.go
@@ -88,7 +88,6 @@ func (n *OperationComplexityEstimator) Do(operation, definition *ast.Document, r
 	n.visitor.maxFieldDepth = 0
 	n.visitor.multipliers = n.visitor.multipliers[:0]
 
-	n.visitor.maxSelectionSetFieldDepth = 0
 	n.visitor.selectionSetDepth = 0
 
 	if n.visitor.calculatedRootFieldStats == nil {
@@ -105,11 +104,10 @@ func (n *OperationComplexityEstimator) Do(operation, definition *ast.Document, r
 
 	n.walker.Walk(operation, definition, report)
 
-	depth := n.visitor.maxFieldDepth - n.visitor.selectionSetDepth
 	globalResult := OperationStats{
 		NodeCount:  n.visitor.count,
 		Complexity: n.visitor.complexity,
-		Depth:      depth,
+		Depth:      n.visitor.maxFieldDepth,
 	}
 
 	return globalResult, n.visitor.calculatedRootFieldStats
@@ -130,15 +128,12 @@ type complexityVisitor struct {
 	maxFieldDepth         int
 	multipliers           []multiplier
 
-	maxSelectionSetFieldDepth int
-	selectionSetDepth         int
+	selectionSetDepth int
 
 	rootOperationTypeNames map[string]struct{}
 
-	currentRootFieldStats                RootFieldStats
-	currentRootFieldMaxDepth             int
-	currentRootFieldMaxSelectionSetDepth int
-	currentRootFieldSelectionSetDepth    int
+	currentRootFieldStats    RootFieldStats
+	currentRootFieldMaxDepth int
 
 	calculatedRootFieldStats []RootFieldStats
 
@@ -218,17 +213,23 @@ func (c *complexityVisitor) EnterField(ref int) {
 	}
 
 	c.complexity = c.complexity + c.calculateMultiplied(1)
-	if c.Depth > c.maxFieldDepth {
-		c.maxFieldDepth = c.Depth
+	// Count the current field and its selected child level.
+	depth := c.selectionSetDepth + 1 + 1
+	if depth > c.maxFieldDepth {
+		c.maxFieldDepth = depth
 	}
 
 	c.currentRootFieldStats.Stats.Complexity = c.currentRootFieldStats.Stats.Complexity + c.calculateMultiplied(1)
-	if c.Depth > c.currentRootFieldMaxDepth {
-		c.currentRootFieldMaxDepth = c.Depth
+	if depth > c.currentRootFieldMaxDepth {
+		c.currentRootFieldMaxDepth = depth
 	}
 }
 
 func (c *complexityVisitor) LeaveField(ref int) {
+	if c.operation.FieldHasSelections(ref) {
+		c.selectionSetDepth--
+	}
+
 	if c.isRootTypeField() {
 		c.endRootFieldComplexityCalculation()
 	}
@@ -249,16 +250,9 @@ func (c *complexityVisitor) EnterSelectionSet(ref int) {
 	}
 
 	c.count = c.count + c.calculateMultiplied(1)
-	if c.Depth > c.maxSelectionSetFieldDepth {
-		c.maxSelectionSetFieldDepth = c.Depth
-		c.selectionSetDepth++
-	}
+	c.selectionSetDepth++
 
 	c.currentRootFieldStats.Stats.NodeCount = c.currentRootFieldStats.Stats.NodeCount + c.calculateMultiplied(1)
-	if c.Depth > c.currentRootFieldMaxSelectionSetDepth {
-		c.currentRootFieldMaxSelectionSetDepth = c.Depth
-		c.currentRootFieldSelectionSetDepth++
-	}
 }
 
 func (c *complexityVisitor) EnterFragmentDefinition(ref int) {
@@ -279,7 +273,7 @@ func (c *complexityVisitor) resetCurrentRootFieldComplexity(typeName, fieldName,
 }
 
 func (c *complexityVisitor) endRootFieldComplexityCalculation() {
-	currentDepth := c.currentRootFieldMaxDepth - c.currentRootFieldSelectionSetDepth
+	currentDepth := c.currentRootFieldMaxDepth
 	if currentDepth > 0 {
 		currentDepth--
 	}
@@ -287,8 +281,6 @@ func (c *complexityVisitor) endRootFieldComplexityCalculation() {
 	c.calculatedRootFieldStats = append(c.calculatedRootFieldStats, c.currentRootFieldStats)
 
 	c.currentRootFieldMaxDepth = 0
-	c.currentRootFieldMaxSelectionSetDepth = 0
-	c.currentRootFieldSelectionSetDepth = 0
 }
 
 func (c *complexityVisitor) extractFieldRelatedNames(ref, definitionRef int) (typeName, fieldName, alias string) {

--- a/v2/pkg/middleware/operation_complexity/operation_complexity_depth_benchmark_test.go
+++ b/v2/pkg/middleware/operation_complexity/operation_complexity_depth_benchmark_test.go
@@ -1,0 +1,69 @@
+package operation_complexity
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/internal/unsafeparser"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/operationreport"
+)
+
+func BenchmarkEstimateComplexityByDepth(b *testing.B) {
+	definition := unsafeparser.ParseGraphqlDocumentString(`
+		scalar String
+
+		schema { query: Query }
+
+		type Query { node: Node }
+		type Node { child: Node leaf: String }
+	`)
+
+	for _, depth := range []int{19, 50} {
+		b.Run(fmt.Sprintf("depth_%d", depth), func(b *testing.B) {
+			operation := unsafeparser.ParseGraphqlDocumentString(operationWithDepth(depth))
+			report := operationreport.Report{}
+			stats, _ := NewOperationComplexityEstimator(false).Do(&operation, &definition, &report)
+			if report.HasErrors() {
+				b.Fatal(report.Error())
+			}
+			if stats.Depth != depth {
+				b.Fatalf("want depth %d, got %d", depth, stats.Depth)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				estimator := NewOperationComplexityEstimator(false)
+				report := operationreport.Report{}
+				stats, _ := estimator.Do(&operation, &definition, &report)
+				if report.HasErrors() {
+					b.Fatal(report.Error())
+				}
+				if stats.Depth != depth {
+					b.Fatalf("want depth %d, got %d", depth, stats.Depth)
+				}
+			}
+		})
+	}
+}
+
+func operationWithDepth(depth int) string {
+	if depth < 2 {
+		panic("depth must be at least 2")
+	}
+
+	var operation strings.Builder
+	operation.WriteString("{ node {")
+	for i := 0; i < depth-2; i++ {
+		operation.WriteString(" child {")
+	}
+	operation.WriteString(" leaf")
+	for i := 0; i < depth-1; i++ {
+		operation.WriteString(" }")
+	}
+	operation.WriteString(" }")
+
+	return operation.String()
+}

--- a/v2/pkg/middleware/operation_complexity/operation_complexity_test.go
+++ b/v2/pkg/middleware/operation_complexity/operation_complexity_test.go
@@ -1,6 +1,7 @@
 package operation_complexity
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -497,6 +498,31 @@ func TestCalculateOperationComplexity(t *testing.T) {
 	})
 }
 
+func TestCalculateOperationComplexityDepth(t *testing.T) {
+	tests := []struct {
+		name       string
+		selections string
+	}{
+		{name: "deep path"},
+		{name: "two shallower siblings", selections: depthRegressionFirstBranch + depthRegressionSecondBranch},
+		{name: "one shallower sibling", selections: depthRegressionSecondBranch},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			definition := unsafeparser.ParseGraphqlDocumentString(depthRegressionDefinition)
+			operation := unsafeparser.ParseGraphqlDocumentString(fmt.Sprintf(depthRegressionQuery, tt.selections))
+			report := operationreport.Report{}
+
+			astnormalization.NormalizeOperation(&operation, &definition, &report)
+			stats, _ := NewOperationComplexityEstimator(false).Do(&operation, &definition, &report)
+
+			require.False(t, report.HasErrors(), report.Error())
+			assert.Equal(t, 11, stats.Depth)
+		})
+	}
+}
+
 func runConfig(t *testing.T, definition, operation string, expectedGlobalComplexityResult OperationStats, expectedFieldsComplexityResult []RootFieldStats, skipIntrospection bool) {
 	def := unsafeparser.ParseGraphqlDocumentString(definition)
 	op := unsafeparser.ParseGraphqlDocumentString(operation)
@@ -579,6 +605,111 @@ const complexQuery = `
 			}
 		}
 	}
+  }
+}`
+
+const depthRegressionDefinition = `
+scalar String
+
+schema { query: Query }
+
+input RootInput { key: String }
+type Query { root(input: RootInput!): RootResult }
+union RootResult = RootSuccess | Failure
+type RootSuccess { results: [Result!]! }
+union Result = ResultSuccess | Failure
+type ResultSuccess { result: Record }
+type Failure { message: String }
+
+interface Record { pathA: PathA alternateOne: AlternateOne }
+type BasicRecord implements Record { pathA: PathA alternateOne: AlternateOne }
+type ExtendedRecord implements Record { pathA: PathA alternateOne: AlternateOne sideLeaf: String branchOne: BranchOne }
+
+type PathA { pathB: PathB }
+union PathB = PathBDetails | Failure
+type PathBDetails { pathC: PathC }
+type PathC { pathD: PathD }
+union PathD = PathDDetails | Failure
+type PathDDetails { pathE: PathE }
+type PathE { pathF: PathF }
+type PathF { pathG: PathG }
+type PathG { leaf: String }
+
+type BranchOne { branchTwo: BranchTwo }
+type BranchTwo { branchLeaf: String branchThree: [BranchThree!] }
+type BranchThree { branchLeaf: String branchFour: [BranchFour!] }
+type BranchFour { branchLeaf: String }
+
+type AlternateOne { alternateTwo: AlternateTwo }
+type AlternateTwo { alternateThree: AlternateThree }
+type AlternateThree { alternateFour: AlternateFour }
+type AlternateFour { alternateFive: AlternateFive }
+type AlternateFive { alternateSix: AlternateSix }
+type AlternateSix { alternateLeaf: String }
+`
+
+const depthRegressionQuery = `
+query Operation($input: RootInput!) {
+  root(input: $input) {
+    ... on RootSuccess {
+      results {
+        ... on ResultSuccess {
+          result {
+            %s
+            pathA {
+              pathB {
+                ... on PathBDetails {
+                  pathC {
+                    pathD {
+                      ... on PathDDetails {
+                        pathE {
+                          pathF {
+                            pathG {
+                              leaf
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+const depthRegressionFirstBranch = `
+... on ExtendedRecord {
+  sideLeaf
+  branchOne {
+    branchTwo {
+      branchLeaf
+      branchThree {
+        branchLeaf
+        branchFour {
+          branchLeaf
+        }
+      }
+    }
+  }
+}`
+
+const depthRegressionSecondBranch = `
+alternateOne {
+  alternateTwo {
+    alternateThree {
+      alternateFour {
+        alternateFive {
+          alternateSix {
+            alternateLeaf
+          }
+        }
+      }
+    }
   }
 }`
 

--- a/v2/pkg/middleware/operation_complexity/operation_complexity_test.go
+++ b/v2/pkg/middleware/operation_complexity/operation_complexity_test.go
@@ -500,25 +500,39 @@ func TestCalculateOperationComplexity(t *testing.T) {
 
 func TestCalculateOperationComplexityDepth(t *testing.T) {
 	tests := []struct {
-		name       string
-		selections string
+		name                         string
+		selections                   string
+		nestedFieldArguments         string
+		leafFieldArguments           string
+		inlineFragmentFieldArguments string
 	}{
 		{name: "deep path"},
 		{name: "two shallower siblings", selections: depthRegressionFirstBranch + depthRegressionSecondBranch},
 		{name: "one shallower sibling", selections: depthRegressionSecondBranch},
+		{name: "complex input literal on nested field", nestedFieldArguments: depthRegressionComplexInputArgument},
+		{name: "complex input literal on leaf field", leafFieldArguments: depthRegressionComplexInputArgument},
+		{name: "complex input literal on field inside inline fragment", inlineFragmentFieldArguments: depthRegressionComplexInputArgument},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			definition := unsafeparser.ParseGraphqlDocumentString(depthRegressionDefinition)
-			operation := unsafeparser.ParseGraphqlDocumentString(fmt.Sprintf(depthRegressionQuery, tt.selections))
+			operation := unsafeparser.ParseGraphqlDocumentString(fmt.Sprintf(
+				depthRegressionQuery,
+				tt.selections,
+				tt.nestedFieldArguments,
+				tt.inlineFragmentFieldArguments,
+				tt.leafFieldArguments,
+			))
 			report := operationreport.Report{}
 
 			astnormalization.NormalizeOperation(&operation, &definition, &report)
-			stats, _ := NewOperationComplexityEstimator(false).Do(&operation, &definition, &report)
+			stats, rootFieldStats := NewOperationComplexityEstimator(false).Do(&operation, &definition, &report)
 
 			require.False(t, report.HasErrors(), report.Error())
 			assert.Equal(t, 11, stats.Depth)
+			require.Len(t, rootFieldStats, 1)
+			assert.Equal(t, 10, rootFieldStats[0].Stats.Depth)
 		})
 	}
 }
@@ -621,19 +635,19 @@ union Result = ResultSuccess | Failure
 type ResultSuccess { result: Record }
 type Failure { message: String }
 
-interface Record { pathA: PathA alternateOne: AlternateOne }
-type BasicRecord implements Record { pathA: PathA alternateOne: AlternateOne }
-type ExtendedRecord implements Record { pathA: PathA alternateOne: AlternateOne sideLeaf: String branchOne: BranchOne }
+interface Record { pathA(input: RootInput): PathA alternateOne: AlternateOne }
+type BasicRecord implements Record { pathA(input: RootInput): PathA alternateOne: AlternateOne }
+type ExtendedRecord implements Record { pathA(input: RootInput): PathA alternateOne: AlternateOne sideLeaf: String branchOne: BranchOne }
 
 type PathA { pathB: PathB }
 union PathB = PathBDetails | Failure
-type PathBDetails { pathC: PathC }
+type PathBDetails { pathC(input: RootInput): PathC }
 type PathC { pathD: PathD }
 union PathD = PathDDetails | Failure
 type PathDDetails { pathE: PathE }
 type PathE { pathF: PathF }
 type PathF { pathG: PathG }
-type PathG { leaf: String }
+type PathG { leaf(input: RootInput): String }
 
 type BranchOne { branchTwo: BranchTwo }
 type BranchTwo { branchLeaf: String branchThree: [BranchThree!] }
@@ -656,16 +670,16 @@ query Operation($input: RootInput!) {
         ... on ResultSuccess {
           result {
             %s
-            pathA {
+            pathA%s {
               pathB {
                 ... on PathBDetails {
-                  pathC {
+                  pathC%s {
                     pathD {
                       ... on PathDDetails {
                         pathE {
                           pathF {
                             pathG {
-                              leaf
+                              leaf%s
                             }
                           }
                         }
@@ -681,6 +695,8 @@ query Operation($input: RootInput!) {
     }
   }
 }`
+
+const depthRegressionComplexInputArgument = `(input: {key: "value"})`
 
 const depthRegressionFirstBranch = `
 ... on ExtendedRecord {

--- a/v2/pkg/middleware/operation_complexity/operation_complexity_test.go
+++ b/v2/pkg/middleware/operation_complexity/operation_complexity_test.go
@@ -501,6 +501,7 @@ func TestCalculateOperationComplexity(t *testing.T) {
 func TestCalculateOperationComplexityDepth(t *testing.T) {
 	tests := []struct {
 		name                         string
+		rootFieldArguments           string
 		selections                   string
 		nestedFieldArguments         string
 		leafFieldArguments           string
@@ -519,6 +520,7 @@ func TestCalculateOperationComplexityDepth(t *testing.T) {
 			definition := unsafeparser.ParseGraphqlDocumentString(depthRegressionDefinition)
 			operation := unsafeparser.ParseGraphqlDocumentString(fmt.Sprintf(
 				depthRegressionQuery,
+				tt.rootFieldArguments,
 				tt.selections,
 				tt.nestedFieldArguments,
 				tt.inlineFragmentFieldArguments,
@@ -535,6 +537,35 @@ func TestCalculateOperationComplexityDepth(t *testing.T) {
 			assert.Equal(t, 10, rootFieldStats[0].Stats.Depth)
 		})
 	}
+}
+
+func TestCalculateOperationComplexityDepthWithRootMultiplier(t *testing.T) {
+	t.Parallel()
+
+	definition := unsafeparser.ParseGraphqlDocumentString(depthRegressionDefinition)
+	operation := unsafeparser.ParseGraphqlDocumentString(fmt.Sprintf(
+		depthRegressionQuery,
+		", first: 2",
+		"",
+		"",
+		"",
+		"",
+	))
+	report := operationreport.Report{}
+
+	astnormalization.NormalizeOperation(&operation, &definition, &report)
+	stats, rootFieldStats := NewOperationComplexityEstimator(false).Do(&operation, &definition, &report)
+
+	require.False(t, report.HasErrors(), report.Error())
+	expectedStats := OperationStats{
+		NodeCount:  20,
+		Complexity: 19,
+		Depth:      11,
+	}
+	assert.Equal(t, expectedStats, stats)
+	require.Len(t, rootFieldStats, 1)
+	expectedStats.Depth--
+	assert.Equal(t, expectedStats, rootFieldStats[0].Stats)
 }
 
 func runConfig(t *testing.T, definition, operation string, expectedGlobalComplexityResult OperationStats, expectedFieldsComplexityResult []RootFieldStats, skipIntrospection bool) {
@@ -623,12 +654,14 @@ const complexQuery = `
 }`
 
 const depthRegressionDefinition = `
+directive @nodeCountMultiply on ARGUMENT_DEFINITION
+
 scalar String
 
 schema { query: Query }
 
 input RootInput { key: String }
-type Query { root(input: RootInput!): RootResult }
+type Query { root(input: RootInput!, first: Int @nodeCountMultiply): RootResult }
 union RootResult = RootSuccess | Failure
 type RootSuccess { results: [Result!]! }
 union Result = ResultSuccess | Failure
@@ -664,7 +697,7 @@ type AlternateSix { alternateLeaf: String }
 
 const depthRegressionQuery = `
 query Operation($input: RootInput!) {
-  root(input: $input) {
+  root(input: $input%s) {
     ... on RootSuccess {
       results {
         ... on ResultSuccess {

--- a/v2/pkg/middleware/operation_complexity/operation_complexity_test.go
+++ b/v2/pkg/middleware/operation_complexity/operation_complexity_test.go
@@ -568,6 +568,35 @@ func TestCalculateOperationComplexityDepthWithRootMultiplier(t *testing.T) {
 	assert.Equal(t, expectedStats, rootFieldStats[0].Stats)
 }
 
+func TestCalculateOperationComplexityDepthWithStackedMultipliers(t *testing.T) {
+	t.Parallel()
+
+	definition := unsafeparser.ParseGraphqlDocumentString(depthRegressionDefinition)
+	operation := unsafeparser.ParseGraphqlDocumentString(fmt.Sprintf(
+		depthRegressionQuery,
+		", first: 2",
+		"",
+		"",
+		`(input: {key: "value"}, first: 3)`,
+		"",
+	))
+	report := operationreport.Report{}
+
+	astnormalization.NormalizeOperation(&operation, &definition, &report)
+	stats, rootFieldStats := NewOperationComplexityEstimator(false).Do(&operation, &definition, &report)
+
+	require.False(t, report.HasErrors(), report.Error())
+	expectedStats := OperationStats{
+		NodeCount:  40,
+		Complexity: 35,
+		Depth:      11,
+	}
+	assert.Equal(t, expectedStats, stats)
+	require.Len(t, rootFieldStats, 1)
+	expectedStats.Depth--
+	assert.Equal(t, expectedStats, rootFieldStats[0].Stats)
+}
+
 func runConfig(t *testing.T, definition, operation string, expectedGlobalComplexityResult OperationStats, expectedFieldsComplexityResult []RootFieldStats, skipIntrospection bool) {
 	def := unsafeparser.ParseGraphqlDocumentString(definition)
 	op := unsafeparser.ParseGraphqlDocumentString(operation)
@@ -674,7 +703,7 @@ type ExtendedRecord implements Record { pathA(input: RootInput): PathA alternate
 
 type PathA { pathB: PathB }
 union PathB = PathBDetails | Failure
-type PathBDetails { pathC(input: RootInput): PathC }
+type PathBDetails { pathC(input: RootInput, first: Int @nodeCountMultiply): PathC }
 type PathC { pathD: PathD }
 union PathD = PathDDetails | Failure
 type PathDDetails { pathE: PathE }

--- a/v2/pkg/middleware/operation_complexity/operation_complexity_test.go
+++ b/v2/pkg/middleware/operation_complexity/operation_complexity_test.go
@@ -1,7 +1,6 @@
 package operation_complexity
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -499,98 +498,110 @@ func TestCalculateOperationComplexity(t *testing.T) {
 }
 
 func TestCalculateOperationComplexityDepth(t *testing.T) {
-	tests := []struct {
-		name                         string
-		rootFieldArguments           string
-		selections                   string
-		nestedFieldArguments         string
-		leafFieldArguments           string
-		inlineFragmentFieldArguments string
-	}{
-		{name: "deep path"},
-		{name: "two shallower siblings", selections: depthRegressionFirstBranch + depthRegressionSecondBranch},
-		{name: "one shallower sibling", selections: depthRegressionSecondBranch},
-		{name: "complex input literal on nested field", nestedFieldArguments: depthRegressionComplexInputArgument},
-		{name: "complex input literal on leaf field", leafFieldArguments: depthRegressionComplexInputArgument},
-		{name: "complex input literal on field inside inline fragment", inlineFragmentFieldArguments: depthRegressionComplexInputArgument},
-	}
+	t.Run("deep path", func(t *testing.T) {
+		runDepthTest(t, `{
+			root {
+				... on Concrete {
+					next {
+						... on Concrete {
+							next { leaf }
+						}
+					}
+				}
+			}
+		}`, OperationStats{NodeCount: 3, Complexity: 3, Depth: 4})
+	})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			definition := unsafeparser.ParseGraphqlDocumentString(depthRegressionDefinition)
-			operation := unsafeparser.ParseGraphqlDocumentString(fmt.Sprintf(
-				depthRegressionQuery,
-				tt.rootFieldArguments,
-				tt.selections,
-				tt.nestedFieldArguments,
-				tt.inlineFragmentFieldArguments,
-				tt.leafFieldArguments,
-			))
-			report := operationreport.Report{}
+	t.Run("two shallower siblings", func(t *testing.T) {
+		runDepthTest(t, `{
+			root {
+				... on Concrete {
+					branchA { next { leaf } }
+					branchB { leaf }
+					next { next { next { leaf } } }
+				}
+			}
+		}`, OperationStats{NodeCount: 7, Complexity: 7, Depth: 5})
+	})
 
-			astnormalization.NormalizeOperation(&operation, &definition, &report)
-			stats, rootFieldStats := NewOperationComplexityEstimator(false).Do(&operation, &definition, &report)
+	t.Run("one shallower sibling", func(t *testing.T) {
+		runDepthTest(t, `{
+			root {
+				... on Concrete {
+					branchB { leaf }
+					next { next { next { leaf } } }
+				}
+			}
+		}`, OperationStats{NodeCount: 5, Complexity: 5, Depth: 5})
+	})
 
-			require.False(t, report.HasErrors(), report.Error())
-			assert.Equal(t, 11, stats.Depth)
-			require.Len(t, rootFieldStats, 1)
-			assert.Equal(t, 10, rootFieldStats[0].Stats.Depth)
-		})
-	}
+	t.Run("complex input literal on root field", func(t *testing.T) {
+		runDepthTest(t,
+			`{ root(input: {key: "value"}) { next { leaf } } }`,
+			OperationStats{NodeCount: 2, Complexity: 2, Depth: 3},
+		)
+	})
+
+	t.Run("complex input literal on nested field", func(t *testing.T) {
+		runDepthTest(t,
+			`{ root { next(input: {key: "value"}) { next { leaf } } } }`,
+			OperationStats{NodeCount: 3, Complexity: 3, Depth: 4},
+		)
+	})
+
+	t.Run("complex input literal on leaf field", func(t *testing.T) {
+		runDepthTest(t,
+			`{ root { next { leaf(input: {key: "value"}) } } }`,
+			OperationStats{NodeCount: 2, Complexity: 2, Depth: 3},
+		)
+	})
+
+	t.Run("complex input literal on field inside inline fragment", func(t *testing.T) {
+		runDepthTest(t, `{
+			root {
+				... on Concrete {
+					next(input: {key: "value"}) { next { leaf } }
+				}
+			}
+		}`, OperationStats{NodeCount: 3, Complexity: 3, Depth: 4})
+	})
 }
 
 func TestCalculateOperationComplexityDepthWithRootMultiplier(t *testing.T) {
 	t.Parallel()
 
-	definition := unsafeparser.ParseGraphqlDocumentString(depthRegressionDefinition)
-	operation := unsafeparser.ParseGraphqlDocumentString(fmt.Sprintf(
-		depthRegressionQuery,
-		", first: 2",
-		"",
-		"",
-		"",
-		"",
-	))
-	report := operationreport.Report{}
-
-	astnormalization.NormalizeOperation(&operation, &definition, &report)
-	stats, rootFieldStats := NewOperationComplexityEstimator(false).Do(&operation, &definition, &report)
-
-	require.False(t, report.HasErrors(), report.Error())
-	expectedStats := OperationStats{
-		NodeCount:  20,
-		Complexity: 19,
-		Depth:      11,
-	}
-	assert.Equal(t, expectedStats, stats)
-	require.Len(t, rootFieldStats, 1)
-	expectedStats.Depth--
-	assert.Equal(t, expectedStats, rootFieldStats[0].Stats)
+	runDepthTest(t, `{
+		root(first: 2) {
+			... on Concrete {
+				next { leaf }
+			}
+		}
+	}`, OperationStats{NodeCount: 4, Complexity: 3, Depth: 3})
 }
 
 func TestCalculateOperationComplexityDepthWithStackedMultipliers(t *testing.T) {
 	t.Parallel()
 
+	runDepthTest(t, `{
+		root(first: 2) {
+			... on Concrete {
+				next(input: {key: "value"}, first: 3) { next { leaf } }
+			}
+		}
+	}`, OperationStats{NodeCount: 14, Complexity: 9, Depth: 4})
+}
+
+func runDepthTest(t *testing.T, operationString string, expectedStats OperationStats) {
+	t.Helper()
+
 	definition := unsafeparser.ParseGraphqlDocumentString(depthRegressionDefinition)
-	operation := unsafeparser.ParseGraphqlDocumentString(fmt.Sprintf(
-		depthRegressionQuery,
-		", first: 2",
-		"",
-		"",
-		`(input: {key: "value"}, first: 3)`,
-		"",
-	))
+	operation := unsafeparser.ParseGraphqlDocumentString(operationString)
 	report := operationreport.Report{}
 
 	astnormalization.NormalizeOperation(&operation, &definition, &report)
 	stats, rootFieldStats := NewOperationComplexityEstimator(false).Do(&operation, &definition, &report)
 
 	require.False(t, report.HasErrors(), report.Error())
-	expectedStats := OperationStats{
-		NodeCount:  40,
-		Complexity: 35,
-		Depth:      11,
-	}
 	assert.Equal(t, expectedStats, stats)
 	require.Len(t, rootFieldStats, 1)
 	expectedStats.Depth--
@@ -690,128 +701,24 @@ scalar String
 schema { query: Query }
 
 input RootInput { key: String }
-type Query { root(input: RootInput!, first: Int @nodeCountMultiply): RootResult }
-union RootResult = RootSuccess | Failure
-type RootSuccess { results: [Result!]! }
-union Result = ResultSuccess | Failure
-type ResultSuccess { result: Record }
-type Failure { message: String }
-
-interface Record {
-  pathA(input: RootInput): PathA
-  alternateOne: AlternateOne
+type Query {
+  root(input: RootInput, first: Int @nodeCountMultiply): Node
 }
 
-type BasicRecord implements Record {
-  pathA(input: RootInput): PathA
-  alternateOne: AlternateOne
+interface Node {
+  next(input: RootInput, first: Int @nodeCountMultiply): Node
+  leaf(input: RootInput): String
+  branchA: Node
+  branchB: Node
 }
 
-type ExtendedRecord implements Record {
-  pathA(input: RootInput): PathA
-  alternateOne: AlternateOne
-  sideLeaf: String
-  branchOne: BranchOne
+type Concrete implements Node {
+  next(input: RootInput, first: Int @nodeCountMultiply): Node
+  leaf(input: RootInput): String
+  branchA: Node
+  branchB: Node
 }
-
-type PathA { pathB: PathB }
-union PathB = PathBDetails | Failure
-type PathBDetails { pathC(input: RootInput, first: Int @nodeCountMultiply): PathC }
-type PathC { pathD: PathD }
-union PathD = PathDDetails | Failure
-type PathDDetails { pathE: PathE }
-type PathE { pathF: PathF }
-type PathF { pathG: PathG }
-type PathG { leaf(input: RootInput): String }
-
-type BranchOne { branchTwo: BranchTwo }
-
-type BranchTwo {
-  branchLeaf: String
-  branchThree: [BranchThree!]
-}
-
-type BranchThree {
-  branchLeaf: String
-  branchFour: [BranchFour!]
-}
-
-type BranchFour { branchLeaf: String }
-
-type AlternateOne { alternateTwo: AlternateTwo }
-type AlternateTwo { alternateThree: AlternateThree }
-type AlternateThree { alternateFour: AlternateFour }
-type AlternateFour { alternateFive: AlternateFive }
-type AlternateFive { alternateSix: AlternateSix }
-type AlternateSix { alternateLeaf: String }
 `
-
-const depthRegressionQuery = `
-query Operation($input: RootInput!) {
-  root(input: $input%s) {
-    ... on RootSuccess {
-      results {
-        ... on ResultSuccess {
-          result {
-            %s
-            pathA%s {
-              pathB {
-                ... on PathBDetails {
-                  pathC%s {
-                    pathD {
-                      ... on PathDDetails {
-                        pathE {
-                          pathF {
-                            pathG {
-                              leaf%s
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}`
-
-const depthRegressionComplexInputArgument = `(input: {key: "value"})`
-
-const depthRegressionFirstBranch = `
-... on ExtendedRecord {
-  sideLeaf
-  branchOne {
-    branchTwo {
-      branchLeaf
-      branchThree {
-        branchLeaf
-        branchFour {
-          branchLeaf
-        }
-      }
-    }
-  }
-}`
-
-const depthRegressionSecondBranch = `
-alternateOne {
-  alternateTwo {
-    alternateThree {
-      alternateFour {
-        alternateFive {
-          alternateSix {
-            alternateLeaf
-          }
-        }
-      }
-    }
-  }
-}`
 
 const testDefinition = `
 

--- a/v2/pkg/middleware/operation_complexity/operation_complexity_test.go
+++ b/v2/pkg/middleware/operation_complexity/operation_complexity_test.go
@@ -697,9 +697,22 @@ union Result = ResultSuccess | Failure
 type ResultSuccess { result: Record }
 type Failure { message: String }
 
-interface Record { pathA(input: RootInput): PathA alternateOne: AlternateOne }
-type BasicRecord implements Record { pathA(input: RootInput): PathA alternateOne: AlternateOne }
-type ExtendedRecord implements Record { pathA(input: RootInput): PathA alternateOne: AlternateOne sideLeaf: String branchOne: BranchOne }
+interface Record {
+  pathA(input: RootInput): PathA
+  alternateOne: AlternateOne
+}
+
+type BasicRecord implements Record {
+  pathA(input: RootInput): PathA
+  alternateOne: AlternateOne
+}
+
+type ExtendedRecord implements Record {
+  pathA(input: RootInput): PathA
+  alternateOne: AlternateOne
+  sideLeaf: String
+  branchOne: BranchOne
+}
 
 type PathA { pathB: PathB }
 union PathB = PathBDetails | Failure
@@ -712,8 +725,17 @@ type PathF { pathG: PathG }
 type PathG { leaf(input: RootInput): String }
 
 type BranchOne { branchTwo: BranchTwo }
-type BranchTwo { branchLeaf: String branchThree: [BranchThree!] }
-type BranchThree { branchLeaf: String branchFour: [BranchFour!] }
+
+type BranchTwo {
+  branchLeaf: String
+  branchThree: [BranchThree!]
+}
+
+type BranchThree {
+  branchLeaf: String
+  branchFour: [BranchFour!]
+}
+
 type BranchFour { branchLeaf: String }
 
 type AlternateOne { alternateTwo: AlternateTwo }


### PR DESCRIPTION
Linear: [ENG-9970](https://linear.app/wundergraph/issue/ENG-9970/depth-calculation-incorrect-under-complexity-limit-metric)

Alternative to #1647. This keeps the fix limited to the existing depth bookkeeping and does not scan field ancestors or register additional visitors.

## Summary

- Add anonymized regressions for the three customer query shapes.
- Track active field-owned selection sets so typed fragments do not affect field depth.
- Add depth 19 and depth 50 benchmarks.

The test-only commit reports depths 19, 18, and 17 instead of 11. The fix makes all three report 11.

## Benchmark

Apple M5 Pro, 8 interleaved samples:

| Depth | master | this PR | Allocations |
| --- | ---: | ---: | ---: |
| 19 | 2.520 µs | 2.468 µs | 29 → 29 |
| 50 | 5.532 µs | 5.405 µs | 41 → 41 |

There is no statistically significant timing change. Memory decreases by 16 B/op at both depths.

## Tests

go test ./v2/... -count=1

## Related issue

Fixes #1052.

This fixes the traversal-order problem reported there: adding, removing, or reordering the shallower `feature` sibling no longer changes the maximum depth around inline fragments. Under the estimator's field-nesting definition, all three query variants report an operation depth of 5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GraphQL operation-depth calculation for root fields, nested selections, inline fragments, and sibling branches.
  * Depth reporting remains accurate with complex input arguments and configured multipliers.
  * Complexity calculations continue to account for field counts and multiplier effects.

* **Tests**
  * Added regression coverage for root, nested, and stacked multiplier scenarios.
  * Added benchmarks for operations at depths of 19 and 50 to validate depth reporting and resource usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->