### PR TITLE
fix: reset operation complexity state after aborted walk

### DIFF
--- a/v2/pkg/middleware/operation_complexity/operation_complexity.go
+++ b/v2/pkg/middleware/operation_complexity/operation_complexity.go
@@ -101,6 +101,7 @@ func (n *OperationComplexityEstimator) Do(operation, definition *ast.Document, r
 	n.visitor.multipliers = n.visitor.multipliers[:0]
 
 	n.visitor.fieldDepth = 0
+	n.visitor.maxRootFieldDepth = 0
 
 	if n.visitor.calculatedRootFieldStats == nil {
 		n.visitor.calculatedRootFieldStats = make([]RootFieldStats, 0, len(definition.RootOperationTypeDefinitions))

--- a/v2/pkg/middleware/operation_complexity/operation_complexity_test.go
+++ b/v2/pkg/middleware/operation_complexity/operation_complexity_test.go
@@ -608,6 +608,53 @@ func runDepthTest(t *testing.T, operationString string, expectedStats OperationS
 	assert.Equal(t, expectedStats, rootFieldStats[0].Stats)
 }
 
+func TestOperationComplexityEstimatorReuseAfterAbortedWalk(t *testing.T) {
+	definition := unsafeparser.ParseGraphqlDocumentString(testDefinition)
+	estimator := NewOperationComplexityEstimator(false)
+
+	invalidOperation := unsafeparser.ParseGraphqlDocumentString(`
+		{
+			users(first: 1) {
+				transactions(first: 1) {
+					sender {
+						address {
+							... on UnknownType {
+								city
+							}
+						}
+					}
+				}
+			}
+		}`)
+	invalidReport := operationreport.Report{}
+	estimator.Do(&invalidOperation, &definition, &invalidReport)
+	require.True(t, invalidReport.HasErrors())
+
+	operation := unsafeparser.ParseGraphqlDocumentString(`
+		{
+			users(first: 1) {
+				id
+				address {
+					city
+				}
+			}
+		}`)
+	normalizationReport := operationreport.Report{}
+	astnormalization.NormalizeOperation(&operation, &definition, &normalizationReport)
+	require.False(t, normalizationReport.HasErrors())
+
+	wantReport := operationreport.Report{}
+	wantGlobal, wantRootFields := NewOperationComplexityEstimator(false).Do(&operation, &definition, &wantReport)
+	require.False(t, wantReport.HasErrors())
+
+	gotReport := operationreport.Report{}
+	gotGlobal, gotRootFields := estimator.Do(&operation, &definition, &gotReport)
+	require.False(t, gotReport.HasErrors())
+
+	assert.Equal(t, wantGlobal, gotGlobal)
+	assert.Equal(t, wantRootFields, gotRootFields)
+}
+
 func runConfig(t *testing.T, definition, operation string, expectedGlobalComplexityResult OperationStats, expectedFieldsComplexityResult []RootFieldStats, skipIntrospection bool) {
 	def := unsafeparser.ParseGraphqlDocumentString(definition)
 	op := unsafeparser.ParseGraphqlDocumentString(operation)

--- a/v2/pkg/middleware/operation_complexity/operation_complexity_test.go
+++ b/v2/pkg/middleware/operation_complexity/operation_complexity_test.go
@@ -639,10 +639,6 @@ func TestOperationComplexityEstimatorReuseAfterAbortedWalk(t *testing.T) {
 				}
 			}
 		}`)
-	normalizationReport := operationreport.Report{}
-	astnormalization.NormalizeOperation(&operation, &definition, &normalizationReport)
-	require.False(t, normalizationReport.HasErrors())
-
 	wantReport := operationreport.Report{}
 	wantGlobal, wantRootFields := NewOperationComplexityEstimator(false).Do(&operation, &definition, &wantReport)
 	require.False(t, wantReport.HasErrors())

--- a/v2/pkg/middleware/operation_complexity/operation_complexity_test.go
+++ b/v2/pkg/middleware/operation_complexity/operation_complexity_test.go
@@ -609,6 +609,8 @@ func runDepthTest(t *testing.T, operationString string, expectedStats OperationS
 }
 
 func TestOperationComplexityEstimatorReuseAfterAbortedWalk(t *testing.T) {
+	t.Parallel()
+
 	definition := unsafeparser.ParseGraphqlDocumentString(testDefinition)
 	estimator := NewOperationComplexityEstimator(false)
 


### PR DESCRIPTION
Linear: [ROUTER-655](https://linear.app/wundergraph/issue/ROUTER-655/reset-operation-complexity-estimator-depth-state-after-an-aborted-walk)

Fixes [ENG-9974](https://linear.app/wundergraph/issue/ENG-9974/complexity-estimator-leaks-state-after-an-aborted-walk)

## Summary

- Reset the per-root-field maximum depth before each complexity estimation.
- Add a regression that aborts one walk, reuses the estimator, and compares the next result with a fresh estimator.

## Context

An aborted walk can skip the root-field cleanup in `LeaveField`. Reusing that estimator then carries a stale `maxRootFieldDepth` into the next operation and can report an incorrect root-field depth.

This PR is stacked on [#1648](https://github.com/wundergraph/graphql-go-tools/pull/1648), so its diff contains only the estimator-reuse fix. PRs [#1626](https://github.com/wundergraph/graphql-go-tools/pull/1626) and [#1647](https://github.com/wundergraph/graphql-go-tools/pull/1647) included equivalent resets alongside their alternative operation-depth rewrites; #1648 plus this focused follow-up supersede both.

## Tests

`go test ./v2/... -count=1`

Closes #1626

Closes #1647

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed operation complexity calculations when the estimator is reused across sequential operations.
  * Prevented depth values from carrying over after an interrupted or invalid operation analysis.
  * Ensured subsequent valid operations receive consistent complexity results after a prior analysis failure.

* **Tests**
  * Added regression coverage for reusing the estimator after an invalid inline fragment is encountered.
  * Verified reused-estimator results match those from a fresh estimator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev).
