### PR TITLE
ci: keep generated files in sync

### DIFF
--- a/.github/workflows/v2.yml
+++ b/.github/workflows/v2.yml
@@ -2,7 +2,13 @@ name: v2-ci
 on:
   pull_request:
     paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'go.work.sum'
       - 'v2/**'
+      - 'execution/**'
+      - 'examples/**'
       - '.github/workflows/v2.yml'
       - '.github/workflows/pr-title.yml'
       - '.github/workflows/release.yml'
@@ -15,7 +21,13 @@ on:
     branches:
       - master
     paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'go.work.sum'
       - 'v2/**'
+      - 'execution/**'
+      - 'examples/**'
       - '.github/workflows/v2.yml'
       - '.github/workflows/pr-title.yml'
       - '.github/workflows/release.yml'
@@ -74,11 +86,33 @@ jobs:
           working-directory: v2
           version: ${{ steps.golangci-lint-version.outputs.version }}
           args: --timeout=3m
+
+  check-generated:
+    name: Check generated files and module metadata
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '^1.25'
+      - name: Check generated files and module metadata
+        run: |
+          make -C v2 generate
+          if test -n "$(git status --porcelain)"; then
+            git status --short
+            git diff
+            echo "::error::Generated files or module metadata are stale. Run 'make -C v2 generate' and commit the result."
+            exit 1
+          fi
+
   ci:
     name: CI Success
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    needs: [test, lint]
+    needs: [test, lint, check-generated]
     steps:
       - run: exit 1
         if: >-

--- a/go.work.sum
+++ b/go.work.sum
@@ -63,6 +63,7 @@ cloud.google.com/go/clouddms v1.8.8/go.mod h1:QtCyw+a73dlkDb2q20aTAPvfaTZCepDDi6
 cloud.google.com/go/clouddms v1.14.0/go.mod h1:qSwET2Q27cJ4wCDsPsbkagXqQqkWfOy+gU3RjMsT/c8=
 cloud.google.com/go/cloudtasks v1.13.7/go.mod h1:H0TThOUG+Ml34e2+ZtW6k6nt4i9KuH3nYAJ5mxh7OM4=
 cloud.google.com/go/cloudtasks v1.19.0/go.mod h1:8q8wNubq0jFvXW5Pz8P3O7QWJBXOmfrY918FqTgIqHA=
+cloud.google.com/go/compute v1.6.1/go.mod h1:g85FgpzFvNULZ+S8AYq87axRKuf2Kh7deLqV/jJ3thU=
 cloud.google.com/go/compute v1.57.0/go.mod h1:3shEe5By6FSIqBbZJBuqC0InvJKBKUiWZjrwGd1wkyA=
 cloud.google.com/go/compute v1.65.0/go.mod h1:vFq+Ztj9Rzhc8zf1t6hGp/6NdrEVG1GakkyVRQPRgKc=
 cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
@@ -145,6 +146,7 @@ cloud.google.com/go/lifesciences v0.10.7/go.mod h1:v3AbTki9iWttEls/Wf4ag3EqeLRHo
 cloud.google.com/go/lifesciences v0.16.0/go.mod h1:axEwGa3A63+vCXIis+0Zkseu8KecqtNoSn7x0zyjJfM=
 cloud.google.com/go/logging v1.13.2/go.mod h1:zaybliM3yun1J8mU2dVQ1/qDzjbOqEijZCn6hSBtKak=
 cloud.google.com/go/logging v1.19.0/go.mod h1:i40NZCHC9Gqvod4yE+yQfDWwlgwW/SrshkkGibCHxcA=
+cloud.google.com/go/longrunning v0.5.6/go.mod h1:vUaDrWYOMKRuhiv6JBnn49YxCPz2Ayn9GqyjaBT8/mA=
 cloud.google.com/go/longrunning v0.8.0/go.mod h1:UmErU2Onzi+fKDg2gR7dusz11Pe26aknR4kHmJJqIfk=
 cloud.google.com/go/longrunning v1.2.0/go.mod h1:5KMQALFGOCtFoi2xSOA1u3H7WKlhmckgiyFw7+LGQp0=
 cloud.google.com/go/managedidentities v1.7.7/go.mod h1:nwNlMxtBo2YJMvsKXRtAD1bL41qiCI9npS7cbqrsJUs=
@@ -228,6 +230,7 @@ cloud.google.com/go/tpu v1.8.4/go.mod h1:ul0cyWSHr6jHGZYElZe6HvQn35VY93RAlwpDiSB
 cloud.google.com/go/tpu v1.14.0/go.mod h1:1pggTTG5npfxea6vYjyl60Fg09VgbM7efBgVjnFZjpo=
 cloud.google.com/go/trace v1.11.7/go.mod h1:TNn9d5V3fQVf6s4SCveVMIBS2LJUqo73GACmq/Tky0s=
 cloud.google.com/go/trace v1.16.0/go.mod h1:r+bdAn16dKLSV1G2D5v3e58IlQlizfxWrUfjx7kM7X0=
+cloud.google.com/go/translate v1.10.3/go.mod h1:GW0vC1qvPtd3pgtypCv4k4U8B7EdgK9/QEF2aJEUovs=
 cloud.google.com/go/translate v1.12.7/go.mod h1:wwJp14NZyWvcrFANhIXutXj0pOBkYciBHwSlUOykcjI=
 cloud.google.com/go/translate v1.18.0/go.mod h1:aRVIE+P+7fngk8HwwFAgis5QA7wphGpKrFpdNoWtGCM=
 cloud.google.com/go/video v1.27.1/go.mod h1:xzfAC77B4vtnbi/TT3UUxEjCa/+Ehy5EA8w470ytOig=
@@ -995,6 +998,7 @@ google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd h1:e0TwkXOdbnH/1x5
 google.golang.org/genproto v0.0.0-20230807174057-1744710a1577 h1:Tyk/35yqszRCvaragTn5NnkY6IiKk/XvHzEWepo71N0=
 google.golang.org/genproto v0.0.0-20230807174057-1744710a1577/go.mod h1:yZTlhN0tQnXo3h00fuXNCxJdLdIdnVFVBaRJ5LWBbw4=
 google.golang.org/genproto v0.0.0-20260128011058-8636f8732409 h1:VQZ/yAbAtjkHgH80teYd2em3xtIkkHd7ZhqfH2N9CsM=
+google.golang.org/genproto v0.0.0-20260128011058-8636f8732409/go.mod h1:rxKD3IEILWEu3P44seeNOAwZN4SaoKaQ/2eTg4mM6EM=
 google.golang.org/genproto v0.0.0-20260803160001-6ac0973c030d h1:33JLrUF0lFT31667SAtJzZAjLewV0ew5Mizks4caz0A=
 google.golang.org/genproto v0.0.0-20260803160001-6ac0973c030d/go.mod h1:I7vGRdTamb7ukERkgP9I+0e4p21O4ak3cM7ICA3krg8=
 google.golang.org/genproto/googleapis/api v0.0.0-20250106144421-5f5ef82da422 h1:GVIKPyP/kLIyVOgOnTwFOrvQaQUzOzGMCxgFUOEmm24=


### PR DESCRIPTION
## Stack

- Linear: [ROUTER-650](https://linear.app/wundergraph/issue/ROUTER-650/graphql-go-tools-add-ci-check-for-generated-files-and-go)

## Summary

- add a compact check-generated job to the existing v2 CI workflow
- call the existing `make -C v2 generate` target instead of duplicating generation commands in CI
- print the working-tree status and diff, then fail with an actionable error when generated files or module metadata are stale
- trigger the check for generator inputs, including every Go file
- include four missing workspace checksum entries surfaced by resolving the full workspace module graph

## Validation

- `make -C v2 generate`
- verified the generation target leaves a clean checkout unchanged
- confirmed `go list -m all` on `master` adds exactly the four included `go.work.sum` entries
- `make -C v2 lint`
- `make -C execution lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded automated validation to cover Go source files, module metadata, executable code, and examples.
  * Added checks that detect stale generated files and module metadata during changes.
  * Updated continuous integration status reporting to include the new validation checks alongside testing and linting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->