### PR TITLE
feat: report TTL for subgraph and cached responses

### DIFF
--- a/v2/pkg/engine/cache/cache_control.go
+++ b/v2/pkg/engine/cache/cache_control.go
@@ -68,6 +68,18 @@ func (f *FieldNames) Fields() iter.Seq[string] {
 	}
 }
 
+// FieldsString returns the field names as a string.
+// The string is wrapped in double quotes and comma-separated.
+func (f *FieldNames) FieldsString() string {
+	parts := make([]string, 0, len(f.fields))
+
+	for field := range f.fields {
+		parts = append(parts, field)
+	}
+
+	return "\"" + strings.Join(parts, ",") + "\""
+}
+
 func (f *FieldNames) has(name string) bool {
 	if f == nil || f.noFields {
 		return false
@@ -118,9 +130,28 @@ func parseDeltaSeconds(s string) (DeltaSeconds, error) {
 	return DeltaSeconds(int32(num)), nil
 }
 
+// ToDeltaSeconds converts a time.Duration to a DeltaSeconds.
+func ToDeltaSeconds(d time.Duration) DeltaSeconds {
+	if d < 0 {
+		return DeltaSeconds(-1)
+	}
+
+	val := int64(d / time.Second)
+	if val > math.MaxInt32 {
+		return DeltaSeconds(math.MaxInt32)
+	}
+
+	return DeltaSeconds(int32(val))
+}
+
 // AsDuration converts a DeltaSeconds to a time.Duration.
 func (d DeltaSeconds) AsDuration() time.Duration {
 	return time.Duration(d) * time.Second
+}
+
+// String converts a DeltaSeconds to a string.
+func (d DeltaSeconds) String() string {
+	return strconv.Itoa(int(d))
 }
 
 type CacheControlResponse struct {
@@ -195,6 +226,37 @@ type CacheControlResponse struct {
 	// store the specified field-names(s), whereas it MAY store the
 	// remainder of the response message.
 	Private *FieldNames
+}
+
+// ToHeaderString converts a CacheControlResponse to a Cache-Control header string.
+func (c *CacheControlResponse) ToHeaderString() string {
+	parts := []string{}
+
+	if c.Public {
+		parts = append(parts, "public")
+	}
+
+	if c.MaxAge != nil {
+		parts = append(parts, "max-age="+c.MaxAge.String())
+	}
+
+	if c.SMaxAge != nil {
+		parts = append(parts, "s-maxage="+c.SMaxAge.String())
+	}
+
+	if c.NoStore {
+		parts = append(parts, "no-store")
+	}
+
+	if c.NoCache != nil {
+		parts = append(parts, "no-cache="+c.NoCache.FieldsString())
+	}
+
+	if c.Private != nil {
+		parts = append(parts, "private="+c.Private.FieldsString())
+	}
+
+	return strings.Join(parts, ", ")
 }
 
 func ParseCacheControlResponse(headers http.Header) (*CacheControlResponse, error) {

--- a/v2/pkg/engine/resolve/loader.go
+++ b/v2/pkg/engine/resolve/loader.go
@@ -61,6 +61,9 @@ type ResponseInfo struct {
 	Request *http.Request
 	// ResponseHeaders contains a clone of the headers of the response from the subgraph.
 	ResponseHeaders http.Header
+	// ResponseCacheTTL is the remaining lifetime of the cache entries this fetch was
+	// served from. Zero when the fetch reached the subgraph.
+	ResponseCacheTTL time.Duration
 	// This should be private as we do not want user's to access the raw responseBody directly
 	responseBody []byte
 }
@@ -71,9 +74,10 @@ func (r *ResponseInfo) GetResponseBody() string {
 
 func newResponseInfo(res *result) *ResponseInfo {
 	responseInfo := &ResponseInfo{
-		StatusCode:   res.statusCode,
-		Err:          res.subgraphError,
-		responseBody: res.out,
+		StatusCode:       res.statusCode,
+		Err:              res.subgraphError,
+		ResponseCacheTTL: res.responseCacheTTL,
+		responseBody:     res.out,
 	}
 	if res.httpResponseContext != nil {
 		// We're using the response.Request here, because the body will be nil (since the response was read) and won't
@@ -135,6 +139,9 @@ type result struct {
 	loaderHookContext context.Context
 
 	httpResponseContext *httpclient.ResponseContext
+	// responseCacheTTL is the min remaining lifetime across this fetch's cache
+	// entries, zero on a miss. Fetch-local, so the unlocked load phase is safe.
+	responseCacheTTL time.Duration
 	// out is the subgraph response body
 	out               []byte
 	singleFlightStats *singleFlightStats

--- a/v2/pkg/engine/resolve/loader.go
+++ b/v2/pkg/engine/resolve/loader.go
@@ -61,11 +61,10 @@ type ResponseInfo struct {
 	Request *http.Request
 	// ResponseHeaders contains a clone of the headers of the response from the subgraph.
 	ResponseHeaders http.Header
-	// ResponseCacheHit reports the fetch was served from the response cache rather
-	// than the subgraph.
+	// ResponseCacheHit reports the fetch was served from the response cache rather than the subgraph.
 	ResponseCacheHit bool
-	// ResponseCacheTTL is the lowest lifetime left on the entries the fetch was served
-	// from. Only positive TTLs are considered.
+	// ResponseCacheTTL is the lowest lifetime left on the entries the fetch was served from. Non-negative TTLs are considered.
+	// Use ResponseCacheHit to distinguish a cache hit with a zero TTL from a cache miss.
 	ResponseCacheTTL time.Duration
 	// This should be private as we do not want user's to access the raw responseBody directly
 	responseBody []byte

--- a/v2/pkg/engine/resolve/loader.go
+++ b/v2/pkg/engine/resolve/loader.go
@@ -61,8 +61,11 @@ type ResponseInfo struct {
 	Request *http.Request
 	// ResponseHeaders contains a clone of the headers of the response from the subgraph.
 	ResponseHeaders http.Header
-	// ResponseCacheTTL is the remaining lifetime of the cache entries this fetch was
-	// served from. Zero when the fetch reached the subgraph.
+	// ResponseCacheHit reports the fetch was served from the response cache rather
+	// than the subgraph.
+	ResponseCacheHit bool
+	// ResponseCacheTTL is the lowest lifetime left on the entries the fetch was served
+	// from. Only positive TTLs are considered.
 	ResponseCacheTTL time.Duration
 	// This should be private as we do not want user's to access the raw responseBody directly
 	responseBody []byte
@@ -76,6 +79,7 @@ func newResponseInfo(res *result) *ResponseInfo {
 	responseInfo := &ResponseInfo{
 		StatusCode:       res.statusCode,
 		Err:              res.subgraphError,
+		ResponseCacheHit: res.responseCacheHit,
 		ResponseCacheTTL: res.responseCacheTTL,
 		responseBody:     res.out,
 	}
@@ -139,8 +143,10 @@ type result struct {
 	loaderHookContext context.Context
 
 	httpResponseContext *httpclient.ResponseContext
-	// responseCacheTTL is the min remaining lifetime across this fetch's cache
-	// entries, zero on a miss. Fetch-local, so the unlocked load phase is safe.
+	// responseCacheHit and responseCacheTTL record that the fetch was served from
+	// the cache and the min lifetime left across its entries. Fetch-local, so the
+	// unlocked load phase is safe.
+	responseCacheHit bool
 	responseCacheTTL time.Duration
 	// out is the subgraph response body
 	out               []byte

--- a/v2/pkg/engine/resolve/loader_test.go
+++ b/v2/pkg/engine/resolve/loader_test.go
@@ -1,6 +1,7 @@
 package resolve
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -2783,14 +2784,18 @@ func TestLoader_CachedFetches(t *testing.T) {
 		loader := &Loader{dataBuffer: &DataBuffer{data: astjson.ObjectValue(nil)}}
 
 		// Fetches run in parallel, so collect and sort before asserting.
+		type cacheReport struct {
+			hit bool
+			ttl time.Duration
+		}
 		var mu sync.Mutex
-		var ttls []time.Duration
-		collectTTLs := func() []time.Duration {
+		var reports []cacheReport
+		collectReports := func() []cacheReport {
 			mu.Lock()
 			defer mu.Unlock()
-			out := slices.Clone(ttls)
-			ttls = ttls[:0]
-			slices.Sort(out)
+			out := slices.Clone(reports)
+			reports = reports[:0]
+			slices.SortFunc(out, func(a, b cacheReport) int { return cmp.Compare(a.ttl, b.ttl) })
 			return out
 		}
 		ctx.SetEngineLoaderHooks(&spyLoaderHooks{
@@ -2799,10 +2804,10 @@ func TestLoader_CachedFetches(t *testing.T) {
 				defer mu.Unlock()
 				// A cache hit has no subgraph headers, so a consumer that synthesizes
 				// one must not write it back here.
-				if info.ResponseCacheTTL > 0 {
-					require.Nil(t, info.ResponseHeaders, "a cache hit must not carry subgraph response headers")
+				if info.ResponseCacheHit {
+					assert.Nil(t, info.ResponseHeaders, "a cache hit must not carry subgraph response headers")
 				}
-				ttls = append(ttls, info.ResponseCacheTTL)
+				reports = append(reports, cacheReport{hit: info.ResponseCacheHit, ttl: info.ResponseCacheTTL})
 			},
 		})
 
@@ -2819,8 +2824,9 @@ func TestLoader_CachedFetches(t *testing.T) {
 
 		require.Len(t, testCache.items, 8, "expected 8 items in the cache: (3 products + 3 stock + 2 users)")
 
-		// First run: nothing came from the cache.
-		require.Equal(t, []time.Duration{0, 0, 0, 0}, collectTTLs())
+		// First run: nothing came from the cache. The flag says so, which a TTL of
+		// zero on its own would not, being a valid lifetime in its own right.
+		require.Equal(t, []cacheReport{{}, {}, {}, {}}, collectReports())
 
 		// Second run: every entity fetch must be served from the cache. The mocks are set to Times(1), so any repeated subgraph call fails the test.
 		loader = &Loader{dataBuffer: &DataBuffer{data: astjson.ObjectValue(nil)}}
@@ -2831,13 +2837,13 @@ func TestLoader_CachedFetches(t *testing.T) {
 		assert.Contains(t, []string{expected1, expected2}, cachedOut)
 
 		// Each cached fetch reports its own subgraph's max-age, not a request-wide
-		// value. The root products fetch is not cacheable, so it reports nothing.
-		require.Equal(t, []time.Duration{
-			0,
-			200 * time.Second,
-			300 * time.Second,
-			400 * time.Second,
-		}, collectTTLs())
+		// value. The root products fetch is not cacheable, so it reports no hit.
+		require.Equal(t, []cacheReport{
+			{hit: false, ttl: 0},
+			{hit: true, ttl: 200 * time.Second},
+			{hit: true, ttl: 300 * time.Second},
+			{hit: true, ttl: 400 * time.Second},
+		}, collectReports())
 	})
 
 }

--- a/v2/pkg/engine/resolve/loader_test.go
+++ b/v2/pkg/engine/resolve/loader_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -2430,268 +2431,244 @@ func TestLoader_AllowCustomExtensionProperties(t *testing.T) {
 }
 
 func TestLoader_CachedFetches(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	headers := http.Header{}
-	headers.Set("Cache-Control", "public, max-age=60")
-
-	productsService := mockedDSWithHeaders(t, ctrl,
-		`{"method":"POST","url":"http://products","body":{"query":"query{topProducts{name __typename upc}}"}}`,
-		`{"data":{"topProducts":[{"name":"Table","__typename":"Product","upc":"1"},{"name":"Couch","__typename":"Product","upc":"2"},{"name":"Chair","__typename":"Product","upc":"3"}]}}`,
-		// Only entity fetches are response-cached, so the root fetch runs on both loads.
-		headers, 2)
-
-	reviewsService := mockedDSWithHeaders(t, ctrl,
-		`{"method":"POST","url":"http://reviews","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){__typename ... on Product {reviews {body author {__typename id}}}}}","variables":{"representations":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"},{"__typename":"Product","upc":"3"}]}}}`,
-		`{"data":{"_entities":[{"__typename":"Product","reviews":[{"body":"Love Table!","author":{"__typename":"User","id":"1"}},{"body":"Prefer other Table.","author":{"__typename":"User","id":"2"}}]},{"__typename":"Product","reviews":[{"body":"Couch Too expensive.","author":{"__typename":"User","id":"1"}}]},{"__typename":"Product","reviews":[{"body":"Chair Could be better.","author":{"__typename":"User","id":"2"}}]}]}}`,
-		headers, 1)
-
-	stockService := mockedDSWithHeaders(t, ctrl,
-		`{"method":"POST","url":"http://stock","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){__typename ... on Product {stock}}}","variables":{"representations":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"},{"__typename":"Product","upc":"3"}]}}}`,
-		`{"data":{"_entities":[{"stock":8},{"stock":2},{"stock":5}]}}`,
-		headers, 1)
-
-	usersService := mockedDSWithHeaders(t, ctrl,
-		`{"method":"POST","url":"http://users","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){__typename ... on User {name}}}","variables":{"representations":[{"__typename":"User","id":"1"},{"__typename":"User","id":"2"}]}}}`,
-		`{"data":{"_entities":[{"name":"user-1"},{"name":"user-2"}]}}`,
-		headers, 1)
-	response := &GraphQLResponse{
-		Fetches: Sequence(
-			Single(&SingleFetch{
-				InputTemplate: InputTemplate{
-					Segments: []TemplateSegment{
-						{
-							Data:        []byte(`{"method":"POST","url":"http://products","body":{"query":"query{topProducts{name __typename upc}}"}}`),
-							SegmentType: StaticSegmentType,
-						},
-					},
-				},
-				FetchConfiguration: FetchConfiguration{
-					DataSource: productsService,
-					PostProcessing: PostProcessingConfiguration{
-						SelectResponseDataPath: []string{"data"},
-					},
-				},
-			}),
-			Parallel(
-				Single(&BatchEntityFetch{
-					Input: BatchInput{
-						Header: InputTemplate{
-							Segments: []TemplateSegment{
-								{
-									Data:        []byte(`{"method":"POST","url":"http://reviews","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){__typename ... on Product {reviews {body author {__typename id}}}}}","variables":{"representations":[`),
-									SegmentType: StaticSegmentType,
-								},
-							},
-						},
-						Items: []InputTemplate{
-							{
-								Segments: []TemplateSegment{
-									{
-										SegmentType:  VariableSegmentType,
-										VariableKind: ResolvableObjectVariableKind,
-										Renderer: NewGraphQLVariableResolveRenderer(&Object{
-											Fields: []*Field{
-												{
-													Name: []byte("__typename"),
-													Value: &String{
-														Path: []string{"__typename"},
-													},
-												},
-												{
-													Name: []byte("upc"),
-													Value: &String{
-														Path: []string{"upc"},
-													},
-												},
-											},
-										}),
-									},
-								},
-							},
-						},
-						Separator: InputTemplate{
-							Segments: []TemplateSegment{
-								{
-									Data:        []byte(`,`),
-									SegmentType: StaticSegmentType,
-								},
-							},
-						},
-						Footer: InputTemplate{
-							Segments: []TemplateSegment{
-								{
-									Data:        []byte(`]}}}`),
-									SegmentType: StaticSegmentType,
-								},
-							},
-						},
-					},
-					DataSource: reviewsService,
-					PostProcessing: PostProcessingConfiguration{
-						SelectResponseDataPath: []string{"data", "_entities"},
-					},
-				}, ArrayPath("topProducts")),
-				Single(&BatchEntityFetch{
-					Input: BatchInput{
-						Header: InputTemplate{
-							Segments: []TemplateSegment{
-								{
-									Data:        []byte(`{"method":"POST","url":"http://stock","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){__typename ... on Product {stock}}}","variables":{"representations":[`),
-									SegmentType: StaticSegmentType,
-								},
-							},
-						},
-						Items: []InputTemplate{
-							{
-								Segments: []TemplateSegment{
-									{
-										SegmentType:  VariableSegmentType,
-										VariableKind: ResolvableObjectVariableKind,
-										Renderer: NewGraphQLVariableResolveRenderer(&Object{
-											Fields: []*Field{
-												{
-													Name: []byte("__typename"),
-													Value: &String{
-														Path: []string{"__typename"},
-													},
-												},
-												{
-													Name: []byte("upc"),
-													Value: &String{
-														Path: []string{"upc"},
-													},
-												},
-											},
-										}),
-									},
-								},
-							},
-						},
-						Separator: InputTemplate{
-							Segments: []TemplateSegment{
-								{
-									Data:        []byte(`,`),
-									SegmentType: StaticSegmentType,
-								},
-							},
-						},
-						Footer: InputTemplate{
-							Segments: []TemplateSegment{
-								{
-									Data:        []byte(`]}}}`),
-									SegmentType: StaticSegmentType,
-								},
-							},
-						},
-					},
-					DataSource: stockService,
-					PostProcessing: PostProcessingConfiguration{
-						SelectResponseDataPath: []string{"data", "_entities"},
-					},
-				}, ArrayPath("topProducts")),
-			),
-			Single(&BatchEntityFetch{
-				Input: BatchInput{
-					Header: InputTemplate{
+	responseWithDataSources := func(productsService, reviewsService, stockService, usersService *MockDataSource) *GraphQLResponse {
+		return &GraphQLResponse{
+			Fetches: Sequence(
+				Single(&SingleFetch{
+					InputTemplate: InputTemplate{
 						Segments: []TemplateSegment{
 							{
-								Data:        []byte(`{"method":"POST","url":"http://users","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){__typename ... on User {name}}}","variables":{"representations":[`),
+								Data:        []byte(`{"method":"POST","url":"http://products","body":{"query":"query{topProducts{name __typename upc}}"}}`),
 								SegmentType: StaticSegmentType,
 							},
 						},
 					},
-					Items: []InputTemplate{
-						{
-							Segments: []TemplateSegment{
+					FetchConfiguration: FetchConfiguration{
+						DataSource: productsService,
+						PostProcessing: PostProcessingConfiguration{
+							SelectResponseDataPath: []string{"data"},
+						},
+					},
+				}),
+				Parallel(
+					Single(&BatchEntityFetch{
+						Input: BatchInput{
+							Header: InputTemplate{
+								Segments: []TemplateSegment{
+									{
+										Data:        []byte(`{"method":"POST","url":"http://reviews","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){__typename ... on Product {reviews {body author {__typename id}}}}}","variables":{"representations":[`),
+										SegmentType: StaticSegmentType,
+									},
+								},
+							},
+							Items: []InputTemplate{
 								{
-									SegmentType:  VariableSegmentType,
-									VariableKind: ResolvableObjectVariableKind,
-									Renderer: NewGraphQLVariableResolveRenderer(&Object{
-										Fields: []*Field{
-											{
-												Name: []byte("__typename"),
-												Value: &String{
-													Path: []string{"__typename"},
+									Segments: []TemplateSegment{
+										{
+											SegmentType:  VariableSegmentType,
+											VariableKind: ResolvableObjectVariableKind,
+											Renderer: NewGraphQLVariableResolveRenderer(&Object{
+												Fields: []*Field{
+													{
+														Name: []byte("__typename"),
+														Value: &String{
+															Path: []string{"__typename"},
+														},
+													},
+													{
+														Name: []byte("upc"),
+														Value: &String{
+															Path: []string{"upc"},
+														},
+													},
 												},
-											},
-											{
-												Name: []byte("id"),
-												Value: &String{
-													Path: []string{"id"},
-												},
-											},
+											}),
 										},
-									}),
-								},
-							},
-						},
-					},
-					Separator: InputTemplate{
-						Segments: []TemplateSegment{
-							{
-								Data:        []byte(`,`),
-								SegmentType: StaticSegmentType,
-							},
-						},
-					},
-					Footer: InputTemplate{
-						Segments: []TemplateSegment{
-							{
-								Data:        []byte(`]}}}`),
-								SegmentType: StaticSegmentType,
-							},
-						},
-					},
-				},
-				DataSource: usersService,
-				PostProcessing: PostProcessingConfiguration{
-					SelectResponseDataPath: []string{"data", "_entities"},
-				},
-			}, ArrayPath("topProducts"), ArrayPath("reviews"), ObjectPath("author")),
-		),
-		Data: &Object{
-			Fields: []*Field{
-				{
-					Name: []byte("topProducts"),
-					Value: &Array{
-						Path: []string{"topProducts"},
-						Item: &Object{
-							Fields: []*Field{
-								{
-									Name: []byte("name"),
-									Value: &String{
-										Path: []string{"name"},
 									},
 								},
-								{
-									Name: []byte("stock"),
-									Value: &Integer{
-										Path: []string{"stock"},
+							},
+							Separator: InputTemplate{
+								Segments: []TemplateSegment{
+									{
+										Data:        []byte(`,`),
+										SegmentType: StaticSegmentType,
 									},
 								},
+							},
+							Footer: InputTemplate{
+								Segments: []TemplateSegment{
+									{
+										Data:        []byte(`]}}}`),
+										SegmentType: StaticSegmentType,
+									},
+								},
+							},
+						},
+						DataSource: reviewsService,
+						PostProcessing: PostProcessingConfiguration{
+							SelectResponseDataPath: []string{"data", "_entities"},
+						},
+					}, ArrayPath("topProducts")),
+					Single(&BatchEntityFetch{
+						Input: BatchInput{
+							Header: InputTemplate{
+								Segments: []TemplateSegment{
+									{
+										Data:        []byte(`{"method":"POST","url":"http://stock","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){__typename ... on Product {stock}}}","variables":{"representations":[`),
+										SegmentType: StaticSegmentType,
+									},
+								},
+							},
+							Items: []InputTemplate{
 								{
-									Name: []byte("reviews"),
-									Value: &Array{
-										Path: []string{"reviews"},
-										Item: &Object{
+									Segments: []TemplateSegment{
+										{
+											SegmentType:  VariableSegmentType,
+											VariableKind: ResolvableObjectVariableKind,
+											Renderer: NewGraphQLVariableResolveRenderer(&Object{
+												Fields: []*Field{
+													{
+														Name: []byte("__typename"),
+														Value: &String{
+															Path: []string{"__typename"},
+														},
+													},
+													{
+														Name: []byte("upc"),
+														Value: &String{
+															Path: []string{"upc"},
+														},
+													},
+												},
+											}),
+										},
+									},
+								},
+							},
+							Separator: InputTemplate{
+								Segments: []TemplateSegment{
+									{
+										Data:        []byte(`,`),
+										SegmentType: StaticSegmentType,
+									},
+								},
+							},
+							Footer: InputTemplate{
+								Segments: []TemplateSegment{
+									{
+										Data:        []byte(`]}}}`),
+										SegmentType: StaticSegmentType,
+									},
+								},
+							},
+						},
+						DataSource: stockService,
+						PostProcessing: PostProcessingConfiguration{
+							SelectResponseDataPath: []string{"data", "_entities"},
+						},
+					}, ArrayPath("topProducts")),
+				),
+				Single(&BatchEntityFetch{
+					Input: BatchInput{
+						Header: InputTemplate{
+							Segments: []TemplateSegment{
+								{
+									Data:        []byte(`{"method":"POST","url":"http://users","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){__typename ... on User {name}}}","variables":{"representations":[`),
+									SegmentType: StaticSegmentType,
+								},
+							},
+						},
+						Items: []InputTemplate{
+							{
+								Segments: []TemplateSegment{
+									{
+										SegmentType:  VariableSegmentType,
+										VariableKind: ResolvableObjectVariableKind,
+										Renderer: NewGraphQLVariableResolveRenderer(&Object{
 											Fields: []*Field{
 												{
-													Name: []byte("body"),
+													Name: []byte("__typename"),
 													Value: &String{
-														Path: []string{"body"},
+														Path: []string{"__typename"},
 													},
 												},
 												{
-													Name: []byte("author"),
-													Value: &Object{
-														Path: []string{"author"},
-														Fields: []*Field{
-															{
-																Name: []byte("name"),
-																Value: &String{
-																	Path: []string{"name"},
+													Name: []byte("id"),
+													Value: &String{
+														Path: []string{"id"},
+													},
+												},
+											},
+										}),
+									},
+								},
+							},
+						},
+						Separator: InputTemplate{
+							Segments: []TemplateSegment{
+								{
+									Data:        []byte(`,`),
+									SegmentType: StaticSegmentType,
+								},
+							},
+						},
+						Footer: InputTemplate{
+							Segments: []TemplateSegment{
+								{
+									Data:        []byte(`]}}}`),
+									SegmentType: StaticSegmentType,
+								},
+							},
+						},
+					},
+					DataSource: usersService,
+					PostProcessing: PostProcessingConfiguration{
+						SelectResponseDataPath: []string{"data", "_entities"},
+					},
+				}, ArrayPath("topProducts"), ArrayPath("reviews"), ObjectPath("author")),
+			),
+			Data: &Object{
+				Fields: []*Field{
+					{
+						Name: []byte("topProducts"),
+						Value: &Array{
+							Path: []string{"topProducts"},
+							Item: &Object{
+								Fields: []*Field{
+									{
+										Name: []byte("name"),
+										Value: &String{
+											Path: []string{"name"},
+										},
+									},
+									{
+										Name: []byte("stock"),
+										Value: &Integer{
+											Path: []string{"stock"},
+										},
+									},
+									{
+										Name: []byte("reviews"),
+										Value: &Array{
+											Path: []string{"reviews"},
+											Item: &Object{
+												Fields: []*Field{
+													{
+														Name: []byte("body"),
+														Value: &String{
+															Path: []string{"body"},
+														},
+													},
+													{
+														Name: []byte("author"),
+														Value: &Object{
+															Path: []string{"author"},
+															Fields: []*Field{
+																{
+																	Name: []byte("name"),
+																	Value: &String{
+																		Path: []string{"name"},
+																	},
 																},
 															},
 														},
@@ -2706,36 +2683,183 @@ func TestLoader_CachedFetches(t *testing.T) {
 					},
 				},
 			},
-		},
+		}
 	}
-	testCache := newTestCache()
 
-	ctx := NewContext(context.Background())
-	ctx.SetResponseCache(testCache, time.Second*60, nil)
-	resolvable := NewResolvable(nil, ResolvableOptions{})
-	loader := &Loader{dataBuffer: &DataBuffer{data: astjson.ObjectValue(nil)}}
-	err := resolvable.Init(ctx, nil, ast.OperationTypeQuery)
-	assert.NoError(t, err)
-	err = loader.LoadGraphQLResponseData(ctx, response)
-	assert.NoError(t, err)
-	out := fastjsonext.PrintGraphQLResponse(loader.dataBuffer.Get(), loader.errors)
+	t.Run("serves every entity fetch from the cache on the second run", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 
-	expected1 := `{"data":{"topProducts":[{"name":"Table","__typename":"Product","upc":"1","reviews":[{"body":"Love Table!","author":{"__typename":"User","id":"1","name":"user-1"}},{"body":"Prefer other Table.","author":{"__typename":"User","id":"2","name":"user-2"}}],"stock":8},{"name":"Couch","__typename":"Product","upc":"2","reviews":[{"body":"Couch Too expensive.","author":{"__typename":"User","id":"1","name":"user-1"}}],"stock":2},{"name":"Chair","__typename":"Product","upc":"3","reviews":[{"body":"Chair Could be better.","author":{"__typename":"User","id":"2","name":"user-2"}}],"stock":5}]}}`
-	expected2 := `{"data":{"topProducts":[{"name":"Table","__typename":"Product","upc":"1","stock":8,"reviews":[{"body":"Love Table!","author":{"__typename":"User","id":"1","name":"user-1"}},{"body":"Prefer other Table.","author":{"__typename":"User","id":"2","name":"user-2"}}]},{"name":"Couch","__typename":"Product","upc":"2","stock":2,"reviews":[{"body":"Couch Too expensive.","author":{"__typename":"User","id":"1","name":"user-1"}}]},{"name":"Chair","__typename":"Product","upc":"3","stock":5,"reviews":[{"body":"Chair Could be better.","author":{"__typename":"User","id":"2","name":"user-2"}}]}]}}`
+		headers := http.Header{}
+		headers.Set("Cache-Control", "public, max-age=60")
 
-	assert.Contains(t, []string{expected1, expected2}, out)
+		productsService := mockedDSWithHeaders(t, ctrl,
+			`{"method":"POST","url":"http://products","body":{"query":"query{topProducts{name __typename upc}}"}}`,
+			`{"data":{"topProducts":[{"name":"Table","__typename":"Product","upc":"1"},{"name":"Couch","__typename":"Product","upc":"2"},{"name":"Chair","__typename":"Product","upc":"3"}]}}`,
+			// Only entity fetches are response-cached, so the root fetch runs on both loads.
+			headers, 2)
 
-	require.Len(t, testCache.items, 8, "expected 8 items in the cache: (3 products + 3 stock + 2 users)")
+		reviewsService := mockedDSWithHeaders(t, ctrl,
+			`{"method":"POST","url":"http://reviews","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){__typename ... on Product {reviews {body author {__typename id}}}}}","variables":{"representations":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"},{"__typename":"Product","upc":"3"}]}}}`,
+			`{"data":{"_entities":[{"__typename":"Product","reviews":[{"body":"Love Table!","author":{"__typename":"User","id":"1"}},{"body":"Prefer other Table.","author":{"__typename":"User","id":"2"}}]},{"__typename":"Product","reviews":[{"body":"Couch Too expensive.","author":{"__typename":"User","id":"1"}}]},{"__typename":"Product","reviews":[{"body":"Chair Could be better.","author":{"__typename":"User","id":"2"}}]}]}}`,
+			headers, 1)
 
-	// Second run: every entity fetch must be served from the cache. The mocks are set to Times(1), so any repeated subgraph call fails the test.
-	loader = &Loader{dataBuffer: &DataBuffer{data: astjson.ObjectValue(nil)}}
-	err = loader.LoadGraphQLResponseData(ctx, response)
-	assert.NoError(t, err)
-	cachedOut := fastjsonext.PrintGraphQLResponse(loader.dataBuffer.Get(), loader.errors)
+		stockService := mockedDSWithHeaders(t, ctrl,
+			`{"method":"POST","url":"http://stock","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){__typename ... on Product {stock}}}","variables":{"representations":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"},{"__typename":"Product","upc":"3"}]}}}`,
+			`{"data":{"_entities":[{"stock":8},{"stock":2},{"stock":5}]}}`,
+			headers, 1)
 
-	assert.Contains(t, []string{expected1, expected2}, cachedOut)
+		usersService := mockedDSWithHeaders(t, ctrl,
+			`{"method":"POST","url":"http://users","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){__typename ... on User {name}}}","variables":{"representations":[{"__typename":"User","id":"1"},{"__typename":"User","id":"2"}]}}}`,
+			`{"data":{"_entities":[{"name":"user-1"},{"name":"user-2"}]}}`,
+			headers, 1)
 
-	ctrl.Finish()
+		response := responseWithDataSources(productsService, reviewsService, stockService, usersService)
+
+		testCache := newTestCache()
+
+		ctx := NewContext(context.Background())
+		ctx.SetResponseCache(testCache, time.Second*60, nil)
+		resolvable := NewResolvable(nil, ResolvableOptions{})
+		loader := &Loader{dataBuffer: &DataBuffer{data: astjson.ObjectValue(nil)}}
+		err := resolvable.Init(ctx, nil, ast.OperationTypeQuery)
+		assert.NoError(t, err)
+		err = loader.LoadGraphQLResponseData(ctx, response)
+		assert.NoError(t, err)
+		out := fastjsonext.PrintGraphQLResponse(loader.dataBuffer.Get(), loader.errors)
+
+		expected1 := `{"data":{"topProducts":[{"name":"Table","__typename":"Product","upc":"1","reviews":[{"body":"Love Table!","author":{"__typename":"User","id":"1","name":"user-1"}},{"body":"Prefer other Table.","author":{"__typename":"User","id":"2","name":"user-2"}}],"stock":8},{"name":"Couch","__typename":"Product","upc":"2","reviews":[{"body":"Couch Too expensive.","author":{"__typename":"User","id":"1","name":"user-1"}}],"stock":2},{"name":"Chair","__typename":"Product","upc":"3","reviews":[{"body":"Chair Could be better.","author":{"__typename":"User","id":"2","name":"user-2"}}],"stock":5}]}}`
+		expected2 := `{"data":{"topProducts":[{"name":"Table","__typename":"Product","upc":"1","stock":8,"reviews":[{"body":"Love Table!","author":{"__typename":"User","id":"1","name":"user-1"}},{"body":"Prefer other Table.","author":{"__typename":"User","id":"2","name":"user-2"}}]},{"name":"Couch","__typename":"Product","upc":"2","stock":2,"reviews":[{"body":"Couch Too expensive.","author":{"__typename":"User","id":"1","name":"user-1"}}]},{"name":"Chair","__typename":"Product","upc":"3","stock":5,"reviews":[{"body":"Chair Could be better.","author":{"__typename":"User","id":"2","name":"user-2"}}]}]}}`
+
+		assert.Contains(t, []string{expected1, expected2}, out)
+
+		require.Len(t, testCache.items, 8, "expected 8 items in the cache: (3 products + 3 stock + 2 users)")
+
+		// Second run: every entity fetch must be served from the cache. The mocks are set to Times(1), so any repeated subgraph call fails the test.
+		loader = &Loader{dataBuffer: &DataBuffer{data: astjson.ObjectValue(nil)}}
+		err = loader.LoadGraphQLResponseData(ctx, response)
+		assert.NoError(t, err)
+		cachedOut := fastjsonext.PrintGraphQLResponse(loader.dataBuffer.Get(), loader.errors)
+
+		assert.Contains(t, []string{expected1, expected2}, cachedOut)
+	})
+
+	t.Run("reports the remaining cache TTL on each fetch served from the cache", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		productsHeaders := http.Header{"Cache-Control": []string{"public, max-age=100"}}
+		reviewsHeaders := http.Header{"Cache-Control": []string{"public, max-age=200"}}
+		stockHeaders := http.Header{"Cache-Control": []string{"public, max-age=300"}}
+		usersHeaders := http.Header{"Cache-Control": []string{"public, max-age=400"}}
+
+		productsService := mockedDSWithHeaders(t, ctrl,
+			`{"method":"POST","url":"http://products","body":{"query":"query{topProducts{name __typename upc}}"}}`,
+			`{"data":{"topProducts":[{"name":"Table","__typename":"Product","upc":"1"},{"name":"Couch","__typename":"Product","upc":"2"},{"name":"Chair","__typename":"Product","upc":"3"}]}}`,
+			// Only entity fetches are response-cached, so the root fetch runs on both loads.
+			productsHeaders, 2)
+
+		reviewsService := mockedDSWithHeaders(t, ctrl,
+			`{"method":"POST","url":"http://reviews","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){__typename ... on Product {reviews {body author {__typename id}}}}}","variables":{"representations":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"},{"__typename":"Product","upc":"3"}]}}}`,
+			`{"data":{"_entities":[{"__typename":"Product","reviews":[{"body":"Love Table!","author":{"__typename":"User","id":"1"}},{"body":"Prefer other Table.","author":{"__typename":"User","id":"2"}}]},{"__typename":"Product","reviews":[{"body":"Couch Too expensive.","author":{"__typename":"User","id":"1"}}]},{"__typename":"Product","reviews":[{"body":"Chair Could be better.","author":{"__typename":"User","id":"2"}}]}]}}`,
+			reviewsHeaders, 1)
+
+		stockService := mockedDSWithHeaders(t, ctrl,
+			`{"method":"POST","url":"http://stock","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){__typename ... on Product {stock}}}","variables":{"representations":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"},{"__typename":"Product","upc":"3"}]}}}`,
+			`{"data":{"_entities":[{"stock":8},{"stock":2},{"stock":5}]}}`,
+			stockHeaders, 1)
+
+		usersService := mockedDSWithHeaders(t, ctrl,
+			`{"method":"POST","url":"http://users","body":{"query":"query($representations: [_Any!]!){_entities(representations: $representations){__typename ... on User {name}}}","variables":{"representations":[{"__typename":"User","id":"1"},{"__typename":"User","id":"2"}]}}}`,
+			`{"data":{"_entities":[{"name":"user-1"},{"name":"user-2"}]}}`,
+			usersHeaders, 1)
+
+		response := responseWithDataSources(productsService, reviewsService, stockService, usersService)
+
+		testCache := newTestCache()
+
+		ctx := NewContext(context.Background())
+		ctx.SetResponseCache(testCache, time.Second*60, nil)
+		resolvable := NewResolvable(nil, ResolvableOptions{})
+		loader := &Loader{dataBuffer: &DataBuffer{data: astjson.ObjectValue(nil)}}
+
+		// Fetches run in parallel, so collect and sort before asserting.
+		var mu sync.Mutex
+		var ttls []time.Duration
+		collectTTLs := func() []time.Duration {
+			mu.Lock()
+			defer mu.Unlock()
+			out := slices.Clone(ttls)
+			ttls = ttls[:0]
+			slices.Sort(out)
+			return out
+		}
+		ctx.SetEngineLoaderHooks(&spyLoaderHooks{
+			onFinished: func(ctx context.Context, ds DataSourceInfo, info *ResponseInfo) {
+				mu.Lock()
+				defer mu.Unlock()
+				// A cache hit has no subgraph headers, so a consumer that synthesizes
+				// one must not write it back here.
+				if info.ResponseCacheTTL > 0 {
+					require.Nil(t, info.ResponseHeaders, "a cache hit must not carry subgraph response headers")
+				}
+				ttls = append(ttls, info.ResponseCacheTTL)
+			},
+		})
+
+		err := resolvable.Init(ctx, nil, ast.OperationTypeQuery)
+		assert.NoError(t, err)
+		err = loader.LoadGraphQLResponseData(ctx, response)
+		assert.NoError(t, err)
+		out := fastjsonext.PrintGraphQLResponse(loader.dataBuffer.Get(), loader.errors)
+
+		expected1 := `{"data":{"topProducts":[{"name":"Table","__typename":"Product","upc":"1","reviews":[{"body":"Love Table!","author":{"__typename":"User","id":"1","name":"user-1"}},{"body":"Prefer other Table.","author":{"__typename":"User","id":"2","name":"user-2"}}],"stock":8},{"name":"Couch","__typename":"Product","upc":"2","reviews":[{"body":"Couch Too expensive.","author":{"__typename":"User","id":"1","name":"user-1"}}],"stock":2},{"name":"Chair","__typename":"Product","upc":"3","reviews":[{"body":"Chair Could be better.","author":{"__typename":"User","id":"2","name":"user-2"}}],"stock":5}]}}`
+		expected2 := `{"data":{"topProducts":[{"name":"Table","__typename":"Product","upc":"1","stock":8,"reviews":[{"body":"Love Table!","author":{"__typename":"User","id":"1","name":"user-1"}},{"body":"Prefer other Table.","author":{"__typename":"User","id":"2","name":"user-2"}}]},{"name":"Couch","__typename":"Product","upc":"2","stock":2,"reviews":[{"body":"Couch Too expensive.","author":{"__typename":"User","id":"1","name":"user-1"}}]},{"name":"Chair","__typename":"Product","upc":"3","stock":5,"reviews":[{"body":"Chair Could be better.","author":{"__typename":"User","id":"2","name":"user-2"}}]}]}}`
+
+		assert.Contains(t, []string{expected1, expected2}, out)
+
+		require.Len(t, testCache.items, 8, "expected 8 items in the cache: (3 products + 3 stock + 2 users)")
+
+		// First run: nothing came from the cache.
+		require.Equal(t, []time.Duration{0, 0, 0, 0}, collectTTLs())
+
+		// Second run: every entity fetch must be served from the cache. The mocks are set to Times(1), so any repeated subgraph call fails the test.
+		loader = &Loader{dataBuffer: &DataBuffer{data: astjson.ObjectValue(nil)}}
+		err = loader.LoadGraphQLResponseData(ctx, response)
+		assert.NoError(t, err)
+		cachedOut := fastjsonext.PrintGraphQLResponse(loader.dataBuffer.Get(), loader.errors)
+
+		assert.Contains(t, []string{expected1, expected2}, cachedOut)
+
+		// Each cached fetch reports its own subgraph's max-age, not a request-wide
+		// value. The root products fetch is not cacheable, so it reports nothing.
+		require.Equal(t, []time.Duration{
+			0,
+			200 * time.Second,
+			300 * time.Second,
+			400 * time.Second,
+		}, collectTTLs())
+	})
+
+}
+
+var _ LoaderHooks = &spyLoaderHooks{}
+
+type spyLoaderHooks struct {
+	onLoad     func(ctx context.Context, ds DataSourceInfo) context.Context
+	onFinished func(ctx context.Context, ds DataSourceInfo, info *ResponseInfo)
+}
+
+func (s *spyLoaderHooks) OnLoad(ctx context.Context, ds DataSourceInfo) context.Context {
+	if s.onLoad == nil {
+		return ctx
+	}
+	return s.onLoad(ctx, ds)
+}
+
+func (s *spyLoaderHooks) OnFinished(ctx context.Context, ds DataSourceInfo, info *ResponseInfo) {
+	if s.onFinished != nil {
+		s.onFinished(ctx, ds, info)
+	}
 }
 
 var _ caching.Cache = &testCache{}

--- a/v2/pkg/engine/resolve/loader_test.go
+++ b/v2/pkg/engine/resolve/loader_test.go
@@ -2725,6 +2725,7 @@ func TestLoader_CachedFetches(t *testing.T) {
 		loader := &Loader{dataBuffer: &DataBuffer{data: astjson.ObjectValue(nil)}}
 		err := resolvable.Init(ctx, nil, ast.OperationTypeQuery)
 		assert.NoError(t, err)
+		// First run: nothing came from the cache. Loader makes all subgraph calls and stores the entities in the cache.
 		err = loader.LoadGraphQLResponseData(ctx, response)
 		assert.NoError(t, err)
 		out := fastjsonext.PrintGraphQLResponse(loader.dataBuffer.Get(), loader.errors)
@@ -2734,6 +2735,7 @@ func TestLoader_CachedFetches(t *testing.T) {
 
 		assert.Contains(t, []string{expected1, expected2}, out)
 
+		// 8 items in the cache: (3 products + 3 stock + 2 users)
 		require.Len(t, testCache.items, 8, "expected 8 items in the cache: (3 products + 3 stock + 2 users)")
 
 		// Second run: every entity fetch must be served from the cache. The mocks are set to Times(1), so any repeated subgraph call fails the test.

--- a/v2/pkg/engine/resolve/response_cache.go
+++ b/v2/pkg/engine/resolve/response_cache.go
@@ -107,21 +107,32 @@ func (l *Loader) responseCacheLookup(prepared *preparedFetch) bool {
 	res := prepared.res
 	res.out = out
 	res.statusCode = http.StatusOK
+	res.responseCacheHit = true
 	res.responseCacheTTL = remainingTTL(found, keys)
 
 	return true
 }
 
 // remainingTTL is the shortest life left across a fetch's entries: a fetch is only
-// as fresh as its least fresh entry. Non-positive TTLs are ignored, GetMany already
-// treats those as misses.
+// as fresh as its least fresh entry. Zero counts, it is an entry that is stale as
+// of now. Only a negative TTL is dropped, as no cache should report one.
 func remainingTTL(found map[string]caching.Item, keys []string) time.Duration {
-	var ttl time.Duration
+	ttl := time.Duration(-1)
 	for _, key := range keys {
-		if t := found[key].TTL; t > 0 && (ttl == 0 || t < ttl) {
-			ttl = t
+		cachedTTL := found[key].TTL
+		if cachedTTL < 0 {
+			continue
+		}
+
+		if ttl < 0 || cachedTTL < ttl {
+			ttl = cachedTTL
 		}
 	}
+
+	if ttl < 0 {
+		return 0
+	}
+
 	return ttl
 }
 

--- a/v2/pkg/engine/resolve/response_cache.go
+++ b/v2/pkg/engine/resolve/response_cache.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
+	"time"
 
 	"github.com/wundergraph/astjson"
 
@@ -106,8 +107,22 @@ func (l *Loader) responseCacheLookup(prepared *preparedFetch) bool {
 	res := prepared.res
 	res.out = out
 	res.statusCode = http.StatusOK
+	res.responseCacheTTL = remainingTTL(found, keys)
 
 	return true
+}
+
+// remainingTTL is the shortest life left across a fetch's entries: a fetch is only
+// as fresh as its least fresh entry. Non-positive TTLs are ignored, GetMany already
+// treats those as misses.
+func remainingTTL(found map[string]caching.Item, keys []string) time.Duration {
+	var ttl time.Duration
+	for _, key := range keys {
+		if t := found[key].TTL; t > 0 && (ttl == 0 || t < ttl) {
+			ttl = t
+		}
+	}
+	return ttl
 }
 
 func (l *Loader) responseCacheCollect(prepared *preparedFetch) error {

--- a/v2/pkg/engine/resolve/response_cache_test.go
+++ b/v2/pkg/engine/resolve/response_cache_test.go
@@ -2,10 +2,12 @@ package resolve
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/caching"
 )
 
 // What the root fetch cache may be asked to key is narrower than what the
@@ -70,4 +72,46 @@ func TestRootFetchCacheable(t *testing.T) {
 		fetch.Info = nil
 		require.False(t, rootFetchCacheable(rootItem(), fetch))
 	})
+}
+
+func TestRemainingTTL(t *testing.T) {
+	item := func(ttl time.Duration) caching.Item { return caching.Item{TTL: ttl} }
+
+	testCases := []struct {
+		name     string
+		found    map[string]caching.Item
+		keys     []string
+		expected time.Duration
+	}{
+		{
+			name:     "the shortest of several entries",
+			found:    map[string]caching.Item{"a": item(30 * time.Second), "b": item(10 * time.Second)},
+			keys:     []string{"a", "b"},
+			expected: 10 * time.Second,
+		},
+		{
+			name:     "zero is a lifetime, not an absent one",
+			found:    map[string]caching.Item{"a": item(30 * time.Second), "b": item(0)},
+			keys:     []string{"a", "b"},
+			expected: 0,
+		},
+		{
+			name:     "a lone zero survives",
+			found:    map[string]caching.Item{"a": item(0)},
+			keys:     []string{"a"},
+			expected: 0,
+		},
+		{
+			name:     "a negative TTL is dropped in favour of its neighbours",
+			found:    map[string]caching.Item{"a": item(-5 * time.Second), "b": item(10 * time.Second)},
+			keys:     []string{"a", "b"},
+			expected: 10 * time.Second,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, remainingTTL(tc.found, tc.keys))
+		})
+	}
 }


### PR DESCRIPTION
Allow the engine to propagate response cache TTLs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for generating `Cache-Control` header values.
  * Exposed whether responses were served from cache and their remaining cache lifetime.
  * Cache hits now report the shortest applicable TTL across cached entries.

* **Bug Fixes**
  * Improved handling of zero and negative cache lifetimes.
  * Ensured cached responses do not include subgraph response headers.
  * Improved cache reporting for uncached responses and responses with no remaining lifetime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->